### PR TITLE
Specialize keyname from str to enum in storage

### DIFF
--- a/arm-storage/2015-06-15/swagger/storage.json
+++ b/arm-storage/2015-06-15/swagger/storage.json
@@ -703,7 +703,16 @@
     "StorageAccountRegenerateKeyParameters": {
       "properties": {
         "keyName": {
-          "type": "string"
+          "type": "string",
+          "description": "Specifies name of the key which should be regenerated: key1 or key2.",
+          "enum": [
+            "key1",
+            "key2"
+          ],
+          "x-ms-enum": {
+            "name": "KeyName",
+            "modelAsString": false
+          }
         }
       },
       "required": [


### PR DESCRIPTION
Hello,

According to the spec here:
https://msdn.microsoft.com/en-us/library/azure/mt163567.aspx

`keyName` can only be the string `key1` or `key2`.
Then this should be an enum and not a string.

Please tell me if I can enhance this!
Thank you!
