### PR TITLE
SearchServiceResource Update

### DIFF
--- a/arm-dns/2015-05-04-preview/swagger/dns.json
+++ b/arm-dns/2015-05-04-preview/swagger/dns.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "DnsManagementClient",
     "description": "Client for managing DNS zones and record.",
-    "version": "2015-11-01"
+    "version": "2015-05-04-preview"
   },
   "host": "management.azure.com",
   "schemes": [

--- a/arm-search/2015-02-28/swagger/search.json
+++ b/arm-search/2015-02-28/swagger/search.json
@@ -379,6 +379,11 @@
     },
     "SearchServiceResource": {
       "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
         "name": {
           "externalDocs": {
             "url": "https://msdn.microsoft.com/library/azure/dn857353.aspx"


### PR DESCRIPTION
The SearchServiceResource structure didn't actually have the ID property defined in it. This PR adds the property so that it can fix https://github.com/Azure/azure-sdk-for-go/issues/268

I have tested that this change to the swagger doc validates against the scheme
