### PR TITLE
Fix MediaService checkNameAvailability

### DIFF
--- a/arm-mediaservices/2015-10-01/swagger/media.json
+++ b/arm-mediaservices/2015-10-01/swagger/media.json
@@ -37,7 +37,7 @@
     "/subscriptions/{subscriptionId}/providers/Microsoft.Media/CheckNameAvailability": {
       "post": {
         "summary": "Check whether the Media Service resource name is available. The name must be globally unique.",
-        "operationId": "MediaService_CheckNameAvailabilty",
+        "operationId": "MediaService_CheckNameAvailability",
         "responses": {
           "200": {
             "description": "OK",
@@ -496,6 +496,10 @@
     },
     "CheckNameAvailabilityInput": {
       "description": "The request body for CheckNameAvailability API.",
+      "required": [
+        "name",
+        "type"
+      ],      
       "properties": {
         "name": {
           "description": "The name of the resource. A name must be globally unique.",
@@ -506,18 +510,30 @@
         },
         "type": {
           "description": "Specifies the type of the resource.",
-          "type": "string"
+          "$ref": "#/definitions/ResourceType"
         }
       }
     },
+    "ResourceType": {
+      "description": "Type of MediaService resource used in CheckNameAvailability.",
+      "readOnly": true,
+      "enum": [
+        "mediaservices"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ResourceType",
+        "modelAsString": false
+      }
+    },    
     "CheckNameAvailabilityOutput": {
       "description": "The response body for CheckNameAvailability API.",
       "properties": {
-        "nameAvailable": {
+        "NameAvailable": {
           "description": "Specifies if the name is available.",
           "type": "boolean"
         },
-        "reason": {
+        "Reason": {
           "description": "Specifies the reason if the name is not available.",
           "type": "string",
           "enum": [
@@ -530,7 +546,7 @@
             "modelAsString": false
           }  
         },
-        "message": {
+        "Message": {
           "description": "Specifies the detailed reason if the name is not available.",
           "type": "string"
         }


### PR DESCRIPTION
After testing in Python the first method "CheckNameAvailability", there is several mistakes in the Swagger file. I'm not yet an expert in Swagger, put I think it's reasonable fixes:
- Fix typo in Operation id
- Make name and type required
- Fix type as a constant
- Fix attribute name in answer to match what we actually get from server:

``` json
{"NameAvailable":true,"Reason":null,"Message":null}
```

which is different from the doc:
https://msdn.microsoft.com/en-us/library/azure/mt750385.aspx

Since there is a lot of mistakes and it's the first method I test, I guess this file is not ready yet? (even if a C# package was published as preview).

Thanks!
