### PR TITLE
Remove cross-file references from SQL specs

### DIFF
--- a/arm-sql/2014-04-01/swagger/databaseSecurityAlertPolicies.json
+++ b/arm-sql/2014-04-01/swagger/databaseSecurityAlertPolicies.json
@@ -120,6 +120,68 @@
     }
   },
   "definitions": {
+    "Resource":{
+      "description":"ARM resource.",
+      "properties":{  
+        "id":{  
+          "readOnly":true,
+          "type":"string",
+          "description":"Resource ID."
+        },
+        "name":{  
+          "readOnly":true,
+          "type":"string",
+          "description":"Resource name."
+        },
+        "type":{  
+          "readOnly":true,
+          "type":"string",
+          "description":"Resource type."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TrackedResource":{  
+      "description":"ARM tracked top level resource.",
+      "properties":{  
+        "tags":{  
+          "type":"object",
+          "additionalProperties":{  
+            "type":"string"
+          },
+          "x-ms-mutability":[  
+            "read",
+            "create",
+            "update"
+          ],
+          "description":"Resource tags."
+        },
+        "location":{  
+          "type":"string",
+          "x-ms-mutability":[  
+            "read",
+            "create"
+          ],
+          "description":"Resource location."
+        }
+      },
+      "required":[  
+        "location"
+      ],
+      "allOf":[  
+        {  
+          "$ref":"#/definitions/Resource"
+        }
+      ]
+    },
+    "ProxyResource":{  
+      "description":"ARM proxy resource.",
+      "allOf":[  
+        {  
+          "$ref":"#/definitions/Resource"
+        }
+      ]
+    },
     "DatabaseSecurityAlertPolicy": {
       "description": "Contains information about a database Threat Detection policy.",
       "type": "object",
@@ -144,7 +206,7 @@
       },
       "allOf": [
         {
-          "$ref": "./sql.core.json#/definitions/ProxyResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ]
     },

--- a/arm-sql/2014-04-01/swagger/firewallRules.json
+++ b/arm-sql/2014-04-01/swagger/firewallRules.json
@@ -190,6 +190,21 @@
     }
   },
   "definitions": {
+    "SubResource": {
+      "description": "Subresource properties",
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource ID."
+        }
+      }
+    },
     "FirewallRuleProperties": {
       "properties": {
         "startIpAddress": {
@@ -229,7 +244,7 @@
       },
       "allOf": [
         {
-          "$ref": "./sql.core.json#/definitions/SubResource"
+          "$ref": "#/definitions/SubResource"
         }
       ],
       "description": "Represents a server firewall rule."

--- a/arm-sql/2014-04-01/swagger/importExport.json
+++ b/arm-sql/2014-04-01/swagger/importExport.json
@@ -175,6 +175,68 @@
         }
     },
     "definitions": {
+    "Resource":{
+      "description":"ARM resource.",
+      "properties":{  
+        "id":{  
+          "readOnly":true,
+          "type":"string",
+          "description":"Resource ID."
+        },
+        "name":{  
+          "readOnly":true,
+          "type":"string",
+          "description":"Resource name."
+        },
+        "type":{  
+          "readOnly":true,
+          "type":"string",
+          "description":"Resource type."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TrackedResource":{  
+      "description":"ARM tracked top level resource.",
+      "properties":{  
+        "tags":{  
+          "type":"object",
+          "additionalProperties":{  
+            "type":"string"
+          },
+          "x-ms-mutability":[  
+            "read",
+            "create",
+            "update"
+          ],
+          "description":"Resource tags."
+        },
+        "location":{  
+          "type":"string",
+          "x-ms-mutability":[  
+            "read",
+            "create"
+          ],
+          "description":"Resource location."
+        }
+      },
+      "required":[  
+        "location"
+      ],
+      "allOf":[  
+        {  
+          "$ref":"#/definitions/Resource"
+        }
+      ]
+    },
+    "ProxyResource":{  
+      "description":"ARM proxy resource.",
+      "allOf":[  
+        {  
+          "$ref":"#/definitions/Resource"
+        }
+      ]
+    },
         "ImportExtensionProperties": {
             "properties": {
                 "operationMode": {
@@ -221,7 +283,7 @@
                 }
             },
             "allOf": [{
-                "$ref": "./sql.core.json#/definitions/ProxyResource"
+                "$ref": "#/definitions/ProxyResource"
             }],
             "description": "Response for Import/Export Get operation."
         },

--- a/arm-sql/2014-04-01/swagger/replicationLinks.json
+++ b/arm-sql/2014-04-01/swagger/replicationLinks.json
@@ -251,6 +251,21 @@
     }
   },
   "definitions": {
+    "SubResource": {
+      "description": "Subresource properties",
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource ID."
+        }
+      }
+    },
     "ReplicationLinkProperties": {
       "properties": {
         "isTerminationAllowed": {
@@ -358,7 +373,7 @@
       },
       "allOf": [
         {
-          "$ref": "./sql.core.json#/definitions/SubResource"
+          "$ref": "#/definitions/SubResource"
         }
       ],
       "description": "Represents a database replication link."

--- a/arm-sql/2015-05-01-preview/swagger/blobAuditingPolicies.json
+++ b/arm-sql/2015-05-01-preview/swagger/blobAuditingPolicies.json
@@ -120,6 +120,68 @@
     }
   },
   "definitions": {
+"Resource":{
+      "description":"ARM resource.",
+      "properties":{  
+        "id":{  
+          "readOnly":true,
+          "type":"string",
+          "description":"Resource ID."
+        },
+        "name":{  
+          "readOnly":true,
+          "type":"string",
+          "description":"Resource name."
+        },
+        "type":{  
+          "readOnly":true,
+          "type":"string",
+          "description":"Resource type."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TrackedResource":{  
+      "description":"ARM tracked top level resource.",
+      "properties":{  
+        "tags":{  
+          "type":"object",
+          "additionalProperties":{  
+            "type":"string"
+          },
+          "x-ms-mutability":[  
+            "read",
+            "create",
+            "update"
+          ],
+          "description":"Resource tags."
+        },
+        "location":{  
+          "type":"string",
+          "x-ms-mutability":[  
+            "read",
+            "create"
+          ],
+          "description":"Resource location."
+        }
+      },
+      "required":[  
+        "location"
+      ],
+      "allOf":[  
+        {  
+          "$ref":"#/definitions/Resource"
+        }
+      ]
+    },
+    "ProxyResource":{  
+      "description":"ARM proxy resource.",
+      "allOf":[  
+        {  
+          "$ref":"#/definitions/Resource"
+        }
+      ]
+    },
     "DatabaseBlobAuditingPolicy": {
       "description": "Contains information about a database Blob Auditing policy.",
       "type": "object",
@@ -143,7 +205,7 @@
         }
       },
       "allOf": [
-        { "$ref": "../../2014-04-01/swagger/sql.core.json#/definitions/ProxyResource" }
+        { "$ref": "#/definitions/ProxyResource" }
       ]
     },
     "DatabaseBlobAuditingPolicyProperties": {


### PR DESCRIPTION
The cross-file references don't work in azure doc build system.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [x] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.