### PR TITLE
Removing key vault management delete return type

### DIFF
--- a/arm-keyvault/2015-06-01/swagger/keyvault.json
+++ b/arm-keyvault/2015-06-01/swagger/keyvault.json
@@ -100,10 +100,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Deleted vault",
-            "schema": {
-              "$ref": "#/definitions/Vault"
-            }
+            "description": ""
           }
         }
       },


### PR DESCRIPTION
Deleting a vault would not return the deleted vault. Fixing the issue [392](https://github.com/Azure/azure-rest-api-specs/issues/392).
