### PR TITLE
change object id type to string and change return type of keyvault list

### DIFF
--- a/arm-keyvault/2015-06-01/swagger/keyvault.json
+++ b/arm-keyvault/2015-06-01/swagger/keyvault.json
@@ -223,7 +223,7 @@
           "200": {
             "description": "Get information about all key vaults in the subscription.",
             "schema": {
-              "$ref": "#/definitions/VaultListResult"
+              "$ref": "#/definitions/ResourceListResult"
             }
           }
         },
@@ -270,7 +270,6 @@
         },
         "objectId": {
           "type": "string",
-          "format": "uuid",
           "description": "The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
         },
         "applicationId": {
@@ -431,6 +430,22 @@
         }
       },
       "description": "List of vaults"
+    },
+    "ResourceListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Resource"
+          },
+          "description": "Gets the list of vault resources."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets the URL to get the next set of vault resources."
+        }
+      },
+      "description": "List of vault resources."
     },
     "Resource": {
       "properties": {


### PR DESCRIPTION
     1. Change object id type to string. 
     2. Change return type of key vault list to resources to represent the REST API. Listing vault under a subscription is a general ARM call and doesn't have key vault specific properties. There is an ask to change the return type to 'Resource' instead of 'Vault' to represent the REST API. 'Vault' object inherits all properties of 'Resource' and include an additional mandatory field of 'properties'

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [x] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.
…st to resources to represent the rest API.