### PR TITLE
Search SDK: (Swagger) Temporarily disabling code generation for more model classes

### DIFF
--- a/search/2015-02-28/swagger/searchservice.json
+++ b/search/2015-02-28/swagger/searchservice.json
@@ -997,7 +997,8 @@
           "description": "Gets the datasources in the Search service."
         }
       },
-      "description": "Response from a List Datasources request. If successful, it includes the full definitions of all datasources."
+      "description": "Response from a List Datasources request. If successful, it includes the full definitions of all datasources.",
+      "x-ms-external": true
     },
     "IndexingSchedule": {
       "properties": {
@@ -1015,7 +1016,8 @@
       "required": [
         "interval"
       ],
-      "description": "Represents a schedule for indexer execution."
+      "description": "Represents a schedule for indexer execution.",
+      "x-ms-external": true
     },
     "IndexingParameters": {
       "properties": {
@@ -1085,7 +1087,8 @@
           "description": "Gets the indexers in the Search service."
         }
       },
-      "description": "Response from a List Indexers request. If successful, it includes the full definitions of all indexers."
+      "description": "Response from a List Indexers request. If successful, it includes the full definitions of all indexers.",
+      "x-ms-external": true
     },
     "ItemError": {
       "properties": {
@@ -1155,7 +1158,8 @@
           "description": "Change tracking state with which an indexer execution finished."
         }
       },
-      "description": "Represents result of an individual indexer execution."
+      "description": "Represents result of an individual indexer execution.",
+      "x-ms-external": true
     },
     "IndexerExecutionStatus": {
       "type": "string",
@@ -1318,7 +1322,8 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines a function that boosts scores based on distance from a geographic location."
+      "description": "Defines a function that boosts scores based on distance from a geographic location.",
+      "x-ms-external": true
     },
     "DistanceScoringParameters": {
       "properties": {
@@ -1356,7 +1361,8 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines a function that boosts scores based on the value of a date-time field."
+      "description": "Defines a function that boosts scores based on the value of a date-time field.",
+      "x-ms-external": true
     },
     "FreshnessScoringParameters": {
       "properties": {
@@ -1390,7 +1396,8 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines a function that boosts scores based on the magnitude of a numeric field."
+      "description": "Defines a function that boosts scores based on the magnitude of a numeric field.",
+      "x-ms-external": true
     },
     "MagnitudeScoringParameters": {
       "properties": {
@@ -1412,7 +1419,8 @@
       "required": [
         "boostingRangeStart", "boostingRangeEnd"
       ],
-      "description": "Provides parameter values to a magnitude scoring function."
+      "description": "Provides parameter values to a magnitude scoring function.",
+      "x-ms-external": true
     },
     "TagScoringFunction": {
       "x-ms-discriminator-value": "tag",
@@ -1433,7 +1441,8 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines a function that boosts scores of documents with string values matching a given list of tags."
+      "description": "Defines a function that boosts scores of documents with string values matching a given list of tags.",
+      "x-ms-external": true
     },
     "TagScoringParameters": {
       "properties": {
@@ -1489,7 +1498,8 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines parameters for an Azure Search index that influence scoring in search queries."
+      "description": "Defines parameters for an Azure Search index that influence scoring in search queries.",
+      "x-ms-external": true
     },
     "ScoringFunctionAggregation": {
       "type": "string",
@@ -1629,7 +1639,8 @@
           "description": "Gets the indexes in the Search service."
         }
       },
-      "description": "Response from a List Indexes request. If successful, it includes the full definitions of all indexes."
+      "description": "Response from a List Indexes request. If successful, it includes the full definitions of all indexes.",
+      "x-ms-external": true
     }
   },
   "parameters": {


### PR DESCRIPTION
Many model classes, such as the classes derived from ScoringFunction, have
properties that ought to be renamed, and constructor parameters and properties
that ought not to be nullable. Until these issues are fixed in AutoRest, we're
disabling code generation for these classes and maintaining them manually.

Related AutoRest issues:
https://github.com/Azure/autorest/issues/375
https://github.com/Azure/autorest/issues/316
