### PR TITLE
Add backupConfiguration to Analysis services request/response properties

### DIFF
--- a/arm-analysisservices/2016-05-16/swagger/analysisservices.json
+++ b/arm-analysisservices/2016-05-16/swagger/analysisservices.json
@@ -509,6 +509,9 @@
       "properties": {
         "asAdministrators": {
           "$ref": "#/definitions/ServerAdministrators"
+        },
+        "backupConfiguration": {
+          "$ref": "#/definitions/BackupConfiguration"
         }
       }
     },
@@ -525,6 +528,28 @@
           "description": "An array of administrator user identities."
         }
       }
+    },
+    "BackupConfiguration": {
+      "description": "An object that represents backup configurations",
+      "type": "object",
+      "properties": {
+        "storageAccount": {
+          "type": "string",
+          "description": "The name of storage account for backup configuration. It is in the format of 'Resource Group Name/Storage Account Name'"
+        },
+        "blobContainer": {
+          "type": "string",
+          "description": "The name of blob container for backup configuration"
+        },
+        "accessKey": {
+          "type": "string",
+          "description": "The access key of storage account used for backup configuration"
+        }
+      },
+      "required": [
+        "storageAccount",
+        "blobContainer"
+      ]
     }
   },
   "parameters": {

--- a/arm-analysisservices/2016-05-16/swagger/analysisservices.json
+++ b/arm-analysisservices/2016-05-16/swagger/analysisservices.json
@@ -535,7 +535,7 @@
       "properties": {
         "storageAccount": {
           "type": "string",
-          "description": "The name of storage account for backup configuration. It is in the format of 'Resource Group Name/Storage Account Name'"
+          "description": "Storage account full resource id for backup configuration"
         },
         "blobContainer": {
           "type": "string",


### PR DESCRIPTION
## Description

This change is to support backup when create, update or get server
details. backup configuration has 3 properties, storage account and blob
container are required for all operations. Access key is required for
create and update operations.

## PR information

- [x] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, see this page.
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the api-version in the path should match the api-version in the spec).

## Quality of Swagger

- [x] I have read the contribution guidelines.
- [ ] My spec meets the review criteria:
  - [x] The spec conforms to the Swagger 2.0 specification.
  - [x] Validation errors from the Linter extension for VS Code have all been fixed for this spec. (Note: for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [ ] The spec follows the patterns described in the Swagger good patterns document unless the service API makes this impossible.