### PR TITLE
Search SDK: Turning off codegen for IndexingParameters

### DIFF
--- a/search/2015-02-28-Preview/swagger/searchservice.json
+++ b/search/2015-02-28-Preview/swagger/searchservice.json
@@ -1075,7 +1075,8 @@
           "description": "A dictionary of indexer-specific configuration properties. Each name is the name of a specific property. Each value must be of a primitive type."
         }
       },
-      "description": "Represents parameters for indexer execution."
+      "description": "Represents parameters for indexer execution.",
+      "x-ms-external": true
     },
     "Indexer": {
       "properties": {


### PR DESCRIPTION
We need to mark a property of this class with the `[Obsolete]` attribute. We need to do this by hand until this AutoRest issue is fixed: https://github.com/Azure/autorest/issues/1285
