### PR TITLE
Running AutoRest Linter Rules in travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ bin/*.dll
 out/*
 tmp/*
 obj/
+
+# AutoRest Nightly #
+AutoRest.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,28 @@ services:
 env:
   matrix:
   - MODE=syntax
-  - MODE=python
-  - MODE=node
-  - MODE=ruby
+  # - MODE=python
+  # - MODE=node
+  # - MODE=ruby
+  - MODE=linter
+  allow_failures:
+  - MODE=linter
   global:
     secure: IwPVExGJQfL6QpTd6Utv3R/qBz7yApgMspzMLSkrq9cMP6t+NHk1vYg0n2evcWaq2rqNZE9xBMfRZi7Yy/RCUT++qALE89xlNvZ/A94PaDUiK3tYYNj1XxsgRauCHshXz6smmLwQMpTKsEl6lyjXeXpwQMDNRehhTu0Hg2tE7ZikfQVb+jjRNcP41RfzzGQyxEhd3fxF2G1G21WXH0cXtZssOd1MYcXhmXk8dR3DyEEMbPzDV1Bk3auXOvbqS79bnZ/Pi4p/7P/aTOm8O2ACKM0XAvww95vAQ0LcPzKnNe3sNjFVAssBiZbIk0Zs30wULBphlTxVoufHKSZuTf+QEBTKpH99v/+SBDDPu9+0q2esq7TKgf8bvzkeXjh54fECdJUqEo9E2gW08+RQxWCqryMJouOPcY2OMs4lZwSMOXQY68a/CYVRWFaFg5s6jntC8sLHtDxV0qem3xyjc+852v8rUfkyvMhOBoZJjWmnqYVqdamHOOfrzjc7AzPUEzSeiN6OPPVli+SzwLHdip0GxdK46pAISCOcbdyYn11VvTIn1QosE66eWhF6SViVH6lNWgSfVTpcQ2zq/qSKh0/zpwn82Ys+wKDOf3EwQAanndgk26npi7Ik4nIuexZ/TE56rQ7qjZqmHoxFz7QMeTZDiVmLFxtR19cTT3GLxDz8nBQ=
 before_install:
   - docker pull lmazuel/swagger-to-sdk
   - python -c "import os; print('\n'.join(v for v in os.environ.keys() if v.startswith('TRAVIS')))" > /tmp/env_file
+  # Install mono and nuget to use latest Nightly of AutoRest.exe
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+  - echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+  - sudo apt-get update
+  - sudo apt-get -q -y install mono-complete
+  - wget -q 'http://mxr.mozilla.org/seamonkey/source/security/nss/lib/ckfw/builtins/certdata.txt?raw=1' -O "/tmp/certdata.txt" 
+  - mozroots --import --ask-remove --file /tmp/certdata.txt
+  - sudo apt-get -q -y install nuget
+  # Installing AutoRest version 1.0.0-Nightly20170129 Issue #https://github.com/Azure/autorest/issues/1776
+  - nuget install AutoRest -Source https://www.myget.org/F/autorest/ -pre -OutputDirectory . -Version 1.0.0-Nightly20170129
+  - mono AutoRest.*/tools/AutoRest.exe -I https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-resources/resources/2016-09-01/swagger/resources.json
 install:
   - npm install
 script:
@@ -21,4 +35,5 @@ script:
   - if [[ $MODE == 'python' ]]; then $DOCKER_CMD AutorestCI/azure-sdk-for-python --pr-repo-id Azure/azure-sdk-for-python -o master -v; fi
   - if [[ $MODE == 'node' ]]; then $DOCKER_CMD AutorestCI/azure-sdk-for-node --pr-repo-id Azure/azure-sdk-for-node -o master -v; fi
   - if [[ $MODE == 'ruby' ]]; then $DOCKER_CMD AutorestCI/azure-sdk-for-ruby --pr-repo-id Azure/azure-sdk-for-ruby -o master -v; fi
-  - if [[ $MODE == 'syntax' ]]; then npm test; fi
+  - if [[ $MODE == 'syntax' ]]; then npm test -- test/test.js; fi
+  - if [[ $MODE == 'linter' ]]; then npm test -- test/linter.js; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ services:
 env:
   matrix:
   - MODE=syntax
-  # - MODE=python
-  # - MODE=node
-  # - MODE=ruby
+  - MODE=python
+  - MODE=node
+  - MODE=ruby
   - MODE=linter
   allow_failures:
   - MODE=linter

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "url": "http://github.com/azure/azure-rest-api-specs/issues"
   },
   "scripts": {
-    "test": "mocha -t 5000"
+    "test": "mocha -t 500000"
   }
 }

--- a/test/linter.js
+++ b/test/linter.js
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License in the project root for license information.
+
+'use strict';
+var glob = require('glob'),
+  path = require('path'),
+  _ = require('lodash');
+
+var globPath, swaggers;
+var exec = require('child_process').exec;
+var isWindows = (process.platform.lastIndexOf('win') === 0);
+
+globPath = path.join(__dirname, '../', '/**/swagger/*.json');
+swaggers = _(glob.sync(globPath));
+
+function clrCmd(cmd){
+  return isWindows ? cmd : ('mono ' + cmd);
+};
+
+describe('AutoRest Linter validation:', function () {
+  var autoRestLocation = './AutoRest.*/tools/AutoRest.exe';
+  _(swaggers).each(function(swagger) {
+    it(swagger + ' should follow linter rules.', function(done) {
+      var cmd = clrCmd(autoRestLocation + ' -CodeGenerator None -I ' + swagger);
+      console.log(cmd);
+      exec(cmd, function(error, stdout, stderr) {
+        console.log(`stdout: \n${stdout}`);
+        console.log(`stderr: \n${stderr}`);
+        if (error !== null) {
+            console.log(`exec error: ${error}`);
+        }
+        done();
+      });
+    });
+  }).value();
+});


### PR DESCRIPTION
@amarzavery @veronicagg @sarangan12 

Here is the dry-run on how we want to run linter rules inside travis-ci. Please review it and let me know your thoughts. 

Sample Outputs: https://travis-ci.org/vishrutshah/azure-rest-api-specs/builds/197485389

Currently it runs on all the swagger specs, once this is done we can accomodate linter.js to run on only changed PR files as well. 