### PR TITLE
webapp: expose entry point for linux web app

### DIFF
--- a/arm-web/2015-08-01/swagger/service.json
+++ b/arm-web/2015-08-01/swagger/service.json
@@ -17992,7 +17992,11 @@
               "type": "string"
             },
             "javaContainerVersion": {
-              "description": "Java container version",
+                "description": "Java container version",
+                "type": "string"
+            },
+            "appCommandLine": {
+              "description": "App Command Line to launch",
               "type": "string"
             },
             "managedPipelineMode": {


### PR DESCRIPTION
Cherry pick from #595 so to unblock azure cli command work for linux webapp support
//cc: @LukaszStem
