### PR TITLE
[media] Fix "sync_keys" and "regenerate_key"

### DIFF
--- a/arm-mediaservices/2015-10-01/swagger/media.json
+++ b/arm-mediaservices/2015-10-01/swagger/media.json
@@ -596,7 +596,6 @@
         "keyType": {
           "description": "The keyType indicating which key you want to regenerate, Primary or Secondary.",
           "type": "string",
-          "required": true,
           "enum": [
             "Primary",
             "Secondary"
@@ -606,7 +605,10 @@
             "modelAsString": false
           }  
         }
-      }
+      },
+      "required": [
+        "keyType"
+      ]
     },
     "RegenerateKeyOutput": {
       "description": "The response body for a RegenerateKey API.",

--- a/arm-mediaservices/2015-10-01/swagger/media.json
+++ b/arm-mediaservices/2015-10-01/swagger/media.json
@@ -416,12 +416,6 @@
         "responses": {
           "200": {
             "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/MediaService"
-            }
-          },
-          "202": {
-            "description": "Accepted"
           },
           "default": {
             "description": "Detailed error information.",
@@ -602,6 +596,7 @@
         "keyType": {
           "description": "The keyType indicating which key you want to regenerate, Primary or Secondary.",
           "type": "string",
+          "required": true,
           "enum": [
             "Primary",
             "Secondary"

--- a/arm-mediaservices/2015-10-01/swagger/media.json
+++ b/arm-mediaservices/2015-10-01/swagger/media.json
@@ -684,7 +684,10 @@
           "description": "The id of the storage account resource.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "id"
+      ]
     },
     "TrackedResource": {
       "description": "ARM tracked resource",

--- a/arm-mediaservices/2015-10-01/swagger/media.json
+++ b/arm-mediaservices/2015-10-01/swagger/media.json
@@ -415,7 +415,7 @@
         "operationId": "MediaService_SyncStorageKeys",
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "OK"
           },
           "default": {
             "description": "Detailed error information.",


### PR DESCRIPTION
- Regenerate_key does not return MediaService:
https://msdn.microsoft.com/en-us/library/azure/mt750386.aspx
- Add "required" to keytype in "sync_keys":
https://msdn.microsoft.com/en-us/library/azure/mt750388.aspx

@amarzavery @BrianBlum for review

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-rest-api-specs/654)
<!-- Reviewable:end -->
