### PR TITLE
Removed Operations API references from two SQL swagger files

### DIFF
--- a/arm-sql/2014-04-01/swagger/firewallRules.json
+++ b/arm-sql/2014-04-01/swagger/firewallRules.json
@@ -187,28 +187,6 @@
           "nextLinkName": null
         }
       }
-    },
-    "/providers/Microsoft.Sql/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Lists all of the available SQL Rest API operations.",
-        "operationId": "ListOperations",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK. The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/OperationListResult"
-            }
-          }
-        }
-      }
     }
   },
   "definitions": {
@@ -280,49 +258,6 @@
           "readOnly": true,
           "type": "string",
           "description": "The resource ID."
-        }
-      }
-    },
-    "OperationListResult": {
-     "description": "Result of the request to list SQL operations. It contains a list of operations and a URL link to get the next set of results.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Operation"
-          },
-          "description": "List of SQL operations supported by the SQL resource provider."
-        },
-        "nextLink": {
-          "type": "string",
-          "description": "URL to get the next set of operation list results if there are any."
-        }
-      }
-    },
-    "Operation": {
-      "description": "SQL REST API operation definition.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Operation name: {provider}/{resource}/{operation}",
-          "type": "string"
-        },
-        "display": {
-          "description": "Display metadata associated with the operation.",
-          "properties": {
-            "provider": {
-              "description": "Service provider: Microsoft SQL Database.",
-              "type": "string"
-            },
-            "resource": {
-              "description": "Resource on which the operation is performed: Server, Database, etc.",
-              "type": "string"
-            },
-            "operation": {
-              "description": "Type of operation: get, read, delete, etc.",
-              "type": "string"
-            }
-          }
         }
       }
     }

--- a/arm-sql/2014-04-01/swagger/replicationLinks.json
+++ b/arm-sql/2014-04-01/swagger/replicationLinks.json
@@ -248,28 +248,6 @@
           "nextLinkName": null
         }
       }
-    },
-    "/providers/Microsoft.Sql/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Lists all of the available SQL Rest API operations.",
-        "operationId": "ListOperations",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK. The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/OperationListResult"
-            }
-          }
-        }
-      }
     }
   },
   "definitions": {
@@ -409,49 +387,6 @@
           "readOnly": true,
           "type": "string",
           "description": "The resource ID."
-        }
-      }
-    },
-    "OperationListResult": {
-     "description": "Result of the request to list SQL operations. It contains a list of operations and a URL link to get the next set of results.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Operation"
-          },
-          "description": "List of SQL operations supported by the SQL resource provider."
-        },
-        "nextLink": {
-          "type": "string",
-          "description": "URL to get the next set of operation list results if there are any."
-        }
-      }
-    },
-    "Operation": {
-      "description": "SQL REST API operation definition.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Operation name: {provider}/{resource}/{operation}",
-          "type": "string"
-        },
-        "display": {
-          "description": "Display metadata associated with the operation.",
-          "properties": {
-            "provider": {
-              "description": "Service provider: Microsoft SQL Database.",
-              "type": "string"
-            },
-            "resource": {
-              "description": "Resource on which the operation is performed: Server, Database, etc.",
-              "type": "string"
-            },
-            "operation": {
-              "description": "Type of operation: get, read, delete, etc.",
-              "type": "string"
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
All 3 SQL swagger files currently reference the same Operations API, which includes the operations from all 3 files.

Updating to only reference this in one place to avoid generating 3 references to this in client SDK.

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [ ] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.