### PR TITLE
Fix the Put and Patch parameter order mismatching existing .Net SDK after documentation update

### DIFF
--- a/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
+++ b/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
@@ -202,7 +202,7 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         },
-        "operationId": "WebServices_ListInResourceGroup",
+        "operationId": "WebServices_ListByResourceGroup",
         "description": "Gets the web services in the specified resource group.",
         "parameters": [
           {

--- a/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
+++ b/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
@@ -27,10 +27,10 @@
         "description": "Create or update a web service. This call will overwrite an existing web service. Note that there is no warning or confirmation. This is a nonrecoverable operation. If your intent is to create a new web service, call the Get operation first to verify that it does not exist.",
         "parameters": [
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
+            "$ref": "#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "#/parameters/APIVersionParameter"
+            "$ref": "#/parameters/WebServiceNameParameter"
           },
           {
             "in": "body",
@@ -42,10 +42,10 @@
             }
           },                
           {
-            "$ref": "#/parameters/ResourceGroupNameParameter"
+            "$ref": "#/parameters/APIVersionParameter"
           },
           {
-            "$ref": "#/parameters/WebServiceNameParameter"
+            "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -72,9 +72,6 @@
         "description": "Gets the Web Service Definiton as specified by a subscription, resource group, and name. Note that the storage credentials and web service keys are not returned by this call. To get the web service access keys, call List Keys.",
         "parameters": [
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
             "$ref": "#/parameters/ResourceGroupNameParameter"
           },
           {
@@ -82,7 +79,10 @@
           },
           {
             "$ref": "#/parameters/APIVersionParameter"
-          }        
+          },        
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
         ],
         "responses": {
           "200": {
@@ -101,10 +101,10 @@
         "description": "Modifies an existing web service resource. The PATCH API call is an asynchronous operation. To determine whether it has completed successfully, you must perform a Get operation.",
         "parameters": [
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
+            "$ref": "#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "#/parameters/APIVersionParameter"
+            "$ref": "#/parameters/WebServiceNameParameter"
           },
           {
             "in": "body",
@@ -116,10 +116,10 @@
             }
           },
           {
-            "$ref": "#/parameters/ResourceGroupNameParameter"
+            "$ref": "#/parameters/APIVersionParameter"
           },
           {
-            "$ref": "#/parameters/WebServiceNameParameter"
+            "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -140,9 +140,6 @@
         "description": "Deletes the specified web service.",
         "parameters": [
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
             "$ref": "#/parameters/ResourceGroupNameParameter"
           },
           {
@@ -150,7 +147,10 @@
           },
           {
             "$ref": "#/parameters/APIVersionParameter"
-          }        
+          },        
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
         ],
         "responses": {
           "202": {
@@ -169,9 +169,6 @@
         "description": "Gets the access keys for the specified web service.",
         "parameters": [
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
             "$ref": "#/parameters/ResourceGroupNameParameter"
           },
           {
@@ -179,6 +176,9 @@
           },
           {
             "$ref": "#/parameters/APIVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -200,13 +200,7 @@
         "description": "Gets the web services in the specified resource group.",
         "parameters": [
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
             "$ref": "#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "$ref": "#/parameters/APIVersionParameter"
           },
           {
             "in": "query",
@@ -214,6 +208,12 @@
             "type": "string",
             "description": "Continuation token for pagination.",
             "required": false
+          },
+          {
+            "$ref": "#/parameters/APIVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -235,17 +235,17 @@
         "description": "Gets the web services in the specified subscription.",
         "parameters": [
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/APIVersionParameter"
-          },
-          {
             "in": "query",
             "name": "$skiptoken",
             "type": "string",
             "description": "Continuation token for pagination.",
             "required": false
+          },
+          {
+            "$ref": "#/parameters/APIVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {

--- a/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
+++ b/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
@@ -30,12 +30,6 @@
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "$ref": "#/parameters/WebServiceNameParameter"
-          },
-          {
             "$ref": "#/parameters/APIVersionParameter"
           },
           {
@@ -46,7 +40,13 @@
             "schema": {
               "$ref": "#/definitions/WebService"
             }
-          }                
+          },                
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/WebServiceNameParameter"
+          }
         ],
         "responses": {
           "200": {
@@ -104,12 +104,6 @@
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "$ref": "#/parameters/WebServiceNameParameter"
-          },
-          {
             "$ref": "#/parameters/APIVersionParameter"
           },
           {
@@ -120,6 +114,12 @@
             "schema": {
               "$ref": "#/definitions/WebService"
             }
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/WebServiceNameParameter"
           }
         ],
         "responses": {

--- a/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
+++ b/arm-machinelearning/2016-05-01-preview/swagger/webservices.json
@@ -155,6 +155,9 @@
         "responses": {
           "202": {
             "description": "Accepted. Note that a 202 status is returned even if the service did not exist."
+          },
+          "204": {
+            "description": "No Content."
           }
         },
         "x-ms-long-running-operation": true
@@ -196,6 +199,9 @@
         "tags": [
           "WebServices"
         ],
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
         "operationId": "WebServices_ListInResourceGroup",
         "description": "Gets the web services in the specified resource group.",
         "parameters": [
@@ -231,6 +237,9 @@
         "tags": [
           "WebServices"
         ],
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
         "operationId": "WebServices_List",
         "description": "Gets the web services in the specified subscription.",
         "parameters": [


### PR DESCRIPTION
In previous documentation polish, the order of parameters for PUT and PATCH were changed. This PR is trying to fix it to make the new version backward compatible.

