### PR TITLE
Fixes some inconsistencies in network api definition

### DIFF
--- a/arm-compute/2016-03-30/swagger/compute.json
+++ b/arm-compute/2016-03-30/swagger/compute.json
@@ -958,6 +958,9 @@
             "$ref": "#/parameters/LocationParameter"
           },
           {
+            "$ref": "#/parameters/TagsParameter"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           },
           {
@@ -4584,6 +4587,18 @@
       "required": true,
       "type": "string",
       "description": "The Azure location."
+    },
+    "TagsParameter": {
+      "name": "tags",
+      "in": "body",
+      "required": false,
+      "schema": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "description": "Resource tags."
     }
   }
 }

--- a/arm-compute/2016-03-30/swagger/compute.json
+++ b/arm-compute/2016-03-30/swagger/compute.json
@@ -946,13 +946,16 @@
             "description": "The name of the virtual machine."
           },
           {
-            "name": "parameters",
+            "name": "properties",
             "in": "body",
             "required": true,
             "schema": {
               "$ref": "#/definitions/VirtualMachine"
             },
             "description": "Parameters supplied to the Create Virtual Machine operation."
+          },
+          {
+            "$ref": "#/parameters/LocationParameter"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -4571,6 +4574,16 @@
       "required": true,
       "type": "string",
       "description": "Client Api Version."
+    },
+    "LocationParameter": {
+      "name": "location",
+      "in": "body",
+      "schema":{
+        "type":"string"
+      },
+      "required": true,
+      "type": "string",
+      "description": "The Azure location."
     }
   }
 }

--- a/arm-network/2016-09-01/swagger/network.json
+++ b/arm-network/2016-09-01/swagger/network.json
@@ -1663,13 +1663,16 @@
             "description": "The name of the network interface."
           },
           {
-            "name": "parameters",
+            "name": "properties",
             "in": "body",
             "required": true,
             "schema": {
               "$ref": "#/definitions/NetworkInterface"
             },
             "description": "Parameters supplied to the create/update NetworkInterface operation"
+          },
+          {
+            "$ref": "#/parameters/LocationParameter"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2306,7 +2309,7 @@
             "description": "The name of the publicIpAddress."
           },
           {
-            "name": "parameters",
+            "name": "properties",
             "in": "body",
             "required": true,
             "schema": {
@@ -2315,11 +2318,15 @@
             "description": "Parameters supplied to the create/update PublicIPAddress operation"
           },
           {
+            "$ref": "#/parameters/LocationParameter"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           },
           {
             "$ref": "#/parameters/SubscriptionIdParameter"
           }
+
         ],
         "responses": {
           "201": {
@@ -8223,6 +8230,16 @@
       "required": true,
       "type": "string",
       "description": "Client Api Version."
+    },
+    "LocationParameter": {
+      "name": "location",
+      "in": "body",
+      "schema":{
+        "type":"string"
+      },
+      "required": true,
+      "type": "string",
+      "description": "The Azure location."
     }
   }
 }

--- a/arm-network/2016-09-01/swagger/network.json
+++ b/arm-network/2016-09-01/swagger/network.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "swagger": "2.0",
   "info": {
     "title": "NetworkManagementClient",
@@ -1675,6 +1675,9 @@
             "$ref": "#/parameters/LocationParameter"
           },
           {
+            "$ref": "#/parameters/TagsParameter"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           },
           {
@@ -2316,6 +2319,9 @@
               "$ref": "#/definitions/PublicIPAddress"
             },
             "description": "Parameters supplied to the create/update PublicIPAddress operation"
+          },
+          {
+            "$ref": "#/parameters/TagsParameter"
           },
           {
             "$ref": "#/parameters/LocationParameter"
@@ -8240,6 +8246,18 @@
       "required": true,
       "type": "string",
       "description": "The Azure location."
+    },
+    "TagsParameter": {
+      "name": "tags",
+      "in": "body",
+      "required": false,
+      "schema": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "description": "Resource tags."
     }
   }
 }


### PR DESCRIPTION
Apparently, and unless we are missing something, some call definitions were not consistent with the parameters this version of the network api expects. This changeset fixes calls 'create or update a network interface card' and 'create or update a public ip address'. Also defines the parameter 'LocationParameter'.

If this pull request does go in the right direction, we could provide more fixes for api definitions.
