### PR TITLE
Resource is type of x-ms-azure-resource type

### DIFF
--- a/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
+++ b/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
@@ -262,6 +262,7 @@
   },
   "definitions": {
     "Resource": {
+      "x-ms-azure-resource": true,
       "required": [
         "location"
       ],


### PR DESCRIPTION
Looking at the definition of the "Resource", it looks like it is x-ms-azure-resource type. 

Reference: https://github.com/Azure/autorest/blob/master/Documentation/swagger-extensions.md#x-ms-azure-resource 
