### PR TITLE
Search SDK: Updating property descriptions in all Search Swagger specs

### DIFF
--- a/arm-search/2015-02-28/swagger/search.json
+++ b/arm-search/2015-02-28/swagger/search.json
@@ -260,12 +260,14 @@
     "AdminKeyResult": {
       "properties": {
         "primaryKey": {
+          "readOnly": true,
           "type": "string",
-          "description": "Gets the primary API key of the Search service."
+          "description": "The primary API key of the Search service."
         },
         "secondaryKey": {
+          "readOnly": true,
           "type": "string",
-          "description": "Gets the secondary API key of the Search service."
+          "description": "The secondary API key of the Search service."
         }
       },
       "description": "Response containing the primary and secondary API keys for a given Azure Search service."
@@ -273,12 +275,14 @@
     "QueryKey": {
       "properties": {
         "name": {
+          "readOnly": true,
           "type": "string",
-          "description": "Gets the name of the query API key; may be empty."
+          "description": "The name of the query API key; may be empty."
         },
         "key": {
+          "readOnly": true,
           "type": "string",
-          "description": "Gets the value of the query API key."
+          "description": "The value of the query API key."
         }
       },
       "description": "Describes an API key for a given Azure Search service that has permissions for query operations only."
@@ -286,11 +290,12 @@
     "ListQueryKeysResult": {
       "properties": {
         "value": {
+          "readOnly": true,
           "type": "array",
           "items": {
             "$ref": "#/definitions/QueryKey"
           },
-          "description": "Gets the query keys for the Azure Search service."
+          "description": "The query keys for the Azure Search service."
         }
       },
       "description": "Response containing the query API keys for a given Azure Search service."
@@ -299,7 +304,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Gets or sets the SKU of the Search service.",
+          "description": "The SKU of the Search service.",
           "enum": [
             "free",
             "standard",
@@ -316,17 +321,17 @@
       "properties": {
         "sku": {
           "$ref": "#/definitions/Sku",
-          "description": "Gets or sets the SKU of the Search Service, which determines price tier and capacity limits."
+          "description": "The SKU of the Search Service, which determines price tier and capacity limits."
         },
         "replicaCount": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the number of replicas in the Search service. If specified, it must be a value between 1 and 6 inclusive."
+          "description": "The number of replicas in the Search service. If specified, it must be a value between 1 and 6 inclusive."
         },
         "partitionCount": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the number of partitions in the Search service; if specified, it can be 1, 2, 3, 4, 6, or 12."
+          "description": "The number of partitions in the Search service; if specified, it can be 1, 2, 3, 4, 6, or 12."
         }
       },
       "description": "Defines properties of an Azure Search service that can be modified."
@@ -335,18 +340,18 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Gets or sets the geographic location of the Search service."
+          "description": "The geographic location of the Search service."
         },
         "tags": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Gets or sets tags to help categorize the Search service in the Azure Portal."
+          "description": "Tags to help categorize the Search service in the Azure Portal."
         },
         "properties": {
           "$ref": "#/definitions/SearchServiceProperties",
-          "description": "Gets or sets properties of the Search service."
+          "description": "Properties of the Search service."
         }
       },
       "description": "Properties that describe an Azure Search service."
@@ -354,8 +359,9 @@
     "SearchServiceReadableProperties": {
       "properties": {
         "status": {
+          "readOnly": true,
           "type": "string",
-          "description": "Gets the status of the Search service.",
+          "description": "The status of the Search service.",
           "enum": [
             "running",
             "provisioning",
@@ -369,12 +375,14 @@
           }
         },
         "statusDetails": {
+          "readOnly": true,
           "type": "string",
-          "description": "Gets the details of the Search service status."
+          "description": "The details of the Search service status."
         },
         "provisioningState": {
+          "readOnly": true,
           "type": "string",
-          "description": "Gets the state of the last provisioning operation performed on the Search service.",
+          "description": "The state of the last provisioning operation performed on the Search service.",
           "enum": [
             "succeeded",
             "provisioning",
@@ -386,17 +394,17 @@
         },
         "sku": {
           "$ref": "#/definitions/Sku",
-          "description": "Gets or sets the SKU of the Search Service, which determines price tier and capacity limits."
+          "description": "The SKU of the Search Service, which determines price tier and capacity limits."
         },
         "replicaCount": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the number of replicas in the Search service. If specified, it must be a value between 1 and 6 inclusive."
+          "description": "The number of replicas in the Search service. If specified, it must be a value between 1 and 6 inclusive."
         },
         "partitionCount": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the number of partitions in the Search service; if specified, it can be 1, 2, 3, 4, 6, or 12."
+          "description": "The number of partitions in the Search service; if specified, it can be 1, 2, 3, 4, 6, or 12."
         }
       },
       "description": "Defines all the properties of an Azure Search service."
@@ -406,29 +414,30 @@
         "id": {
           "readOnly": true,
           "type": "string",
-          "description": "Resource Id"
+          "description": "The resource Id of the Azure Search service."
         },
         "name": {
           "externalDocs": {
             "url": "https://msdn.microsoft.com/library/azure/dn857353.aspx"
           },
           "type": "string",
-          "description": "Gets or sets the name of the Search service."
+          "description": "The name of the Search service."
         },
         "location": {
           "type": "string",
-          "description": "Gets or sets the geographic location of the Search service."
+          "description": "The geographic location of the Search service."
         },
         "tags": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Gets or sets tags to help categorize the Search service in the Azure Portal."
+          "description": "Tags to help categorize the Search service in the Azure Portal."
         },
         "properties": {
+          "readOnly": true,
           "$ref": "#/definitions/SearchServiceReadableProperties",
-          "description": "Gets properties of the Search service."
+          "description": "Properties of the Search service."
         }
       },
       "description": "Describes an Azure Search service and its current state."
@@ -436,11 +445,12 @@
     "SearchServiceListResult": {
       "properties": {
         "value": {
+          "readOnly": true,
           "type": "array",
           "items": {
             "$ref": "#/definitions/SearchServiceResource"
           },
-          "description": "Gets the Search services in the resource group."
+          "description": "The Search services in the resource group."
         }
       },
       "description": "Response containing a list of Azure Search services for a given resource group."

--- a/search/2015-02-28-Preview/swagger/searchindex.json
+++ b/search/2015-02-28-Preview/swagger/searchindex.json
@@ -29,7 +29,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping":  { "name": "search-request-options" }
           },
@@ -56,23 +56,23 @@
         "key": {
           "type": "string",
           "readOnly": true,
-          "description": "Gets the key of a document that was in the indexing request."
+          "description": "The key of a document that was in the indexing request."
         },
         "status": {
           "type": "boolean",
           "readOnly": true,
-          "description": "Gets a value indicating whether the indexing operation succeeded for the document identified by the key."
+          "description": "A value indicating whether the indexing operation succeeded for the document identified by the key."
         },
         "errorMessage": {
           "type": "string",
           "readOnly": true,
-          "description": "Gets the error message explaining why the indexing operation failed for the document identified by the key; null if indexing succeeded."
+          "description": "The error message explaining why the indexing operation failed for the document identified by the key; null if indexing succeeded."
         },
         "statusCode": {
           "type": "integer",
           "format": "int32",
           "readOnly": true,
-          "description": "Gets the status code of the indexing operation. Possible values include: 200 for a successful update or delete, 201 for successful document creation, 400 for a malformed input document, 404 for document not found, 409 for a version conflict, 422 when the index is temporarily unavailable, or 503 for when the service is too busy."
+          "description": "The status code of the indexing operation. Possible values include: 200 for a successful update or delete, 201 for successful document creation, 400 for a malformed input document, 404 for document not found, 409 for a version conflict, 422 when the index is temporarily unavailable, or 503 for when the service is too busy."
         }
       },
       "description": "Status of an indexing operation for a single document.",
@@ -86,7 +86,7 @@
           "items": {
             "$ref": "#/definitions/IndexingResult"
           },
-          "description": "Gets the list of status information for each document in the indexing request."
+          "description": "The list of status information for each document in the indexing request."
         }
       },
       "description": "Response containing the status of operations for all documents in the indexing request.",
@@ -128,38 +128,38 @@
             "url": "https://msdn.microsoft.com/library/azure/dn798921.aspx"
           },
           "type": "string",
-          "description": "Gets or sets the OData $filter expression to apply to the search query."
+          "description": "The OData $filter expression to apply to the search query."
         },
         "highlightFields": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Gets or sets the list of field names to use for hit highlights. Only searchable fields can be used for hit highlighting."
+          "description": "The list of field names to use for hit highlights. Only searchable fields can be used for hit highlighting."
         },
         "highlightPostTag": {
           "type": "string",
-          "description": "Gets or sets a string tag that is appended to hit highlights. Must be set with HighlightPreTag. Default is &lt;/em&gt;."
+          "description": "A string tag that is appended to hit highlights. Must be set with HighlightPreTag. Default is &lt;/em&gt;."
         },
         "highlightPreTag": {
           "type": "string",
-          "description": "Gets or sets a string tag that is prepended to hit highlights. Must be set with HighlightPostTag. Default is &lt;em&gt;."
+          "description": "A string tag that is prepended to hit highlights. Must be set with HighlightPostTag. Default is &lt;em&gt;."
         },
         "includeTotalResultCount": {
           "type": "boolean",
-          "description": "Gets or sets a value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation."
+          "description": "A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation."
         },
         "minimumCoverage": {
           "type": "number",
           "format": "double",
-          "description": "Gets or sets a number between 0 and 100 indicating the percentage of the index that must be covered by a search query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 100."
+          "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by a search query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 100."
         },
         "orderBy": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Gets or sets the list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
+          "description": "The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
         },
         "queryType": {
           "$ref": "#/definitions/QueryType",
@@ -170,34 +170,34 @@
           "items": {
             "type": "string"
           },
-          "description": "Gets or sets the list of parameter values to be used in scoring functions (for example, referencePointParameter) using the format name:value. For example, if the scoring profile defines a function with a parameter called 'mylocation' the parameter string would be \"mylocation:-122.2,44.8\"(without the quotes)."
+          "description": "The list of parameter values to be used in scoring functions (for example, referencePointParameter) using the format name:value. For example, if the scoring profile defines a function with a parameter called 'mylocation' the parameter string would be \"mylocation:-122.2,44.8\"(without the quotes)."
         },
         "scoringProfile": {
           "type": "string",
-          "description": "Gets or sets the name of a scoring profile to evaluate match scores for matching documents in order to sort the results."
+          "description": "The name of a scoring profile to evaluate match scores for matching documents in order to sort the results."
         },
         "searchFields": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Gets or sets the list of field names to include in the full-text search."
+          "description": "The list of field names to include in the full-text search."
         },
         "searchMode": {
           "$ref": "#/definitions/SearchMode",
-          "description": "Gets or sets a value that specifies whether any or all of the search terms must be matched in order to count the document as a match."
+          "description": "A value that specifies whether any or all of the search terms must be matched in order to count the document as a match."
         },
         "select": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Gets or sets the list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included."
+          "description": "The list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included."
         },
         "skip": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the number of search results to skip. This value cannot be greater than 100,000. If you need to scan documents in sequence, but cannot use Skip due to this limitation, consider using OrderBy on a totally-ordered key and Filter with a range query instead."
+          "description": "The number of search results to skip. This value cannot be greater than 100,000. If you need to scan documents in sequence, but cannot use Skip due to this limitation, consider using OrderBy on a totally-ordered key and Filter with a range query instead."
         },
         "top": {
           "externalDocs": {
@@ -205,7 +205,7 @@
           },
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the number of search results to retrieve. This can be used in conjunction with Skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be passed to ContinueSearch to retrieve the next page of results. See DocumentSearchResponse.ContinuationToken for more information."
+          "description": "The number of search results to retrieve. This can be used in conjunction with Skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be passed to ContinueSearch to retrieve the next page of results. See DocumentSearchResponse.ContinuationToken for more information."
         }
       },
       "description": "Parameters for filtering, sorting, faceting, paging, and other search query behaviors.",
@@ -218,50 +218,50 @@
             "url": "https://msdn.microsoft.com/library/azure/dn798921.aspx"
           },
           "type": "string",
-          "description": "Gets or sets the OData $filter expression to apply to the suggestions query."
+          "description": "The OData $filter expression to apply to the suggestions query."
         },
         "highlightPostTag": {
           "type": "string",
-          "description": "Gets or sets a string tag that is appended to hit highlights. Must be set with HighlightPreTag. If omitted, hit highlighting of suggestions is disabled."
+          "description": "A string tag that is appended to hit highlights. Must be set with HighlightPreTag. If omitted, hit highlighting of suggestions is disabled."
         },
         "highlightPreTag": {
           "type": "string",
-          "description": "Gets or sets a string tag that is prepended to hit highlights. Must be set with HighlightPostTag. If omitted, hit highlighting of suggestions is disabled."
+          "description": "A string tag that is prepended to hit highlights. Must be set with HighlightPostTag. If omitted, hit highlighting of suggestions is disabled."
         },
         "minimumCoverage": {
           "type": "number",
           "format": "double",
-          "description": "Gets or sets a number between 0 and 100 indicating the percentage of the index that must be covered by a suggestion query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80."
+          "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by a suggestion query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80."
         },
         "orderBy": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Gets or sets the list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
+          "description": "The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
         },
         "searchFields": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Gets or sets the list of field names to consider when querying for suggestions."
+          "description": "The list of field names to consider when querying for suggestions."
         },
         "select": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Gets or sets the list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included."
+          "description": "The list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included."
         },
         "top": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the number of suggestions to retrieve. This must be a value between 1 and 100. The default is to 5."
+          "description": "The number of suggestions to retrieve. This must be a value between 1 and 100. The default is to 5."
         },
         "useFuzzyMatching": {
           "type": "boolean",
-          "description": "Gets or sets a value indicating whether to use fuzzy matching for the suggestion query. Default is false. when set to true, the query will find suggestions even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios it comes at a performance cost as fuzzy suggestion searches are slower and consume more resources."
+          "description": "A value indicating whether to use fuzzy matching for the suggestion query. Default is false. when set to true, the query will find suggestions even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios it comes at a performance cost as fuzzy suggestion searches are slower and consume more resources."
         }
       },
       "description": "Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors.",

--- a/search/2015-02-28-Preview/swagger/searchservice.json
+++ b/search/2015-02-28-Preview/swagger/searchservice.json
@@ -45,7 +45,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -92,7 +92,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -133,7 +133,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -169,7 +169,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -212,7 +212,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -255,7 +255,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -295,7 +295,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -344,7 +344,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -391,7 +391,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -432,7 +432,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -468,7 +468,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -511,7 +511,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -554,7 +554,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -599,7 +599,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -640,7 +640,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -692,7 +692,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -739,7 +739,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -780,7 +780,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -823,7 +823,7 @@
             "required": false,
             "type": "string",
             "format": "uuid",
-            "description": "Tracking ID sent with the request to help with debugging.",
+            "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
@@ -851,7 +851,7 @@
             "url": "https://msdn.microsoft.com/library/azure/dn946876.aspx"
           },
           "type": "string",
-          "description": "Gets or sets the connection string for the datasource."
+          "description": "The connection string for the datasource."
         }
       },
       "required": [
@@ -863,11 +863,11 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Gets or sets the name of the table or view (for Azure SQL data source) or collection (for DocumentDB data source) that will be indexed."
+          "description": "The name of the table or view (for Azure SQL data source) or collection (for DocumentDB data source) that will be indexed."
         },
         "query": {
           "type": "string",
-          "description": "Gets or sets a query that is applied to this data container. Only supported by DocumentDb datasources."
+          "description": "A query that is applied to this data container. Only supported by DocumentDb datasources."
         }
       },
       "required": [
@@ -898,7 +898,7 @@
       "properties": {
         "highWaterMarkColumnName": {
           "type": "string",
-          "description": "Gets or sets the name of the high water mark column."
+          "description": "The name of the high water mark column."
         }
       },
       "required": [
@@ -937,11 +937,11 @@
       "properties": {
         "softDeleteColumnName": {
           "type": "string",
-          "description": "Gets or sets the name of the column to use for soft-deletion detection."
+          "description": "The name of the column to use for soft-deletion detection."
         },
         "softDeleteMarkerValue": {
           "type": "string",
-          "description": "Gets or sets the marker value that indentifies an item as deleted."
+          "description": "The marker value that indentifies an item as deleted."
         }
       }
     },
@@ -952,31 +952,31 @@
             "url": "https://msdn.microsoft.com/library/azure/dn857353.aspx"
           },
           "type": "string",
-          "description": "Gets or sets the name of the datasource."
+          "description": "The name of the datasource."
         },
         "description": {
           "type": "string",
-          "description": "Gets or sets the description of the datasource."
+          "description": "The description of the datasource."
         },
         "type": {
           "type": "string",
-          "description": "Gets or sets the type of the datasource."
+          "description": "The type of the datasource."
         },
         "credentials": {
           "$ref": "#/definitions/DataSourceCredentials",
-          "description": "Gets or sets credentials for the datasource."
+          "description": "Credentials for the datasource."
         },
         "container": {
           "$ref": "#/definitions/DataContainer",
-          "description": "Gets or sets the data container for the datasource."
+          "description": "The data container for the datasource."
         },
         "dataChangeDetectionPolicy": {
           "$ref": "#/definitions/DataChangeDetectionPolicy",
-          "description": "Gets or sets the data change detection policy for the datasource."
+          "description": "The data change detection policy for the datasource."
         },
         "dataDeletionDetectionPolicy": {
           "$ref": "#/definitions/DataDeletionDetectionPolicy",
-          "description": "Gets or sets the data deletion detection policy for the datasource."
+          "description": "The data deletion detection policy for the datasource."
         }
       },
       "required": [
@@ -992,7 +992,7 @@
           "items": {
             "$ref": "#/definitions/DataSource"
           },
-          "description": "Gets the datasources in the Search service."
+          "description": "The datasources in the Search service."
         }
       },
       "description": "Response from a List Datasources request. If successful, it includes the full definitions of all datasources.",
@@ -1003,12 +1003,12 @@
         "interval": {
           "type": "string",
           "format": "duration",
-          "description": "Gets or sets the interval of time between indexer executions."
+          "description": "The interval of time between indexer executions."
         },
         "startTime": {
           "type": "string",
           "format": "date-time",
-          "description": "Gets or sets the time when an indexer should start running."
+          "description": "The time when an indexer should start running."
         }
       },
       "required": [
@@ -1022,16 +1022,16 @@
         "maxFailedItems": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the maximum number of items that can fail indexing for indexer execution to still be considered successful. -1 means no limit. Default is 0."
+          "description": "The maximum number of items that can fail indexing for indexer execution to still be considered successful. -1 means no limit. Default is 0."
         },
         "maxFailedItemsPerBatch": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the maximum number of items in a single batch that can fail indexing for the batch to still be considered successful. -1 means no limit. Default is 0."
+          "description": "The maximum number of items in a single batch that can fail indexing for the batch to still be considered successful. -1 means no limit. Default is 0."
         },
         "base64EncodeKeys": {
           "type": "boolean",
-          "description": "Gets or sets whether indexer will base64-encode all values that are inserted into key field of the target index. This is needed if keys can contain characters that are invalid in keys (such as dot '.'). Default is false."
+          "description": "Whether indexer will base64-encode all values that are inserted into key field of the target index. This is needed if keys can contain characters that are invalid in keys (such as dot '.'). Default is false."
         }
       },
       "description": "Represents parameters for indexer execution."
@@ -1043,27 +1043,27 @@
             "url": "https://msdn.microsoft.com/library/azure/dn857353.aspx"
           },
           "type": "string",
-          "description": "Gets or sets the name of the indexer."
+          "description": "The name of the indexer."
         },
         "description": {
           "type": "string",
-          "description": "Gets or sets the description of the indexer."
+          "description": "The description of the indexer."
         },
         "dataSourceName": {
           "type": "string",
-          "description": "Gets or sets the name of the datasource from which this indexer reads data."
+          "description": "The name of the datasource from which this indexer reads data."
         },
         "targetIndexName": {
           "type": "string",
-          "description": "Gets or sets the name of the index to which this indexer writes data."
+          "description": "The name of the index to which this indexer writes data."
         },
         "schedule": {
           "$ref": "#/definitions/IndexingSchedule",
-          "description": "Gets or sets the schedule for this indexer."
+          "description": "The schedule for this indexer."
         },
         "parameters": {
           "$ref": "#/definitions/IndexingParameters",
-          "description": "Gets or sets parameters for indexer execution."
+          "description": "Parameters for indexer execution."
         }
       },
       "required": [
@@ -1082,7 +1082,7 @@
           "items": {
             "$ref": "#/definitions/Indexer"
           },
-          "description": "Gets the indexers in the Search service."
+          "description": "The indexers in the Search service."
         }
       },
       "description": "Response from a List Indexers request. If successful, it includes the full definitions of all indexers.",
@@ -1093,12 +1093,12 @@
         "key": {
           "type": "string",
           "readOnly": true,
-          "description": "Gets the key of the item for which indexing failed."
+          "description": "The key of the item for which indexing failed."
         },
         "errorMessage": {
           "type": "string",
           "readOnly": true,
-          "description": "Gets the message describing the error that occurred while attempting to index the item."
+          "description": "The message describing the error that occurred while attempting to index the item."
         }
       },
       "description": "Represents an item- or document-level indexing error."
@@ -1108,24 +1108,24 @@
         "status": {
           "$ref": "#/definitions/IndexerExecutionStatus",
           "readOnly": true,
-          "description": "Gets the outcome of this indexer execution."
+          "description": "The outcome of this indexer execution."
         },
         "errorMessage": {
           "type": "string",
           "readOnly": true,
-          "description": "Gets the error message indicating the top-level error, if any."
+          "description": "The error message indicating the top-level error, if any."
         },
         "startTime": {
           "type": "string",
           "format": "date-time",
           "readOnly": true,
-          "description": "Gets the start time of this indexer execution."
+          "description": "The start time of this indexer execution."
         },
         "endTime": {
           "type": "string",
           "format": "date-time",
           "readOnly": true,
-          "description": "Gets the end time of this indexer execution, if the execution has already completed."
+          "description": "The end time of this indexer execution, if the execution has already completed."
         },
         "errors": {
           "type": "array",
@@ -1133,19 +1133,19 @@
           "items": {
             "$ref": "#/definitions/ItemError"
           },
-          "description": "Gets the item-level indexing errors"
+          "description": "The item-level indexing errors"
         },
         "itemsProcessed": {
           "type": "integer",
           "format": "int32",
           "readOnly": true,
-          "description": "Gets the number of items that were processed during this indexer execution. This includes both successfully processed items and items where indexing was attempted but failed."
+          "description": "The number of items that were processed during this indexer execution. This includes both successfully processed items and items where indexing was attempted but failed."
         },
         "itemsFailed": {
           "type": "integer",
           "format": "int32",
           "readOnly": true,
-          "description": "Gets the number of items that failed to be indexed during this indexer execution."
+          "description": "The number of items that failed to be indexed during this indexer execution."
         },
         "initialTrackingState": {
           "type": "string",
@@ -1213,11 +1213,11 @@
             "url": "https://msdn.microsoft.com/library/azure/dn857353.aspx"
           },
           "type": "string",
-          "description": "Gets or sets the name of the field."
+          "description": "The name of the field."
         },
         "type": {
           "type": "string",
-          "description": "Gets or sets the data type of the field."
+          "description": "The data type of the field."
         },
         "analyzer": {
           "externalDocs": {
@@ -1228,27 +1228,27 @@
         },
         "key": {
           "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field is the key of the index. Valid only for string fields. Every index must have exactly one key field."
+          "description": "A value indicating whether the field is the key of the index. Valid only for string fields. Every index must have exactly one key field."
         },
         "searchable": {
           "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field is included in full-text searches. Valid only forstring or string collection fields. Default is false."
+          "description": "A value indicating whether the field is included in full-text searches. Valid only forstring or string collection fields. Default is false."
         },
         "filterable": {
           "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field can be used in filter expressions. Default is false."
+          "description": "A value indicating whether the field can be used in filter expressions. Default is false."
         },
         "sortable": {
           "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field can be used in orderby expressions. Not valid for string collection fields. Default is false."
+          "description": "A value indicating whether the field can be used in orderby expressions. Not valid for string collection fields. Default is false."
         },
         "facetable": {
           "type": "boolean",
-          "description": "Gets or sets a value indicating whether it is possible to facet on this field. Not valid for geo-point fields. Default is false."
+          "description": "A value indicating whether it is possible to facet on this field. Not valid for geo-point fields. Default is false."
         },
         "retrievable": {
           "type": "boolean",
-          "description": "Gets or sets a value indicating whether the field can be returned in a search result. Default is true."
+          "description": "A value indicating whether the field can be returned in a search result. Default is true."
         }
       },
       "required": [
@@ -1268,7 +1268,7 @@
             "type": "number",
             "format": "double"
           },
-          "description": "Gets the dictionary of per-field weights to boost document scoring. The keys are field names and the values are the weights for each field."
+          "description": "The dictionary of per-field weights to boost document scoring. The keys are field names and the values are the weights for each field."
         }
       },
       "required": [
@@ -1285,16 +1285,16 @@
         },
         "fieldName": {
           "type": "string",
-          "description": "Gets or sets the name of the field used as input to the scoring function."
+          "description": "The name of the field used as input to the scoring function."
         },
         "boost": {
           "type": "number",
           "format": "double",
-          "description": "Gets or sets a multiplier for the raw score. Must be a positive number not equal to 1.0."
+          "description": "A multiplier for the raw score. Must be a positive number not equal to 1.0."
         },
         "interpolation": {
           "$ref": "#/definitions/ScoringFunctionInterpolation",
-          "description": "Gets or sets a value indicating how boosting will be interpolated across document scores; defaults to \"Linear\"."
+          "description": "A value indicating how boosting will be interpolated across document scores; defaults to \"Linear\"."
         }
       },
       "required": [
@@ -1316,7 +1316,7 @@
       "properties": {
         "distance": {
           "$ref": "#/definitions/DistanceScoringParameters",
-          "description": "Gets parameter values for the distance scoring function."
+          "description": "Parameter values for the distance scoring function."
         }
       },
       "required": [
@@ -1332,12 +1332,12 @@
       "properties": {
         "referencePointParameter": {
           "type": "string",
-          "description": "Gets or sets the name of the parameter passed in search queries to specify the reference location."
+          "description": "The name of the parameter passed in search queries to specify the reference location."
         },
         "boostingDistance": {
           "type": "number",
           "format": "double",
-          "description": "Gets or sets the distance in kilometers from the reference location where the boosting range ends."
+          "description": "The distance in kilometers from the reference location where the boosting range ends."
         }
       },
       "required": [
@@ -1356,7 +1356,7 @@
       "properties": {
         "freshness": {
           "$ref": "#/definitions/FreshnessScoringParameters",
-          "description": "Gets parameter values for the freshness scoring function."
+          "description": "Parameter values for the freshness scoring function."
         }
       },
       "required": [
@@ -1373,7 +1373,7 @@
         "boostingDuration": {
           "type": "string",
           "format": "duration",
-          "description": "Gets or sets the expiration period after which boosting will stop for a particular document."
+          "description": "The expiration period after which boosting will stop for a particular document."
         }
       },
       "required": [
@@ -1392,7 +1392,7 @@
       "properties": {
         "magnitude": {
           "$ref": "#/definitions/MagnitudeScoringParameters",
-          "description": "Gets parameter values for the magnitude scoring function."
+          "description": "Parameter values for the magnitude scoring function."
         }
       },
       "required": [
@@ -1409,16 +1409,16 @@
         "boostingRangeStart": {
           "type": "number",
           "format": "double",
-          "description": "Gets or sets the field value at which boosting starts."
+          "description": "The field value at which boosting starts."
         },
         "boostingRangeEnd": {
           "type": "number",
           "format": "double",
-          "description": "Gets or sets the field value at which boosting ends."
+          "description": "The field value at which boosting ends."
         },
         "constantBoostBeyondRange": {
           "type": "boolean",
-          "description": "Gets or sets a value indicating whether to apply a constant boost for field values beyond the range end value; default is false."
+          "description": "A value indicating whether to apply a constant boost for field values beyond the range end value; default is false."
         }
       },
       "required": [
@@ -1453,7 +1453,7 @@
       "properties": {
         "tagsParameter": {
           "type": "string",
-          "description": "Gets or sets the name of the parameter passed in search queries to specify the list of tags to compare against the target field."
+          "description": "The name of the parameter passed in search queries to specify the list of tags to compare against the target field."
         }
       },
       "required": [
@@ -1479,22 +1479,22 @@
             "url": "https://msdn.microsoft.com/library/azure/dn857353.aspx"
           },
           "type": "string",
-          "description": "Gets or sets the name of the scoring profile."
+          "description": "The name of the scoring profile."
         },
         "text": {
           "$ref": "#/definitions/TextWeights",
-          "description": "Gets or sets parameters that boost scoring based on text matches in certain index fields."
+          "description": "Parameters that boost scoring based on text matches in certain index fields."
         },
         "functions": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ScoringFunction"
           },
-          "description": "Gets the collection of functions that influence the scoring of documents."
+          "description": "The collection of functions that influence the scoring of documents."
         },
         "functionAggregation": {
           "$ref": "#/definitions/ScoringFunctionAggregation",
-          "description": "Gets or sets a value indicating how the results of individual scoring functions should be combined. Defaults to \"Sum\". Ignored if there are no scoring functions."
+          "description": "A value indicating how the results of individual scoring functions should be combined. Defaults to \"Sum\". Ignored if there are no scoring functions."
         }
       },
       "required": [
@@ -1525,12 +1525,12 @@
           "items": {
             "type": "string"
           },
-          "description": "Gets the list of origins from which JavaScript code will be granted access to your index. Can contain a list of hosts of the form {protocol}://{fully-qualified-domain-name}[:{port#}], or a single '*' to allow all origins (not recommended)."
+          "description": "The list of origins from which JavaScript code will be granted access to your index. Can contain a list of hosts of the form {protocol}://{fully-qualified-domain-name}[:{port#}], or a single '*' to allow all origins (not recommended)."
         },
         "maxAgeInSeconds": {
           "type": "integer",
           "format": "int64",
-          "description": "Gets or sets the duration for which browsers should cache CORS preflight responses. Defaults to 5 mintues."
+          "description": "The duration for which browsers should cache CORS preflight responses. Defaults to 5 mintues."
         }
       },
       "required": [
@@ -1545,18 +1545,18 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Gets or sets the name of the suggester."
+          "description": "The name of the suggester."
         },
         "searchMode": {
           "$ref": "#/definitions/SuggesterSearchMode",
-          "description": "Gets or sets a value indicating the capabilities of the suggester."
+          "description": "A value indicating the capabilities of the suggester."
         },
         "sourceFields": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Gets the list of field names to which the suggester applies. Each field must be searchable."
+          "description": "The list of field names to which the suggester applies. Each field must be searchable."
         }
       },
       "required": [
@@ -1580,36 +1580,36 @@
             "url": "https://msdn.microsoft.com/library/azure/dn857353.aspx"
           },
           "type": "string",
-          "description": "Gets or sets the name of the index."
+          "description": "The name of the index."
         },
         "fields": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Field"
           },
-          "description": "Gets or sets the fields of the index."
+          "description": "The fields of the index."
         },
         "scoringProfiles": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ScoringProfile"
           },
-          "description": "Gets or sets the scoring profiles for the index."
+          "description": "The scoring profiles for the index."
         },
         "defaultScoringProfile": {
           "type": "string",
-          "description": "Gets or sets the name of the scoring profile to use if none is specified in the query. If this property is not set and no scoring profile is specified in the query, then default scoring (tf-idf) will be used."
+          "description": "The name of the scoring profile to use if none is specified in the query. If this property is not set and no scoring profile is specified in the query, then default scoring (tf-idf) will be used."
         },
         "corsOptions": {
           "$ref": "#/definitions/CorsOptions",
-          "description": "Gets or sets options to control Cross-Origin Resource Sharing (CORS) for the index."
+          "description": "Options to control Cross-Origin Resource Sharing (CORS) for the index."
         },
         "suggesters": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Suggester"
           },
-          "description": "Gets or sets the suggesters for the index."
+          "description": "The suggesters for the index."
         }
       },
       "required": [
@@ -1623,13 +1623,13 @@
           "type": "integer",
           "format": "int64",
           "readOnly": true,
-          "description": "Gets the number of documents in the index."
+          "description": "The number of documents in the index."
         },
         "storageSize": {
           "type": "integer",
           "format": "int64",
           "readOnly": true,
-          "description": "Gets the amount of storage in bytes consumed by the index."
+          "description": "The amount of storage in bytes consumed by the index."
         }
       },
       "description": "Statistics for a given index. Statistics are collected periodically and are not guaranteed to always be up-to-date.",
@@ -1643,7 +1643,7 @@
           "items": {
             "$ref": "#/definitions/Index"
           },
-          "description": "Gets the indexes in the Search service."
+          "description": "The indexes in the Search service."
         }
       },
       "description": "Response from a List Indexes request. If successful, it includes the full definitions of all indexes.",


### PR DESCRIPTION
The latest version of AutoRest automatically injects "Gets or sets" or "Gets" into property descriptions in generated C# code. Removing these from the Search specs so that they aren't duplicated in the generated code.

Also adding a few readOnly's to the arm-search spec where they were missing.

@chaosrealm @seansaleh FYI
