### PR TITLE
Search SDK: Re-enabling code generation for most model classes

### DIFF
--- a/search/2015-02-28-Preview/swagger/searchindex.json
+++ b/search/2015-02-28-Preview/swagger/searchindex.json
@@ -3,7 +3,10 @@
   "info": {
     "title": "SearchIndexClient",
     "description": "Client that can be used to query an Azure Search index and upload, merge, or delete documents.",
-    "version": "2015-02-28-Preview"
+    "version": "2015-02-28-Preview",
+    "x-ms-code-generation-settings": {  
+      "useDateTimeOffset": true  
+    }  
   },
   "consumes": [
     "application/json"
@@ -58,15 +61,16 @@
           "readOnly": true,
           "description": "The key of a document that was in the indexing request."
         },
-        "status": {
-          "type": "boolean",
-          "readOnly": true,
-          "description": "A value indicating whether the indexing operation succeeded for the document identified by the key."
-        },
         "errorMessage": {
           "type": "string",
           "readOnly": true,
           "description": "The error message explaining why the indexing operation failed for the document identified by the key; null if indexing succeeded."
+        },
+        "status": {
+          "x-ms-client-name": "Succeeded",
+          "type": "boolean",
+          "readOnly": true,
+          "description": "A value indicating whether the indexing operation succeeded for the document identified by the key."
         },
         "statusCode": {
           "type": "integer",
@@ -81,6 +85,7 @@
     "DocumentIndexResult": {
       "properties": {
         "value": {
+          "x-ms-client-name": "Results",
           "type": "array",
           "readOnly":  true,
           "items": {
@@ -89,8 +94,7 @@
           "description": "The list of status information for each document in the indexing request."
         }
       },
-      "description": "Response containing the status of operations for all documents in the indexing request.",
-      "x-ms-external": true
+      "description": "Response containing the status of operations for all documents in the indexing request."
     },
     "IndexActionType": {
       "type": "string",
@@ -121,8 +125,22 @@
       "x-ms-enum": { "name": "QueryType" },
       "description": "Specifies the syntax of the search query. The default is 'simple'. Use 'full' if your query uses the Lucene query syntax."
     },
-    "SearchParameters": {
+    "SearchParametersPayload": {
       "properties": {
+        "count": {
+          "type": "boolean",
+          "description": "A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation."
+        },
+        "facets": {
+          "externalDocs": {
+            "url": "https://msdn.microsoft.com/library/azure/dn798927.aspx"
+          },
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of facet expressions to apply to the search query. Each facet expression contains a field name, optionally followed by a comma-separated list of name:value pairs."
+        },
         "filter": {
           "externalDocs": {
             "url": "https://msdn.microsoft.com/library/azure/dn798921.aspx"
@@ -130,12 +148,9 @@
           "type": "string",
           "description": "The OData $filter expression to apply to the search query."
         },
-        "highlightFields": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The list of field names to use for hit highlights. Only searchable fields can be used for hit highlighting."
+        "highlight": {
+          "type": "string",
+          "description": "The comma-separated list of field names to use for hit highlights. Only searchable fields can be used for hit highlighting."
         },
         "highlightPostTag": {
           "type": "string",
@@ -145,21 +160,15 @@
           "type": "string",
           "description": "A string tag that is prepended to hit highlights. Must be set with HighlightPostTag. Default is &lt;em&gt;."
         },
-        "includeTotalResultCount": {
-          "type": "boolean",
-          "description": "A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation."
-        },
         "minimumCoverage": {
           "type": "number",
           "format": "double",
           "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by a search query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 100."
         },
-        "orderBy": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
+        "orderby": {
+          "x-ms-client-name": "OrderBy",
+          "type": "string",
+          "description": "The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
         },
         "queryType": {
           "$ref": "#/definitions/QueryType",
@@ -176,23 +185,24 @@
           "type": "string",
           "description": "The name of a scoring profile to evaluate match scores for matching documents in order to sort the results."
         },
-        "searchFields": {
-          "type": "array",
-          "items": {
-            "type": "string"
+        "search": {
+          "externalDocs": {
+            "url": "https://msdn.microsoft.com/library/azure/dn798920.aspx"
           },
-          "description": "The list of field names to include in the full-text search."
+          "type": "string",
+          "description": "A full-text search query expression; Use null or \"*\" to match all documents."
+        },
+        "searchFields": {
+          "type": "string",
+          "description": "The comma-separated list of field names to include in the full-text search."
         },
         "searchMode": {
           "$ref": "#/definitions/SearchMode",
           "description": "A value that specifies whether any or all of the search terms must be matched in order to count the document as a match."
         },
         "select": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included."
+          "type": "string",
+          "description": "The comma-separated list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included."
         },
         "skip": {
           "type": "integer",
@@ -208,10 +218,9 @@
           "description": "The number of search results to retrieve. This can be used in conjunction with Skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be passed to ContinueSearch to retrieve the next page of results. See DocumentSearchResponse.ContinuationToken for more information."
         }
       },
-      "description": "Parameters for filtering, sorting, faceting, paging, and other search query behaviors.",
-      "x-ms-external": true
+      "description": "Parameters for filtering, sorting, faceting, paging, and other search query behaviors."
     },
-    "SuggestParameters": {
+    "SuggestParametersPayload": {
       "properties": {
         "filter": {
           "externalDocs": {
@@ -219,6 +228,10 @@
           },
           "type": "string",
           "description": "The OData $filter expression to apply to the suggestions query."
+        },
+        "fuzzy": {
+          "type": "boolean",
+          "description": "A value indicating whether to use fuzzy matching for the suggestion query. Default is false. when set to true, the query will find suggestions even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios it comes at a performance cost as fuzzy suggestion searches are slower and consume more resources."
         },
         "highlightPostTag": {
           "type": "string",
@@ -233,39 +246,34 @@
           "format": "double",
           "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by a suggestion query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80."
         },
-        "orderBy": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
+        "orderby": {
+          "x-ms-client-name": "OrderBy",
+          "type": "string",
+          "description": "The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
+        },
+        "search": {
+          "type": "string",
+          "description": "The search text on which to base suggestions."
         },
         "searchFields": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The list of field names to consider when querying for suggestions."
+          "type": "string",
+          "description": "The comma-separated list of field names to consider when querying for suggestions."
         },
         "select": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included."
+          "type": "string",
+          "description": "The comma-separated list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included."
+        },
+        "suggesterName": {
+          "type": "string",
+          "description": "The name of the suggester as specified in the suggesters collection that's part of the index definition."
         },
         "top": {
           "type": "integer",
           "format": "int32",
           "description": "The number of suggestions to retrieve. This must be a value between 1 and 100. The default is to 5."
-        },
-        "useFuzzyMatching": {
-          "type": "boolean",
-          "description": "A value indicating whether to use fuzzy matching for the suggestion query. Default is false. when set to true, the query will find suggestions even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios it comes at a performance cost as fuzzy suggestion searches are slower and consume more resources."
         }
       },
-      "description": "Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors.",
-      "x-ms-external": true
+      "description": "Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors."
     }
   },
   "parameters": {

--- a/search/2015-02-28-Preview/swagger/searchservice.json
+++ b/search/2015-02-28-Preview/swagger/searchservice.json
@@ -3,7 +3,10 @@
   "info": {
     "title": "SearchServiceClient",
     "description": "Client that can be used to manage and query indexes and documents, as well as manage other resources, on an Azure Search service.",
-    "version": "2015-02-28-Preview"
+    "version": "2015-02-28-Preview",
+    "x-ms-code-generation-settings": {  
+      "useDateTimeOffset": true  
+    }  
   },
   "consumes": [
     "application/json"
@@ -987,6 +990,7 @@
     "DataSourceListResult": {
       "properties": {
         "value": {
+          "x-ms-client-name": "DataSources",
           "type": "array",
           "readOnly": true,
           "items": {
@@ -995,8 +999,7 @@
           "description": "The datasources in the Search service."
         }
       },
-      "description": "Response from a List Datasources request. If successful, it includes the full definitions of all datasources.",
-      "x-ms-external": true
+      "description": "Response from a List Datasources request. If successful, it includes the full definitions of all datasources."
     },
     "IndexingSchedule": {
       "properties": {
@@ -1014,8 +1017,7 @@
       "required": [
         "interval"
       ],
-      "description": "Represents a schedule for indexer execution.",
-      "x-ms-external": true
+      "description": "Represents a schedule for indexer execution."
     },
     "IndexingParameters": {
       "properties": {
@@ -1077,6 +1079,7 @@
     "IndexerListResult": {
       "properties": {
         "value": {
+          "x-ms-client-name": "Indexers",
           "type": "array",
           "readOnly": true,
           "items": {
@@ -1085,8 +1088,7 @@
           "description": "The indexers in the Search service."
         }
       },
-      "description": "Response from a List Indexers request. If successful, it includes the full definitions of all indexers.",
-      "x-ms-external": true
+      "description": "Response from a List Indexers request. If successful, it includes the full definitions of all indexers."
     },
     "ItemError": {
       "properties": {
@@ -1136,12 +1138,14 @@
           "description": "The item-level indexing errors"
         },
         "itemsProcessed": {
+          "x-ms-client-name": "itemCount",
           "type": "integer",
           "format": "int32",
           "readOnly": true,
           "description": "The number of items that were processed during this indexer execution. This includes both successfully processed items and items where indexing was attempted but failed."
         },
         "itemsFailed": {
+          "x-ms-client-name": "failedItemCount",
           "type": "integer",
           "format": "int32",
           "readOnly": true,
@@ -1158,7 +1162,7 @@
           "description": "Change tracking state with which an indexer execution finished."
         }
       },
-      "description": "Represents result of an individual indexer execution.",
+      "description": "Represents the result of an individual indexer execution.",
       "x-ms-external": true
     },
     "IndexerExecutionStatus": {
@@ -1303,8 +1307,7 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Abstract base class for functions that can modify document scores during ranking.",
-      "x-ms-external": true
+      "description": "Abstract base class for functions that can modify document scores during ranking."
     },
     "DistanceScoringFunction": {
       "x-ms-discriminator-value": "distance",
@@ -1315,6 +1318,7 @@
       ],
       "properties": {
         "distance": {
+          "x-ms-client-name": "Parameters",
           "$ref": "#/definitions/DistanceScoringParameters",
           "description": "Parameter values for the distance scoring function."
         }
@@ -1325,8 +1329,7 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines a function that boosts scores based on distance from a geographic location.",
-      "x-ms-external": true
+      "description": "Defines a function that boosts scores based on distance from a geographic location."
     },
     "DistanceScoringParameters": {
       "properties": {
@@ -1343,8 +1346,7 @@
       "required": [
         "referencePointParameter", "boostingDistance"
       ],
-      "description": "Provides parameter values to a distance scoring function.",
-      "x-ms-external": true
+      "description": "Provides parameter values to a distance scoring function."
     },
     "FreshnessScoringFunction": {
       "x-ms-discriminator-value": "freshness",
@@ -1355,6 +1357,7 @@
       ],
       "properties": {
         "freshness": {
+          "x-ms-client-name": "Parameters",
           "$ref": "#/definitions/FreshnessScoringParameters",
           "description": "Parameter values for the freshness scoring function."
         }
@@ -1365,8 +1368,7 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines a function that boosts scores based on the value of a date-time field.",
-      "x-ms-external": true
+      "description": "Defines a function that boosts scores based on the value of a date-time field."
     },
     "FreshnessScoringParameters": {
       "properties": {
@@ -1379,8 +1381,7 @@
       "required": [
         "boostingDuration"
       ],
-      "description": "Provides parameter values to a freshness scoring function.",
-      "x-ms-external": true
+      "description": "Provides parameter values to a freshness scoring function."
     },
     "MagnitudeScoringFunction": {
       "x-ms-discriminator-value": "magnitude",
@@ -1391,6 +1392,7 @@
       ],
       "properties": {
         "magnitude": {
+          "x-ms-client-name": "Parameters",
           "$ref": "#/definitions/MagnitudeScoringParameters",
           "description": "Parameter values for the magnitude scoring function."
         }
@@ -1401,8 +1403,7 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines a function that boosts scores based on the magnitude of a numeric field.",
-      "x-ms-external": true
+      "description": "Defines a function that boosts scores based on the magnitude of a numeric field."
     },
     "MagnitudeScoringParameters": {
       "properties": {
@@ -1417,6 +1418,7 @@
           "description": "The field value at which boosting ends."
         },
         "constantBoostBeyondRange": {
+          "x-ms-client-name": "ShouldBoostBeyondRangeByConstant",
           "type": "boolean",
           "description": "A value indicating whether to apply a constant boost for field values beyond the range end value; default is false."
         }
@@ -1424,8 +1426,7 @@
       "required": [
         "boostingRangeStart", "boostingRangeEnd"
       ],
-      "description": "Provides parameter values to a magnitude scoring function.",
-      "x-ms-external": true
+      "description": "Provides parameter values to a magnitude scoring function."
     },
     "TagScoringFunction": {
       "x-ms-discriminator-value": "tag",
@@ -1436,8 +1437,9 @@
       ],
       "properties": {
         "tag": {
+          "x-ms-client-name": "Parameters",
           "$ref": "#/definitions/TagScoringParameters",
-          "description": "Gets parameter values for the tag scoring function."
+          "description": "Parameter values for the tag scoring function."
         }
       },
       "required": [
@@ -1446,8 +1448,7 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines a function that boosts scores of documents with string values matching a given list of tags.",
-      "x-ms-external": true
+      "description": "Defines a function that boosts scores of documents with string values matching a given list of tags."
     },
     "TagScoringParameters": {
       "properties": {
@@ -1482,6 +1483,7 @@
           "description": "The name of the scoring profile."
         },
         "text": {
+          "x-ms-client-name": "TextWeights",
           "$ref": "#/definitions/TextWeights",
           "description": "Parameters that boost scoring based on text matches in certain index fields."
         },
@@ -1503,8 +1505,7 @@
       "externalDocs": {
         "url": "https://msdn.microsoft.com/library/azure/dn798928.aspx"
       },
-      "description": "Defines parameters for an Azure Search index that influence scoring in search queries.",
-      "x-ms-external": true
+      "description": "Defines parameters for an Azure Search index that influence scoring in search queries."
     },
     "ScoringFunctionAggregation": {
       "type": "string",
@@ -1562,8 +1563,7 @@
       "required": [
         "name", "searchMode", "sourceFields"
       ],
-      "description": "Defines how the Suggest API should apply to a group of fields in the index.",
-      "x-ms-external": true
+      "description": "Defines how the Suggest API should apply to a group of fields in the index."
     },
     "SuggesterSearchMode": {
       "type": "string",
@@ -1638,6 +1638,7 @@
     "IndexListResult": {
       "properties": {
         "value": {
+          "x-ms-client-name": "Indexes",
           "type": "array",
           "readOnly": true,
           "items": {
@@ -1646,8 +1647,7 @@
           "description": "The indexes in the Search service."
         }
       },
-      "description": "Response from a List Indexes request. If successful, it includes the full definitions of all indexes.",
-      "x-ms-external": true
+      "description": "Response from a List Indexes request. If successful, it includes the full definitions of all indexes."
     }
   },
   "parameters": {

--- a/search/2015-02-28-Preview/swagger/searchservice.json
+++ b/search/2015-02-28-Preview/swagger/searchservice.json
@@ -1138,14 +1138,14 @@
           "description": "The item-level indexing errors"
         },
         "itemsProcessed": {
-          "x-ms-client-name": "itemCount",
+          "x-ms-client-name": "ItemCount",
           "type": "integer",
           "format": "int32",
           "readOnly": true,
           "description": "The number of items that were processed during this indexer execution. This includes both successfully processed items and items where indexing was attempted but failed."
         },
         "itemsFailed": {
-          "x-ms-client-name": "failedItemCount",
+          "x-ms-client-name": "FailedItemCount",
           "type": "integer",
           "format": "int32",
           "readOnly": true,


### PR DESCRIPTION
Now that many issues in AutoRest have been fixed, we're able to generate more model classes. Specifically, required parameters are now non-nullable in C#, the C# code generators support using `DateTimeOffset` instead of `DateTime`, and the `x-ms-client-name` extension allows us to rename things in the generated code.

FYI @chaosrealm @seansaleh 
