### PR TITLE
Removed Erroneous SubscriptionID as Required Path Parameter

### DIFF
--- a/insights/2016-09-01/swagger/insightsClient.json
+++ b/insights/2016-09-01/swagger/insightsClient.json
@@ -154,13 +154,6 @@
     }
   },
   "parameters": {
-    "SubscriptionIdParameter": {
-      "name": "subscriptionId",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "The Azure subscription Id."
-    },
     "ApiVersionParameter": {
       "name": "api-version",
       "in": "query",

--- a/insights/2016-09-01/swagger/insightsClient.json
+++ b/insights/2016-09-01/swagger/insightsClient.json
@@ -31,9 +31,6 @@
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {


### PR DESCRIPTION
This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [ x] The title of the PR is clear and informative.
- [ x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x ] If applicable, the PR references the bug/issue that it fixes.
- [x ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x ] My spec meets the review criteria:
  - [x ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x ] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [ ] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.
The generated code from this Azure spec is currently failing with the error shown in this ticket: 

https://github.com/Azure/autorest/issues/1550

We determined that the problem was that the subscriptionID parameter should not be a required path parameter.  The subscriptionID is already included in the resourceUri parameter, so it was clearly redundant and also causing calls for metrics to fail.  Only after we removed the "subscriptionId" field as a required parameter in the generated sources, were we able to retrieve metric definitions with the generated code. 

The same problem exists on the "metricDefinitions" endpoint on api version 2016-03-01.  I have submitted the following PR for that:  
https://github.com/Azure/azure-rest-api-specs/pull/660

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-rest-api-specs/661)
<!-- Reviewable:end -->
