### PR TITLE
Adding DataLake* Swagger Specs

### DIFF
--- a/arm-datalake-analytics/account/2015-10-01-preview/swagger/account.json
+++ b/arm-datalake-analytics/account/2015-10-01-preview/swagger/account.json
@@ -139,7 +139,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/StorageAccountProperties"
+              "$ref": "#/definitions/AddStorageAccountParameters"
             },
             "description": "The parameters containing the access key and suffix to update the storage account with."
           },
@@ -189,7 +189,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/StorageAccountProperties"
+              "$ref": "#/definitions/AddStorageAccountParameters"
             },
             "description": "The parameters containing the access key and optional suffix for the Azure Storage Account."
           },
@@ -548,7 +548,7 @@
             "in": "body",
             "required": false,
             "schema": {
-              "$ref": "#/definitions/DataLakeStoreAccountProperties"
+              "$ref": "#/definitions/AddDataLakeStoreParameters"
             },
             "description": "The parameters containing the optional properties associated with the named Data Lake account."
           },
@@ -1316,6 +1316,24 @@
         }
       },
       "description": "The account specific properties that are associated with an underlying Data Lake Analytics account."
+    },
+    "AddDataLakeStoreParameters": {
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DataLakeStoreAccountProperties",
+          "description": "Gets or sets the properties for the Data Lake Store account being added."
+        }
+      },
+      "description": "Additional Data Lake Store parameters."
+    },
+    "AddStorageAccountParameters": {
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageAccountProperties",
+          "description": "Gets or sets the properties for the Azure Storage account being added."
+        }
+      },
+      "description": "Additional Azure Storage account parameters."
     },
     "DataLakeAnalyticsAccount": {
       "properties": {

--- a/arm-datalake-analytics/account/2015-10-01-preview/swagger/account.json
+++ b/arm-datalake-analytics/account/2015-10-01-preview/swagger/account.json
@@ -1,0 +1,1529 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "DataLakeAnalyticsManagementClient",
+    "description": "Creates an Azure Data Lake Analytics account management client.",
+    "version": "2015-10-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "produces": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}/StorageAccounts/{storageAccountName}": {
+      "get": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_GetStorageAccount",
+        "description": "Gets the specified Azure storage account details in the specified Data Lake Analytics account.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to retrieve the Azure storage account details from"
+          },
+          {
+            "name": "storageAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to retrieve"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/StorageAccount"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_DeleteStorageAccount",
+        "description": "Updates the Data Lake Analytics account specified to remove the specified Azure Storage account.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The Data Lake Analytics account name to remove the Azure Storage account from"
+          },
+          {
+            "name": "storageAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure Storage account to remove"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_UpdateStorageAccount",
+        "description": "Updates the specified storage account. This is currently only supported for Azure blob accounts to update their access keys and suffix.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The Data Lake Analytics account name to modify storage accounts in"
+          },
+          {
+            "name": "storageAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The Azure Storage account to modify"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddStorageAccountParameters"
+            },
+            "description": "The parameters containing the access key and suffix to update the storage account with."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_AddStorageAccount",
+        "description": "Updates the Data Lake Analytics account specified to include the additional Azure Storage account.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The Data Lake Analytics account name to add the Azure Storage account to"
+          },
+          {
+            "name": "storageAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure Storage account to add"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddStorageAccountParameters"
+            },
+            "description": "The parameters containing the access key and optional suffix for the Azure Storage Account."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}/StorageAccounts/{storageAccountName}/Containers/{containerName}": {
+      "get": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_GetStorageContainer",
+        "description": "Gets the specified Azure Storage container object associated with the specified Data Lake Analytics and Azure Storage accounts.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to retrieve blob container for"
+          },
+          {
+            "name": "storageAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure storage account to retrieve the blob container from"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure storage container to retrieve"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/BlobContainer"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}/StorageAccounts/{storageAccountName}/Containers": {
+      "get": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_ListStorageContainers",
+        "description": "Gets the Azure Storage containers object associated with the specified Data Lake Analytics and Azure Storage accounts.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to retrieve blob containers for"
+          },
+          {
+            "name": "storageAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure storage account to retrieve blob containers from"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ListBlobContainersResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{nextLink}": {
+      "get": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_StorageContainersListNext",
+        "description": "Gets the next page of the Azure Storage Container objects within the specified Azure Storage account, if any.",
+        "parameters": [
+          {
+            "name": "nextLink",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The url to the next Azure Storage Container page.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ListBlobContainersResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      },
+      "post": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_SasTokensListNext",
+        "description": "Gets the next page of the SAS token objects within the specified Azure Storage account and container, if any.",
+        "parameters": [
+          {
+            "name": "nextLink",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The url to the next Azure Storage Container SAS token page.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ListSasTokensResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}/StorageAccounts/{storageAccountName}/Containers/{containerName}/listSasTokens": {
+      "post": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_ListSasTokens",
+        "description": "Gets the SAS token associated with the specified Data Lake Analytics and WASB storage account and container combination.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to get the SAS token for"
+          },
+          {
+            "name": "storageAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure storage account to retrieve the blob container from"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure storage container to retrieve"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ListSasTokensResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}/DataLakeStoreAccounts/{dataLakeStoreAccountName}": {
+      "get": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_GetDataLakeStoreAccount",
+        "description": "Gets the specified Data Lake Store account details in the specified Data Lake Analytics account.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to retrieve the Data Lake Store account details from"
+          },
+          {
+            "name": "dataLakeStoreAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to retrieve"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreAccount"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_DeleteDataLakeStoreAccount",
+        "description": "Updates the Data Lake Analytics account specified to remove the specified Data Lake Store account.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The Data Lake Analytics account name to remove the Data Lake Store account from"
+          },
+          {
+            "name": "dataLakeStoreAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to remove"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_AddDataLakeStoreAccount",
+        "description": "Updates the Data Lake Analytics account specified to include the additional Data Lake Store account.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The Data Lake Analytics account name to add the Data Lake Store account to"
+          },
+          {
+            "name": "dataLakeStoreAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to add"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/AddDataLakeStoreParameters"
+            },
+            "description": "The parameters containing the optional properties associated with the named Data Lake account."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}/StorageAccounts/": {
+      "get": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_ListStorageAccounts",
+        "description": "Gets the first page of the Data Lake Analytics account objects within the subscription or within a specific resource group. This includes a link to the next page, if any.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to list Storage accounts for."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccountListStorageAccountsResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/StorageAccount"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}/DataLakeStoreAccounts/": {
+      "get": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_ListDataLakeStoreAccounts",
+        "description": "Gets the first page of the Data Lake Store account objects within the specified Data Lake Analytics account. This includes a link to the next page, if any.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to list Data Lake Store accounts for."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccountListDataLakeStoreResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/DataLakeStoreAccount"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts": {
+      "get": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_List",
+        "description": "Gets the first page of the Data Lake Analytics account objects within the subscription or within a specific resource group. This includes a link to the next page, if any.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "name": "$format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all account items."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccountListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/DataLakeAnalyticsAccount"
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}": {
+      "get": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_Get",
+        "description": "Gets the Data Lake Analytics account object specified by the account name.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to retrieve"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccount"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_Delete",
+        "description": "Begins the delete delete process for the Data Lake Analytics account object specified by the account name.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to delete"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "202": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          },
+          "204": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{name}": {
+      "put": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_Create",
+        "description": "Begins the creation process for the specified Data Lake Analytics account.This supplies the user with computation services for Data Lake Analytics workloads",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group the account will be associated with."
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Parameters supplied to the create Data Lake Analytics account operation."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccountCreateOrUpdateParameters"
+            },
+            "description": "Parameters supplied to the create Data Lake Analytics account operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          },
+          "200": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "DataLakeAnalyticsAccount"
+        ],
+        "operationId": "DataLakeAnalyticsAccount_Update",
+        "description": "Updates the Data Lake Analytics account object specified by the accountName with the contents of the account object.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Parameters supplied to the update Data Lake Analytics account operation."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccountCreateOrUpdateParameters"
+            },
+            "description": "Parameters supplied to the update Data Lake Analytics account operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "201": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "StorageAccountProperties": {
+      "properties": {
+        "accessKey": {
+          "type": "string",
+          "description": "Gets or sets the access key associated with this Azure Storage account that will be used to connect to it."
+        },
+        "suffix": {
+          "type": "string",
+          "description": "Gets or sets the optional suffix for the Data Lake account."
+        }
+      },
+      "description": "Azure Storage account properties information."
+    },
+    "StorageAccount": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the account name associated with the Azure storage account."
+        },
+        "properties": {
+          "$ref": "#/definitions/StorageAccountProperties",
+          "description": "Gets or sets the properties associated with this storage account."
+        }
+      },
+      "description": "Azure Storage account information."
+    },
+    "BlobContainerProperties": {
+      "properties": {
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the last modified time of the blob container."
+        }
+      },
+      "description": "Azure Storage blob container properties information."
+    },
+    "BlobContainer": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the blob container."
+        },
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the unique identifier of the blob container."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the type of the blob container."
+        },
+        "properties": {
+          "$ref": "#/definitions/BlobContainerProperties",
+          "description": "Gets or sets the properties of the blob container."
+        }
+      },
+      "description": "Azure Storage blob container information."
+    },
+    "ListBlobContainersResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BlobContainer"
+          },
+          "description": "Gets or set the results of the list operation"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link (url) to the next page of results."
+        }
+      },
+      "description": "The list of blob containers associated with the storage account attached to the Data Lake Analytics account."
+    },
+    "SasTokenInfo": {
+      "properties": {
+        "accessToken": {
+          "type": "string",
+          "description": "Gets or sets the access token for the associated Azure Storage Container."
+        }
+      },
+      "description": "SAS token information."
+    },
+    "ListSasTokensResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SasTokenInfo"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link (url) to the next page of results."
+        }
+      },
+      "description": "The SAS response that contains the storage account, container and associated SAS token for connection use."
+    },
+    "DataLakeStoreAccountProperties": {
+      "properties": {
+        "suffix": {
+          "type": "string",
+          "description": "Gets or sets the optional suffix for the Data Lake Store account."
+        }
+      },
+      "description": "Data Lake Store account properties information."
+    },
+    "DataLakeStoreAccount": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the account name of the Data Lake Store account."
+        },
+        "properties": {
+          "$ref": "#/definitions/DataLakeStoreAccountProperties",
+          "description": "Gets or sets the properties associated with this Data Lake Store account."
+        }
+      },
+      "description": "Data Lake Store account information."
+    },
+    "DataLakeAnalyticsAccountListStorageAccountsResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StorageAccount"
+          },
+          "description": "Gets or set the results of the list operation"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets total number of results."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link (url) to the next page of results."
+        }
+      },
+      "description": "Azure Storage Account list information."
+    },
+    "DataLakeAnalyticsAccountListDataLakeStoreResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataLakeStoreAccount"
+          },
+          "description": "Gets or set the results of the list operation"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets total number of results."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link (url) to the next page of results."
+        }
+      },
+      "description": "Data Lake Account list information."
+    },
+    "AddDataLakeStoreParameters": {
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DataLakeStoreAccountProperties",
+          "description": "Gets or sets the properties for the Data Lake Store account being added."
+        }
+      },
+      "description": "Additional Data Lake Store parameters."
+    },
+    "AddStorageAccountParameters": {
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageAccountProperties",
+          "description": "Gets or sets the properties for the Azure Storage account being added."
+        }
+      },
+      "description": "Additional Azure Storage account parameters."
+    },
+    "DataLakeAnalyticsAccountProperties": {
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Gets the provisioning status of the Data Lake Analytics account.",
+          "enum": [
+            "Failed",
+            "Creating",
+            "Running",
+            "Succeeded",
+            "Patching",
+            "Suspending",
+            "Resuming",
+            "Deleting",
+            "Deleted"
+          ],
+          "x-ms-enum": {
+            "name": "DataLakeAnalyticsAccountStatus",
+            "modelAsString": "False"
+          }
+        },
+        "state": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Gets the state of the Data Lake Analytics account.",
+          "enum": [
+            "active",
+            "suspended"
+          ],
+          "x-ms-enum": {
+            "name": "DataLakeAnalyticsAccountState",
+            "modelAsString": "False"
+          }
+        },
+        "defaultDataLakeStoreAccount": {
+          "type": "string",
+          "description": "Gets or sets the default data lake storage account associated with this Data Lake Analytics account."
+        },
+        "maxDegreeOfParallelism": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the maximum supported degree of parallelism for this acocunt."
+        },
+        "maxJobCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the maximum supported jobs running under the account at the same time."
+        },
+        "dataLakeStoreAccounts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataLakeStoreAccount"
+          },
+          "description": "Gets or sets the list of Data Lake storage accounts associated with this account."
+        },
+        "storageAccounts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StorageAccount"
+          },
+          "description": "Gets or sets the list of Azure Blob storage accounts associated with this account."
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the account creation time."
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the account last modified time."
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Gets or sets the full CName endpoint for this account."
+        }
+      },
+      "description": "The account specific properties that are associated with an underlying Data Lake Analytics account."
+    },
+    "DataLakeAnalyticsAccount": {
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the account regional location."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the account name."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the namespace and type of the account."
+        },
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the account subscription ID."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Gets or sets the value of custom properties."
+        },
+        "properties": {
+          "$ref": "#/definitions/DataLakeAnalyticsAccountProperties",
+          "description": "Gets or sets the properties defined by Data Lake Analytics all properties are specific to each resource provider."
+        }
+      },
+      "description": "A Data Lake Analytics account object, containing all information associated with the named Data Lake Analytics account."
+    },
+    "DataLakeAnalyticsAccountListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataLakeAnalyticsAccount"
+          },
+          "description": "Gets or set the results of the list operation"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link (url) to the next page of results."
+        }
+      },
+      "description": "DataLakeAnalytics Account list information."
+    },
+    "DataLakeAnalyticsAccountCreateOrUpdateParameters": {
+      "properties": {
+        "DataLakeAnalyticsAccount": {
+          "$ref": "#/definitions/DataLakeAnalyticsAccount",
+          "description": "Gets or sets the account object that is being created."
+        }
+      },
+      "required": [
+        "DataLakeAnalyticsAccount"
+      ],
+      "description": "DataLakeAnalytics DataLakeAnalyticsAccount information."
+    },
+    "ErrorDetails": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Gets or sets the HTTP status code or error code associated with this error"
+        },
+        "message": {
+          "type": "string",
+          "description": "Gets or sets the error message localized based on Accept-Language"
+        },
+        "target": {
+          "type": "string",
+          "description": "Gets or sets the target of the particular error (for example, the name of the property in error)."
+        }
+      },
+      "description": "Generic resource error details information."
+    },
+    "InnerError": {
+      "properties": {
+        "trace": {
+          "type": "string",
+          "description": "Gets or sets the stack trace for the error"
+        },
+        "context": {
+          "type": "string",
+          "description": "Gets or sets the context for the error message"
+        }
+      },
+      "description": "Generic resource inner error information."
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Gets or sets the HTTP status code or error code associated with this error"
+        },
+        "message": {
+          "type": "string",
+          "description": "Gets or sets the error message to display."
+        },
+        "target": {
+          "type": "string",
+          "description": "Gets or sets the target of the error."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorDetails"
+          },
+          "description": "Gets or sets the list of error details"
+        },
+        "innerError": {
+          "$ref": "#/definitions/InnerError",
+          "description": "Gets or sets the inner exceptions or errors, if any"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "description": "Generic resource error information."
+    },
+    "AzureAsyncOperationResult": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Gets or sets the status of the AzureAsuncOperation",
+          "enum": [
+            "InProgress",
+            "Succeeded",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "OperationStatus",
+            "modelAsString": "False"
+          }
+        },
+        "error": {
+          "$ref": "#/definitions/Error"
+        }
+      },
+      "description": "The response body contains the status of the specified asynchronous operation, indicating whether it has succeeded, is inprogress, or has failed. Note that this status is distinct from the HTTP status code returned for the Get Operation Status operation itself. If the asynchronous operation succeeded, the response body includes the HTTP status code for the successful request. If the asynchronous operation failed, the response body includes the HTTP status code for the failed request and error information regarding the failure."
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "SubResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource Id"
+        }
+      },
+      "x-ms-azure-resource": true
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    }
+  }
+}

--- a/arm-datalake-analytics/account/2015-10-01-preview/swagger/account.json
+++ b/arm-datalake-analytics/account/2015-10-01-preview/swagger/account.json
@@ -139,7 +139,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/AddStorageAccountParameters"
+              "$ref": "#/definitions/StorageAccountProperties"
             },
             "description": "The parameters containing the access key and suffix to update the storage account with."
           },
@@ -189,7 +189,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/AddStorageAccountParameters"
+              "$ref": "#/definitions/StorageAccountProperties"
             },
             "description": "The parameters containing the access key and optional suffix for the Azure Storage Account."
           },
@@ -548,7 +548,7 @@
             "in": "body",
             "required": false,
             "schema": {
-              "$ref": "#/definitions/AddDataLakeStoreParameters"
+              "$ref": "#/definitions/DataLakeStoreAccountProperties"
             },
             "description": "The parameters containing the optional properties associated with the named Data Lake account."
           },
@@ -593,7 +593,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The filter to apply on the operation."
+            "description": "Gets or sets OData filter. Optional."
           },
           {
             "name": "$top",
@@ -601,7 +601,7 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the number of items to return. Optional."
           },
           {
             "name": "$skip",
@@ -609,49 +609,49 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
           },
           {
             "name": "$expand",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
           },
           {
             "name": "$select",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
           },
           {
             "name": "$orderby",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
           },
           {
             "name": "$count",
             "in": "query",
             "required": false,
             "type": "boolean",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "name": "$search",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets a free form search. A free-text search expression to match for whether a particular entry should be included in the feed, e.g. Categories?$search=blue OR green. Optional."
           },
           {
             "name": "$format",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the return format. Return the response in particular formatxii without access to request headers for standard content-type negotiation (e.g Orders?$format=json). Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -701,7 +701,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The filter to apply on the operation."
+            "description": "Gets or sets OData filter. Optional."
           },
           {
             "name": "$top",
@@ -709,7 +709,7 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the number of items to return. Optional."
           },
           {
             "name": "$skip",
@@ -717,49 +717,49 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
           },
           {
             "name": "$expand",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
           },
           {
             "name": "$select",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
           },
           {
             "name": "$orderby",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
           },
           {
             "name": "$count",
             "in": "query",
             "required": false,
             "type": "boolean",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "name": "$search",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets a free form search. A free-text search expression to match for whether a particular entry should be included in the feed, e.g. Categories?$search=blue OR green. Optional."
           },
           {
             "name": "$format",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the return format. Return the response in particular formatxii without access to request headers for standard content-type negotiation (e.g Orders?$format=json). Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -802,7 +802,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The filter to apply on the operation."
+            "description": "Gets or sets OData filter. Optional."
           },
           {
             "name": "$top",
@@ -810,7 +810,7 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the number of items to return. Optional."
           },
           {
             "name": "$skip",
@@ -818,49 +818,49 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
           },
           {
             "name": "$expand",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
           },
           {
             "name": "$select",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
           },
           {
             "name": "$orderby",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
           },
           {
             "name": "$count",
             "in": "query",
             "required": false,
             "type": "boolean",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "name": "$search",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets a free form search. A free-text search expression to match for whether a particular entry should be included in the feed, e.g. Categories?$search=blue OR green. Optional."
           },
           {
             "name": "$format",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all account items."
+            "description": "Gets or sets the return format. Return the response in particular formatxii without access to request headers for standard content-type negotiation (e.g Orders?$format=json). Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -986,14 +986,14 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Parameters supplied to the create Data Lake Analytics account operation."
+            "description": "The name of the Data Lake Analytics account to create."
           },
           {
             "name": "parameters",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/DataLakeAnalyticsAccountCreateOrUpdateParameters"
+              "$ref": "#/definitions/DataLakeAnalyticsAccount"
             },
             "description": "Parameters supplied to the create Data Lake Analytics account operation."
           },
@@ -1006,10 +1006,16 @@
         ],
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccount"
+            }
           },
           "200": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccount"
+            }
           }
         },
         "x-ms-long-running-operation": true
@@ -1033,14 +1039,14 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Parameters supplied to the update Data Lake Analytics account operation."
+            "description": "The name of the Data Lake Analytics account to update."
           },
           {
             "name": "parameters",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/DataLakeAnalyticsAccountCreateOrUpdateParameters"
+              "$ref": "#/definitions/DataLakeAnalyticsAccount"
             },
             "description": "Parameters supplied to the update Data Lake Analytics account operation."
           },
@@ -1053,10 +1059,16 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccount"
+            }
           },
           "201": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsAccount"
+            }
           }
         },
         "x-ms-long-running-operation": true
@@ -1225,24 +1237,6 @@
       },
       "description": "Data Lake Account list information."
     },
-    "AddDataLakeStoreParameters": {
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/DataLakeStoreAccountProperties",
-          "description": "Gets or sets the properties for the Data Lake Store account being added."
-        }
-      },
-      "description": "Additional Data Lake Store parameters."
-    },
-    "AddStorageAccountParameters": {
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/StorageAccountProperties",
-          "description": "Gets or sets the properties for the Azure Storage account being added."
-        }
-      },
-      "description": "Additional Azure Storage account parameters."
-    },
     "DataLakeAnalyticsAccountProperties": {
       "properties": {
         "provisioningState": {
@@ -1370,18 +1364,6 @@
         }
       },
       "description": "DataLakeAnalytics Account list information."
-    },
-    "DataLakeAnalyticsAccountCreateOrUpdateParameters": {
-      "properties": {
-        "DataLakeAnalyticsAccount": {
-          "$ref": "#/definitions/DataLakeAnalyticsAccount",
-          "description": "Gets or sets the account object that is being created."
-        }
-      },
-      "required": [
-        "DataLakeAnalyticsAccount"
-      ],
-      "description": "DataLakeAnalytics DataLakeAnalyticsAccount information."
     },
     "ErrorDetails": {
       "properties": {

--- a/arm-datalake-analytics/catalog/2015-10-01-preview/swagger/catalog.json
+++ b/arm-datalake-analytics/catalog/2015-10-01-preview/swagger/catalog.json
@@ -5,6 +5,7 @@
     "description": "Creates an Azure Data Lake Analytics catalog management client.",
     "version": "2015-10-01-preview"
   },
+  "host": "accountname.catalogserviceuri",
   "schemes": [
     "https"
   ],
@@ -19,7 +20,7 @@
     "application/octet-stream"
   ],
   "paths": {
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/secrets/{secretName}": {
+    "/catalog/usql/databases/{databaseName}/secrets/{secretName}": {
       "put": {
         "tags": [
           "Catalog"
@@ -28,7 +29,7 @@
         "description": "Creates the specified secret for use with external data sources in the specified database",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -48,13 +49,7 @@
             "type": "string",
             "description": "The parameters required to create the secret (name and password)"
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "name": "parameters",
             "in": "body",
@@ -91,7 +86,7 @@
         "description": "Modifies the specified secret for use with external data sources in the specified database",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -111,13 +106,7 @@
             "type": "string",
             "description": "The parameters required to modify the secret (name and password)"
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "name": "parameters",
             "in": "body",
@@ -154,7 +143,7 @@
         "description": "Gets the specified secret in the specified database",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -174,13 +163,7 @@
             "type": "string",
             "description": "The name of the secret to get"
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -208,7 +191,7 @@
         "description": "Deletes the specified secret in the specified database",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -228,13 +211,7 @@
             "type": "string",
             "description": "The name of the secret to delete"
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -252,7 +229,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/externaldatasources/{externalDataSourceName}": {
+    "/catalog/usql/databases/{databaseName}/externaldatasources/{externalDataSourceName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -261,7 +238,7 @@
         "description": "Retrieves the specified external data source from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -281,13 +258,7 @@
             "type": "string",
             "description": "The name of the external Data Source to find."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -308,7 +279,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/externaldatasources": {
+    "/catalog/usql/databases/{databaseName}/externaldatasources": {
       "get": {
         "tags": [
           "Catalog"
@@ -317,7 +288,7 @@
         "description": "Retrieves the list of external data sources from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -330,12 +301,57 @@
             "type": "string",
             "description": "The name of the database to find the external Data Source in."
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -360,7 +376,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/credentials/{credentialName}": {
+    "/catalog/usql/databases/{databaseName}/credentials/{credentialName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -369,7 +385,7 @@
         "description": "Retrieves the specified credential from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -389,13 +405,7 @@
             "type": "string",
             "description": "The name of the credential to find."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -416,7 +426,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/credentials": {
+    "/catalog/usql/databases/{databaseName}/credentials": {
       "get": {
         "tags": [
           "Catalog"
@@ -425,7 +435,7 @@
         "description": "Retrieves the list of credentials from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -438,12 +448,57 @@
             "type": "string",
             "description": "The name of the database to find the schema in."
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -468,7 +523,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/procedures/{procedureName}": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/procedures/{procedureName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -477,7 +532,7 @@
         "description": "Retrieves the specified procedure from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -504,13 +559,7 @@
             "type": "string",
             "description": "The name of the procedure to find."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -531,7 +580,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/procedures": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/procedures": {
       "get": {
         "tags": [
           "Catalog"
@@ -540,7 +589,7 @@
         "description": "Retrieves the list of procedures from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -560,12 +609,57 @@
             "type": "string",
             "description": "The name of the schema to find the procedures in."
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -590,7 +684,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -599,7 +693,7 @@
         "description": "Retrieves the specified table from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -626,13 +720,7 @@
             "type": "string",
             "description": "The name of the table to find."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -653,7 +741,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables": {
       "get": {
         "tags": [
           "Catalog"
@@ -662,7 +750,7 @@
         "description": "Retrieves the list of tables from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -682,12 +770,57 @@
             "type": "string",
             "description": "The name of the schema to find the tables in."
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -712,7 +845,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/views/{viewName}": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/views/{viewName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -721,7 +854,7 @@
         "description": "Retrieves the specified view from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -748,13 +881,7 @@
             "type": "string",
             "description": "The name of the view to find."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -775,7 +902,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/views": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/views": {
       "get": {
         "tags": [
           "Catalog"
@@ -784,7 +911,7 @@
         "description": "Retrieves the list of views from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -804,12 +931,57 @@
             "type": "string",
             "description": "The name of the schema to find the views in."
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -834,7 +1006,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/statistics/{statisticsName}": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/statistics/{statisticsName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -843,7 +1015,7 @@
         "description": "Retrieves the specified table from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -877,13 +1049,7 @@
             "type": "string",
             "description": "The name of the table statistics to find."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -904,7 +1070,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/statistics": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/statistics": {
       "get": {
         "tags": [
           "Catalog"
@@ -913,7 +1079,7 @@
         "description": "Retrieves the list of tables from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -940,12 +1106,57 @@
             "type": "string",
             "description": "The name of the table to find the statistics in."
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -970,7 +1181,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/types": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/types": {
       "get": {
         "tags": [
           "Catalog"
@@ -979,7 +1190,7 @@
         "description": "Retrieves the list of catalog types within the specified database and schema for the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -1004,7 +1215,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The filter to apply on the operation."
+            "description": "Gets or sets OData filter. Optional."
           },
           {
             "name": "$top",
@@ -1012,7 +1223,7 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all catalog type items."
+            "description": "Gets or sets the number of items to return. Optional."
           },
           {
             "name": "$skip",
@@ -1020,29 +1231,37 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all catalog type items."
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
           },
           {
-            "name": "$orderby",
+            "name": "$expand",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all catalog type items."
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
           },
           {
             "name": "$select",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all catalog type items."
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
           },
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
           },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
+          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -1067,7 +1286,7 @@
         "x-ms-odata": "#/definitions/USqlType"
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tablevaluedfunctions/{tableValuedFunctionName}": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tablevaluedfunctions/{tableValuedFunctionName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -1076,7 +1295,7 @@
         "description": "Retrieves the specified table valued function from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -1103,13 +1322,7 @@
             "type": "string",
             "description": "The name of the tableValuedFunction to find."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -1130,7 +1343,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tablevaluedfunctions": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tablevaluedfunctions": {
       "get": {
         "tags": [
           "Catalog"
@@ -1139,7 +1352,7 @@
         "description": "Retrieves the list of table valued functions from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -1159,12 +1372,57 @@
             "type": "string",
             "description": "The name of the schema to find the table valued functions in."
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1189,7 +1447,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/assemblies/{assemblyName}": {
+    "/catalog/usql/databases/{databaseName}/assemblies/{assemblyName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -1198,7 +1456,7 @@
         "description": "Retrieves the specified assembly from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -1218,13 +1476,7 @@
             "type": "string",
             "description": "The name of the assembly to find."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -1245,7 +1497,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/assemblies": {
+    "/catalog/usql/databases/{databaseName}/assemblies": {
       "get": {
         "tags": [
           "Catalog"
@@ -1254,7 +1506,7 @@
         "description": "Retrieves the list of assemblies from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -1267,12 +1519,57 @@
             "type": "string",
             "description": "The name of the database to find the assembly in."
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1297,7 +1594,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}": {
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -1306,7 +1603,7 @@
         "description": "Retrieves the specified schema from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -1326,13 +1623,7 @@
             "type": "string",
             "description": "The name of the schema to find."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -1353,7 +1644,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas": {
+    "/catalog/usql/databases/{databaseName}/schemas": {
       "get": {
         "tags": [
           "Catalog"
@@ -1362,7 +1653,7 @@
         "description": "Retrieves the list of schemas from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -1375,12 +1666,57 @@
             "type": "string",
             "description": "The name of the database to find the schema in."
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1405,7 +1741,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}": {
+    "/catalog/usql/databases/{databaseName}": {
       "get": {
         "tags": [
           "Catalog"
@@ -1414,7 +1750,7 @@
         "description": "Retrieves the specified database from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -1427,13 +1763,7 @@
             "type": "string",
             "description": "The path to the file to create."
           },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
-          },
+          
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -1454,7 +1784,7 @@
         }
       }
     },
-    "/{accountName}.{catalogServiceUri}/catalog/usql/databases": {
+    "/catalog/usql/databases": {
       "get": {
         "tags": [
           "Catalog"
@@ -1463,18 +1793,63 @@
         "description": "Retrieves the list of databases from the current Data Lake Analytics catalog",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
             "description": "The name of the account to use"
           },
+          
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$filter",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+            "description": "Gets or sets OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2735,10 +3110,11 @@
       "description": "Client Api Version."
     },
     "catalogServiceUriInPathParameter": {
-      "name": "catalogServiceUri",
+      "name": "catalogserviceuri",
       "in": "path",
       "required": true,
       "type": "string",
+      "default": "\"azuredatalakeanalytics.net\"",
       "description": "Gets the URI used as the base for all cloud service requests."
     }
   }

--- a/arm-datalake-analytics/catalog/2015-10-01-preview/swagger/catalog.json
+++ b/arm-datalake-analytics/catalog/2015-10-01-preview/swagger/catalog.json
@@ -1,0 +1,2745 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "DataLakeAnalyticsCatalogManagementClient",
+    "description": "Creates an Azure Data Lake Analytics catalog management client.",
+    "version": "2015-10-01-preview"
+  },
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "produces": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "paths": {
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/secrets/{secretName}": {
+      "put": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_CreateSecret",
+        "description": "Creates the specified secret for use with external data sources in the specified database",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to create the secret in."
+          },
+          {
+            "name": "secretName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The parameters required to create the secret (name and password)"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsCatalogSecretCreateOrUpdateParameters"
+            },
+            "description": "The parameters required to create the secret (name and password)"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlSecret"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_UpdateSecret",
+        "description": "Modifies the specified secret for use with external data sources in the specified database",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to modify the secret in."
+          },
+          {
+            "name": "secretName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The parameters required to modify the secret (name and password)"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DataLakeAnalyticsCatalogSecretCreateOrUpdateParameters"
+            },
+            "description": "The parameters required to modify the secret (name and password)"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlSecret"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetSecret",
+        "description": "Gets the specified secret in the specified database",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to get the secret from."
+          },
+          {
+            "name": "secretName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the secret to get"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlSecret"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_DeleteSecret",
+        "description": "Deletes the specified secret in the specified database",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to delete the secret from."
+          },
+          {
+            "name": "secretName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the secret to delete"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/externaldatasources/{externalDataSourceName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetExternalDataSource",
+        "description": "Retrieves the specified external data source from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the external Data Source in."
+          },
+          {
+            "name": "externalDataSourceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the external Data Source to find."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlExternalDataSource"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/externaldatasources": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListExternalDataSources",
+        "description": "Retrieves the list of external data sources from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the external Data Source in."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlExternalDataSourceList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/credentials/{credentialName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetCredential",
+        "description": "Retrieves the specified credential from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the schema in."
+          },
+          {
+            "name": "credentialName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the credential to find."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlCredential"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/credentials": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListCredentials",
+        "description": "Retrieves the list of credentials from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the schema in."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlCredentialList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/procedures/{procedureName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetProcedure",
+        "description": "Retrieves the specified procedure from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the procedure in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the procedure in."
+          },
+          {
+            "name": "procedureName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the procedure to find."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlProcedure"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/procedures": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListProcedures",
+        "description": "Retrieves the list of procedures from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the procedures in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the procedures in."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlProcedureList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetTable",
+        "description": "Retrieves the specified table from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the table in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the table in."
+          },
+          {
+            "name": "tableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the table to find."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlTable"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListTables",
+        "description": "Retrieves the list of tables from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the tables in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the tables in."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlTableList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/views/{viewName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetView",
+        "description": "Retrieves the specified view from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the view in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the view in."
+          },
+          {
+            "name": "viewName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the view to find."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlView"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/views": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListViews",
+        "description": "Retrieves the list of views from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the views in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the views in."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlViewList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/statistics/{statisticsName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetTableStatistic",
+        "description": "Retrieves the specified table from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the statistics in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the statistics in."
+          },
+          {
+            "name": "tableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the table to find the statistics in."
+          },
+          {
+            "name": "statisticsName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the table statistics to find."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlTableStatistics"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/statistics": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListTableStatistics",
+        "description": "Retrieves the list of tables from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the statistics in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the statistics in."
+          },
+          {
+            "name": "tableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the table to find the statistics in."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlTableStatisticsList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/types": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListTypes",
+        "description": "Retrieves the list of catalog types within the specified database and schema for the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the types in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the types in."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all catalog type items."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all catalog type items."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all catalog type items."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all catalog type items."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlTypeList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/USqlType"
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tablevaluedfunctions/{tableValuedFunctionName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetTableValuedFunction",
+        "description": "Retrieves the specified table valued function from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the table valued function in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the table valued function in."
+          },
+          {
+            "name": "tableValuedFunctionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the tableValuedFunction to find."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlTableValuedFunction"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tablevaluedfunctions": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListTableValuedFunctions",
+        "description": "Retrieves the list of table valued functions from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the table valued functions in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find the table valued functions in."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlTableValuedFunctionList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/assemblies/{assemblyName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetAssembly",
+        "description": "Retrieves the specified assembly from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the assembly in."
+          },
+          {
+            "name": "assemblyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the assembly to find."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlAssembly"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/assemblies": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListAssemblies",
+        "description": "Retrieves the list of assemblies from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the assembly in."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlAssemblyList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas/{schemaName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetSchema",
+        "description": "Retrieves the specified schema from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the schema in."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema to find."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlSchema"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}/schemas": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListSchemas",
+        "description": "Retrieves the list of schemas from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database to find the schema in."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlSchemaList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases/{databaseName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetDatabase",
+        "description": "Retrieves the specified database from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to create."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlDatabase"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{catalogServiceUri}/catalog/usql/databases": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListDatabases",
+        "description": "Retrieves the list of databases from the current Data Lake Analytics catalog",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resourceGroup the Data Lake Analytics account is in"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/catalogServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/USqlDatabaseList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "DataLakeAnalyticsCatalogSecretCreateOrUpdateParameters": {
+      "properties": {
+        "password": {
+          "type": "string",
+          "description": "Gets or sets the password for the secret to pass in"
+        },
+        "uri": {
+          "type": "string",
+          "description": "Gets or sets the URI identifier for the secret in the format <hostname>:<port>"
+        }
+      },
+      "required": [
+        "password"
+      ],
+      "description": "DataLakeAnalytics DataLakeAnalyticsAccount information."
+    },
+    "USqlSecret": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "secretName": {
+          "type": "string",
+          "description": "Gets or sets the name of the secret."
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the creation time of the credential object. This is the only information returned about a secret from a GET."
+        },
+        "uri": {
+          "type": "string",
+          "description": "Gets or sets the URI identifier for the secret in the format <hostname>:<port>"
+        },
+        "password": {
+          "type": "string",
+          "description": "Gets or sets the password for the secret to pass in"
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL secret item."
+    },
+    "USqlExternalDataSource": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "externalDataSourceName": {
+          "type": "string",
+          "description": "Gets or sets the name of the external data source."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Gets or sets the name of the provider for the external data source."
+        },
+        "providerString": {
+          "type": "string",
+          "description": "Gets or sets the name of the provider string for the external data source."
+        },
+        "pushdownTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the list of types to push down from the external data source."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL external datasource item."
+    },
+    "USqlExternalDataSourceList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlExternalDataSource"
+          },
+          "description": "Gets or sets the list of external data sources in the database"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL external datasource item list."
+    },
+    "USqlCredential": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database the credential is in."
+        },
+        "identity": {
+          "type": "string",
+          "description": "Gets or sets the name of the secret associated with the credential."
+        },
+        "credentialName": {
+          "type": "string",
+          "description": "Gets or sets the name of the credential."
+        },
+        "userName": {
+          "type": "string",
+          "description": "Gets or sets the user name associated with the credential."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL credential item."
+    },
+    "USqlCredentialList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlCredential"
+          },
+          "description": "Gets or sets the list of credentials in the database"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL credential item list."
+    },
+    "USqlProcedure": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "schemaName": {
+          "type": "string",
+          "description": "Gets or sets the name of the schema associated with this procedure and database."
+        },
+        "procName": {
+          "type": "string",
+          "description": "Gets or sets the name of the procedure."
+        },
+        "definition": {
+          "type": "string",
+          "description": "Gets or sets the defined query of the procedure."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL procedure item."
+    },
+    "USqlProcedureList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlProcedure"
+          },
+          "description": "Gets or sets the list of procedure in the database and schema combination"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL procedure item list."
+    },
+    "USqlTableColumn": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the column in the table."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the object type of the specified column (such as System.String)."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL table column item."
+    },
+    "USqlDirectedColumn": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the index in the table."
+        },
+        "descending": {
+          "type": "boolean",
+          "description": "Gets or sets the switch indicating if the index is descending or not."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL directed column item."
+    },
+    "USqlDistributionInfo": {
+      "properties": {
+        "type": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the type of this distribution."
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlDirectedColumn"
+          },
+          "description": "Gets or sets the list of directed columns in the distribution"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of indices using this distribution."
+        },
+        "dynamicCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the dynamic count of indices using this distribution."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL distribution information object."
+    },
+    "USqlIndex": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the index in the table."
+        },
+        "indexKeys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlDirectedColumn"
+          },
+          "description": "Gets or sets the list of directed columns in the index"
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the list of columns in the index"
+        },
+        "distributionInfo": {
+          "$ref": "#/definitions/USqlDistributionInfo",
+          "description": "Gets or sets the distributions info of the index"
+        },
+        "partitionFunction": {
+          "type": "string",
+          "description": "Gets or sets partition function ID for the index."
+        },
+        "partitionKeyList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the list of partion keys in the index"
+        },
+        "streamNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the list of full paths to the streams that contain this index in the DataLake account."
+        },
+        "isColumnstore": {
+          "type": "boolean",
+          "description": "Gets or sets the switch indicating if this index is a columnstore index."
+        },
+        "indexId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the ID of this index within the table."
+        },
+        "isUnique": {
+          "type": "boolean",
+          "description": "Gets or sets the switch indicating if this index is a unique index."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL table index item."
+    },
+    "DdlName": {
+      "properties": {
+        "firstPart": {
+          "type": "string",
+          "description": "Gets or sets the name of the table associated with this database and schema."
+        },
+        "secondPart": {
+          "type": "string",
+          "description": "Gets or sets the name of the table associated with this database and schema."
+        },
+        "thirdPart": {
+          "type": "string",
+          "description": "Gets or sets the name of the table associated with this database and schema."
+        },
+        "server": {
+          "type": "string",
+          "description": "Gets or sets the name of the table associated with this database and schema."
+        }
+      },
+      "description": "A Data Lake Analytics DDL name item."
+    },
+    "EntityId": {
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/DdlName",
+          "description": "Gets or sets the name of the external table associated with this database, schema and table."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the external data source."
+        }
+      },
+      "description": "A Data Lake Analytics catalog entity identifier object."
+    },
+    "ExternalTable": {
+      "properties": {
+        "tableName": {
+          "type": "string",
+          "description": "Gets or sets the name of the table associated with this database and schema."
+        },
+        "dataSource": {
+          "$ref": "#/definitions/EntityId",
+          "description": "Gets or sets the data source associated with this external table."
+        }
+      },
+      "description": "A Data Lake Analytics catalog external table item."
+    },
+    "USqlTable": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "schemaName": {
+          "type": "string",
+          "description": "Gets or sets the name of the schema associated with this table and database."
+        },
+        "tableName": {
+          "type": "string",
+          "description": "Gets or sets the name of the table."
+        },
+        "columnList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlTableColumn"
+          },
+          "description": "Gets or sets the list of columns in this table"
+        },
+        "indexList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlIndex"
+          },
+          "description": "Gets or sets the list of indices in this table"
+        },
+        "partitionKeyList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the list of partition keys in the table"
+        },
+        "externalTable": {
+          "$ref": "#/definitions/ExternalTable",
+          "description": "Gets or sets the external table associated with the table."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL table item."
+    },
+    "USqlTableList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlTable"
+          },
+          "description": "Gets or sets the list of tables in the database and schema combination"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL table item list."
+    },
+    "USqlView": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "schemaName": {
+          "type": "string",
+          "description": "Gets or sets the name of the schema associated with this view and database."
+        },
+        "viewName": {
+          "type": "string",
+          "description": "Gets or sets the name of the view."
+        },
+        "definition": {
+          "type": "string",
+          "description": "Gets or sets the defined query of the view."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL view item."
+    },
+    "USqlViewList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlView"
+          },
+          "description": "Gets or sets the list of view in the database and schema combination"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL view item list."
+    },
+    "USqlTableStatistics": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "schemaName": {
+          "type": "string",
+          "description": "Gets or sets the name of the schema associated with this table and database."
+        },
+        "tableName": {
+          "type": "string",
+          "description": "Gets or sets the name of the table."
+        },
+        "statisticsName": {
+          "type": "string",
+          "description": "Gets or sets the name of the table statistics."
+        },
+        "userStatName": {
+          "type": "string",
+          "description": "Gets or sets the name of the user statistics."
+        },
+        "statDataPath": {
+          "type": "string",
+          "description": "Gets or sets the path to the statistics data."
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the creation time of the statistics."
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the last time the statistics were updated."
+        },
+        "isUserCreated": {
+          "type": "boolean",
+          "description": "Gets or sets the switch indicating if these statistics are user created."
+        },
+        "isAutoCreated": {
+          "type": "boolean",
+          "description": "Gets or sets the switch indicating if these statistics are automatically created."
+        },
+        "hasFilter": {
+          "type": "boolean",
+          "description": "Gets or sets the switch indicating if these statistics have a filter."
+        },
+        "filterDefinition": {
+          "type": "string",
+          "description": "Gets or sets the filter definition for the statistics."
+        },
+        "colNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the list of column names associated with these statistics."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL table statistics item."
+    },
+    "USqlTableStatisticsList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlTableStatistics"
+          },
+          "description": "Gets or sets the list of table statistics in the database, schema and table combination"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL table statistics item list."
+    },
+    "USqlType": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "schemaName": {
+          "type": "string",
+          "description": "Gets or sets the name of the schema associated with this table and database."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Gets or sets the name of type for this type."
+        },
+        "typeFamily": {
+          "type": "string",
+          "description": "Gets or sets the type family for this type."
+        },
+        "cSharpName": {
+          "type": "string",
+          "description": "Gets or sets the C# name for this type."
+        },
+        "fullCSharpName": {
+          "type": "string",
+          "description": "Gets or sets the fully qualified C# name for this type."
+        },
+        "systemTypeId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the system type ID for this type."
+        },
+        "userTypeId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the user type ID for this type."
+        },
+        "schemaId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the schema ID for this type."
+        },
+        "principalId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the principal ID for this type."
+        },
+        "isNullable": {
+          "type": "boolean",
+          "description": "Gets or sets the the switch indicating if this type is nullable."
+        },
+        "isUserDefined": {
+          "type": "boolean",
+          "description": "Gets or sets the the switch indicating if this type is user defined."
+        },
+        "isAssemblyType": {
+          "type": "boolean",
+          "description": "Gets or sets the the switch indicating if this type is an assembly type."
+        },
+        "isTableType": {
+          "type": "boolean",
+          "description": "Gets or sets the the switch indicating if this type is a table type."
+        },
+        "isComplexType": {
+          "type": "boolean",
+          "description": "Gets or sets the the switch indicating if this type is a complex type."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL type item."
+    },
+    "USqlTypeList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlType"
+          },
+          "description": "Gets or sets the list of types in the database and schema combination"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL type item list."
+    },
+    "USqlTableValuedFunction": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "schemaName": {
+          "type": "string",
+          "description": "Gets or sets the name of the schema associated with this database."
+        },
+        "tvfName": {
+          "type": "string",
+          "description": "Gets or sets the name of the table valued function."
+        },
+        "definition": {
+          "type": "string",
+          "description": "Gets or sets the definition of the table valued function."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL table valued function item."
+    },
+    "USqlTableValuedFunctionList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlTableValuedFunction"
+          },
+          "description": "Gets or sets the list of table valued functions in the database and schema combination"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL table valued function item list."
+    },
+    "USqlAssemblyFileInfo": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the assembly file type.",
+          "enum": [
+            "Assembly",
+            "Resource"
+          ],
+          "x-ms-enum": {
+            "name": "FileType",
+            "modelAsString": "False"
+          }
+        },
+        "originalPath": {
+          "type": "string",
+          "description": "Gets or sets the the original path to the assembly file."
+        },
+        "contentPath": {
+          "type": "string",
+          "description": "Gets or sets the the content path to the assembly file."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL assembly file information item."
+    },
+    "USqlAssemblyDependencyInfo": {
+      "properties": {
+        "entityId": {
+          "$ref": "#/definitions/EntityId",
+          "description": "Gets or sets the EntityId of the dependency."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL dependency information item."
+    },
+    "USqlAssembly": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "assemblyName": {
+          "type": "string",
+          "description": "Gets or sets the name of the assembly."
+        },
+        "clrName": {
+          "type": "string",
+          "description": "Gets or sets the name of the CLR."
+        },
+        "isVisible": {
+          "type": "boolean",
+          "description": "Gets or sets the switch indicating if this assembly is visible or not."
+        },
+        "isUserDefined": {
+          "type": "boolean",
+          "description": "Gets or sets the switch indicating if this assembly is user defined or not."
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlAssemblyFileInfo"
+          },
+          "description": "Gets or sets the list of files associated with the assembly"
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlAssemblyDependencyInfo"
+          },
+          "description": "Gets or sets the list of dependencies associated with the assembly"
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL Assembly."
+    },
+    "USqlAssemblyClr": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "assemblyClrName": {
+          "type": "string",
+          "description": "Gets or sets the name of the assembly."
+        },
+        "clrName": {
+          "type": "string",
+          "description": "Gets or sets the name of the CLR."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL assembly CLR item."
+    },
+    "USqlAssemblyList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlAssemblyClr"
+          },
+          "description": "Gets or sets the list of assemblies in the database"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL assembly CLR item list."
+    },
+    "USqlSchema": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "schemaName": {
+          "type": "string",
+          "description": "Gets or sets the name of the schema."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL schema item."
+    },
+    "USqlSchemaList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlSchema"
+          },
+          "description": "Gets or sets the list of schemas in the database"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL schema item list."
+    },
+    "USqlDatabase": {
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Gets or sets the name of the database."
+        },
+        "computeAccountName": {
+          "type": "string",
+          "description": "Gets or sets the name of the Data Lake Analytics account."
+        },
+        "version": {
+          "type": "string",
+          "description": "Gets or sets the version of the catalog item."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL database item."
+    },
+    "USqlDatabaseList": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/USqlDatabase"
+          },
+          "description": "Gets or sets the list of databases"
+        },
+        "itemType": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or USql).",
+          "enum": [
+            "usqlDatabase",
+            "usqlSchema",
+            "usqlAssembly",
+            "usqlTable",
+            "uSqlView",
+            "uSqlProcedure",
+            "uSqlCredential",
+            "usqlTableValuedFunction",
+            "usqlTableStatistics",
+            "usqlSecret",
+            "usqlExternalDataSource",
+            "usqlType"
+          ],
+          "x-ms-enum": {
+            "name": "CatalogItemType",
+            "modelAsString": "True"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the count of items in the list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link to the next page of results."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL database item list."
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "SubResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource Id"
+        }
+      },
+      "x-ms-azure-resource": true
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "header",
+      "required": true,
+      "type": "string",
+      "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    },
+    "catalogServiceUriInPathParameter": {
+      "name": "catalogServiceUri",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Gets the URI used as the base for all cloud service requests."
+    }
+  }
+}

--- a/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
+++ b/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
@@ -706,6 +706,11 @@
       }
     },
     "JobProperties": {
+      "discriminator": "type",
+      "required": [
+        "script",
+        "type"
+      ],
       "properties": {
         "runtimeVersion": {
           "type": "string",
@@ -724,15 +729,10 @@
           ],
           "x-ms-enum": {
             "name": "JobType",
-            "modelAsString": "True"
+            "modelAsString": "False"
           }
         }
       },
-      "discriminator": "type",
-      "required": [
-        "script",
-        "type"
-      ],
       "description": "The common Data Lake Analytics job properties."
     },
     "JobInformation": {
@@ -754,7 +754,7 @@
           ],
           "x-ms-enum": {
             "name": "JobType",
-            "modelAsString": "True"
+            "modelAsString": "False"
           }
         },
         "submitter": {

--- a/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
+++ b/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
@@ -5,6 +5,7 @@
     "description": "Creates an Azure Data Lake Analytics job management client.",
     "version": "2015-10-01-preview"
   },
+  "host": "accountname.jobserviceuri",
   "schemes": [
     "https"
   ],
@@ -19,7 +20,7 @@
     "application/octet-stream"
   ],
   "paths": {
-    "/{accountName}.{jobServiceUri}/Jobs/{jobIdentity}/GetStatistics": {
+    "/Jobs/{jobIdentity}/GetStatistics": {
       "post": {
         "tags": [
           "Jobs"
@@ -27,8 +28,9 @@
         "operationId": "Jobs_GetStatistics",
         "description": "Gets the job statistics object specified by the job ID.",
         "parameters": [
+          
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -40,13 +42,6 @@
             "required": true,
             "type": "string",
             "description": "JobInfo ID."
-          },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resource group."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -68,7 +63,7 @@
         }
       }
     },
-    "/{accountName}.{jobServiceUri}/Jobs/{jobIdentity}/GetDebugDataPath": {
+    "/Jobs/{jobIdentity}/GetDebugDataPath": {
       "post": {
         "tags": [
           "Jobs"
@@ -76,8 +71,9 @@
         "operationId": "Jobs_GetDebugDataPath",
         "description": "Gets the U-SQL job debug data information specified by the job ID.",
         "parameters": [
+          
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -89,13 +85,6 @@
             "required": true,
             "type": "string",
             "description": "JobInfo ID."
-          },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resource group."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -117,7 +106,7 @@
         }
       }
     },
-    "/{accountName}.{jobServiceUri}/BuildJob": {
+    "/BuildJob": {
       "post": {
         "tags": [
           "Jobs"
@@ -125,26 +114,20 @@
         "operationId": "Jobs_Build",
         "description": "Builds (compiles) the specified job in the specified Data Lake Analytics account for job correctness and validation.",
         "parameters": [
+          
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
             "description": "The name of the Data Lake Analytics account to build the job for"
           },
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resource group."
-          },
-          {
             "name": "parameters",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/JobInfoBuildOrCreateParameters"
+              "$ref": "#/definitions/JobInformation"
             },
             "description": "The parameters to build a job, which simulates submission."
           },
@@ -168,7 +151,7 @@
         }
       }
     },
-    "/{accountName}.{jobServiceUri}/Jobs/{jobId}": {
+    "/Jobs/{jobId}": {
       "put": {
         "tags": [
           "Jobs"
@@ -176,8 +159,9 @@
         "operationId": "Jobs_Create",
         "description": "Submits the specified job to the specified Data Lake Analytics account for computation.",
         "parameters": [
+          
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -191,18 +175,11 @@
             "description": "The parameters to submit a job."
           },
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resource group."
-          },
-          {
             "name": "parameters",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/JobInfoBuildOrCreateParameters"
+              "$ref": "#/definitions/JobInformation"
             },
             "description": "The parameters to submit a job."
           },
@@ -226,7 +203,7 @@
         }
       }
     },
-    "/{accountName}.{jobServiceUri}/Jobs/{jobIdentity}/CancelJob": {
+    "/Jobs/{jobIdentity}/CancelJob": {
       "post": {
         "tags": [
           "Jobs"
@@ -234,8 +211,9 @@
         "operationId": "Jobs_Cancel",
         "description": "Cancels the running job specified by the job ID.",
         "parameters": [
+          
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -247,13 +225,6 @@
             "required": true,
             "type": "string",
             "description": "JobInfo ID to cancel."
-          },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resource group."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -272,7 +243,7 @@
         }
       }
     },
-    "/{accountName}.{jobServiceUri}/Jobs/{jobIdentity}": {
+    "/Jobs/{jobIdentity}": {
       "get": {
         "tags": [
           "Jobs"
@@ -280,8 +251,9 @@
         "operationId": "Jobs_Get",
         "description": "Gets the JobInfo object specified by the job ID.",
         "parameters": [
+          
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -293,13 +265,6 @@
             "required": true,
             "type": "string",
             "description": "JobInfo ID."
-          },
-          {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
-            "type": "string",
-            "description": "The name of the resource group."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -321,7 +286,7 @@
         }
       }
     },
-    "/{accountName}.{jobServiceUri}/Jobs": {
+    "/Jobs": {
       "get": {
         "tags": [
           "Jobs"
@@ -329,8 +294,9 @@
         "operationId": "Jobs_List",
         "description": "Gets the first page of the Data Lake Analytics JobInformation objects within the specified resource group with a link to the next page, if any.",
         "parameters": [
+          
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -341,7 +307,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The filter to apply on the operation."
+            "description": "Gets or sets OData filter. Optional."
           },
           {
             "name": "$top",
@@ -349,7 +315,7 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all JobInfo items."
+            "description": "Gets or sets the number of items to return. Optional."
           },
           {
             "name": "$skip",
@@ -357,28 +323,49 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all JobInfo items."
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
           },
           {
-            "name": "$orderby",
+            "name": "$expand",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all JobInfo items."
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
           },
           {
             "name": "$select",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all JobInfo items."
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
           },
           {
-            "name": "resourceGroupName",
-            "in": "header",
-            "required": true,
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
             "type": "string",
-            "description": "The name of the resource group."
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
+          },
+          {
+            "name": "$search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets a free form search. A free-text search expression to match for whether a particular entry should be included in the feed, e.g. Categories?$search=blue OR green. Optional."
+          },
+          {
+            "name": "$format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Gets or sets the return format. Return the response in particular formatxii without access to request headers for standard content-type negotiation (e.g Orders?$format=json). Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -569,6 +556,155 @@
       },
       "description": "The Data Lake Analytics U-SQL job state audit records for tracking the lifecycle of a job."
     },
+    "JobResource": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the resource."
+        },
+        "resourcePath": {
+          "type": "string",
+          "description": "Gets or sets the path to the resource."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the job resource type.",
+          "enum": [
+            "VertexResource",
+            "StatisticsResource"
+          ],
+          "x-ms-enum": {
+            "name": "Type",
+            "modelAsString": "True"
+          }
+        }
+      },
+      "description": "The Data Lake Analytics U-SQL job resources."
+    },
+    "USql": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/JobProperties"
+        }
+      ],
+      "properties": {
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JobResource"
+          },
+          "description": "Gets or sets the list of resources that are required by the job"
+        },
+        "statistics": {
+          "$ref": "#/definitions/JobStatistics",
+          "description": "Gets or sets the job specific statistics."
+        },
+        "debugData": {
+          "$ref": "#/definitions/JobDataPath",
+          "description": "Gets or sets the job specific debug data locations."
+        },
+        "algebraFilePath": {
+          "type": "string",
+          "description": "Gets or sets the U-SQL algebra file path after the job has completed"
+        },
+        "totalCompilationTime": {
+          "type": "string",
+          "description": "Gets or sets the total time this job spent compiling. This value should not be set by the user and will be ignored if it is."
+        },
+        "totalPauseTime": {
+          "type": "string",
+          "description": "Gets or sets the total time this job spent paused. This value should not be set by the user and will be ignored if it is."
+        },
+        "totalQueuedTime": {
+          "type": "string",
+          "description": "Gets or sets the total time this job spent queued. This value should not be set by the user and will be ignored if it is."
+        },
+        "totalRunningTime": {
+          "type": "string",
+          "description": "Gets or sets the total time this job spent executing. This value should not be set by the user and will be ignored if it is."
+        },
+        "rootProcessNodeId": {
+          "type": "string",
+          "description": "Gets or sets the ID used to identify the job manager coordinating job execution. This value should not be set by the user and will be ignored if it is."
+        },
+        "yarnApplicationId": {
+          "type": "string",
+          "description": "Gets or sets the ID used to identify the yarn application executing the job. This value should not be set by the user and will be ignored if it is."
+        },
+        "yarnApplicationTimeStamp": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the timestamp (in ticks) for the yarn application executing the job. This value should not be set by the user and will be ignored if it is."
+        },
+        "compileMode": {
+          "type": "string",
+          "description": "Gets or sets the compile mode for the job.",
+          "enum": [
+            "Semantic",
+            "Full",
+            "SingleBox"
+          ],
+          "x-ms-enum": {
+            "name": "CompileMode",
+            "modelAsString": "True"
+          }
+        }
+      }
+    },
+    "HiveJobStatementInfo": {
+      "properties": {
+        "logLocation": {
+          "type": "string",
+          "description": "Gets or sets the log location for this statement."
+        },
+        "resultPreviewLocation": {
+          "type": "string",
+          "description": "Gets or sets the result preview location for this statement."
+        },
+        "resultLocation": {
+          "type": "string",
+          "description": "Gets or sets the result location for this statement."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Gets or sets the error message for this statement."
+        }
+      }
+    },
+    "Hive": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/JobProperties"
+        }
+      ],
+      "properties": {
+        "statementInfo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HiveJobStatementInfo"
+          },
+          "description": "Gets or sets the statement information for each statement in the script"
+        },
+        "logsLocation": {
+          "type": "string",
+          "description": "Gets or sets the Hive logs location"
+        },
+        "warehouseLocation": {
+          "type": "string",
+          "description": "Gets or sets the runtime version of the U-SQL engine to use"
+        },
+        "statementCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of statements that will be run based on the script"
+        },
+        "executedStatementCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of statements that have been run based on the script"
+        }
+      }
+    },
     "JobProperties": {
       "properties": {
         "runtimeVersion": {
@@ -592,8 +728,10 @@
           }
         }
       },
+      "discriminator": "type",
       "required": [
-        "script"
+        "script",
+        "type"
       ],
       "description": "The common Data Lake Analytics job properties."
     },
@@ -706,15 +844,6 @@
       ],
       "description": "The common Data Lake Analytics job information properties."
     },
-    "JobInfoBuildOrCreateParameters": {
-      "properties": {
-        "Job": {
-          "$ref": "#/definitions/JobInformation",
-          "description": "Gets or sets a job information object."
-        }
-      },
-      "description": "Data Lake Analytics job information parameters for building and submitting jobs."
-    },
     "JobInfoListResult": {
       "properties": {
         "value": {
@@ -796,10 +925,11 @@
       "description": "Client Api Version."
     },
     "jobServiceUriInPathParameter": {
-      "name": "jobServiceUri",
+      "name": "jobserviceuri",
       "in": "path",
       "required": true,
       "type": "string",
+      "default": "\"azuredatalakeanalytics.net\"",
       "description": "Gets the URI used as the base for all cloud service requests."
     }
   }

--- a/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
+++ b/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
@@ -724,7 +724,7 @@
         },
         "type": {
           "type": "string",
-          "description": "Gets or sets the job type of the current job (i.e. Hive or U-SQL).",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or U-SQL)."
         }
       },
       "description": "The common Data Lake Analytics job properties."

--- a/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
+++ b/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
@@ -1,0 +1,806 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "DataLakeAnalyticsJobManagementClient",
+    "description": "Creates an Azure Data Lake Analytics job management client.",
+    "version": "2015-10-01-preview"
+  },
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "produces": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "paths": {
+    "/{accountName}.{jobServiceUri}/Jobs/{jobIdentity}/GetStatistics": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "operationId": "Jobs_GetStatistics",
+        "description": "Gets the job statistics object specified by the job ID.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to get the job from"
+          },
+          {
+            "name": "jobIdentity",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "JobInfo ID."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/jobServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/JobStatistics"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{jobServiceUri}/Jobs/{jobIdentity}/GetDebugDataPath": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "operationId": "Jobs_GetDebugDataPath",
+        "description": "Gets the U-SQL job debug data information specified by the job ID.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to get the job from"
+          },
+          {
+            "name": "jobIdentity",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "JobInfo ID."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/jobServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/JobDataPath"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{jobServiceUri}/BuildJob": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "operationId": "Jobs_Build",
+        "description": "Builds (compiles) the specified job in the specified Data Lake Analytics account for job correctness and validation.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to build the job for"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/JobInfoBuildOrCreateParameters"
+            },
+            "description": "The parameters to build a job, which simulates submission."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/jobServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/JobInformation"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{jobServiceUri}/Jobs/{jobId}": {
+      "put": {
+        "tags": [
+          "Jobs"
+        ],
+        "operationId": "Jobs_Create",
+        "description": "Submits the specified job to the specified Data Lake Analytics account for computation.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to create the job for"
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The parameters to submit a job."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/JobInfoBuildOrCreateParameters"
+            },
+            "description": "The parameters to submit a job."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/jobServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/JobInformation"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{jobServiceUri}/Jobs/{jobIdentity}/CancelJob": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "operationId": "Jobs_Cancel",
+        "description": "Cancels the running job specified by the job ID.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to cancel the job for"
+          },
+          {
+            "name": "jobIdentity",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "JobInfo ID to cancel."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/jobServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/{accountName}.{jobServiceUri}/Jobs/{jobIdentity}": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "operationId": "Jobs_Get",
+        "description": "Gets the JobInfo object specified by the job ID.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to get the job from"
+          },
+          {
+            "name": "jobIdentity",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "JobInfo ID."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/jobServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/JobInformation"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{jobServiceUri}/Jobs": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "operationId": "Jobs_List",
+        "description": "Gets the first page of the Data Lake Analytics JobInformation objects within the specified resource group with a link to the next page, if any.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Analytics account to get the job from"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all JobInfo items."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all JobInfo items."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all JobInfo items."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all JobInfo items."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/jobServiceUriInPathParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/JobInfoListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/JobInformation"
+      }
+    }
+  },
+  "definitions": {
+    "JobStatisticsVertexStage": {
+      "properties": {
+        "dataRead": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the amount of data read, in bytes."
+        },
+        "dataReadCrossPod": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the amount of data read across multiple pods, in bytes."
+        },
+        "dataReadIntraPod": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the amount of data read in one pod, in bytes."
+        },
+        "dataToRead": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the amount of data remaining to be read, in bytes."
+        },
+        "dataWritten": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the amount of data written, in bytes."
+        },
+        "duplicateDiscardCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of duplicates that were discarded."
+        },
+        "failedCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of failures that occured in this stage."
+        },
+        "maxVertexDataRead": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the maximum amount of data read in a single vertex, in bytes."
+        },
+        "minVertexDataRead": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the minimum amount of data read in a single vertex, in bytes."
+        },
+        "readFailureCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of read failures in this stage."
+        },
+        "revocationCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of vertices that were revoked during this stage."
+        },
+        "runningCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of currently running vertices in this stage."
+        },
+        "scheduledCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of currently scheduled vertices in this stage"
+        },
+        "stageName": {
+          "type": "string",
+          "description": "Gets or sets the name of this stage in job execution."
+        },
+        "succeededCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of vertices that succeeded in this stage."
+        },
+        "tempDataWritten": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the amount of temporary data written, in bytes."
+        },
+        "totalCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the total vertex count for this stage."
+        },
+        "totalFailedTime": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the amount of time that failed vertices took up in this stage."
+        },
+        "totalProgress": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the current progress of this stage, as a percentage."
+        },
+        "totalSucceededTime": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the amount of time all successful vertices took in this stage."
+        }
+      },
+      "description": "The Data Lake Analytics U-SQL job statistics vertex stage information."
+    },
+    "JobStatistics": {
+      "properties": {
+        "lastUpdateTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the last update time for the statistics."
+        },
+        "stages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JobStatisticsVertexStage"
+          },
+          "description": "Gets or sets the list of stages for the job."
+        }
+      },
+      "description": "The Data Lake Analytics U-SQL job execution statistics."
+    },
+    "JobDataPath": {
+      "properties": {
+        "jobId": {
+          "type": "string",
+          "description": "Gets or sets the id of the job this data is for."
+        },
+        "command": {
+          "type": "string",
+          "description": "Gets or sets the command that this job data relates to."
+        },
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the list of paths to all of the job data."
+        }
+      },
+      "description": "A Data Lake Analytics U-SQL job data path item."
+    },
+    "JobStateAuditRecord": {
+      "properties": {
+        "newState": {
+          "type": "string",
+          "description": "Gets or sets the new state the job is in."
+        },
+        "timeStamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the time stamp that the state change took place."
+        },
+        "requestedByUser": {
+          "type": "string",
+          "description": "Gets or sets the user who requests the change."
+        },
+        "details": {
+          "type": "string",
+          "description": "Gets or sets  the details of the audit log."
+        }
+      },
+      "description": "The Data Lake Analytics U-SQL job state audit records for tracking the lifecycle of a job."
+    },
+    "JobProperties": {
+      "properties": {
+        "runtimeVersion": {
+          "type": "string",
+          "description": "Gets or sets the runtime version of the U-SQL engine to use"
+        },
+        "script": {
+          "type": "string",
+          "description": "Gets or sets the U-SQL script to run"
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or U-SQL).",
+          "enum": [
+            "USql",
+            "Hive"
+          ],
+          "x-ms-enum": {
+            "name": "JobType",
+            "modelAsString": "True"
+          }
+        }
+      },
+      "required": [
+        "script"
+      ],
+      "description": "The common Data Lake Analytics job properties."
+    },
+    "JobInformation": {
+      "properties": {
+        "jobId": {
+          "type": "string",
+          "description": "Gets or sets the job's unique identifier."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the friendly name of the job."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the job type of the current job (i.e. Hive or U-SQL).",
+          "enum": [
+            "USql",
+            "Hive"
+          ],
+          "x-ms-enum": {
+            "name": "JobType",
+            "modelAsString": "True"
+          }
+        },
+        "submitter": {
+          "type": "string",
+          "description": "Gets or sets the user or account that submitted the job."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Gets or sets the error message details for the job, if it failed."
+        },
+        "degreeOfParallelism": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the degree of parallelism used for this job. This must have a minimum value of 2"
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the priority value for the current job which must be greater than 1."
+        },
+        "submitTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the time the job was submitted to the service."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the start time of the job."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the completion time of the job"
+        },
+        "state": {
+          "type": "string",
+          "description": "Gets or sets a more detailed state of the job than the result. Especially used for intermediate states and errors",
+          "enum": [
+            "Accepted",
+            "Compiling",
+            "Ended",
+            "New",
+            "Queued",
+            "Running",
+            "Scheduling",
+            "Starting",
+            "Paused",
+            "WaitingForCapacity"
+          ],
+          "x-ms-enum": {
+            "name": "JobState",
+            "modelAsString": "False"
+          }
+        },
+        "result": {
+          "type": "string",
+          "description": "Gets or sets the result of job execution or the current result of the running job.",
+          "enum": [
+            "None",
+            "Succeeded",
+            "Cancelled",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "JobResult",
+            "modelAsString": "False"
+          }
+        },
+        "stateAuditRecords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JobStateAuditRecord"
+          },
+          "description": "Gets or sets the job state audit records, indicating when various operations have been performed on this job."
+        },
+        "properties": {
+          "$ref": "#/definitions/JobProperties",
+          "description": "Gets or sets the job specific properties."
+        }
+      },
+      "required": [
+        "jobId",
+        "name",
+        "type",
+        "properties"
+      ],
+      "description": "The common Data Lake Analytics job information properties."
+    },
+    "JobInfoBuildOrCreateParameters": {
+      "properties": {
+        "Job": {
+          "$ref": "#/definitions/JobInformation",
+          "description": "Gets or sets a job information object."
+        }
+      },
+      "description": "Data Lake Analytics job information parameters for building and submitting jobs."
+    },
+    "JobInfoListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JobInformation"
+          },
+          "description": "Gets or sets the list of jobInfo items."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link (url) to the next page of results."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the total count of results that are available, but might not be returned in the current page."
+        }
+      },
+      "description": "List of jobInfo items."
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "SubResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource Id"
+        }
+      },
+      "x-ms-azure-resource": true
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "header",
+      "required": true,
+      "type": "string",
+      "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    },
+    "jobServiceUriInPathParameter": {
+      "name": "jobServiceUri",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Gets the URI used as the base for all cloud service requests."
+    }
+  }
+}

--- a/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
+++ b/arm-datalake-analytics/job/2015-10-01-preview/swagger/job.json
@@ -581,7 +581,8 @@
       },
       "description": "The Data Lake Analytics U-SQL job resources."
     },
-    "USql": {
+    "USqlProperties": {
+      "x-ms-discriminator-value": "USql",
       "allOf": [
         {
           "$ref": "#/definitions/JobProperties"
@@ -671,7 +672,8 @@
         }
       }
     },
-    "Hive": {
+    "HiveProperties": {
+      "x-ms-discriminator-value": "Hive",
       "allOf": [
         {
           "$ref": "#/definitions/JobProperties"
@@ -723,14 +725,6 @@
         "type": {
           "type": "string",
           "description": "Gets or sets the job type of the current job (i.e. Hive or U-SQL).",
-          "enum": [
-            "USql",
-            "Hive"
-          ],
-          "x-ms-enum": {
-            "name": "JobType",
-            "modelAsString": "False"
-          }
         }
       },
       "description": "The common Data Lake Analytics job properties."

--- a/arm-datalake-store/account/2015-10-01-preview/swagger/account.json
+++ b/arm-datalake-store/account/2015-10-01-preview/swagger/account.json
@@ -1,0 +1,860 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "DataLakeStoreManagementClient",
+    "description": "Creates a Data Lake Store account management client.",
+    "version": "2015-10-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "produces": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{accountName}/firewallRules/{firewallRuleName}": {
+      "delete": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_DeleteFirewallRule",
+        "description": "Deletes the specified firewall rule from the specified Data Lake Store account",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to delete the firewall rule from"
+          },
+          {
+            "name": "firewallRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the firewall rule to delete"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "204": {
+            "description": ""
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_GetFirewallRule",
+        "description": "Gets the specified Data Lake firewall rules.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group the account is in."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to get the firewall rules from"
+          },
+          {
+            "name": "firewallRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "the name of the firewall rule to retrieve."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FirewallRule"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{accountName}/firewallRules": {
+      "get": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_ListFirewallRules",
+        "description": "Lists the Data Lake firewall rules objects within the specified Data Lake Store account.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to get the firewall rules from"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreFirewallRuleListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{nextLink}": {
+      "get": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_FirewallRulesListNext",
+        "description": "Gets the next page of the Data Lake firewall rule objects within the specified account, if any.",
+        "parameters": [
+          {
+            "name": "nextLink",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The url to the next firewall rule page.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreFirewallRuleListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{accountName}/firewallRules/{name}": {
+      "put": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_CreateOrUpdateFirewallRule",
+        "description": "Creates or updates the specified Data Lake Store account with the specified firewall rules.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group the account is in."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to add the firewall rule to"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Parameters supplied to the create firewall rule operation."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreFirewallRuleCreateOrUpdateParameters"
+            },
+            "description": "Parameters supplied to the create firewall rule operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FirewallRule"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{name}": {
+      "put": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_Create",
+        "description": "Creates the specified Data Lake Store account.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group the account will be associated with."
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Parameters supplied to the create Data Lake Store account operation."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreAccountCreateOrUpdateParameters"
+            },
+            "description": "Parameters supplied to the create Data Lake Store account operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          },
+          "200": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_Update",
+        "description": "Updates the Data Lake Store account object specified by the account name with the contents of the account object.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Parameters supplied to the update Data Lake Store account operation."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreAccountCreateOrUpdateParameters"
+            },
+            "description": "Parameters supplied to the update Data Lake Store account operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "201": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{accountName}": {
+      "delete": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_Delete",
+        "description": "Deletes the Data Lake Store account object specified by the account name.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to delete"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          },
+          "204": {
+            "description": ""
+          },
+          "202": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_Get",
+        "description": "Gets the Data Lake Store account object specified by the account name.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to retrieve"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreAccount"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts": {
+      "get": {
+        "tags": [
+          "DataLakeStoreAccount"
+        ],
+        "operationId": "DataLakeStoreAccount_List",
+        "description": "Lists the Data Lake Store account objects within the subscription or within a specific resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+          },
+          {
+            "name": "$search",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+          },
+          {
+            "name": "$format",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreAccountListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/DataLakeStoreAccount"
+      }
+    }
+  },
+  "definitions": {
+    "FirewallRuleProperties": {
+      "properties": {
+        "startIpAddress": {
+          "type": "string",
+          "description": "Gets or sets the start IP address for the firewall rule."
+        },
+        "endIpAddress": {
+          "type": "string",
+          "description": "Gets or sets the end IP address for the firewall rule."
+        }
+      },
+      "description": "Data Lake firewall rule properties information"
+    },
+    "FirewallRule": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the Firewall Rule's name."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the namespace and type of the Firewall Rule."
+        },
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the Firewall Rule's subscription ID."
+        },
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the Firewall Rule's regional location."
+        },
+        "properties": {
+          "$ref": "#/definitions/FirewallRuleProperties",
+          "description": "Gets or sets the properties defined by Data Lake all properties are specific to each resource provider."
+        }
+      },
+      "description": "Data Lake firewall rule information"
+    },
+    "DataLakeStoreFirewallRuleListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallRule"
+          },
+          "description": "Gets or set the results of the list operation"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link (url) to the next page of results."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the total count of results that are available, but might not be returned in the current page."
+        }
+      },
+      "description": "Data Lake firewall rule list information."
+    },
+    "DataLakeStoreFirewallRuleCreateOrUpdateParameters": {
+      "properties": {
+        "FirewallRule": {
+          "$ref": "#/definitions/FirewallRule",
+          "description": "Gets or sets the firewall rules that are being added or updated."
+        }
+      },
+      "required": [
+        "FirewallRule"
+      ],
+      "description": "Data Lake Store firewall rule parameters for creation and updates to the firewall rules."
+    },
+    "DataLakeStoreAccountProperties": {
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Gets the status of the Data Lake Store account while being provisioned.",
+          "enum": [
+            "Failed",
+            "Creating",
+            "Running",
+            "Succeeded",
+            "Patching",
+            "Suspending",
+            "Resuming",
+            "Deleting",
+            "Deleted"
+          ],
+          "x-ms-enum": {
+            "name": "DataLakeStoreAccountStatus",
+            "modelAsString": "False"
+          }
+        },
+        "state": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Gets the status of the Data Lake Account after provisioning has completed.",
+          "enum": [
+            "active",
+            "suspended"
+          ],
+          "x-ms-enum": {
+            "name": "DataLakeStoreAccountState",
+            "modelAsString": "False"
+          }
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the account creation time."
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the account last modified time."
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Gets or sets the gateway host."
+        },
+        "defaultGroup": {
+          "type": "string",
+          "description": "Gets or sets the default owner group for all new folders and files created in the DataLake."
+        }
+      },
+      "description": "Data Lake Store account properties information"
+    },
+    "DataLakeStoreAccount": {
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the account regional location."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the account name."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the namespace and type of the account."
+        },
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the account subscription ID."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Gets or sets the value of custom properties."
+        },
+        "properties": {
+          "$ref": "#/definitions/DataLakeStoreAccountProperties",
+          "description": "Gets or sets the properties defined by Data Lake all properties are specific to each resource provider."
+        }
+      },
+      "description": "Data Lake Store account information"
+    },
+    "DataLakeStoreAccountCreateOrUpdateParameters": {
+      "properties": {
+        "DataLakeStoreAccount": {
+          "$ref": "#/definitions/DataLakeStoreAccount",
+          "description": "Gets or sets the account object that is being created or updated."
+        }
+      },
+      "required": [
+        "DataLakeStoreAccount"
+      ],
+      "description": "Data Lake Store Account parameters for creation and update of a Data Lake Store account."
+    },
+    "DataLakeStoreAccountListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataLakeStoreAccount"
+          },
+          "description": "Gets or set the results of the list operation"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the link (url) to the next page of results."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the total count of results that are available, but might not be returned in the current page."
+        }
+      },
+      "description": "Data Lake Store account list information response."
+    },
+    "ErrorDetails": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Gets or sets the HTTP status code or error code associated with this error"
+        },
+        "message": {
+          "type": "string",
+          "description": "Gets or sets the error message localized based on Accept-Language"
+        },
+        "target": {
+          "type": "string",
+          "description": "Gets or sets the target of the particular error (for example, the name of the property in error)."
+        }
+      },
+      "description": "Data Lake error details information"
+    },
+    "InnerError": {
+      "properties": {
+        "trace": {
+          "type": "string",
+          "description": "Gets or sets the stack trace for the error"
+        },
+        "context": {
+          "type": "string",
+          "description": "Gets or sets the context for the error message"
+        }
+      },
+      "description": "Data Lake inner error information"
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Gets or sets the HTTP status code or error code associated with this error"
+        },
+        "message": {
+          "type": "string",
+          "description": "Gets or sets the error message to display."
+        },
+        "target": {
+          "type": "string",
+          "description": "Gets or sets the target of the error."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorDetails"
+          },
+          "description": "Gets or sets the list of error details"
+        },
+        "innerError": {
+          "$ref": "#/definitions/InnerError",
+          "description": "Gets or sets the inner exceptions or errors, if any"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "description": "Data Lake error information"
+    },
+    "AzureAsyncOperationResult": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Gets or sets the status of the AzureAsuncOperation",
+          "enum": [
+            "InProgress",
+            "Succeeded",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "OperationStatus",
+            "modelAsString": "False"
+          }
+        },
+        "error": {
+          "$ref": "#/definitions/Error"
+        }
+      },
+      "description": "The response body contains the status of the specified asynchronous operation, indicating whether it has succeeded, is inprogress, or has failed. Note that this status is distinct from the HTTP status code returned for the Get Operation Status operation itself. If the asynchronous operation succeeded, the response body includes the HTTP status code for the successful request. If the asynchronous operation failed, the response body includes the HTTP status code for the failed request and error information regarding the failure."
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "SubResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource Id"
+        }
+      },
+      "x-ms-azure-resource": true
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    }
+  }
+}

--- a/arm-datalake-store/account/2015-10-01-preview/swagger/account.json
+++ b/arm-datalake-store/account/2015-10-01-preview/swagger/account.json
@@ -212,14 +212,14 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Parameters supplied to the create firewall rule operation."
+            "description": "The new of the firewall rule to create or update."
           },
           {
             "name": "parameters",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/DataLakeStoreFirewallRuleCreateOrUpdateParameters"
+              "$ref": "#/definitions/FirewallRule"
             },
             "description": "Parameters supplied to the create firewall rule operation."
           },
@@ -260,14 +260,14 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Parameters supplied to the create Data Lake Store account operation."
+            "description": "The name of the Data Lake Store account to create."
           },
           {
             "name": "parameters",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/DataLakeStoreAccountCreateOrUpdateParameters"
+              "$ref": "#/definitions/DataLakeStoreAccount"
             },
             "description": "Parameters supplied to the create Data Lake Store account operation."
           },
@@ -280,10 +280,16 @@
         ],
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreAccount"
+            }
           },
           "200": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreAccount"
+            }
           }
         },
         "x-ms-long-running-operation": true
@@ -307,14 +313,14 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Parameters supplied to the update Data Lake Store account operation."
+            "description": "The name of the Data Lake Store account to update."
           },
           {
             "name": "parameters",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/DataLakeStoreAccountCreateOrUpdateParameters"
+              "$ref": "#/definitions/DataLakeStoreAccount"
             },
             "description": "Parameters supplied to the update Data Lake Store account operation."
           },
@@ -327,10 +333,16 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreAccount"
+            }
           },
           "201": {
-            "description": ""
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DataLakeStoreAccount"
+            }
           }
         },
         "x-ms-long-running-operation": true
@@ -439,7 +451,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The filter to apply on the operation."
+            "description": "Gets or sets OData filter. Optional."
           },
           {
             "name": "$top",
@@ -447,7 +459,7 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+            "description": "Gets or sets the number of items to return. Optional."
           },
           {
             "name": "$skip",
@@ -455,49 +467,49 @@
             "required": false,
             "type": "integer",
             "format": "int32",
-            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
           },
           {
             "name": "$expand",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+            "description": "Gets or sets OData expansion. Expand related resources in line with the retrieved resources, e.g. Categories/$expand=Products would expand Product data in line with each Category entry. Optional."
           },
           {
             "name": "$select",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+            "description": "Gets or sets OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
           },
           {
             "name": "$orderby",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+            "description": "Gets or sets the OrderBy clause. One or more comma-separated expressions with an optional “asc” (the default) or “desc” depending on the order you’d like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
           },
           {
             "name": "$count",
             "in": "query",
             "required": false,
             "type": "boolean",
-            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+            "description": "Gets or sets a Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
           },
           {
             "name": "$search",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+            "description": "Gets or sets a free form search. A free-text search expression to match for whether a particular entry should be included in the feed, e.g. Categories?$search=blue OR green. Optional."
           },
           {
             "name": "$format",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Query parameters. If null is passed returns all Data Lake Store account items."
+            "description": "Gets or sets the return format. Return the response in particular formatxii without access to request headers for standard content-type negotiation (e.g Orders?$format=json). Optional."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -580,18 +592,6 @@
         }
       },
       "description": "Data Lake firewall rule list information."
-    },
-    "DataLakeStoreFirewallRuleCreateOrUpdateParameters": {
-      "properties": {
-        "FirewallRule": {
-          "$ref": "#/definitions/FirewallRule",
-          "description": "Gets or sets the firewall rules that are being added or updated."
-        }
-      },
-      "required": [
-        "FirewallRule"
-      ],
-      "description": "Data Lake Store firewall rule parameters for creation and updates to the firewall rules."
     },
     "DataLakeStoreAccountProperties": {
       "properties": {
@@ -680,18 +680,6 @@
         }
       },
       "description": "Data Lake Store account information"
-    },
-    "DataLakeStoreAccountCreateOrUpdateParameters": {
-      "properties": {
-        "DataLakeStoreAccount": {
-          "$ref": "#/definitions/DataLakeStoreAccount",
-          "description": "Gets or sets the account object that is being created or updated."
-        }
-      },
-      "required": [
-        "DataLakeStoreAccount"
-      ],
-      "description": "Data Lake Store Account parameters for creation and update of a Data Lake Store account."
     },
     "DataLakeStoreAccountListResult": {
       "properties": {

--- a/arm-datalake-store/filesystem/2015-10-01-preview/swagger/filesystem.json
+++ b/arm-datalake-store/filesystem/2015-10-01-preview/swagger/filesystem.json
@@ -1,0 +1,1214 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "DataLakeStoreFileSystemManagementClient",
+    "description": "Creates a Data Lake Store filesystem management client.",
+    "version": "2015-10-01-preview"
+  },
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "produces": [
+    "application/json",
+    "text/json",
+    "application/octet-stream"
+  ],
+  "paths": {
+    "/{accountName}.{dataLakeServiceUri}/WebHdfsExt/{filePath}": {
+      "post": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_ConcurrentAppend",
+        "description": "Appends to the file specified. This method supports multiple concurrent appends to the file. NOTE: that concurrent append and serial append CANNOT be used interchangeably. Once a file has been appended to using either one, it can only be appended to using that type of append.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the data lake account that the file lives in."
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to append to using concurrent append."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "concurrentappend"
+          },
+          {
+            "name": "streamContents",
+            "in": "body",
+            "schema": {
+              "type": "string",
+              "format": "byte"
+            },
+            "required": true,
+            "description": "The file contents to include when appending to the file."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/{path}": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_CheckAccess",
+        "description": "Checks if the specified access is available at the given path.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file or folder to check access for."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "CHECKACCESS"
+          },
+          {
+            "name": "fsaction",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "File system operation read/write/execute in string form, matching regex pattern '[rwx-]{3}'"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_Mkdirs",
+        "description": "Creates a directory.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory to create."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "MKDIRS"
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The optional permissions to set on the directories"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileOperationResultResult"
+            }
+          }
+        }
+      }
+    },
+    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/{destinationPath}": {
+      "post": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_Concat",
+        "description": "Concatenates the list of files into the target file.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "destinationPath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the destination file resulting from the concatenation."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "CONCAT"
+          },
+          {
+            "name": "sources",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "A list of comma seperated absolute FileSystem paths without scheme and authority"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/{filePath}": {
+      "post": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_BeginAppend",
+        "description": "Initiates a file append request, resulting in a return of the data node location that will service the request.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to append to the file in"
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to append to."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "APPEND"
+          },
+          {
+            "name": "buffersize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The optional buffer size to use when appending data"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileCreateOpenAndAppendResult"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_DirectAppend",
+        "description": "Directly appends to a file with the specified content, without requiring a redirect. This API is NOT webhdfs compliant. It should be used only by tools that do not rely on webhdfs interoperability.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to append to the file in"
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to append to."
+          },
+          {
+            "name": "streamContents",
+            "in": "body",
+            "schema": {
+              "type": "string",
+              "format": "byte"
+            },
+            "required": true,
+            "description": "The file contents to include when appending to the file."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "APPEND"
+          },
+          {
+            "name": "buffersize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The optional buffer size to use when appending data"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileCreateOpenAndAppendResult"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_BeginCreate",
+        "description": "Initiates a file creation request, resulting in a return of the data node location that will service the request.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to create the file in"
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to create."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "CREATE"
+          },
+          {
+            "name": "buffersize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The size of the buffer used in transferring data."
+          },
+          {
+            "name": "overwrite",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The indication of if the file should be overwritten."
+          },
+          {
+            "name": "blocksize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The block size of a file, in bytes."
+          },
+          {
+            "name": "replication",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int16",
+            "description": "The number of replications of a file."
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The permissions of a file or directory."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileCreateOpenAndAppendResult"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_DirectCreate",
+        "description": "Directly creates a file with the specified content, without requiring a redirect. This API is NOT webhdfs compliant. It should be used only by tools that do not rely on webhdfs interoperability.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to create the file in"
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to create."
+          },
+          {
+            "name": "streamContents",
+            "in": "body",
+            "schema": {
+              "type": "string",
+              "format": "byte"
+            },
+            "required": true,
+            "description": "The file contents to include when creating the file. This parameter is required, however it can be an empty stream. Just not null."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "CREATE"
+          },
+          {
+            "name": "write",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "default": true
+          },
+          {
+            "name": "buffersize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The size of the buffer used in transferring data."
+          },
+          {
+            "name": "overwrite",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The indication of if the file should be overwritten."
+          },
+          {
+            "name": "blocksize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The block size of a file, in bytes."
+          },
+          {
+            "name": "replication",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int16",
+            "description": "The number of replications of a file."
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The permissions of a file or directory."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_BeginOpen",
+        "description": "Initiates a file open (read) request, resulting in a return of the data node location that will service the request.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the data lake account that the file lives in."
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to open."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "open"
+          },
+          {
+            "name": "length",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "buffersize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileCreateOpenAndAppendResult"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_DirectOpen",
+        "description": "Directly opens and reads from the specified file, without requiring a redirect. This API is NOT webhdfs compliant. It should be used only by tools that do not rely on webhdfs interoperability.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the data lake account that the file lives in."
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to open."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "open"
+          },
+          {
+            "name": "length",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "buffersize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": 
+            {
+              "type": "file"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_Delete",
+        "description": "Deletes the requested file or folder, optionally recursively.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file or folder to delete."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "DELETE"
+          },
+          {
+            "name": "recursive",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The optional switch indicating if the delete should be recursive"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileOperationResultResult"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_RemoveAcl",
+        "description": "Removes the existing ACL on a file or folder.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to remove ACL on."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "REMOVEACL"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_GetAclStatus",
+        "description": "Gets ACL entries on a file or folder.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to get ACLs on."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "GETACLSTATUS"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/AclStatusResult"
+            }
+          }
+        }
+      }
+    },
+    "/{fileAppendRequestLink}": {
+      "post": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_Append",
+        "description": "Appends to the file specified in the link that was returned from BeginAppend.",
+        "parameters": [
+          {
+            "name": "fileAppendRequestLink",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The link to the file to append to including all required parameters.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "streamContents",
+            "in": "body",
+            "schema": {
+              "type": "string",
+              "format": "byte"
+            },
+            "required": true,
+            "description": "The file contents to include when appending to the file."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/{sourcePath}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_SetTimes",
+        "description": "Sets the access or modification time on a file or folder.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "sourcePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to set permissions on."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "SETTIMES"
+          },
+          {
+            "name": "modificationtime",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The modification time of a file/directory. If -1 remains unchanged"
+          },
+          {
+            "name": "accesstime",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The access time of a file/directory. If -1 remains unchanged"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_GetHomeDirectory",
+        "description": "Get the home directory for the specified account.",
+        "parameters": [
+          {
+            "name": "accountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "GETHOMEDIRECTORY"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/HomeDirectoryResult"
+            }
+          }
+        }
+      }
+    },
+    "/{fileCreateRequestLink}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_Create",
+        "description": "Creates the file specified in the link that was returned from BeginCreate.",
+        "parameters": [
+          {
+            "name": "fileCreateRequestLink",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The link to the file to create including all required parameters.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "streamContents",
+            "in": "body",
+            "schema": {
+              "type": "string",
+              "format": "byte"
+            },
+            "required": true,
+            "description": "The file contents to include when creating the file. This parameter is required, however it can be an empty stream. Just not null."
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/{fileOpenRequestLink}": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_Open",
+        "description": "Gets the data associated with the file handle requested.",
+        "parameters": [
+          {
+            "name": "fileOpenRequestLink",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The link to the file to open including all required parameters.",
+            "x-ms-skip-url-encoding": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": 
+            {
+              "type": "file"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "FileOperationResultResult": {
+      "properties": {
+        "boolean": {
+          "type": "boolean",
+          "description": "Gets or sets the result of the operation or request"
+        }
+      },
+      "description": "The result of the request or operation."
+    },
+    "AclStatus": {
+      "properties": {
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the list of ACLSpec entries on a file or folder."
+        },
+        "group": {
+          "type": "string",
+          "description": "Gets or sets the group owner."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Gets or sets the user who is the owner."
+        },
+        "stickyBit": {
+          "type": "boolean",
+          "description": "Gets or sets the indicator of whether the sticky bit is on or off."
+        }
+      },
+      "description": "Data Lake ACL status information"
+    },
+    "AclStatusResult": {
+      "properties": {
+        "AclStatus": {
+          "$ref": "#/definitions/AclStatus",
+          "description": "Gets or sets the AclStatus object for a given folder or file"
+        }
+      },
+      "description": "Data Lake Store filesystem Acl information."
+    },
+    "HomeDirectoryResult": {
+      "properties": {
+        "Path": {
+          "type": "string",
+          "description": "Gets or sets the file path to the home directory"
+        }
+      },
+      "description": "Data Lake Store filesystem home path response."
+    },
+    "ContentSummary": {
+      "properties": {
+        "directoryCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the number of directories."
+        },
+        "fileCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the number of files."
+        },
+        "length": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the number of bytes used by the contet."
+        },
+        "quota": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the namespace quota of this directory."
+        },
+        "spaceConsumed": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the disk space consumed by the content."
+        },
+        "spaceQuota": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the disk space quota."
+        }
+      },
+      "description": "Data Lake content summary information"
+    },
+    "ContentSummaryResult": {
+      "properties": {
+        "ContentSummary": {
+          "$ref": "#/definitions/ContentSummary",
+          "description": "Gets or sets the content summary for the specified path"
+        }
+      },
+      "description": "Data Lake Store filesystem content summary information response."
+    },
+    "FileStatusProperties": {
+      "properties": {
+        "accessTime": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the last access time."
+        },
+        "blockSize": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the block size for the file."
+        },
+        "childrenNum": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the number of children in the directory."
+        },
+        "fileId": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the file identifier."
+        },
+        "group": {
+          "type": "string",
+          "description": "Gets or sets the group owner."
+        },
+        "length": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the number of bytes in a file."
+        },
+        "modificationTime": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets or sets the modification time."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Gets or sets the user who is the owner."
+        },
+        "pathSuffix": {
+          "type": "string",
+          "description": "Gets or sets the path suffix."
+        },
+        "permission": {
+          "type": "string",
+          "description": "Gets or sets the permission represented as an octal string."
+        },
+        "replication": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the number of replications of a file."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the type of the path object.",
+          "enum": [
+            "FILE",
+            "DIRECTORY"
+          ],
+          "x-ms-enum": {
+            "name": "FileType",
+            "modelAsString": "False"
+          }
+        }
+      },
+      "description": "Data Lake file status properties information"
+    },
+    "FileStatuses": {
+      "properties": {
+        "FileStatus": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FileStatusProperties"
+          },
+          "description": "Gets or sets the object containing the list of properties of the files."
+        }
+      },
+      "description": "Data Lake file status list information"
+    },
+    "FileStatusesResult": {
+      "properties": {
+        "FileStatuses": {
+          "$ref": "#/definitions/FileStatuses",
+          "description": "Gets or sets the object representing the list of file statuses"
+        }
+      },
+      "description": "Data Lake Store filesystem file status list information response."
+    },
+    "FileStatusResult": {
+      "properties": {
+        "FileStatus": {
+          "$ref": "#/definitions/FileStatusProperties",
+          "description": "Gets or sets the file status object associated with the specified file path"
+        }
+      },
+      "description": "Data Lake Store filesystem file status information response."
+    },
+    "FileCreateOpenAndAppendResult": {
+      "properties": {
+        "Location": {
+          "type": "string",
+          "description": "Gets or sets the redirect URI location with any necessary parameters"
+        }
+      },
+      "description": "The response recieved after the BeginOpen, BeginCreate and BeginAppend requests."
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    },
+    "dataLakeServiceUriInPath": {
+      "name": "dataLakeServiceUri",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Gets the URI used as the base for all cloud service requests."
+    }
+  }
+}

--- a/arm-datalake-store/filesystem/2015-10-01-preview/swagger/filesystem.json
+++ b/arm-datalake-store/filesystem/2015-10-01-preview/swagger/filesystem.json
@@ -46,7 +46,8 @@
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "file"
+              "type": "object",
+              "format": "file"
             },
             "required": true,
             "description": "The file contents to include when appending to the file."
@@ -276,7 +277,8 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "file"
+              "type": "object",
+              "format": "file"
             },
             "description": "A list of comma seperated absolute FileSystem paths without scheme and authority. In the format: 'sources=<comma separated list>'"
           },
@@ -501,7 +503,8 @@
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "file"
+              "type": "object",
+              "format": "file"
             },
             "required": true,
             "description": "The file contents to include when appending to the file."
@@ -572,7 +575,8 @@
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "file"
+              "type": "object",
+              "format": "file"
             },
             "required": false,
             "description": "The file contents to include when creating the file. This parameter is optional, resulting in an empty file if not specified."
@@ -1632,7 +1636,8 @@
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "file"
+              "type": "object",
+              "format": "file"
             },
             "required": true,
             "description": "The file contents to include when appending to the file."
@@ -1773,7 +1778,8 @@
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "file"
+              "type": "object",
+              "format": "file"
             },
             "required": false,
             "description": "The file contents to include when creating the file. This parameter is not required, and if not passed results an empty file."

--- a/arm-datalake-store/filesystem/2015-10-01-preview/swagger/filesystem.json
+++ b/arm-datalake-store/filesystem/2015-10-01-preview/swagger/filesystem.json
@@ -5,6 +5,7 @@
     "description": "Creates a Data Lake Store filesystem management client.",
     "version": "2015-10-01-preview"
   },
+  "host": "accountname.datalakeserviceuri",
   "schemes": [
     "https"
   ],
@@ -19,7 +20,7 @@
     "application/octet-stream"
   ],
   "paths": {
-    "/{accountName}.{dataLakeServiceUri}/WebHdfsExt/{filePath}": {
+    "/WebHdfsExt/{filePath}": {
       "post": {
         "tags": [
           "FileSystem"
@@ -28,13 +29,6 @@
         "description": "Appends to the file specified. This method supports multiple concurrent appends to the file. NOTE: that concurrent append and serial append CANNOT be used interchangeably. Once a file has been appended to using either one, it can only be appended to using that type of append.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the data lake account that the file lives in."
-          },
-          {
             "name": "filePath",
             "in": "path",
             "required": true,
@@ -42,24 +36,34 @@
             "description": "The path to the file to append to using concurrent append."
           },
           {
-            "name": "op",
-            "in": "query",
-            "required": false,
+            "name": "accountname",
+            "in": "path",
+            "required": true,
             "type": "string",
-            "default": "concurrentappend"
+            "description": "The name of the data lake account that the file lives in."
           },
           {
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "string",
-              "format": "byte"
+              "type": "file"
             },
             "required": true,
             "description": "The file contents to include when appending to the file."
           },
           {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "CONCURRENTAPPEND"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
             "$ref": "#/parameters/dataLakeServiceUriInPath"
@@ -72,7 +76,7 @@
         }
       }
     },
-    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/{path}": {
+    "/webhdfs/v1/{path}": {
       "get": {
         "tags": [
           "FileSystem"
@@ -81,13 +85,6 @@
         "description": "Checks if the specified access is available at the given path.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the account to use"
-          },
-          {
             "name": "path",
             "in": "path",
             "required": true,
@@ -95,11 +92,11 @@
             "description": "The path to the file or folder to check access for."
           },
           {
-            "name": "op",
-            "in": "query",
-            "required": false,
+            "name": "accountname",
+            "in": "path",
+            "required": true,
             "type": "string",
-            "default": "CHECKACCESS"
+            "description": "The name of the account to use"
           },
           {
             "name": "fsaction",
@@ -109,7 +106,18 @@
             "description": "File system operation read/write/execute in string form, matching regex pattern '[rwx-]{3}'"
           },
           {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "CHECKACCESS"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -130,13 +138,6 @@
         "description": "Creates a directory.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the account to use"
-          },
-          {
             "name": "path",
             "in": "path",
             "required": true,
@@ -144,11 +145,11 @@
             "description": "The path to the directory to create."
           },
           {
-            "name": "op",
-            "in": "query",
-            "required": false,
+            "name": "accountname",
+            "in": "path",
+            "required": true,
             "type": "string",
-            "default": "MKDIRS"
+            "description": "The name of the account to use"
           },
           {
             "name": "permission",
@@ -158,7 +159,18 @@
             "description": "The optional permissions to set on the directories"
           },
           {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "MKDIRS"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -169,13 +181,13 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/FileOperationResultResult"
+              "$ref": "#/definitions/FileOperationResult"
             }
           }
         }
       }
     },
-    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/{destinationPath}": {
+    "/webhdfs/v1/{destinationPath}": {
       "post": {
         "tags": [
           "FileSystem"
@@ -184,13 +196,6 @@
         "description": "Concatenates the list of files into the target file.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the account to use"
-          },
-          {
             "name": "destinationPath",
             "in": "path",
             "required": true,
@@ -198,11 +203,11 @@
             "description": "The path to the destination file resulting from the concatenation."
           },
           {
-            "name": "op",
-            "in": "query",
-            "required": false,
+            "name": "accountname",
+            "in": "path",
+            "required": true,
             "type": "string",
-            "default": "CONCAT"
+            "description": "The name of the account to use"
           },
           {
             "name": "sources",
@@ -212,7 +217,18 @@
             "description": "A list of comma seperated absolute FileSystem paths without scheme and authority"
           },
           {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "CONCAT"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -226,59 +242,240 @@
         }
       }
     },
-    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/{filePath}": {
+    "/webhdfs/v1/{msConcatDestinationPath}": {
       "post": {
         "tags": [
           "FileSystem"
         ],
-        "operationId": "FileSystem_BeginAppend",
-        "description": "Initiates a file append request, resulting in a return of the data node location that will service the request.",
+        "operationId": "FileSystem_MsConcat",
+        "description": "Concatenates the list of files into the target file. This API is NOT webhdfs compliant, however supports a much larger list of files in the concatenate list.",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "msConcatDestinationPath",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the Data Lake Store account to append to the file in"
+            "description": "The path to the destination file resulting from the concatenation."
           },
           {
-            "name": "filePath",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The path to the file to append to."
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "deletesourcedirectory",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Indicates two things to the system which allow for optimizations and increased concatenate performance. First, that all the streams being concatenated are in the same source directory. Second, that the source directory ONLY has streams in it that are being concatenated into the destination stream. Note that only the first requirement is strictly enforced (concatenate will ignore the flag and only delete the source streams, not the folder). If the first option is met, ALL data that was not part of the set of streams being concatenated WILL BE LOST. It is critical to only use this option if you are certain the two requirements are met."
+          },
+          {
+            "name": "streamContents",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "file"
+            },
+            "description": "A list of comma seperated absolute FileSystem paths without scheme and authority. In the format: 'sources=<comma separated list>'"
           },
           {
             "name": "op",
             "in": "query",
             "required": false,
             "type": "string",
-            "default": "APPEND"
-          },
-          {
-            "name": "buffersize",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64",
-            "description": "The optional buffer size to use when appending data"
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "MSCONCAT"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
           {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
             "$ref": "#/parameters/dataLakeServiceUriInPath"
           }
         ],
         "responses": {
-          "307": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{listFilePath}": {
+    "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_ListFileStatus",
+        "description": "Get the list of file status objects specified by the file path.",
+        "parameters": [
+          {
+            "name": "listFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to retrieve status for."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "description": "Gets or sets the number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "LISTSTATUS"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/FileCreateOpenAndAppendResult"
+              "$ref": "#/definitions/FileStatusesResult"
             }
           }
         }
-      },
+      }
+    },
+    "/webhdfs/va/{getContentSummaryFilePath}": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_GetContentSummary",
+        "description": "Gets the file content summary object specified by the file path.",
+        "parameters": [
+          {
+            "name": "getContentSummaryFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to retrieve the summary for."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "GETCONTENTSUMMARY"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ContentSummaryResult"
+            }
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{getFilePath}": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_GetFileStatus",
+        "description": "Get the file status object specified by the file path.",
+        "parameters": [
+          {
+            "name": "getFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to retrieve status for."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "GETFILESTATUS"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileStatusResult"
+            }
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{directFilePath}": {
       "post": {
         "tags": [
           "FileSystem"
@@ -287,35 +484,27 @@
         "description": "Directly appends to a file with the specified content, without requiring a redirect. This API is NOT webhdfs compliant. It should be used only by tools that do not rely on webhdfs interoperability.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the Data Lake Store account to append to the file in"
-          },
-          {
-            "name": "filePath",
+            "name": "directFilePath",
             "in": "path",
             "required": true,
             "type": "string",
             "description": "The path to the file to append to."
           },
           {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to append to the file in"
+          },
+          {
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "string",
-              "format": "byte"
+              "type": "file"
             },
             "required": true,
             "description": "The file contents to include when appending to the file."
-          },
-          {
-            "name": "op",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "default": "APPEND"
           },
           {
             "name": "buffersize",
@@ -326,90 +515,26 @@
             "description": "The optional buffer size to use when appending data"
           },
           {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          
-          {
-            "$ref": "#/parameters/dataLakeServiceUriInPath"
-          }
-        ],
-        "responses": {
-          "307": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/FileCreateOpenAndAppendResult"
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "FileSystem"
-        ],
-        "operationId": "FileSystem_BeginCreate",
-        "description": "Initiates a file creation request, resulting in a return of the data node location that will service the request.",
-        "parameters": [
-          {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the Data Lake Store account to create the file in"
-          },
-          {
-            "name": "filePath",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The path to the file to create."
-          },
-          {
             "name": "op",
             "in": "query",
             "required": false,
             "type": "string",
-            "default": "CREATE"
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "APPEND"
           },
           {
-            "name": "buffersize",
+            "name": "append",
             "in": "query",
             "required": false,
-            "type": "integer",
-            "format": "int64",
-            "description": "The size of the buffer used in transferring data."
-          },
-          {
-            "name": "overwrite",
-            "in": "query",
-            "required": false,
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
             "type": "boolean",
-            "description": "The indication of if the file should be overwritten."
-          },
-          {
-            "name": "blocksize",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64",
-            "description": "The block size of a file, in bytes."
-          },
-          {
-            "name": "replication",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int16",
-            "description": "The number of replications of a file."
-          },
-          {
-            "name": "permission",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "The permissions of a file or directory."
+            "default": "true"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -417,11 +542,8 @@
           }
         ],
         "responses": {
-          "307": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/FileCreateOpenAndAppendResult"
-            }
+          "200": {
+            "description": ""
           }
         }
       },
@@ -433,42 +555,27 @@
         "description": "Directly creates a file with the specified content, without requiring a redirect. This API is NOT webhdfs compliant. It should be used only by tools that do not rely on webhdfs interoperability.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the Data Lake Store account to create the file in"
-          },
-          {
-            "name": "filePath",
+            "name": "directFilePath",
             "in": "path",
             "required": true,
             "type": "string",
             "description": "The path to the file to create."
           },
           {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to create the file in"
+          },
+          {
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "string",
-              "format": "byte"
+              "type": "file"
             },
-            "required": true,
-            "description": "The file contents to include when creating the file. This parameter is required, however it can be an empty stream. Just not null."
-          },
-          {
-            "name": "op",
-            "in": "query",
             "required": false,
-            "type": "string",
-            "default": "CREATE"
-          },
-          {
-            "name": "write",
-            "in": "query",
-            "required": false,
-            "type": "boolean",
-            "default": true
+            "description": "The file contents to include when creating the file. This parameter is optional, resulting in an empty file if not specified."
           },
           {
             "name": "buffersize",
@@ -509,7 +616,26 @@
             "description": "The permissions of a file or directory."
           },
           {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "CREATE"
+          },
+          {
+            "name": "write",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "true"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
             "$ref": "#/parameters/dataLakeServiceUriInPath"
@@ -525,95 +651,22 @@
         "tags": [
           "FileSystem"
         ],
-        "operationId": "FileSystem_BeginOpen",
-        "description": "Initiates a file open (read) request, resulting in a return of the data node location that will service the request.",
-        "parameters": [
-          {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the data lake account that the file lives in."
-          },
-          {
-            "name": "filePath",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The path to the file to open."
-          },
-          {
-            "name": "op",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "default": "open"
-          },
-          {
-            "name": "length",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "name": "buffersize",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          
-          {
-            "$ref": "#/parameters/dataLakeServiceUriInPath"
-          }
-        ],
-        "responses": {
-          "307": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/FileCreateOpenAndAppendResult"
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "FileSystem"
-        ],
         "operationId": "FileSystem_DirectOpen",
         "description": "Directly opens and reads from the specified file, without requiring a redirect. This API is NOT webhdfs compliant. It should be used only by tools that do not rely on webhdfs interoperability.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the data lake account that the file lives in."
-          },
-          {
-            "name": "filePath",
+            "name": "directFilePath",
             "in": "path",
             "required": true,
             "type": "string",
             "description": "The path to the file to open."
           },
           {
-            "name": "op",
-            "in": "query",
-            "required": false,
+            "name": "accountname",
+            "in": "path",
+            "required": true,
             "type": "string",
-            "default": "open"
+            "description": "The name of the data lake account that the file lives in."
           },
           {
             "name": "length",
@@ -637,7 +690,26 @@
             "format": "int64"
           },
           {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "OPEN"
+          },
+          {
+            "name": "read",
+            "in": "query",
+            "required": false,
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "type": "boolean",
+            "default": "true"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -649,48 +721,55 @@
             "description": "",
             "schema": 
             {
-              "type": "file"
+              "type": "string",
+              "format": "byte"
             }
           }
         }
-      },
-      "delete": {
+      }
+    },
+    "/webhdfs/v1/{setAclFilePath}": {
+      "put": {
         "tags": [
           "FileSystem"
         ],
-        "operationId": "FileSystem_Delete",
-        "description": "Deletes the requested file or folder, optionally recursively.",
+        "operationId": "FileSystem_SetAcl",
+        "description": "Sets ACL entries on a file or folder.",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "setAclFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to set ACLs on."
+          },
+          {
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
             "description": "The name of the account to use"
           },
           {
-            "name": "filePath",
-            "in": "path",
+            "name": "aclspec",
+            "in": "query",
             "required": true,
             "type": "string",
-            "description": "The path to the file or folder to delete."
+            "description": "The ACL spec included in ACL creation operations in the format '[default:]user|group|other::r|-w|-x|-'"
           },
           {
             "name": "op",
             "in": "query",
             "required": false,
             "type": "string",
-            "default": "DELETE"
-          },
-          {
-            "name": "recursive",
-            "in": "query",
-            "required": false,
-            "type": "boolean",
-            "description": "The optional switch indicating if the delete should be recursive"
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "SETACL"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -699,13 +778,170 @@
         ],
         "responses": {
           "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/FileOperationResultResult"
-            }
+            "description": ""
           }
         }
-      },
+      }
+    },
+    "/webhdfs/v1/{modifyAclFilePath}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_ModifyAclEntries",
+        "description": "Modifies existing ACL entries on a file or folder.",
+        "parameters": [
+          {
+            "name": "modifyAclFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to modify ACLs on."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "aclspec",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The ACL spec included in ACL modification operations in the format '[default:]user|group|other::r|-w|-x|-'"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "MODIFYACLENTRIES"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{removeAclFilePath}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_RemoveAclEntries",
+        "description": "Removes existing ACL entries on a file or folder.",
+        "parameters": [
+          {
+            "name": "removeAclFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to remove ACLs on."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "aclspec",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The ACL spec included in ACL removal operations in the format '[default:]user|group|other'"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "REMOVEACLENTRIES"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{removeDefaultAclFilePath}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_RemoveDefaultAcl",
+        "description": "Removes default ACL entries on a file or folder.",
+        "parameters": [
+          {
+            "name": "removeDefaultAclFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to remove ACL on."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "REMOVEDEFAULTACL"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{aclFilePath}": {
       "put": {
         "tags": [
           "FileSystem"
@@ -714,28 +950,32 @@
         "description": "Removes the existing ACL on a file or folder.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the account to use"
-          },
-          {
-            "name": "filePath",
+            "name": "aclFilePath",
             "in": "path",
             "required": true,
             "type": "string",
             "description": "The path to the directory or file to remove ACL on."
           },
           {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
             "name": "op",
             "in": "query",
             "required": false,
             "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
             "default": "REMOVEACL"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -756,28 +996,32 @@
         "description": "Gets ACL entries on a file or folder.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the account to use"
-          },
-          {
-            "name": "filePath",
+            "name": "aclFilePath",
             "in": "path",
             "required": true,
             "type": "string",
             "description": "The path to the directory or file to get ACLs on."
           },
           {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
             "name": "op",
             "in": "query",
             "required": false,
             "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
             "default": "GETACLSTATUS"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -789,6 +1033,580 @@
             "description": "",
             "schema": {
               "$ref": "#/definitions/AclStatusResult"
+            }
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{filePath}": {
+      "post": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_BeginAppend",
+        "description": "Initiates a file append request, resulting in a return of the data node location that will service the request.",
+        "parameters": [
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to append to."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to append to the file in"
+          },
+          {
+            "name": "buffersize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The optional buffer size to use when appending data"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "APPEND"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "",
+            "headers": {
+              "location": { 
+                "description": "The location of the file to be appended to",
+                "type": "string"
+              } 
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_BeginCreate",
+        "description": "Initiates a file creation request, resulting in a return of the data node location that will service the request.",
+        "parameters": [
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to create."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Data Lake Store account to create the file in"
+          },
+          {
+            "name": "buffersize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The size of the buffer used in transferring data."
+          },
+          {
+            "name": "overwrite",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The indication of if the file should be overwritten."
+          },
+          {
+            "name": "blocksize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64",
+            "description": "The block size of a file, in bytes."
+          },
+          {
+            "name": "replication",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int16",
+            "description": "The number of replications of a file."
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The permissions of a file or directory."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "CREATE"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "",
+            "headers": {
+              "location": { 
+                "description": "The location of the file to be created",
+                "type": "string"
+              } 
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_BeginOpen",
+        "description": "Initiates a file open (read) request, resulting in a return of the data node location that will service the request.",
+        "parameters": [
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file to open."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the data lake account that the file lives in."
+          },
+          {
+            "name": "length",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "buffersize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "OPEN"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "",
+            "headers": {
+              "location": { 
+                "description": "The location of the file to be opened",
+                "type": "string"
+              } 
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_Delete",
+        "description": "Deletes the requested file or folder, optionally recursively.",
+        "parameters": [
+          {
+            "name": "filePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the file or folder to delete."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "recursive",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The optional switch indicating if the delete should be recursive"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "DELETE"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileOperationResult"
+            }
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{symLinkFilePath}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_CreateSymLink",
+        "description": "Creates a symbolic link.",
+        "parameters": [
+          {
+            "name": "symLinkFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to create a symlink of."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "destination",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The path to create the symlink at"
+          },
+          {
+            "name": "createParent",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "default": "false",
+            "description": "If the parent directories do not exist, indicates if they should be created."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "CREATESYMLINK"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{renameFilePath}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_Rename",
+        "description": "Rename a directory or file.",
+        "parameters": [
+          {
+            "name": "renameFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory to move/rename."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "destination",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The path to move/rename the file or folder to"
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "RENAME"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileOperationResult"
+            }
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{setOwnerFilePath}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_SetOwner",
+        "description": "Sets the owner of a file or folder.",
+        "parameters": [
+          {
+            "name": "setOwnerFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to set the owner on."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "owner",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The username who is the owner of a file/directory, if empty remains unchanged."
+          },
+          {
+            "name": "group",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The group who is the group owner of a file/directory, if empty remains unchanged."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "SETOWNER"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{setPermissionFilePath}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_SetPermission",
+        "description": "Sets the permission of the file or folder.",
+        "parameters": [
+          {
+            "name": "setPermissionFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to set permissions on."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "A string octal representation of the permission (i.e 'rwx'), if empty remains unchanged."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "SETPERMISSION"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/webhdfs/v1/{setReplicationFilePath}": {
+      "put": {
+        "tags": [
+          "FileSystem"
+        ],
+        "operationId": "FileSystem_SetReplication",
+        "description": "Sets the value of the replication factor.",
+        "parameters": [
+          {
+            "name": "setReplicationFilePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path to the directory or file to create a replication of."
+          },
+          {
+            "name": "accountname",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the account to use"
+          },
+          {
+            "name": "replication",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "description": "The number of replications of a file."
+          },
+          {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "SETREPLICATION"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/dataLakeServiceUriInPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/FileOperationResult"
             }
           }
         }
@@ -814,8 +1632,7 @@
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "string",
-              "format": "byte"
+              "type": "file"
             },
             "required": true,
             "description": "The file contents to include when appending to the file."
@@ -828,7 +1645,7 @@
         }
       }
     },
-    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/{sourcePath}": {
+    "/webhdfs/v1/{sourcePath}": {
       "put": {
         "tags": [
           "FileSystem"
@@ -837,13 +1654,6 @@
         "description": "Sets the access or modification time on a file or folder.",
         "parameters": [
           {
-            "name": "accountName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the account to use"
-          },
-          {
             "name": "sourcePath",
             "in": "path",
             "required": true,
@@ -851,11 +1661,11 @@
             "description": "The path to the directory or file to set permissions on."
           },
           {
-            "name": "op",
-            "in": "query",
-            "required": false,
+            "name": "accountname",
+            "in": "path",
+            "required": true,
             "type": "string",
-            "default": "SETTIMES"
+            "description": "The name of the account to use"
           },
           {
             "name": "modificationtime",
@@ -874,7 +1684,18 @@
             "description": "The access time of a file/directory. If -1 remains unchanged"
           },
           {
+            "name": "op",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
+            "default": "SETTIMES"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -888,7 +1709,7 @@
         }
       }
     },
-    "/{accountName}.{dataLakeServiceUri}/webhdfs/v1/": {
+    "/webhdfs/v1/": {
       "get": {
         "tags": [
           "FileSystem"
@@ -897,7 +1718,7 @@
         "description": "Get the home directory for the specified account.",
         "parameters": [
           {
-            "name": "accountName",
+            "name": "accountname",
             "in": "path",
             "required": true,
             "type": "string",
@@ -908,10 +1729,14 @@
             "in": "query",
             "required": false,
             "type": "string",
+            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
             "default": "GETHOMEDIRECTORY"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           },
           
           {
@@ -948,11 +1773,10 @@
             "name": "streamContents",
             "in": "body",
             "schema": {
-              "type": "string",
-              "format": "byte"
+              "type": "file"
             },
-            "required": true,
-            "description": "The file contents to include when creating the file. This parameter is required, however it can be an empty stream. Just not null."
+            "required": false,
+            "description": "The file contents to include when creating the file. This parameter is not required, and if not passed results an empty file."
           }
         ],
         "responses": {
@@ -984,7 +1808,8 @@
             "description": "",
             "schema": 
             {
-              "type": "file"
+              "type": "string",
+              "format": "byte"
             }
           }
         }
@@ -992,7 +1817,7 @@
     }
   },
   "definitions": {
-    "FileOperationResultResult": {
+    "FileOperationResult": {
       "properties": {
         "boolean": {
           "type": "boolean",
@@ -1144,8 +1969,8 @@
           "type": "string",
           "description": "Gets or sets the type of the path object.",
           "enum": [
-            "FILE",
-            "DIRECTORY"
+            "File",
+            "Directory"
           ],
           "x-ms-enum": {
             "name": "FileType",
@@ -1196,6 +2021,13 @@
     }
   },
   "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "header",
+      "required": true,
+      "type": "string",
+      "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
     "ApiVersionParameter": {
       "name": "api-version",
       "in": "query",
@@ -1204,10 +2036,11 @@
       "description": "Client Api Version."
     },
     "dataLakeServiceUriInPath": {
-      "name": "dataLakeServiceUri",
+      "name": "datalakeserviceuri",
       "in": "path",
       "required": true,
       "type": "string",
+      "default": "\"azuredatalakestore.net\"",
       "description": "Gets the URI used as the base for all cloud service requests."
     }
   }


### PR DESCRIPTION
This is the first round of DataLake\* swagger specs.
Known issues:
1. Variable host name in Job, Catalog and filesystem does not translate in swagger or code gen
2. Missing application/octet-stream as a valid content type for generation
3. No ability to define redirect behavior
4. No way to define an API that takes in a variable that is a full URI (when manually handling redirects)
5. No way to define that, if the return type is bytes, to return a byte array and not a string converted into a byte array (issue with code gen).
