### PR TITLE
Add redis firewallRules to swagger specs w/ examples. (+minor descrip…

### DIFF
--- a/arm-redis/2016-04-01/examples/RedisCacheFirewallRuleCreate.json
+++ b/arm-redis/2016-04-01/examples/RedisCacheFirewallRuleCreate.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "ruleName": "rule1",
+    "cacheName": "cache1",
+    "resourceGroupName": "rg1",
+    "api-version": "2016-04-01",
+    "subscriptionId": "subid",
+    "parameters": {
+      "properties": {
+        "startIP": "192.168.1.1",
+        "endIP": "192.168.1.4"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Cache/Redis/cache1/firewallRules/rule1",
+        "name": "cache1/rule1",
+        "type": "Microsoft.Cache/Redis/firewallRules",
+        "properties": {
+          "startIP": "192.168.1.1",
+          "endIP": "192.168.1.4"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Cache/Redis/cache1/firewallRules/rule1",
+        "name": "cache1/rule1",
+        "type": "Microsoft.Cache/Redis/firewallRules",
+        "properties": {
+          "startIP": "192.168.1.1",
+          "endIP": "192.168.1.4"
+        }
+      }
+    }
+  }
+}

--- a/arm-redis/2016-04-01/examples/RedisCacheFirewallRuleDelete.json
+++ b/arm-redis/2016-04-01/examples/RedisCacheFirewallRuleDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "ruleName": "rule1",
+    "cacheName": "cache1",
+    "resourceGroupName": "rg1",
+    "api-version": "2016-04-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+    },
+    "204": {
+    }
+  }
+}

--- a/arm-redis/2016-04-01/examples/RedisCacheFirewallRuleGet.json
+++ b/arm-redis/2016-04-01/examples/RedisCacheFirewallRuleGet.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "ruleName": "rule1",
+    "cacheName": "cache1",
+    "resourceGroupName": "rg1",
+    "api-version": "2016-04-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Cache/Redis/cache1/firewallRules/rule1",
+        "name": "cache1/rule1",
+        "type": "Microsoft.Cache/Redis/firewallRules",
+        "properties": {
+          "startIP": "192.168.1.1",
+          "endIP": "192.168.1.4"
+        }
+      }
+    }
+  }
+}

--- a/arm-redis/2016-04-01/examples/RedisCacheFirewallRulesList.json
+++ b/arm-redis/2016-04-01/examples/RedisCacheFirewallRulesList.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "cacheName": "cache1",
+    "resourceGroupName": "rg1",
+    "api-version": "2016-04-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Cache/Redis/cache1/firewallRules/rule1",
+            "name": "rule1",
+            "type": "Microsoft.Cache/Redis/firewallRules",
+            "properties": {
+              "startIP": "192.168.1.1",
+              "endIP": "192.168.1.4"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Cache/Redis/cache1/firewallRules/rule2",
+            "name": "rule2",
+            "type": "Microsoft.Cache/Redis/firewallRules",
+            "properties": {
+              "startIP": "192.169.1.0",
+              "endIP": "192.169.1.255"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/arm-redis/2016-04-01/swagger/redis.json
+++ b/arm-redis/2016-04-01/swagger/redis.json
@@ -545,7 +545,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}/firewallRules/": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{cacheName}/firewallRules/": {
       "get": {
         "tags": [
           "Redis",
@@ -591,7 +591,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{cacheName}/firewallRules/{rule}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{cacheName}/firewallRules/{ruleName}": {
       "put": {
         "tags": [
           "Redis",

--- a/arm-redis/2016-04-01/swagger/redis.json
+++ b/arm-redis/2016-04-01/swagger/redis.json
@@ -551,7 +551,7 @@
           "Redis",
           "FirewallRules"
         ],
-        "operationId": "RedisFirewallRules_List",
+        "operationId": "FirewallRules_List",
         "description": "Gets all firewall rules in the specified redis cache.",
         "x-ms-examples": { 
           "RedisCacheFirewallRulesList": { "$ref": "../examples/RedisCacheFirewallRulesList.json" } 

--- a/arm-redis/2016-04-01/swagger/redis.json
+++ b/arm-redis/2016-04-01/swagger/redis.json
@@ -545,7 +545,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{cacheName}/firewallRules/": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{cacheName}/firewallRules": {
       "get": {
         "tags": [
           "Redis",

--- a/arm-redis/2016-04-01/swagger/redis.json
+++ b/arm-redis/2016-04-01/swagger/redis.json
@@ -34,6 +34,31 @@
     }
   },
   "paths": {
+    "/providers/Microsoft.Cache/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists all of the available REST API operations of the Microsoft.Cache provider.",
+        "operationId": "Operations_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the list of operations.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
       "put": {
         "tags": [
@@ -1408,6 +1433,53 @@
         }
       },
       "description": "Response to force reboot for Redis cache."
+    },
+    "Operation": {
+      "description": "REST API operation",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Operation name: {provider}/{resource}/{operation}",
+          "type": "string"
+        },
+        "display": {
+          "description": "The object that describes the operation.",
+          "properties": {
+            "provider": {
+              "description": "Friendly name of the provider",
+              "type": "string"
+            },
+            "operation": {
+              "description": "Operation type: read, write, delete, listKeys/action, etc.",
+              "type": "string"
+            },
+            "resource": {
+              "description": "Resource type on which the operation is performed.",
+              "type": "string"
+            },
+            "description": {
+              "description": "Friendly name of the operation",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "OperationListResult": {
+     "description": "Result of the request to list CDN operations. It contains a list of operations and a URL link to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          },
+          "description": "List of CDN operations supported by the CDN resource provider."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of operation list results if there are any."
+        }
+      }
     }
   },
   "parameters": {

--- a/arm-redis/2016-04-01/swagger/redis.json
+++ b/arm-redis/2016-04-01/swagger/redis.json
@@ -1446,7 +1446,7 @@
           "description": "The object that describes the operation.",
           "properties": {
             "provider": {
-              "description": "Friendly name of the provider",
+              "description": "Friendly name of the resource provider",
               "type": "string"
             },
             "operation": {
@@ -1466,14 +1466,14 @@
       }
     },
     "OperationListResult": {
-     "description": "Result of the request to list CDN operations. It contains a list of operations and a URL link to get the next set of results.",
+     "description": "Result of the request to list REST API operations. It contains a list of operations and a URL nextLink to get the next set of results.",
       "properties": {
         "value": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Operation"
           },
-          "description": "List of CDN operations supported by the CDN resource provider."
+          "description": "List of operations supported by the resource provider."
         },
         "nextLink": {
           "type": "string",

--- a/arm-redis/2016-04-01/swagger/redis.json
+++ b/arm-redis/2016-04-01/swagger/redis.json
@@ -174,10 +174,10 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Successfully deleted the cache."
           },
           "204": {
-            "description": ""
+            "description": "Successfully deleted the cache."
           }
         }
       },
@@ -214,7 +214,7 @@
         ],
         "responses": {
           "200": {
-            "description": "",
+            "description": "Successfully found the cache",
             "schema": {
               "$ref": "#/definitions/RedisResource"
             }
@@ -287,7 +287,7 @@
           }
         },
         "x-ms-pageable": {
-            "nextLinkName": "nextLink"
+          "nextLinkName": "nextLink"
         }
       }
     },
@@ -541,6 +541,213 @@
           },
           "204": {
             "description": "Export operation succeeded."
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}/firewallRules/": {
+      "get": {
+        "tags": [
+          "Redis",
+          "FirewallRules"
+        ],
+        "operationId": "RedisFirewallRules_List",
+        "description": "Gets all firewall rules in the specified redis cache.",
+        "x-ms-examples": { 
+          "RedisCacheFirewallRulesList": { "$ref": "../examples/RedisCacheFirewallRulesList.json" } 
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "cacheName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Redis cache."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully got the current rules",
+            "schema": {
+              "$ref": "#/definitions/RedisFirewallRuleListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{cacheName}/firewallRules/{rule}": {
+      "put": {
+        "tags": [
+          "Redis",
+          "FirewallRules"
+        ],
+        "operationId": "RedisFirewallRule_CreateOrUpdate",
+        "description": "Create or update a redis cache firewall rule",
+        "x-ms-examples": { 
+          "RedisCacheFirewallRuleCreate": { "$ref": "../examples/RedisCacheFirewallRuleCreate.json" }
+        },
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "cacheName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Redis cache."
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the firewall rule."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RedisFirewallRule"
+            },
+            "description": "Parameters supplied to the create or update redis firewall rule operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource was successfully updated",
+            "schema": {
+              "$ref": "#/definitions/RedisFirewallRule"
+            }
+          },
+          "201": {
+            "description": "Resource was successfully created",
+            "schema": {
+              "$ref": "#/definitions/RedisFirewallRule"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Redis",
+          "FirewallRules"
+        ],
+        "operationId": "RedisFirewallRule_Get",
+        "description": "Gets a single firewall rule in a specified redis cache.",
+        "x-ms-examples": { 
+          "RedisCacheFirewallRuleGet": { "$ref": "../examples/RedisCacheFirewallRuleGet.json" }
+        },
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "cacheName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Redis cache."
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the firewall rule."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully found the rule",
+            "schema": {
+              "$ref": "#/definitions/RedisFirewallRule"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Redis",
+          "FirewallRules"
+        ],
+        "operationId": "RedisFirewallRule_Delete",
+        "description": "Deletes a single firewall rule in a specified redis cache.",
+        "x-ms-examples": { 
+          "RedisCacheFirewallRuleDelete": { "$ref": "../examples/RedisCacheFirewallRuleDelete.json" }
+        },
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "cacheName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Redis cache."
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the firewall rule."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted the rule"
+          },
+          "204": {
+            "description": "Successfully deleted the rule"
           }
         }
       }
@@ -863,7 +1070,7 @@
         }
       },
       "description": "Parameters supplied to the Update Redis operation."
-    },    
+    },
     "RedisAccessKeys": {
       "properties": {
         "primaryKey": {
@@ -878,6 +1085,70 @@
         }
       },
       "description": "Redis cache access keys."
+    },
+    "RedisFirewallRule": {
+      "description": "A firewall rule on a redis cache has a name, and describes a contiguous range of IP addresses permitted to connect",
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "resource ID (of the firewall rule)"
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true,
+          "description": "name of the firewall rule"
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true,
+          "description": "type (of the firewall rule resource = 'Microsoft.Cache/redis/firewallRule')"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/RedisFirewallRuleProperties",
+          "description": "redis cache firewall rule properties"
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "RedisFirewallRuleProperties": {
+      "description": "Specifies a range of IP addresses permitted to connect to the cache",
+      "properties": {
+        "startIP": {
+          "type": "string",
+          "description": "lowest IP address included in the range"
+        },
+        "endIP": {
+          "type": "string",
+          "description": "highest IP address included in the range"
+        }
+      },
+      "required": [
+        "startIP",
+        "endIP"
+      ]
+    },
+    "RedisFirewallRuleListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RedisFirewallRule"
+          },
+          "description": "Results of the list firewall rules operation."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Link for next set of locations."
+        }
+      },
+      "description": "The response of list firewall rules Redis operation.",
+      "required": [
+        "value"
+      ]
     },
     "RedisResourceProperties": {
       "properties": {


### PR DESCRIPTION
…tive changes to existing APIs).
(Reissue of PR #977 to get around CI issues...)

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [x] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.