### PR TITLE
Microsoft.Commerce: Ratecard updates

### DIFF
--- a/arm-commerce/2015-06-01-preview/examples/GetRatecard.json
+++ b/arm-commerce/2015-06-01-preview/examples/GetRatecard.json
@@ -1,0 +1,34 @@
+{
+    "title": "Get RateCard",
+    "parameters": {
+        "subscriptionId": "6d61cc05-8f8f-4916-b1b9-f1d9c25aae27",
+        "api-version": "2015-06-01-preview",
+        "$filter": "OfferDurableId eq 'MS-AZR-0003P' and Currency eq 'USD' and Locale eq 'en-US' and RegionInfo eq 'US'"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "OfferTerms": [],
+                "Meters": [
+                    {
+                        "EffectiveDate": "2017-09-01T00:00:00Z",
+                        "IncludedQuantity": 0,
+                        "MeterCategory": "Test Category",
+                        "MeterId": "1d7518e5-bc2f-4a93-9057-1b3047856645",
+                        "MeterName": "Test Meter",
+                        "MeterRates": {
+                            "0": 1.99,
+                            "100": 0.99
+                        },
+                        "MeterRegion": "US West",
+                        "MeterSubCategory": "Test Subcategory",
+                        "MeterTags": [
+                            "Third Party"
+                        ],
+                        "Unit": "Hours"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/arm-commerce/2015-06-01-preview/swagger/commerce.json
+++ b/arm-commerce/2015-06-01-preview/swagger/commerce.json
@@ -378,7 +378,7 @@
     },
     "MonetaryCredit": {
       "x-ms-discriminator-value": "Monetary Credit",
-      "description": "Indicates that a that this is a monetary credit offer.",
+      "description": "Indicates that this is a monetary credit offer.",
       "allOf": [
         {
           "$ref": "#/definitions/OfferTermInfo"

--- a/arm-commerce/2015-06-01-preview/swagger/commerce.json
+++ b/arm-commerce/2015-06-01-preview/swagger/commerce.json
@@ -110,6 +110,11 @@
         "externalDocs": {
           "url": "https://docs.microsoft.com/rest/api/commerce/ratecard"
         },
+        "x-ms-examples": {
+          "GetRateCard": {
+            "$ref": "../examples/GetRatecard.json"
+          }
+        },
         "parameters": [
           {
             "name": "$filter",
@@ -248,7 +253,12 @@
     },
     "RateCardQueryParameters": {
       "description": "Parameters that are used in the odata $filter query parameter for providing RateCard information.",
-      "required": [ "OfferDurableId", "Currency", "Locale", "RegionInfo" ],
+      "required": [
+        "OfferDurableId",
+        "Currency",
+        "Locale",
+        "RegionInfo"
+      ],
       "properties": {
         "OfferDurableId": {
           "description": "The Offer ID parameter consists of the 'MS-AZR-' prefix, plus the Offer ID number (e.g., MS-AZR-0026P). See https://azure.microsoft.com/en-us/support/legal/offer-details/ for more information on the list of available Offer IDs, country/region availability, and billing currency.",
@@ -358,7 +368,9 @@
     "OfferTermInfo": {
       "description": "Describes the offer term.",
       "discriminator": "Name",
-      "required": [ "Name" ],
+      "required": [
+        "Name"
+      ],
       "properties": {
         "Name": {
           "description": "Name of the offer term",
@@ -367,7 +379,11 @@
             "Recurring Charge",
             "Monetary Commitment",
             "Monetary Credit"
-          ]
+          ],
+            "x-ms-enum": {
+              "name": "OfferTermInfo",
+              "modelAsString": false
+            }
         },
         "EffectiveDate": {
           "description": "Indicates the date from which the offer term is effective.",

--- a/arm-commerce/2015-06-01-preview/swagger/commerce.json
+++ b/arm-commerce/2015-06-01-preview/swagger/commerce.json
@@ -114,7 +114,7 @@
           {
             "name": "$filter",
             "in": "query",
-            "required": false,
+            "required": true,
             "type": "string",
             "description": "The filter to apply on the operation. It ONLY supports the 'eq' and 'and' logical operators at this time. All the 4 query parameters 'OfferDurableId',  'Currency', 'Locale', 'Region' are required to be a part of the $filter."
           },
@@ -284,17 +284,6 @@
           "description": "All rates are pretax, so this will always be returned as 'false'.",
           "type": "boolean"
         },
-        "MeterRegion": {
-          "description": "The region in which the Azure service is available.",
-          "type": "string"
-        },
-        "Tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Provides additional meter data. 'Third Party' indicates a meter with no discount. Blanks indicate First Party."
-        },
         "OfferTerms": {
           "type": "array",
           "items": {
@@ -335,6 +324,17 @@
           "description": "The unit in which the meter consumption is charged, e.g., 'Hours', 'GB', etc.",
           "type": "string"
         },
+        "MeterTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Provides additional meter data. 'Third Party' indicates a meter with no discount. Blanks indicate First Party."
+        },
+        "MeterRegion": {
+          "description": "The region in which the Azure service is available.",
+          "type": "string"
+        },
         "MeterRates": {
           "description": "The list of key/value pairs for the meter rates, in the format 'key':'value' where key = the meter quantity, and value = the corresponding price",
           "type": "object",
@@ -344,7 +344,7 @@
           }
         },
         "EffectiveDate": {
-          "description": "Indicates the date from which the meter rate or offer term is effective.",
+          "description": "Indicates the date from which the meter rate is effective.",
           "type": "string",
           "format": "date-time"
         },
@@ -361,13 +361,34 @@
       "required": [ "Name" ],
       "properties": {
         "Name": {
-          "description": "Name of the offer term. For example: 'Monetary Credit', 'Monetary Commitment",
-          "type": "string"
+          "description": "Name of the offer term",
+          "type": "string",
+          "enum": [
+            "Recurring Charge",
+            "Monetary Commitment",
+            "Monetary Credit"
+          ]
         },
         "EffectiveDate": {
-          "description": "Indicates the date from which the meter rate or offer term is effective.",
+          "description": "Indicates the date from which the offer term is effective.",
           "type": "string",
           "format": "date-time"
+        }
+      }
+    },
+    "MonetaryCredit": {
+      "x-ms-discriminator-value": "Monetary Credit",
+      "description": "Indicates that a that this is a monetary credit offer.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/OfferTermInfo"
+        }
+      ],
+      "properties": {
+        "Credit": {
+          "description": "The amount of credit provided under the terms of the given offer level.",
+          "type": "number",
+          "format": "decimal"
         },
         "ExcludedMeterIds": {
           "description": "An array of meter ids that are excluded from the given offer terms.",
@@ -379,23 +400,9 @@
         }
       }
     },
-    "MonetaryCredit": {
-      "x-ms-discriminator-value": "Monetary Credit",
-      "allOf": [
-        {
-          "$ref": "#/definitions/OfferTermInfo"
-        }
-      ],
-      "properties": {
-        "Credit": {
-          "description": "The amount of credit provided under the terms of the given offer level. This field is used only by offer terms of type 'MonetaryCredit'.",
-          "type": "number",
-          "format": "decimal"
-        }
-      }
-    },
     "MonetaryCommitment": {
       "x-ms-discriminator-value": "Monetary Commitment",
+      "description": "Indicates that a monetary commitment is required for this offer",
       "allOf": [
         {
           "$ref": "#/definitions/OfferTermInfo"
@@ -409,11 +416,20 @@
             "type": "number",
             "format": "decimal"
           }
+        },
+        "ExcludedMeterIds": {
+          "description": "An array of meter ids that are excluded from the given offer terms.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uuid"
+          }
         }
       }
     },
     "RecurringCharge": {
       "x-ms-discriminator-value": "Recurring Charge",
+      "description": "Indicates a recurring charge is present for this offer.",
       "allOf": [
         {
           "$ref": "#/definitions/OfferTermInfo"


### PR DESCRIPTION
- Moved Meter Region and Tags to MeterInfo
- Updated Offer Terms to acurately repersent the response

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [ x] The title of the PR is clear and informative.
- [ x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x ] If applicable, the PR references the bug/issue that it fixes.
- [x ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ x] My spec meets the review criteria:
  - [x ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x ] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [x ] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.