### PR TITLE
Add vmId property which is a Azure Unique VM id

### DIFF
--- a/arm-compute/2016-03-30/swagger/compute.json
+++ b/arm-compute/2016-03-30/swagger/compute.json
@@ -4307,6 +4307,11 @@
           "type": "boolean",
           "description": "Specifies whether the latest model has been applied to the virtual machine."
         },
+        "vmId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Azure VM unique ID."
+        },
         "instanceView": {
           "$ref": "#/definitions/VirtualMachineInstanceView",
           "readOnly": true,


### PR DESCRIPTION
This pull request adds missing vmId property to VirtualMachineScaleSetVMProperties 

See issue #343


