### PR TITLE
'properties' property must be a required property for Deployment

### DIFF
--- a/arm-resources/resources/2016-09-01/swagger/resources.json
+++ b/arm-resources/resources/2016-09-01/swagger/resources.json
@@ -1877,6 +1877,9 @@
           "description": "The deployment properties."
         }
       },
+      "required": [
+        "properties"
+      ],
       "description": "Deployment operation parameters."
     },
     "DeploymentExportResult": {


### PR DESCRIPTION
Found an issue while using the node sdk https://github.com/Azure/azure-sdk-for-node/issues/2100

The server says:
`{"code":"InvalidRequestContent","message":"The request content was invalid and could not be deserialized: 'Required property 'properties' not found in JSON. Path '', line 1, position 2.'."}`

With this fix, the sdk will throw a better serialization error. In this scenario the customer is providing
- a deployment template  file/url which points to a  **JSON** doc that has properties every where in it
- deployment parameters file/url which also points to a **JSON** doc has properties every where in it
- the body parameter which is obviously a **JSON**.

In this case, "properties" property was missing in the **body parameter**. With the 400 response message sent from the service it was hard to tell what was wrong.

With this fix, in the above scenario the generated sdk would fail on client side validation with a better error message.
@tianoMS @vivsriaus  please take a look.

/cc @balajikris 