### PR TITLE
Fixed case on property "timeStamp" to match API and fix deserialization

### DIFF
--- a/insights/2016-09-01/swagger/insightsClient.json
+++ b/insights/2016-09-01/swagger/insightsClient.json
@@ -83,9 +83,9 @@
       }
     },
     "MetricValue": {
-      "required": [ "timestamp" ],
+      "required": [ "timeStamp" ],
       "properties": {
-        "timestamp": {
+        "timeStamp": {
           "type": "string",
           "format": "date-time",
           "description": "the timestamp for the metric value in ISO 8601 format."


### PR DESCRIPTION
This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [ x] The title of the PR is clear and informative.
- [x ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [ x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x ] If applicable, the PR references the bug/issue that it fixes.
- [ x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ x] My spec meets the review criteria:
  - [x ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ x] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [ x] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.

### Summary of Change
This change fixes a bug where metric "timestamp" property was not being deserialized properly when using classes generated by Autorest + this REST spec.  The resulting classes returned timestamps that were "null", apparently due to the spec featuring the property name in lowercase. 

### Analysis:
The API reference shows the property name camel case:       "timeStamp	String	Time stamp of a particular data point."
This is Confirmed in Raw API JSON output:                 "timeStamp" : "2016-11-04T07:27:00Z"
API Reference:   https://msdn.microsoft.com/en-us/library/azure/mt743622.aspx

### Before this change applied:  
Autorest Generated Java property:     private DateTime timestamp;
Test:                                                     println returned[0].name().value() + " = " + returned[0].data().last().timestamp()
Result:                                                  Percentage CPU = null

### After this change applied: 
Autorest Generated Java property:     private DateTime timeStamp;
Test:                                                     println returned[0].name().value() + " = " + returned[0].data().last().timeStamp()
Result:                                                  Percentage CPU 2016-11-04T08:10:00.000Z

The timeStamp property is now deserialized properly after this change.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-rest-api-specs/672)
<!-- Reviewable:end -->
