### PR TITLE
Removing begin* functionality and 307 logic

### DIFF
--- a/arm-datalake-store/filesystem/2015-10-01-preview/swagger/filesystem.json
+++ b/arm-datalake-store/filesystem/2015-10-01-preview/swagger/filesystem.json
@@ -491,7 +491,7 @@
         "consumes": [
           "application/octet-stream"
         ],
-        "operationId": "FileSystem_DirectAppend",
+        "operationId": "FileSystem_Append",
         "description": "Directly appends to a file with the specified content, without requiring a redirect. This API is NOT webhdfs compliant. It should be used only by tools that do not rely on webhdfs interoperability.",
         "parameters": [
           {
@@ -566,7 +566,7 @@
         "consumes": [
           "application/octet-stream"
         ],
-        "operationId": "FileSystem_DirectCreate",
+        "operationId": "FileSystem_Create",
         "description": "Directly creates a file with the specified content, without requiring a redirect. This API is NOT webhdfs compliant. It should be used only by tools that do not rely on webhdfs interoperability.",
         "parameters": [
           {
@@ -667,7 +667,7 @@
         "tags": [
           "FileSystem"
         ],
-        "operationId": "FileSystem_DirectOpen",
+        "operationId": "FileSystem_Open",
         "description": "Directly opens and reads from the specified file, without requiring a redirect. This API is NOT webhdfs compliant. It should be used only by tools that do not rely on webhdfs interoperability.",
         "parameters": [
           {
@@ -1054,228 +1054,6 @@
       }
     },
     "/webhdfs/v1/{filePath}": {
-      "post": {
-        "tags": [
-          "FileSystem"
-        ],
-        "operationId": "FileSystem_BeginAppend",
-        "description": "Initiates a file append request, resulting in a return of the data node location that will service the request.",
-        "parameters": [
-          {
-            "name": "filePath",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The path to the file to append to."
-          },
-          {
-            "name": "accountname",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the Data Lake Store account to append to the file in"
-          },
-          {
-            "name": "buffersize",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64",
-            "description": "The optional buffer size to use when appending data"
-          },
-          {
-            "name": "op",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
-            "default": "APPEND"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/dataLakeServiceUriInPath"
-          }
-        ],
-        "responses": {
-          "307": {
-            "description": "",
-            "headers": {
-              "location": { 
-                "description": "The location of the file to be appended to",
-                "type": "string"
-              } 
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "FileSystem"
-        ],
-        "operationId": "FileSystem_BeginCreate",
-        "description": "Initiates a file creation request, resulting in a return of the data node location that will service the request.",
-        "parameters": [
-          {
-            "name": "filePath",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The path to the file to create."
-          },
-          {
-            "name": "accountname",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the Data Lake Store account to create the file in"
-          },
-          {
-            "name": "buffersize",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64",
-            "description": "The size of the buffer used in transferring data."
-          },
-          {
-            "name": "overwrite",
-            "in": "query",
-            "required": false,
-            "type": "boolean",
-            "description": "The indication of if the file should be overwritten."
-          },
-          {
-            "name": "blocksize",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64",
-            "description": "The block size of a file, in bytes."
-          },
-          {
-            "name": "replication",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int16",
-            "description": "The number of replications of a file."
-          },
-          {
-            "name": "permission",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "The permissions of a file or directory."
-          },
-          {
-            "name": "op",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
-            "default": "CREATE"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          
-          {
-            "$ref": "#/parameters/dataLakeServiceUriInPath"
-          }
-        ],
-        "responses": {
-          "307": {
-            "description": "",
-            "headers": {
-              "location": { 
-                "description": "The location of the file to be created",
-                "type": "string"
-              } 
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "FileSystem"
-        ],
-        "operationId": "FileSystem_BeginOpen",
-        "description": "Initiates a file open (read) request, resulting in a return of the data node location that will service the request.",
-        "parameters": [
-          {
-            "name": "filePath",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The path to the file to open."
-          },
-          {
-            "name": "accountname",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the data lake account that the file lives in."
-          },
-          {
-            "name": "length",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "name": "buffersize",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "name": "op",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "This is the REQUIRED value for this parameter and method combination. Changing the value will result in unexpected behavior, please do not do so.",
-            "default": "OPEN"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          
-          {
-            "$ref": "#/parameters/dataLakeServiceUriInPath"
-          }
-        ],
-        "responses": {
-          "307": {
-            "description": "",
-            "headers": {
-              "location": { 
-                "description": "The location of the file to be opened",
-                "type": "string"
-              } 
-            }
-          }
-        }
-      },
       "delete": {
         "tags": [
           "FileSystem"
@@ -1627,43 +1405,6 @@
         }
       }
     },
-    "/{fileAppendRequestLink}": {
-      "post": {
-        "tags": [
-          "FileSystem"
-        ],
-        "consumes": [
-          "application/octet-stream"
-        ],
-        "operationId": "FileSystem_Append",
-        "description": "Appends to the file specified in the link that was returned from BeginAppend.",
-        "parameters": [
-          {
-            "name": "fileAppendRequestLink",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The link to the file to append to including all required parameters.",
-            "x-ms-skip-url-encoding": true
-          },
-          {
-            "name": "streamContents",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "format": "file"
-            },
-            "required": true,
-            "description": "The file contents to include when appending to the file."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        }
-      }
-    },
     "/webhdfs/v1/{sourcePath}": {
       "put": {
         "tags": [
@@ -1767,71 +1508,6 @@
             "description": "",
             "schema": {
               "$ref": "#/definitions/HomeDirectoryResult"
-            }
-          }
-        }
-      }
-    },
-    "/{fileCreateRequestLink}": {
-      "put": {
-        "tags": [
-          "FileSystem"
-        ],
-        "consumes": [
-          "application/octet-stream"
-        ],
-        "operationId": "FileSystem_Create",
-        "description": "Creates the file specified in the link that was returned from BeginCreate.",
-        "parameters": [
-          {
-            "name": "fileCreateRequestLink",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The link to the file to create including all required parameters.",
-            "x-ms-skip-url-encoding": true
-          },
-          {
-            "name": "streamContents",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "format": "file"
-            },
-            "required": false,
-            "description": "The file contents to include when creating the file. This parameter is not required, and if not passed results an empty file."
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/{fileOpenRequestLink}": {
-      "get": {
-        "tags": [
-          "FileSystem"
-        ],
-        "operationId": "FileSystem_Open",
-        "description": "Gets the data associated with the file handle requested.",
-        "parameters": [
-          {
-            "name": "fileOpenRequestLink",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The link to the file to open including all required parameters.",
-            "x-ms-skip-url-encoding": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": 
-            {
-              "type": "file"
             }
           }
         }


### PR DESCRIPTION
After working with PMs, we have decided to remove the 307 related logic
from our SDKs, as our SDKs are not required to be completely webhdfs
compliant. As a result, we can remove a lot of the complex post code gen
logic around redirect handling and multi level requests. This
drastically simplifies our SDK as well as our generation process.
