### PR TITLE
Search SDK: Renaming operation group in the SearchIndexClient spec

### DIFF
--- a/search/2015-02-28-Preview/swagger/searchindex.json
+++ b/search/2015-02-28-Preview/swagger/searchindex.json
@@ -15,9 +15,9 @@
     "/docs/$count": {
       "get": {
         "tags": [
-          "Documents"
+          "DocumentsProxy"
         ],
-        "operationId": "Documents_Count",
+        "operationId": "DocumentsProxy_Count",
         "description": "Queries the number of documents in the Azure Search index.",
         "externalDocs": {
           "url": "https://msdn.microsoft.com/library/azure/dn798924.aspx"


### PR DESCRIPTION
AutoRest does not support the advanced features we need for a good data plane client, like C# generics. Up until now we've worked around this by hand-writing most of the methods in the Documents operation group. However, this must change over time if we're to easily port our SDK to other languages.

The approach we will take starting with this change is to wrap AutoRest-generated methods wherever possible. The generated methods will go in a new operation group, DocumentsProxy, which we will exclude from our SDK's public interface for ease of versioning. Our public methods will be hand-written wrappers that still live in the Documents operation group.

In this change we just establish the basic pattern with the Count operation, which previously had the wrong return type in C# (long? instead of long) due to AutoRest's lack of support for nullable type semantics.

FYI @chaosrealm @seansaleh
