### PR TITLE
Fix bug with account creation with sub resources and address validation errors

### DIFF
--- a/arm-datalake-analytics/account/2016-11-01/swagger/account.json
+++ b/arm-datalake-analytics/account/2016-11-01/swagger/account.json
@@ -1074,10 +1074,17 @@
       "description": "Azure Storage account properties information to update."
     },
     "StorageAccountInfo": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubResource"
+        }
+      ],
+      "required": [
+        "properties"
+      ],
       "properties": {
         "name": {
           "type": "string",
-          "readOnly": true,
           "description": "the account name associated with the Azure storage account."
         },
         "properties": {
@@ -1087,24 +1094,6 @@
         }
       },
       "description": "Azure Storage account information."
-    },
-    "CreateStorageAccountInfo": {
-      "required": [
-        "properties",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "the account name associated with the Azure storage account to add to the Data Lake analytics account being created."
-        },
-        "properties": {
-          "$ref": "#/definitions/StorageAccountProperties",
-          "description": "the properties associated with this storage account to add to the Data Lake analytics account being created.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "description": "Azure Storage account information to add to the Data Lake analytics account being created."
     },
     "StorageContainerProperties": {
       "properties": {
@@ -1198,8 +1187,10 @@
       "description": "Data Lake Store account properties information."
     },
     "DataLakeStoreAccountInfo": {
-      "required": [
-        "name"
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubResource"
+        }
       ],
       "properties": {
         "name": {
@@ -1571,6 +1562,29 @@
       },
       "required": [
         "location"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "SubResource": {
+      "description": "The Sub Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        }
+      },
+      "required": [
+        "name"
       ],
       "x-ms-azure-resource": true
     }

--- a/arm-datalake-analytics/account/2016-11-01/swagger/account.json
+++ b/arm-datalake-analytics/account/2016-11-01/swagger/account.json
@@ -931,9 +931,7 @@
           }
         },
         "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{name}": {
+      },
       "put": {
         "tags": [
           "Account"
@@ -1472,54 +1470,6 @@
         }
       },
       "description": "Generic resource error details information."
-    },
-    "InnerError": {
-      "properties": {
-        "trace": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the stack trace for the error"
-        },
-        "context": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the context for the error message"
-        }
-      },
-      "description": "Generic resource inner error information."
-    },
-    "Error": {
-      "properties": {
-        "code": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the HTTP status code or error code associated with this error"
-        },
-        "message": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the error message to display."
-        },
-        "target": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the target of the error."
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ErrorDetails"
-          },
-          "readOnly": true,
-          "description": "The list of error details"
-        },
-        "innerError": {
-          "$ref": "#/definitions/InnerError",
-          "readOnly": true,
-          "description": "The inner exceptions or errors, if any"
-        }
-      },
-      "description": "Generic resource error information."
     },
     "Resource": {
       "description": "The Resource model definition.",

--- a/arm-datalake-analytics/account/2016-11-01/swagger/account.json
+++ b/arm-datalake-analytics/account/2016-11-01/swagger/account.json
@@ -1082,10 +1082,6 @@
         "properties"
       ],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "the account name associated with the Azure storage account."
-        },
         "properties": {
           "$ref": "#/definitions/StorageAccountProperties",
           "description": "the properties associated with this storage account.",
@@ -1192,10 +1188,6 @@
         }
       ],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "the account name of the Data Lake Store account to add to the Data Lake Analytics account being created."
-        },
         "properties": {
           "$ref": "#/definitions/DataLakeStoreAccountInfoProperties",
           "description": "the properties associated with this Data Lake Store account.",

--- a/arm-datalake-analytics/account/2016-11-01/swagger/account.json
+++ b/arm-datalake-analytics/account/2016-11-01/swagger/account.json
@@ -499,7 +499,6 @@
           {
             "name": "parameters",
             "in": "body",
-            "required": true,
             "schema": {
               "$ref": "#/definitions/AddDataLakeStoreParameters"
             },

--- a/arm-datalake-analytics/account/2016-11-01/swagger/account.json
+++ b/arm-datalake-analytics/account/2016-11-01/swagger/account.json
@@ -947,7 +947,7 @@
             "description": "The name of the Azure resource group that contains the Data Lake Analytics account.the account will be associated with."
           },
           {
-            "name": "name",
+            "name": "accountName",
             "in": "path",
             "required": true,
             "type": "string",
@@ -1000,7 +1000,7 @@
             "description": "The name of the Azure resource group that contains the Data Lake Analytics account."
           },
           {
-            "name": "name",
+            "name": "accountName",
             "in": "path",
             "required": true,
             "type": "string",

--- a/arm-datalake-analytics/catalog/2016-11-01/swagger/catalog.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/swagger/catalog.json
@@ -72,10 +72,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successfully created the specified secret in the specified database.",
-            "schema": {
-              "$ref": "#/definitions/USqlSecret"
-            }
+            "description": "Successfully created the specified secret in the specified database."
           }
         }
       },

--- a/arm-datalake-analytics/job/2016-11-01/swagger/job.json
+++ b/arm-datalake-analytics/job/2016-11-01/swagger/job.json
@@ -66,7 +66,7 @@
       }
     },
     "/Jobs/{jobIdentity}/GetDebugDataPath": {
-      "post": {
+      "get": {
         "tags": [
           "Job"
         ],

--- a/arm-datalake-store/account/2016-11-01/swagger/account.json
+++ b/arm-datalake-store/account/2016-11-01/swagger/account.json
@@ -529,7 +529,7 @@
             "description": "The name of the Azure resource group that contains the Data Lake Store account."
           },
           {
-            "name": "accountName",
+            "name": "name",
             "in": "path",
             "required": true,
             "type": "string",
@@ -570,7 +570,7 @@
             "description": "The name of the Azure resource group that contains the Data Lake Store account."
           },
           {
-            "name": "accountName",
+            "name": "name",
             "in": "path",
             "required": true,
             "type": "string",

--- a/arm-datalake-store/account/2016-11-01/swagger/account.json
+++ b/arm-datalake-store/account/2016-11-01/swagger/account.json
@@ -1204,54 +1204,6 @@
       },
       "description": "Data Lake Store error details information"
     },
-    "InnerError": {
-      "properties": {
-        "trace": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the stack trace for the error"
-        },
-        "context": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the context for the error message"
-        }
-      },
-      "description": "Data Lake Store inner error information"
-    },
-    "Error": {
-      "properties": {
-        "code": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the HTTP status code or error code associated with this error"
-        },
-        "message": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the error message to display."
-        },
-        "target": {
-          "type": "string",
-          "readOnly": true,
-          "description": "the target of the error."
-        },
-        "details": {
-          "type": "array",
-          "readOnly": true,
-          "items": {
-            "$ref": "#/definitions/ErrorDetails"
-          },
-          "description": "the list of error details"
-        },
-        "innerError": {
-          "$ref": "#/definitions/InnerError",
-          "readOnly": true,
-          "description": "the inner exceptions or errors, if any"
-        }
-      },
-      "description": "Data Lake Store error information"
-    },
     "Resource": {
       "description": "The Resource model definition.",
       "properties": {

--- a/arm-datalake-store/account/2016-11-01/swagger/account.json
+++ b/arm-datalake-store/account/2016-11-01/swagger/account.json
@@ -513,9 +513,7 @@
           }
         },
         "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{accountName}": {
+      },
       "delete": {
         "tags": [
           "Account"
@@ -845,9 +843,6 @@
         {
           "$ref": "#/definitions/SubResource"
         }
-      ],
-      "required": [
-        "properties"
       ],
       "properties": {
         "properties": {

--- a/arm-datalake-store/filesystem/2016-11-01/swagger/filesystem.json
+++ b/arm-datalake-store/filesystem/2016-11-01/swagger/filesystem.json
@@ -97,6 +97,23 @@
             ]
           },
           {
+            "name": "syncFlag",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "DATA",
+            "description": "Optionally indicates what to do after completion of the concurrent append. DATA indicates more data is coming so no sync takes place, METADATA indicates a sync should be done to refresh metadata of the file only. CLOSE indicates that both the stream and metadata should be refreshed upon append completion.",
+            "enum": [
+              "DATA",
+              "METADATA",
+              "CLOSE"
+            ],
+            "x-ms-enum": {
+            "name": "SyncFlag",
+            "modelAsString": false
+            }
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           }
         ],


### PR DESCRIPTION
This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [x] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.
StorageAccountInfo objects must require name and properties, since they
are only ever passed in during DataLake Analytics account creation.