### PR TITLE
Add the new 2017-01-31 api version for Azure Container Service

### DIFF
--- a/arm-compute/2017-01-31/swagger/containerService.json
+++ b/arm-compute/2017-01-31/swagger/containerService.json
@@ -1,0 +1,609 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServiceClient",
+    "description": "The Container Service Client.",
+    "version": "2017-01-31"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/containerServices": {
+      "get": {
+        "tags": [
+          "ContainerServices"
+        ],
+        "operationId": "ContainerServices_List",
+        "summary": "Gets a list of container services in the specified subscription.",
+        "description": "Gets a list of container services in the specified subscription. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ContainerServiceListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}": {
+      "put": {
+        "tags": [
+          "ContainerServices"
+        ],
+        "operationId": "ContainerServices_CreateOrUpdate",
+        "summary": "Creates or updates a container service.",
+        "description": "Creates or updates a container service with the specified configuration of orchestrator, masters, and agents.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "containerServiceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the container service in the specified subscription and resource group."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            },
+            "description": "Parameters supplied to the Create or Update a Container Service operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "ContainerService"
+        ],
+        "operationId": "ContainerServices_Get",
+        "summary":"Gets the properties of the specified container service.",
+        "description": "Gets the properties of the specified container service in the specified subscription and resource group. The operation returns the properties including state, orchestrator, number of masters and agents, and FQDNs of masters and agents. ",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "containerServiceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the container service in the specified subscription and resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ContainerService"
+        ],
+        "operationId": "ContainerServices_Delete",
+        "summary": "Deletes the specified container service.",
+        "description": "Deletes the specified container service in the specified subscription and resource group. The operation does not delete other resources created as part of creating a container service, including storage accounts, VMs, and availability sets. All the other resources created with the container service are part of the same resource group and can be deleted individually.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "containerServiceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the container service in the specified subscription and resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "204": {
+            "description": "Not found"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices": {
+      "get": {
+        "tags": [
+          "ContainerService"
+        ],
+        "operationId": "ContainerServices_ListByResourceGroup",
+        "summary": "Gets a list of container services in the specified resource group.",
+        "description": "Gets a list of container services in the specified subscription and resource group. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ContainerServiceListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "ContainerServiceCustomProfile": {
+      "properties": {
+        "orchestrator": {
+          "type": "string",
+          "description": "The name of the custom orchestrator to use."
+        }
+      },
+      "description": "Properties to configure a custom container service cluster.",
+      "required": ["orchestrator"]
+    },
+    "ContainerServiceServicePrincipalProfile": {
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The ID for the service principal."
+        },
+        "secret": {
+          "type": "string",
+          "description": "The secret password associated with the service principal."
+        }
+      },
+      "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs.",
+      "required": [
+        "clientId",
+        "secret"
+      ]
+    },
+    "ContainerServiceOrchestratorProfile": {
+      "properties": {
+        "orchestratorType": {
+          "type": "string",
+          "enum": [
+            "Swarm",
+            "DCOS",
+            "Custom",
+            "Kubernetes"
+          ],
+          "x-ms-enum": {
+            "name": "ContainerServiceOchestratorTypes",
+            "modelAsString": false
+          },
+          "description": "The orchestrator to use to manage container service cluster resources. Valid values are Swarm, DCOS, and Custom."
+        }
+      },
+      "description": "Profile for the container service orchestrator.",
+      "required": [ "orchestratorType" ]
+    },
+    "ContainerServiceMasterProfile": {
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "enum": [
+            1,
+            3,
+            5
+          ],
+          "description": "Number of masters (VMs) in the container service cluster. Allowed values are 1, 3, and 5. The default value is 1.",
+          "default": 1
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix to be used to create the FQDN for master."
+        },
+        "fqdn": {
+          "readOnly": true,
+          "type": "string",
+          "description": "FDQN for the master."
+        }
+      },
+      "required": [
+        "dnsPrefix"
+      ],
+      "description": "Profile for the container service master."
+    },
+    "ContainerServiceAgentPoolProfile": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name of the agent pool profile in the context of the subscription and resource group."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 100,
+          "minimum": 1,
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. ",
+          "default": 1
+        },
+        "vmSize": {
+          "type": "string",
+          "enum": [
+            "Standard_A0",
+            "Standard_A1",
+            "Standard_A2",
+            "Standard_A3",
+            "Standard_A4",
+            "Standard_A5",
+            "Standard_A6",
+            "Standard_A7",
+            "Standard_A8",
+            "Standard_A9",
+            "Standard_A10",
+            "Standard_A11",
+            "Standard_D1",
+            "Standard_D2",
+            "Standard_D3",
+            "Standard_D4",
+            "Standard_D11",
+            "Standard_D12",
+            "Standard_D13",
+            "Standard_D14",
+            "Standard_D1_v2",
+            "Standard_D2_v2",
+            "Standard_D3_v2",
+            "Standard_D4_v2",
+            "Standard_D5_v2",
+            "Standard_D11_v2",
+            "Standard_D12_v2",
+            "Standard_D13_v2",
+            "Standard_D14_v2",
+            "Standard_G1",
+            "Standard_G2",
+            "Standard_G3",
+            "Standard_G4",
+            "Standard_G5",
+            "Standard_DS1",
+            "Standard_DS2",
+            "Standard_DS3",
+            "Standard_DS4",
+            "Standard_DS11",
+            "Standard_DS12",
+            "Standard_DS13",
+            "Standard_DS14",
+            "Standard_GS1",
+            "Standard_GS2",
+            "Standard_GS3",
+            "Standard_GS4",
+            "Standard_GS5"
+          ],
+          "x-ms-enum": {
+            "name": "ContainerServiceVMSizeTypes",
+            "modelAsString": true
+          },
+          "description": "Size of agent VMs."
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix to be used to create the FQDN for the agent pool."
+        },
+        "fqdn": {
+          "readOnly": true,
+          "type": "string",
+          "description": "FDQN for the agent pool."
+        }
+      },
+      "required": [
+        "name",
+        "dnsPrefix",
+        "count",
+        "vmSize"
+      ],
+      "description": "Profile for the container service agent pool."
+    },
+    "ContainerServiceWindowsProfile": {
+      "properties": {
+        "adminUsername": {
+          "type": "string",
+          "description": "The administrator username to use for Windows VMs.",
+          "pattern": "^[a-zA-Z0-9]+([._]?[a-zA-Z0-9]+)*$"
+        },
+        "adminPassword": {
+          "type": "string",
+          "description": "The administrator password to use for Windows VMs.",
+          "pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%\\^&\\*\\(\\)])[a-zA-Z\\d!@#$%\\^&\\*\\(\\)]{12,123}$"
+        }
+      },
+      "required": [
+        "adminUsername",
+        "adminPassword"
+      ],
+      "description": "Profile for Windows VMs in the container service cluster."
+    },
+    "ContainerServiceLinuxProfile": {
+      "properties": {
+        "adminUsername": {
+          "type": "string",
+          "description": "The administrator username to use for Linux VMs.",
+          "pattern": "^[a-z][a-z0-9_-]*$"
+        },
+        "ssh": {
+          "$ref": "#/definitions/ContainerServiceSshConfiguration",
+          "description": "The ssh key configuration for Linux VMs."
+        }
+      },
+      "required": [
+        "adminUsername",
+        "ssh"
+      ],
+      "description": "Profile for Linux VMs in the container service cluster."
+    },
+    "ContainerServiceSshConfiguration": {
+      "properties": {
+        "publicKeys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContainerServiceSshPublicKey"
+          },
+          "description": "the list of SSH public keys used to authenticate with Linux-based VMs."
+        }
+      },
+      "description": "SSH configuration for Linux-based VMs running on Azure.",
+      "required": ["publicKeys"]
+    },
+    "ContainerServiceSshPublicKey": {
+      "properties": {
+        "keyData": {
+          "type": "string",
+          "description": "Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers."
+        }
+      },
+      "required": [
+        "keyData"
+      ],
+      "description": "Contains information about SSH certificate public key data."
+    },
+    "ContainerServiceDiagnosticsProfile": {
+      "properties": {
+        "vmDiagnostics": {
+          "$ref": "#/definitions/ContainerServiceVMDiagnostics",
+          "description": "Profile for the container service VM diagnostic agent."
+        }
+      },
+      "required": ["vmDiagnostics"]
+    },
+    "ContainerServiceVMDiagnostics": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the VM diagnostic agent is provisioned on the VM."
+        },
+        "storageUri": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URI of the storage account where diagnostics are stored."
+        }
+      },
+      "description": "Profile for diagnostics on the container service VMs.",
+      "required": [
+        "enabled"
+      ]
+    },
+    "ContainerService": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ContainerServiceProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "description": "Container service."
+    },
+    "ContainerServiceListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+             "$ref": "#/definitions/ContainerService"
+          },
+          "description": "the list of container services."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of container service results."
+        }
+      },
+      "description": "The response from the List Container Services operation."
+    },
+    "ContainerServiceProperties": {
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "the current deployment or provisioning state, which only appears in the response."
+        },
+        "orchestratorProfile": {
+          "$ref": "#/definitions/ContainerServiceOrchestratorProfile",
+          "description": "Properties of the orchestrator."
+        },
+        "customProfile": {
+          "$ref": "#/definitions/ContainerServiceCustomProfile",
+          "description": "Properties for custom clusters."
+        },
+        "servicePrincipalProfile": {
+          "$ref": "#/definitions/ContainerServiceServicePrincipalProfile",
+          "description": "Properties for cluster service principals."
+        },
+        "masterProfile": {
+          "$ref": "#/definitions/ContainerServiceMasterProfile",
+          "description": "Properties of master agents."
+        },
+        "agentPoolProfiles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContainerServiceAgentPoolProfile"
+          },
+          "description": "Properties of the agent pool."
+        },
+        "windowsProfile": {
+          "$ref": "#/definitions/ContainerServiceWindowsProfile",
+          "description": "Properties of Windows VMs."
+        },
+        "linuxProfile": {
+          "$ref": "#/definitions/ContainerServiceLinuxProfile",
+          "description": "Properties of Linux VMs."
+        },
+        "diagnosticsProfile": {
+          "$ref": "#/definitions/ContainerServiceDiagnosticsProfile",
+          "description": "Properties of the diagnostic agent."
+        }
+      },
+      "required": [
+        "masterProfile",
+        "agentPoolProfiles",
+        "linuxProfile"
+      ],
+      "description": "Properties of the container service."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    }
+  }
+}

--- a/arm-compute/compositeComputeClient.json
+++ b/arm-compute/compositeComputeClient.json
@@ -5,7 +5,7 @@
   },
   "documents": [
     "./2016-04-30-preview/swagger/compute.json",
-    "./2016-09-30/swagger/containerService.json",
+    "./2017-01-31/swagger/containerService.json",
     "./2016-04-30-preview/swagger/disk.json"
   ]
 }


### PR DESCRIPTION
This is a straight copy of the 2016-09-30 API. We are rolling some new functionality and need to distinguish between clusters created with the new features, and older pre-existing clusters.