### PR TITLE
Add Kubernetes as an orchestrator type in ACS Swagger.

### DIFF
--- a/arm-compute/2016-09-30/swagger/containerService.json
+++ b/arm-compute/2016-09-30/swagger/containerService.json
@@ -291,7 +291,8 @@
               "enum": [
                 "Swarm",
                 "DCOS",
-                "Custom"
+                "Custom",
+                "Kubernetes"
               ],
               "x-ms-enum": {
                 "name": "ContainerServiceOchestratorTypes",


### PR DESCRIPTION
Small additive change.  @amarzavery

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-rest-api-specs/709)
<!-- Reviewable:end -->
