### PR TITLE
Search SDK: Marking PathHierarchyTokenizer as x-ms-external

### DIFF
--- a/search/2015-02-28-Preview/swagger/searchservice.json
+++ b/search/2015-02-28-Preview/swagger/searchservice.json
@@ -1622,7 +1622,8 @@
       "description": "Tokenizer for path-like hierarchies. This tokenizer is implemented using Apache Lucene.",
       "externalDocs": {
         "url": "http://lucene.apache.org/core/4_10_3/analyzers-common/org/apache/lucene/analysis/path/PathHierarchyTokenizer.html"
-      }
+      },
+      "x-ms-external": true
     },
     "PatternTokenizer": {
       "x-ms-discriminator-value": "#Microsoft.Azure.Search.PatternTokenizer",


### PR DESCRIPTION
This is a temporary workaround until we upgrade to the latest version of AutoRest, which supports format:char.

FYI @Yahnoosh @fearthecowboy 
