### PR TITLE
[DocDB] Create fix: DatabaseAccountOfferType should be in "properties"

### DIFF
--- a/arm-documentdb/2015-04-08/swagger/documentdb.json
+++ b/arm-documentdb/2015-04-08/swagger/documentdb.json
@@ -601,11 +601,15 @@
           "items": {
             "$ref": "#/definitions/Location"
           }
+        },
+        "databaseAccountOfferType": {
+          "$ref": "#/definitions/DatabaseAccountOfferType"
         }
       },
       "required": [
         "consistencyPolicy",
-        "locations"
+        "locations",
+        "databaseAccountOfferType"
       ]
     },
     "DatabaseAccountCreateUpdateParameters": {
@@ -615,9 +619,6 @@
         "properties": {
           "x-ms-client-flatten": true,
           "$ref": "#/definitions/DatabaseAccountCreateUpdateProperties"
-        },
-        "databaseAccountOfferType": {
-          "$ref": "#/definitions/DatabaseAccountOfferType"
         }
       },
       "allOf": [
@@ -626,7 +627,6 @@
         }
       ],
       "required": [
-        "databaseAccountOfferType",
         "properties"
       ]
     },

--- a/arm-documentdb/2015-04-08/swagger/documentdb.json
+++ b/arm-documentdb/2015-04-08/swagger/documentdb.json
@@ -607,7 +607,6 @@
         }
       },
       "required": [
-        "consistencyPolicy",
         "locations",
         "databaseAccountOfferType"
       ]


### PR DESCRIPTION
DatabaseAccountOfferType has to be in properties:
https://github.com/Azure/azure-quickstart-templates/blob/master/101-documentdb-account-create/azuredeploy.json

The current Swagger spec uses it at the root, sibling of "properties". This lead to invalid SDK:
```python
Message: The request content was invalid and could not be deserialized: 'Could not find member 'databaseAccountOfferType' on object of type 'ResourceDefinition'. Path 'databaseAccountOfferType', line 1, position 145.'.
```
 FYI @dmakwana @amarzavery 

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-rest-api-specs/682)
<!-- Reviewable:end -->
