### PR TITLE
ARM Network: removed required properties for inbound NAT rules

### DIFF
--- a/arm-network/2015-06-15/swagger/network.json
+++ b/arm-network/2015-06-15/swagger/network.json
@@ -5437,7 +5437,6 @@
           "description": "Gets or sets Provisioning state of the PublicIP resource Updating/Deleting/Failed"
         }
       },
-      "required": [],
       "description": "Properties of Inbound NAT rule"
     },
     "InboundNatRule": {

--- a/arm-network/2015-06-15/swagger/network.json
+++ b/arm-network/2015-06-15/swagger/network.json
@@ -5437,11 +5437,7 @@
           "description": "Gets or sets Provisioning state of the PublicIP resource Updating/Deleting/Failed"
         }
       },
-      "required": [
-        "protocol",
-        "frontendPort",
-        "enableFloatingIP"
-      ],
+      "required": [],
       "description": "Properties of Inbound NAT rule"
     },
     "InboundNatRule": {


### PR DESCRIPTION
@DeepakRajendranMsft @amarzavery 

Not sure is this correct approach, because ‘protocol’, ‘frontendPort’ and ‘enableFloatingIP’ are required to create inboundNatRule inside LB,
but blocks me from specifying just inboundNatRule ID’s for NIC.
