### PR TITLE
Changing any short $refs to the standard JSON reference pattern

### DIFF
--- a/arm-compute/quickstart-templates/swagger.json
+++ b/arm-compute/quickstart-templates/swagger.json
@@ -129,9 +129,6 @@
           ]
         }
       },
-      "required": [
-        "mode"
-      ],
       "description": "Deployment properties."
     },
     "Deployment": {

--- a/arm-dns/2015-05-04-preview/swagger/dns.json
+++ b/arm-dns/2015-05-04-preview/swagger/dns.json
@@ -846,7 +846,7 @@
       },
       "allOf": [
         {
-          "$ref": "Resource"
+          "$ref": "#/definitions/Resource"
         }
       ],
       "description": "Describes a DNS RecordSet (a set of DNS records with the same name and type)."
@@ -895,7 +895,7 @@
       },
       "allOf": [
         {
-          "$ref": "Resource"
+          "$ref": "#/definitions/Resource"
         }
       ],
       "description": "Describes a DNS zone."

--- a/arm-logic/2015-02-01-preview/swagger/logic.json
+++ b/arm-logic/2015-02-01-preview/swagger/logic.json
@@ -2205,7 +2205,7 @@
       },
       "allOf": [
         {
-          "$ref": "WorkflowParameter"
+          "$ref": "#/definitions/WorkflowParameter"
         }
       ]
     },

--- a/arm-logic/2016-06-01/swagger/logic.json
+++ b/arm-logic/2016-06-01/swagger/logic.json
@@ -2009,7 +2009,7 @@
       },
       "allOf": [
         {
-          "$ref": "WorkflowParameter"
+          "$ref": "#/definitions/WorkflowParameter"
         }
       ]
     },

--- a/arm-resources/resources/2015-11-01/swagger/resources.json
+++ b/arm-resources/resources/2015-11-01/swagger/resources.json
@@ -2483,7 +2483,7 @@
       },
       "allOf": [
         {
-          "$ref": "Resource"
+          "$ref": "#/definitions/Resource"
         }
       ],
       "description": "Resource information."

--- a/arm-trafficmanager/2015-11-01/swagger/trafficmanager.json
+++ b/arm-trafficmanager/2015-11-01/swagger/trafficmanager.json
@@ -671,7 +671,7 @@
       },
       "allOf": [
         {
-          "$ref": "Resource"
+          "$ref": "#/definitions/Resource"
         }
       ],
       "description": "Class representing a Traffic Manager profile."


### PR DESCRIPTION
Since the short version is only understood by AutoRest, they mess with other tools that work with standard Swagger. I'll also open an issue in the AutoRest repo to possibly remove support for this non-standard $ref.

cc: @hellosnow and @bradygaster 
