### PR TITLE
Update ARM-Network Swagger spec with IPv6 properties and IDNS Properties

### DIFF
--- a/arm-network/2016-03-30/swagger/network.json
+++ b/arm-network/2016-03-30/swagger/network.json
@@ -5972,7 +5972,7 @@
             "$ref": "#/definitions/ApplicationGatewayBackendAddressPool"
           },
           "description": "Gets or sets the reference of ApplicationGatewayBackendAddressPool resource"
-        },      
+        },
         "loadBalancerBackendAddressPools": {
           "type": "array",
           "items": {
@@ -5999,6 +5999,18 @@
           ],
           "x-ms-enum": {
             "name": "IPAllocationMethod",
+            "modelAsString": true
+          }
+        },
+        "privateIPAddressVersion": {
+          "type": "string",
+          "description": "Gets or sets PrivateIP address version (IPv4/IPv6)",
+          "enum": [
+            "IPv4",
+            "IPv6"
+          ],
+          "x-ms-enum": {
+            "name": "IPVersion",
             "modelAsString": true
           }
         },
@@ -6058,7 +6070,11 @@
         },
         "internalFqdn": {
           "type": "string",
-          "description": "Gets or sets full IDNS name in the form, DnsName.VnetId.ZoneId.TopleveSuffix. This is set when the NIC is associated to a VM"
+          "description": "Gets or sets the internal fqdn."
+        },
+        "internalDomainNameSuffix": {
+          "type": "string",
+          "description": "Gets or sets internal domain name suffix of the NIC."
         }
       },
       "description": "Dns Settings of a network interface"
@@ -6343,6 +6359,18 @@
           ],
           "x-ms-enum": {
             "name": "IPAllocationMethod",
+            "modelAsString": true
+          }
+        },
+        "publicIPAddressVersion": {
+          "type": "string",
+          "description": "Gets or sets PublicIP address version (IPv4/IPv6)",
+          "enum": [
+            "IPv4",
+            "IPv6"
+          ],
+          "x-ms-enum": {
+            "name": "IPVersion",
             "modelAsString": true
           }
         },


### PR DESCRIPTION
Update ARM-Network Swagger spec with IPv6 properties on PublicIP and NetworkInterface resources and IDNS Properties on the NetworkInterfaceDnsSettings resources
