### PR TITLE
Search SDK: Updates and fixes to Azure Search Swagger specs

### DIFF
--- a/search/2015-02-28/swagger/searchindex.json
+++ b/search/2015-02-28/swagger/searchindex.json
@@ -41,11 +41,21 @@
   },
   "definitions": {
     "IndexResult": {
-      "properties": {}
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Gets the key of a document that was in the indexing request."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Gets the error message explaining why the indexing operation failed for the document identified by Key; null if Succeeded is true."
+        }
+      },
+      "description": "Status of an indexing operation for a single document."
     },
     "DocumentIndexResult": {
       "properties": {
-        "results": {
+        "value": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/IndexResult"

--- a/search/2015-02-28/swagger/searchservice.json
+++ b/search/2015-02-28/swagger/searchservice.json
@@ -476,6 +476,13 @@
         },
         "parameters": [
           {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Selects which properties of the index definitions to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
@@ -775,6 +782,7 @@
       "properties": {
         "interval": {
           "type": "string",
+          "format": "duration",
           "description": "Gets or sets the interval of time between indexer executions."
         },
         "startTime": {
@@ -966,30 +974,6 @@
           "type": "string",
           "description": "Gets or sets the data type of the field."
         },
-        "key": {
-          "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field is the key of the index. Valid only for string fields. Every index must have exactly one key field."
-        },
-        "searchable": {
-          "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field is included in full-text searches. Valid only forstring or string collection fields. Default is false."
-        },
-        "filterable": {
-          "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field can be used in filter expressions. Default is false."
-        },
-        "sortable": {
-          "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field can be used in orderby expressions. Not valid for string collection fields. Default is false."
-        },
-        "facetable": {
-          "type": "boolean",
-          "description": "Gets or sets a value indicating whether it is possible to facet on this field. Not valid for geo-point fields. Default is false."
-        },
-        "retrievable": {
-          "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field can be returned in a search result. Default is true."
-        },
         "analyzer": {
           "externalDocs": {
             "url": "https://msdn.microsoft.com/library/azure/dn879793.aspx"
@@ -1100,6 +1084,7 @@
       "properties": {
         "boostingDuration": {
           "type": "string",
+          "format": "duration",
           "description": "Gets or sets the expiration period after which boosting will stop for a particular document."
         }
       },
@@ -1341,13 +1326,13 @@
       "description": "Response from a List Indexes request. If successful, it includes the full definitions of all indexes."
     }
   },
-    "parameters": {
-      "ApiVersionParameter": {
-        "name": "api-version",
-        "in": "query",
-        "required": true,
-        "type": "string",
-        "description": "Client Api Version."
-      }
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
     }
   }
+}


### PR DESCRIPTION
This change fixes a few issues found while migrating the Search SDK to
AutoRest:
- IndexResult was missing some properties
- DocumentIndexResult property was named incorrectly
- Added $select property to Indexes_List to make it much cheaper to implement
  Indexes.ListNames()
- Used the new "duration" format for IndexingSchedule.interval and
  FreshnessScoringParameters.boostingDuration
- Removed a bunch of properties from Field because we need to rename them in
  the .NET SDK. This is possible since AutoRest generates partial classes in
  C#, but it is really a workaround. The correct solution would be to extend
  AutoRest to support property renames, since it is unrealistic to expect
  REST APIs to change to suit the tool and not the other way around. See
  GitHub issue https://github.com/Azure/autorest/issues/316
