### PR TITLE
Consistency of privateIPAllocationMethod property in arm-network

### DIFF
--- a/arm-network/2015-06-15/swagger/network.json
+++ b/arm-network/2015-06-15/swagger/network.json
@@ -5757,7 +5757,16 @@
           "type": "string"
         },
         "privateIPAllocationMethod": {
-          "type": "string"
+          "type": "string",
+          "description": "Gets or sets PrivateIP allocation method (Static/Dynamic)",
+          "enum": [
+            "Static",
+            "Dynamic"
+          ],
+          "x-ms-enum": {
+            "name": "IPAllocationMethod",
+            "modelAsString": true
+          }
         },
         "subnet": {
           "$ref": "#/definitions/Subnet"


### PR DESCRIPTION
Hello,

I'm at the Python SDK team and we working on testing the auto-generated version currently. I found while testing that in `arm-network` the `privateIPAllocationMethod` property is used 5 times:
- 4 times an enum of `static` / `dynamic`
- 1 time of a simple string

I think this property should be consistent in the file (actually, I think that the Python SDK should be consistent in this property, and this belongs to this file :)).

It's my first PR here, please tell me if I do not respect a process or something else.

Thank you,
