### PR TITLE
Search SDK: ETags for Azure Search Indexes, Indexers, and DataSources

### DIFF
--- a/search/2015-02-28-Preview/swagger/searchservice.json
+++ b/search/2015-02-28-Preview/swagger/searchservice.json
@@ -53,6 +53,22 @@
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
           {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-Match condition. The operation will be performed only if the ETag on the server matches this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-None-Match condition. The operation will be performed only if the ETag on the server does not match this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
@@ -98,6 +114,22 @@
             "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-Match condition. The operation will be performed only if the ETag on the server matches this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-None-Match condition. The operation will be performed only if the ETag on the server does not match this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -352,6 +384,22 @@
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
           {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-Match condition. The operation will be performed only if the ETag on the server matches this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-None-Match condition. The operation will be performed only if the ETag on the server does not match this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
@@ -397,6 +445,22 @@
             "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-Match condition. The operation will be performed only if the ETag on the server matches this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-None-Match condition. The operation will be performed only if the ETag on the server does not match this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -700,6 +764,22 @@
             "x-ms-parameter-grouping": { "name": "search-request-options" }
           },
           {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-Match condition. The operation will be performed only if the ETag on the server matches this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-None-Match condition. The operation will be performed only if the ETag on the server does not match this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
@@ -745,6 +825,22 @@
             "description": "The tracking ID sent with the request to help with debugging.",
             "x-ms-client-request-id": true,
             "x-ms-parameter-grouping": { "name": "search-request-options" }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-Match condition. The operation will be performed only if the ETag on the server matches this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "Defines the If-None-Match condition. The operation will be performed only if the ETag on the server does not match this value.",
+            "x-ms-parameter-grouping": { "name": "access-condition" }
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1004,6 +1100,11 @@
         "dataDeletionDetectionPolicy": {
           "$ref": "#/definitions/DataDeletionDetectionPolicy",
           "description": "The data deletion detection policy for the datasource."
+        },
+		"@odata.etag": {
+          "x-ms-client-name": "ETag",
+          "type": "string",
+          "description": "The ETag of the DataSource."
         }
       },
       "required": [
@@ -1167,6 +1268,11 @@
           "type": "boolean",
           "default": false,
           "description": "A value indicating whether the indexer is disabled. Default is false."
+        },
+		"@odata.etag": {
+          "x-ms-client-name": "ETag",
+          "type": "string",
+          "description": "The ETag of the Indexer."
         }
       },
       "required": [
@@ -1717,6 +1823,11 @@
             "$ref": "#/definitions/Suggester"
           },
           "description": "The suggesters for the index."
+        },
+		"@odata.etag": {
+          "x-ms-client-name": "ETag",
+          "type": "string",
+          "description": "The ETag of the index."
         }
       },
       "required": [


### PR DESCRIPTION
This adds swagger specs for Azure Search's ETag support
