### PR TITLE
Updating return types for pageable operations to contain nextLink

### DIFF
--- a/arm-mobileengagement/2014-12-01/swagger/mobile-engagement.json
+++ b/arm-mobileengagement/2014-12-01/swagger/mobile-engagement.json
@@ -2186,6 +2186,10 @@
             "$ref": "#/definitions/App"
           },
           "description": "The list of Apps and their properties."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "When the results are paged, the nextLink is the URI for the next page of results. This property is empty when there are no additional pages."
         }
       },
       "description": "The list Apps operation response."
@@ -2228,6 +2232,10 @@
             "$ref": "#/definitions/AppCollection"
           },
           "description": "The list of AppCollections and their properties."
+        },
+          "nextLink": {
+          "type": "string",
+          "description": "When the results are paged, the nextLink is the URI for the next page of results. This property is empty when there are no additional pages."
         }
       },
       "description": "The list AppCollections operation response."


### PR DESCRIPTION
The spec is missing nextLink for 2 models that are return type of pageable operations, so generated models don't include nextLink which are needed for pageable operations to work properly.
