### PR TITLE
Revert property names for CheckNameAvailability. The next version of our API will use camelCasing for CheckNameAvailability

### DIFF
--- a/arm-mediaservices/2015-10-01/swagger/media.json
+++ b/arm-mediaservices/2015-10-01/swagger/media.json
@@ -592,26 +592,26 @@
        "example": { 
          "value": [
            {
-             "nameAvailable": true
+             "NameAvailable": true
            }, 
            {  
-             "nameAvailable": false,
-             "reason": "AlreadyExists",
-             "message": "Already in use by another Media Service instance. Please try again with a name that is not likely to be in use."
+             "NameAvailable": false,
+             "Reason": "AlreadyExists",
+             "Message": "Already in use by another Media Service instance. Please try again with a name that is not likely to be in use."
            },
            {
-             "nameAvailable": false,
-             "reason": "Invalid",
-             "message": "The media service name should be between 3 and 24 characters and may contain only lowercase letters and numbers."
+             "NameAvailable": false,
+             "Reason": "Invalid",
+             "Message": "The media service name should be between 3 and 24 characters and may contain only lowercase letters and numbers."
            }  
          ]
       },  
       "properties": {
-        "nameAvailable": {
+        "NameAvailable": {
           "description": "Specifies if the name is available.",
           "type": "boolean"
         },
-        "reason": {
+        "Reason": {
           "description": "Specifies the reason if the name is not available.",
           "type": "string",
           "enum": [
@@ -624,7 +624,7 @@
             "modelAsString": false
           }  
         },
-        "message": {
+        "Message": {
           "description": "Specifies the detailed reason if the name is not available.",
           "type": "string"
         }


### PR DESCRIPTION
This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).   - [x] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [x] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.
The next version of our API will camelCase the property names.

