### PR TITLE
Add 404 responses for HEAD on Azure Batch file properties

### DIFF
--- a/batch/2016-02-01.3.0/swagger/BatchService.json
+++ b/batch/2016-02-01.3.0/swagger/BatchService.json
@@ -1642,6 +1642,9 @@
             },
             "description": "Found the file"
           },
+          "404": {
+            "description": "File was not found"
+          },
           "default": {
             "description": "The error from the Batch service.",
             "schema": {
@@ -2074,6 +2077,9 @@
               }
             },
             "description": "Found the file"
+          },
+          "404": {
+            "description": "File was not found"
           },
           "default": {
             "description": "The error from the Batch service.",


### PR DESCRIPTION
This was causing AutoRest to generate warnings previously.
