### PR TITLE
network/OutboundNatRulePropertiesFormat: Changed fieldname to singular as its type and description suggests.

### DIFF
--- a/arm-network/2015-06-15/swagger/network.json
+++ b/arm-network/2015-06-15/swagger/network.json
@@ -3583,7 +3583,7 @@
               "type": "string"
             }
           }
-        }        
+        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualnetworks/{virtualNetworkName}": {
@@ -5340,7 +5340,7 @@
     },
     "OutboundNatRulePropertiesFormat": {
       "properties": {
-        "allocatedOutboundPorts": {
+        "allocatedOutboundPort": {
           "type": "integer",
           "format": "int32",
           "description": "Gets or sets the number of outbound ports to be used for SNAT"


### PR DESCRIPTION
As @brendandixon was kind enough to point out; there was some sort of irregularity with the specifications of [this](https://github.com/Azure/azure-rest-api-specs/blob/master/arm-network/2015-06-15/swagger/network.json#L5343) OutboundNatRulePropertiesFormat field.
It's type is an int exactly as its description hints, but the name of the field is a plural.

In hopes that the type and description are to be trusted, this PR changes the field's name to its singular form, and also removes some trailing spaces and adds a new line at EOF.
