### PR TITLE
#12345 Fix virtualNetworkGateway resource swagger to remove unnecessary required param.

### DIFF
--- a/arm-network/2016-12-01/swagger/virtualNetworkGateway.json
+++ b/arm-network/2016-12-01/swagger/virtualNetworkGateway.json
@@ -1052,8 +1052,7 @@
       },
       "required": [
         "ipConfigurations",
-        "gatewayType",
-        "vpnType"
+        "gatewayType"
       ],
       "description": "VirtualNetworkGateway properties"
     },


### PR DESCRIPTION
Last time, as a part of improvements in swagger, I had added param:” vpnType” as required in definition: VirtualNetworkGatewayPropertiesFormat which is actually not true for every case. So, we want to remove that param from “required” section.
Can you Please help accept below PR related to virtualNetworkGateway.json swagger. 