### PR TITLE
Add vmId to the virtual machine properties.

### DIFF
--- a/arm-compute/2016-03-30/swagger/compute.json
+++ b/arm-compute/2016-03-30/swagger/compute.json
@@ -3640,6 +3640,10 @@
         "licenseType": {
           "type": "string",
           "description": "Gets or sets the license type, which is for bring your own license scenario."
+        },
+        "vmId": {
+          "type": "string",
+          "description": "Gets the virtual machine unique id."  
         }
       },
       "description": "Describes the properties of a Virtual Machine."


### PR DESCRIPTION
Resolve the issue #188 for the api version 2016-03-30. 

Azure REST API request/response example: 

```
https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ds-vms-rg/providers/Microsoft.Compute/virtualMachines/TestImageVMCentOS?api-version=2016-03-30
```

``` js
{
  "properties": {
    "vmId": "c8fdfbd8-7745-48d2-afd6-63cb6495b4c8",
    "hardwareProfile": {
      "vmSize": "Standard_A1"
    },
    "storageProfile": {
      "imageReference": {
        "publisher": "OpenLogic",
        "offer": "CentOS",
        "sku": "7.2",
        "version": "latest"
      },
      "osDisk": {
        "osType": "Linux",
        "name": "TestImageVMCentOS",
        "createOption": "FromImage",
        "vhd": {
          "uri": "https://storageaccount.blob.core.windows.net/vhds/OSDisk.vhd"
        },
        "caching": "ReadWrite"
      },
      "dataDisks": []
    },
    "osProfile": {
      "computerName": "TestVM",
      "adminUsername": "azureadmin",
      "linuxConfiguration": {
        "disablePasswordAuthentication": false
      },
      "secrets": []
    },
    "networkProfile": {
      "networkInterfaces": [
        {
          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ds-vms-rg/providers/Microsoft.Network/networkInterfaces/testvmnic"
        }
      ]
    },
    "provisioningState": "Succeeded"
  },
  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myTestResourceGroup/providers/Microsoft.Compute/virtualMachines/TestVM",
  "name": "TestVM",
  "type": "Microsoft.Compute/virtualMachines",
  "location": "westeurope"
}
```

We have the same field in the list of VMs:

```
https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myTestResourceGroup/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
```
