### PR TITLE
Update WebApps AppServicePlans: Fix delete response code, add ScmType…

### DIFF
--- a/arm-web/2016-03-01/DeletedWebApps.json
+++ b/arm-web/2016-03-01/DeletedWebApps.json
@@ -792,6 +792,10 @@
               "description": "Version of Node.js.",
               "type": "string"
             },
+            "linuxFxVersion": {
+              "description": "Linux App Framework and version",
+              "type": "string"
+            },
             "requestTracingEnabled": {
               "description": "<code>true</code> if request tracing is enabled; otherwise, <code>false</code>.",
               "type": "boolean"
@@ -858,8 +862,26 @@
             },
             "scmType": {
               "description": "SCM type.",
+              "enum": [
+                "None",
+                "Dropbox",
+                "Tfs",
+                "LocalGit",
+                "GitHub",
+                "CodePlexGit",
+                "CodePlexHg",
+                "BitbucketGit",
+                "BitbucketHg",
+                "ExternalGit",
+                "ExternalHg",
+                "OneDrive",
+                "VSO"
+              ],
               "type": "string",
-              "readOnly": true
+              "x-ms-enum": {
+                "name": "ScmType",
+                "modelAsString": true
+              }
             },
             "use32BitWorkerProcess": {
               "description": "<code>true</code> to use 32-bit worker process; otherwise, <code>false</code>.",

--- a/arm-web/2016-09-01/AppServiceEnvironments.json
+++ b/arm-web/2016-09-01/AppServiceEnvironments.json
@@ -2063,7 +2063,8 @@
             "defaultFrontEndScaleFactor": {
               "format": "int32",
               "description": "Default Scale Factor for FrontEnds.",
-              "type": "integer"
+              "type": "integer",
+              "readOnly": true
             },
             "apiManagementAccountId": {
               "description": "API Management Account associated with the App Service Environment.",
@@ -3456,6 +3457,10 @@
               "description": "Version of Node.js.",
               "type": "string"
             },
+            "linuxFxVersion": {
+              "description": "Linux App Framework and version",
+              "type": "string"
+            },
             "requestTracingEnabled": {
               "description": "<code>true</code> if request tracing is enabled; otherwise, <code>false</code>.",
               "type": "boolean"
@@ -3522,8 +3527,26 @@
             },
             "scmType": {
               "description": "SCM type.",
+              "enum": [
+                "None",
+                "Dropbox",
+                "Tfs",
+                "LocalGit",
+                "GitHub",
+                "CodePlexGit",
+                "CodePlexHg",
+                "BitbucketGit",
+                "BitbucketHg",
+                "ExternalGit",
+                "ExternalHg",
+                "OneDrive",
+                "VSO"
+              ],
               "type": "string",
-              "readOnly": true
+              "x-ms-enum": {
+                "name": "ScmType",
+                "modelAsString": true
+              }
             },
             "use32BitWorkerProcess": {
               "description": "<code>true</code> to use 32-bit worker process; otherwise, <code>false</code>.",

--- a/arm-web/2016-09-01/AppServicePlans.json
+++ b/arm-web/2016-09-01/AppServicePlans.json
@@ -212,8 +212,8 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "No Content"
+          "200": {
+            "description": "OK."
           }
         }
       }
@@ -2587,6 +2587,10 @@
               "description": "Version of Node.js.",
               "type": "string"
             },
+            "linuxFxVersion": {
+              "description": "Linux App Framework and version",
+              "type": "string"
+            },
             "requestTracingEnabled": {
               "description": "<code>true</code> if request tracing is enabled; otherwise, <code>false</code>.",
               "type": "boolean"
@@ -2653,8 +2657,26 @@
             },
             "scmType": {
               "description": "SCM type.",
+              "enum": [
+                "None",
+                "Dropbox",
+                "Tfs",
+                "LocalGit",
+                "GitHub",
+                "CodePlexGit",
+                "CodePlexHg",
+                "BitbucketGit",
+                "BitbucketHg",
+                "ExternalGit",
+                "ExternalHg",
+                "OneDrive",
+                "VSO"
+              ],
               "type": "string",
-              "readOnly": true
+              "x-ms-enum": {
+                "name": "ScmType",
+                "modelAsString": true
+              }
             },
             "use32BitWorkerProcess": {
               "description": "<code>true</code> to use 32-bit worker process; otherwise, <code>false</code>.",


### PR DESCRIPTION
… enum, add linuxFxVersion property

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes.
- [X] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [X] My spec meets the review criteria:
  - [X] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [X] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [X] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.