### PR TITLE
[Media] - remove tags from required

### DIFF
--- a/arm-mediaservices/2015-10-01/swagger/media.json
+++ b/arm-mediaservices/2015-10-01/swagger/media.json
@@ -698,8 +698,7 @@
         }
       ],
       "required": [
-        "location",
-        "tags"
+        "location"
       ],
       "properties": {
         "location": {


### PR DESCRIPTION
@amarzavery I don't know if this is the right fix honestly, but I know for sure that "tags" is not required in the "create" operation. Also RestAPI ref:
https://msdn.microsoft.com/en-us/library/azure/mt750387.aspx

Since it's indirectly inherited, maybe _some_ objects have "tags" as required, in this case the split in objects must be re-thinked.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-rest-api-specs/641)

<!-- Reviewable:end -->
