### PR TITLE
Update compute swagger document to accurately reflect the difference …

### DIFF
--- a/arm-compute/2015-06-15/swagger/compute.json
+++ b/arm-compute/2015-06-15/swagger/compute.json
@@ -3696,7 +3696,7 @@
           "items": {
             "$ref": "#/definitions/SubResource"
           },
-          "description": "Gets the virtual machine child extension resources."
+          "description": "Gets the list of sub resources associated with the virtual machine."
         }
       },
       "allOf": [

--- a/arm-compute/2015-06-15/swagger/compute.json
+++ b/arm-compute/2015-06-15/swagger/compute.json
@@ -3680,12 +3680,38 @@
       ],
       "description": "Describes a Virtual Machine."
     },
+    "VirtualMachineListItem": {
+      "properties": {
+        "plan": {
+          "$ref": "#/definitions/Plan",
+          "description": "Gets or sets the purchase plan when deploying virtual machine from VM Marketplace images."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VirtualMachineProperties"
+        },
+        "resources": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SubResource"
+          },
+          "description": "Gets the virtual machine child extension resources."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "description": "Describes a Virtual Machine."
+    },
     "VirtualMachineListResult": {
       "properties": {
         "value": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/VirtualMachine"
+            "$ref": "#/definitions/VirtualMachineListItem"
           },
           "description": "Gets or sets the list of virtual machines."
         },


### PR DESCRIPTION
…between the information returned by a vm list/list_all vs. vm get. Specifically, for the list items, the resources contains a list of references to extensions as opposed to a list of inline extensions
