### PR TITLE
Search SDK: Initial commit of Swagger spec for Search Management SDK

### DIFF
--- a/arm-search/2015-02-28/swagger/search.json
+++ b/arm-search/2015-02-28/swagger/search.json
@@ -1,0 +1,460 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "SearchManagementClient",
+    "version": "2015-02-28"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{serviceName}/listAdminKeys": {
+      "post": {
+        "tags": [
+          "AdminKeys"
+        ],
+        "operationId": "AdminKeys_List",
+        "description": "Returns the primary and secondary API keys for the given Azure Search service.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group within the current subscription."
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Search service for which to list admin keys."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/AdminKeyResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{serviceName}/listQueryKeys": {
+      "get": {
+        "tags": [
+          "QueryKeys"
+        ],
+        "operationId": "QueryKeys_List",
+        "description": "Returns the list of query API keys for the given Azure Search service.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group within the current subscription."
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Search service for which to list query keys."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ListQueryKeysResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{serviceName}": {
+      "put": {
+        "tags": [
+          "Services"
+        ],
+        "operationId": "Services_CreateOrUpdate",
+        "description": "Creates or updates a Search service in the given resource group. If the Search service already exists, all properties will be updated with the given values.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group within the current subscription."
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Search service to create or update."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SearchServiceCreateOrUpdateParameters"
+            },
+            "description": "The properties to set or update on the Search service."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SearchServiceResource"
+            }
+          },
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SearchServiceResource"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Services"
+        ],
+        "operationId": "Services_Delete",
+        "description": "Deletes a Search service in the given resource group, along with its associated resources.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group within the current subscription."
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Search service to delete."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          },
+          "204": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices": {
+      "get": {
+        "tags": [
+          "Services"
+        ],
+        "operationId": "Services_List",
+        "description": "Returns a list of all Search services in the given resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group within the current subscription."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SearchServiceListResult"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AdminKeyResult": {
+      "properties": {
+        "primaryKey": {
+          "type": "string",
+          "description": "Gets the primary API key of the Search service."
+        },
+        "secondaryKey": {
+          "type": "string",
+          "description": "Gets the secondary API key of the Search service."
+        }
+      },
+      "description": "Response containing the primary and secondary API keys for a given Azure Search service."
+    },
+    "QueryKey": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets the name of the query API key; may be empty."
+        },
+        "key": {
+          "type": "string",
+          "description": "Gets the value of the query API key."
+        }
+      },
+      "description": "Describes an API key for a given Azure Search service that has permissions for query operations only."
+    },
+    "ListQueryKeysResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueryKey"
+          },
+          "description": "Gets the query keys for the Azure Search service."
+        }
+      },
+      "description": "Response containing the query API keys for a given Azure Search service."
+    },
+    "Sku": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the SKU of the Search service.",
+          "enum": [
+            "free",
+            "standard",
+            "standard2"
+          ],
+          "x-ms-enum": "SkuType"
+        }
+      },
+      "description": "Defines the SKU of an Azure Search Service, which determines price tier and capacity limits."
+    },
+    "SearchServiceProperties": {
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Gets or sets the SKU of the Search Service, which determines price tier and capacity limits."
+        },
+        "replicaCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of replicas in the Search service. If specified, it must be a value between 1 and 6 inclusive."
+        },
+        "partitionCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of partitions in the Search service; if specified, it can be 1, 2, 3, 4, 6, or 12."
+        }
+      },
+      "description": "Defines properties of an Azure Search service that can be modified."
+    },
+    "SearchServiceCreateOrUpdateParameters": {
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the geographic location of the Search service."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Gets or sets tags to help categorize the Search service in the Azure Portal."
+        },
+        "properties": {
+          "$ref": "#/definitions/SearchServiceProperties",
+          "description": "Gets or sets properties of the Search service."
+        }
+      },
+      "description": "Properties that describe an Azure Search service."
+    },
+    "SearchServiceReadableProperties": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Gets the status of the Search service.",
+          "enum": [
+            "running",
+            "provisioning",
+            "deleting",
+            "degraded",
+            "disabled",
+            "error"
+          ],
+          "x-ms-enum": "SearchServiceStatus"
+        },
+        "statusDetails": {
+          "type": "string",
+          "description": "Gets the details of the Search service status."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the state of the last provisioning operation performed on the Search service.",
+          "enum": [
+            "succeeded",
+            "provisioning",
+            "failed"
+          ],
+          "x-ms-enum": "ProvisioningState"
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Gets or sets the SKU of the Search Service, which determines price tier and capacity limits."
+        },
+        "replicaCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of replicas in the Search service. If specified, it must be a value between 1 and 6 inclusive."
+        },
+        "partitionCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of partitions in the Search service; if specified, it can be 1, 2, 3, 4, 6, or 12."
+        }
+      },
+      "description": "Defines all the properties of an Azure Search service."
+    },
+    "SearchServiceResource": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the Search service."
+        },
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the geographic location of the Search service."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Gets or sets tags to help categorize the Search service in the Azure Portal."
+        },
+        "properties": {
+          "$ref": "#/definitions/SearchServiceReadableProperties",
+          "description": "Gets properties of the Search service."
+        }
+      },
+      "description": "Describes an Azure Search service and its current state."
+    },
+    "SearchServiceListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SearchServiceResource"
+          },
+          "description": "Gets the Search services in the resource group."
+        }
+      },
+      "description": "Response containing a list of Azure Search services for a given resource group."
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-external": true
+    },
+    "SubResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource Id"
+        }
+      },
+      "x-ms-external": true
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    }
+  }
+}


### PR DESCRIPTION
This initial version of the Swagger spec was generated by a tool. I'll definitely be tweaking it as time goes on; I just wanted to get it committed as a baseline.
