### PR TITLE
Remove two required properties

### DIFF
--- a/arm-network/2015-06-15/swagger/network.json
+++ b/arm-network/2015-06-15/swagger/network.json
@@ -5297,10 +5297,8 @@
         }
       },
       "required": [
-        "backendAddressPool",
         "protocol",
-        "frontendPort",
-        "enableFloatingIP"
+        "frontendPort"
       ],
       "description": "Properties of the load balancer"
     },


### PR DESCRIPTION
backendAddressPool and enableFloatingIP are not required per the rest documentation on MSDN and per testing.
