### PR TITLE
Search SDK: Disabling synchronous methods for SearchIndexClient

### DIFF
--- a/search/2015-02-28-Preview/swagger/searchindex.json
+++ b/search/2015-02-28-Preview/swagger/searchindex.json
@@ -5,7 +5,8 @@
     "description": "Client that can be used to query an Azure Search index and upload, merge, or delete documents.",
     "version": "2015-02-28-Preview",
     "x-ms-code-generation-settings": {  
-      "useDateTimeOffset": true  
+      "useDateTimeOffset": true,
+      "syncMethods": "None"  
     }  
   },
   "consumes": [


### PR DESCRIPTION
Currently we are using the spec for SearchIndexClient to generate a proxy that is then wrapped with hand-written code. The hand-written C# code always calls async methods, so there is no need for the proxy to have synchronous methods.

FYI @chaosrealm @seansaleh @yahnoosh @mhko @bernitorres 
