### PR TITLE
Add Azure SQL Database Failover Group REST API specs

### DIFF
--- a/arm-sql/2014-04-01/swagger/replicationLinks.json
+++ b/arm-sql/2014-04-01/swagger/replicationLinks.json
@@ -116,7 +116,7 @@
           "DatabaseReplicationLinks"
         ],
         "operationId": "Databases_FailoverReplicationLink",
-        "description": "Failover the database replication link.",
+        "description": "Sets which replica database is primary by failing over from the current primary replica database.",
         "x-ms-examples": {
           "Failover a replication link": { "$ref": "../examples/ReplicationLinkFailover.json" }
         },
@@ -165,7 +165,7 @@
           "DatabaseReplicationLinks"
         ],
         "operationId": "Databases_FailoverReplicationLinkAllowDataLoss",
-        "description": "Force failover the database replication link, which may result in data loss.",
+        "description": "Sets which replica database is primary by failing over from the current primary replica database. This operation might result in data loss.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/arm-sql/2015-05-01-preview/examples/DatabaseBlobAuditingGet.json
+++ b/arm-sql/2015-05-01-preview/examples/DatabaseBlobAuditingGet.json
@@ -13,7 +13,7 @@
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/blobauditingtest-6852/providers/Microsoft.Sql/servers/blobauditingtest-2080/databases/testdb",
             "name": "Default",
             "type": "Microsoft.Sql/servers/databases/auditingSettings",
-            "location": "Japan East",
+            "location": "Japan Eastasd",
             "kind": "V12",
             "properties": {
                 "state": "Disabled",

--- a/arm-sql/2015-05-01-preview/examples/DatabaseBlobAuditingGet.json
+++ b/arm-sql/2015-05-01-preview/examples/DatabaseBlobAuditingGet.json
@@ -13,7 +13,7 @@
             "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/blobauditingtest-6852/providers/Microsoft.Sql/servers/blobauditingtest-2080/databases/testdb",
             "name": "Default",
             "type": "Microsoft.Sql/servers/databases/auditingSettings",
-            "location": "Japan Eastasd",
+            "location": "Japan East",
             "kind": "V12",
             "properties": {
                 "state": "Disabled",

--- a/arm-sql/2015-05-01-preview/examples/FailoverGroupCreateOrUpdate.json
+++ b/arm-sql/2015-05-01-preview/examples/FailoverGroupCreateOrUpdate.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "Default",
+    "serverName": "failover-group-primary-server",
+    "failoverGroupName": "failover-group-test-3",
+    "api-version": "2015-05-01-preview",
+    "failoverGroup": {
+      "properties": {
+        "readWriteEndpoint": {
+          "failoverPolicy": "Automatic",
+          "failoverWithDataLossGracePeriodMinutes": 480
+        },
+        "readOnlyEndpoint": {
+          "failoverPolicy": "Disabled"
+        },
+        "partnerServers": [
+          {
+            "id":"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server"
+          }
+        ],
+        "databases": [
+          "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/databases/testdb-1",
+          "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/databases/testdb-2"
+        ]
+      }
+    }
+  },
+  "responses": {
+      "200": {
+        "body": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/failoverGroups/failover-group-test-3",
+            "name": "failover-group-test-3",
+            "type": "Microsoft.Sql/servers/failoverGroups",
+            "location": "Japan East",
+            "properties": {
+              "readWriteEndpoint": {
+                "failoverPolicy": "Automatic",
+                "failoverWithDataLossGracePeriodMinutes": 480
+              },
+              "readOnlyEndpoint": {
+                "failoverPolicy": "Disabled"
+              },
+              "replicationRole": "Primary",
+              "replicationState": "CATCH_UP",
+              "partnerServers": [
+                {
+                  "id":"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server",
+                  "location":"Japan West",
+                  "replicationRole":"Secondary"
+                }
+              ],
+              "databases": [
+                "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/databases/testdb-1",
+                "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/databases/testdb-2"
+              ]
+            }
+        }
+    },
+    "201": {
+        "body": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/failoverGroups/failover-group-test-3",
+            "name": "failover-group-test-3",
+            "type": "Microsoft.Sql/servers/failoverGroups",
+            "location": "Japan East",
+            "properties": {
+              "readWriteEndpoint": {
+                "failoverPolicy": "Automatic",
+                "failoverWithDataLossGracePeriodMinutes": 480
+              },
+              "readOnlyEndpoint": {
+                "failoverPolicy": "Disabled"
+              },
+              "replicationRole": "Primary",
+              "replicationState": "CATCH_UP",
+              "partnerServers": [
+                {
+                  "id":"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server",
+                  "location":"Japan West",
+                  "replicationRole":"Secondary"
+                }
+              ],
+              "databases": [
+                "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/databases/testdb-1",
+                "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/databases/testdb-2"
+              ]
+            }
+        }
+    }
+  }
+}

--- a/arm-sql/2015-05-01-preview/examples/FailoverGroupDelete.json
+++ b/arm-sql/2015-05-01-preview/examples/FailoverGroupDelete.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "Default",
+    "serverName": "failover-group-primary-server",
+    "failoverGroupName": "failover-group-test-1",
+    "api-version": "2015-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "204": {
+      "body": ""
+    }
+  }
+}

--- a/arm-sql/2015-05-01-preview/examples/FailoverGroupFailover.json
+++ b/arm-sql/2015-05-01-preview/examples/FailoverGroupFailover.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "Default",
+    "serverName": "failover-group-secondary-server",
+    "failoverGroupName": "failover-group-test-3",
+    "api-version": "2015-05-01-preview"
+  },
+  "responses": {
+      "200": {
+        "body": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server/failoverGroups/failover-group-test-3",
+            "name": "failover-group-test-3",
+            "type": "Microsoft.Sql/servers/failoverGroups",
+            "location": "Japan West",
+            "properties": {
+              "readWriteEndpoint": {
+                "failoverPolicy": "Automatic",
+                "failoverWithDataLossGracePeriodMinutes": 120
+              },
+              "readOnlyEndpoint": {
+                "failoverPolicy": "Disabled"
+              },
+              "replicationRole": "Primary",
+              "replicationState": "CATCH_UP",
+              "partnerServers": [
+                {
+                  "id":"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server",
+                  "location":"Japan East",
+                  "replicationRole":"Secondary"
+                }
+              ],
+              "databases": [
+                "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server/databases/testdb-1",
+                "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server/databases/testdb-2"
+              ]
+            }
+        }
+    }
+  }
+}

--- a/arm-sql/2015-05-01-preview/examples/FailoverGroupForceFailoverAllowDataLoss.json
+++ b/arm-sql/2015-05-01-preview/examples/FailoverGroupForceFailoverAllowDataLoss.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "Default",
+    "serverName": "failover-group-secondary-server",
+    "failoverGroupName": "failover-group-test-3",
+    "api-version": "2015-05-01-preview"
+  },
+  "responses": {
+      "200": {
+        "body": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server/failoverGroups/failover-group-test-3",
+            "name": "failover-group-test-3",
+            "type": "Microsoft.Sql/servers/failoverGroups",
+            "location": "Japan West",
+            "properties": {
+              "readWriteEndpoint": {
+                "failoverPolicy": "Automatic",
+                "failoverWithDataLossGracePeriodMinutes": 120
+              },
+              "readOnlyEndpoint": {
+                "failoverPolicy": "Disabled"
+              },
+              "replicationRole": "Primary",
+              "replicationState": "CATCH_UP",
+              "partnerServers": [
+                {
+                  "id":"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server",
+                  "location":"Japan East",
+                  "replicationRole":"Secondary"
+                }
+              ],
+              "databases": [
+                "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server/databases/testdb-1",
+                "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server/databases/testdb-2"
+              ]
+            }
+        }
+    }
+  }
+}

--- a/arm-sql/2015-05-01-preview/examples/FailoverGroupGet.json
+++ b/arm-sql/2015-05-01-preview/examples/FailoverGroupGet.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "Default",
+    "serverName": "failover-group-primary-server",
+    "failoverGroupName": "failover-group-test",
+    "api-version": "2015-05-01-preview"
+  },
+  "responses": {
+    "200": {
+        "body": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/failoverGroups/failover-group-test",
+            "name": "failover-group-test",
+            "type": "Microsoft.Sql/servers/failoverGroups",
+            "location": "Japan East",
+            "properties": {
+                "readWriteEndpoint": {
+                      "failoverPolicy": "Automatic",
+                      "failoverWithDataLossGracePeriodMinutes": 480
+                  },
+                  "readOnlyEndpoint": {
+                      "failoverPolicy": "Disabled"
+                  },
+                  "replicationRole": "Primary",
+                  "replicationState": "CATCH_UP",
+                  "partnerServers": [
+                      {
+                          "id":"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server",
+                          "location":"Japan West",
+                          "replicationRole":"Secondary"
+                      }
+                  ],
+                  "databases": []
+            }
+        }
+    }
+  }
+}

--- a/arm-sql/2015-05-01-preview/examples/FailoverGroupList.json
+++ b/arm-sql/2015-05-01-preview/examples/FailoverGroupList.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "Default",
+    "serverName": "failover-group-primary-server",
+    "api-version": "2015-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/failoverGroups/failover-group-test",
+            "name": "failover-group-test",
+            "type": "Microsoft.Sql/servers/failoverGroups",
+            "location": "Japan East",
+            "properties": {
+              "readWriteEndpoint": {
+                "failoverPolicy": "Automatic",
+                "failoverWithDataLossGracePeriodMinutes": 480
+              },
+              "readOnlyEndpoint": {
+                "failoverPolicy": "Disabled"
+              },
+              "replicationRole": "Primary",
+              "replicationState": "CATCH_UP",
+              "partnerServers": [
+                {
+                  "id":"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server",
+                  "location":"Japan West",
+                  "replicationRole":"Secondary"
+                }
+              ],
+              "databases": []
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/failoverGroups/failover-group-test-2",
+            "name": "failover-group-test-2",
+            "type": "Microsoft.Sql/servers/failoverGroups",
+            "location": "Japan East",
+            "properties": {
+              "readWriteEndpoint": {
+                "failoverPolicy": "Automatic",
+                "failoverWithDataLossGracePeriodMinutes": 480
+              },
+              "readOnlyEndpoint": {
+                "failoverPolicy": "Disabled"
+              },
+              "replicationRole": "Primary",
+              "replicationState": "CATCH_UP",
+              "partnerServers": [
+                {
+                  "id":"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server",
+                  "location":"Japan West",
+                  "replicationRole":"Secondary"
+                }
+              ],
+              "databases": []
+            }
+          }   
+        ]
+      }
+    }
+  }
+}

--- a/arm-sql/2015-05-01-preview/examples/FailoverGroupUpdate.json
+++ b/arm-sql/2015-05-01-preview/examples/FailoverGroupUpdate.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "Default",
+    "serverName": "failover-group-primary-server",
+    "failoverGroupName": "failover-group-test-1",
+    "api-version": "2015-05-01-preview",
+    "failoverGroup": {
+      "properties": {
+        "readWriteEndpoint": {
+          "failoverPolicy": "Automatic",
+          "failoverWithDataLossGracePeriodMinutes": 120
+        },
+        "databases": [
+          "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/databases/testdb-1"
+        ]
+      }
+    }
+  },
+  "responses": {
+      "200": {
+        "body": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/failoverGroups/failover-group-test-3",
+            "name": "failover-group-test-3",
+            "type": "Microsoft.Sql/servers/failoverGroups",
+            "location": "Japan East",
+            "properties": {
+              "readWriteEndpoint": {
+                "failoverPolicy": "Automatic",
+                "failoverWithDataLossGracePeriodMinutes": 120
+              },
+              "readOnlyEndpoint": {
+                "failoverPolicy": "Disabled"
+              },
+              "replicationRole": "Primary",
+              "replicationState": "CATCH_UP",
+              "partnerServers": [
+                {
+                  "id":"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-secondary-server",
+                  "location":"Japan West",
+                  "replicationRole":"Secondary"
+                }
+              ],
+              "databases": [
+                "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default/providers/Microsoft.Sql/servers/failover-group-primary-server/databases/testdb-1"
+              ]
+            }
+        }
+      }
+  }
+}

--- a/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
+++ b/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
@@ -30,6 +30,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
@@ -40,9 +43,6 @@
           },
           {
             "$ref": "#/parameters/FailoverGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -71,6 +71,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
@@ -81,9 +84,6 @@
           },
           {
             "$ref": "#/parameters/FailoverGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
           },
           {
             "$ref": "#/parameters/FailoverGroupBodyParameter"
@@ -122,6 +122,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
@@ -132,9 +135,6 @@
           },
           {
             "$ref": "#/parameters/FailoverGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -164,6 +164,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
@@ -174,9 +177,6 @@
           },
           {
             "$ref": "#/parameters/FailoverGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
           },
           {
             "$ref": "#/parameters/FailoverGroupBodyParameter"
@@ -211,6 +211,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
@@ -218,9 +221,6 @@
           },
           {
             "$ref": "#/parameters/ServerParameter"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -251,6 +251,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
@@ -261,9 +264,6 @@
           },
           {
             "$ref": "#/parameters/FailoverGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -295,6 +295,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
@@ -305,9 +308,6 @@
           },
           {
             "$ref": "#/parameters/FailoverGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -348,39 +348,6 @@
       },
       "x-ms-azure-resource": true
     },
-    "TrackedResource": {
-      "description": "ARM tracked top level resource.",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-ms-mutability": [
-            "read",
-            "create",
-            "update"
-          ],
-          "description": "Resource tags."
-        },
-        "location": {
-          "type": "string",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ],
-          "description": "Resource location."
-        }
-      },
-      "required": [
-        "location"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/Resource"
-        }
-      ]
-    },
     "ProxyResource": {
       "description": "ARM proxy resource.",
       "allOf": [
@@ -414,7 +381,9 @@
           "description": "Resource tags."
         },
         "properties": {
-          "$ref": "#/definitions/FailoverGroupProperties"
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/FailoverGroupProperties",
+          "description": "The properties representing the resource."
         }
       },
       "allOf": [
@@ -444,7 +413,8 @@
           "readOnly": true,
           "type": "string",
           "x-ms-enum": {
-            "name": "FailoverGroupReplicationRole"
+            "name": "FailoverGroupReplicationRole",
+            "modelAsString": true
           }
         },
         "replicationState": {
@@ -479,7 +449,8 @@
           ],
           "type": "string",
           "x-ms-enum": {
-            "name": "ReadWriteEndpointFailoverPolicy"
+            "name": "ReadWriteEndpointFailoverPolicy",
+            "modelAsString": true
           }
         },
         "failoverWithDataLossGracePeriodMinutes": {
@@ -500,7 +471,8 @@
           ],
           "type": "string",
           "x-ms-enum": {
-            "name": "ReadOnlyEndpointFailoverPolicy"
+            "name": "ReadOnlyEndpointFailoverPolicy",
+            "modelAsString": true
           }
         }
       }
@@ -526,7 +498,8 @@
           ],
           "type": "string",
           "x-ms-enum": {
-            "name": "FailoverGroupReplicationRole"
+            "name": "FailoverGroupReplicationRole",
+            "modelAsString": true
           }
         }
       }

--- a/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
+++ b/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
@@ -1,0 +1,643 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "2.0",
+        "title": "SqlManagementClient",
+        "description": "The Azure SQL Database management API provides a RESTful set of web APIs that interact with Azure SQL Database services to manage your databases. The API enables users to create, retrieve, update, and delete databases, servers, and other entities."
+    },
+    "host": "management.azure.com",
+    "schemes": [
+        "https"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}": {
+            "get": {
+                "tags": [
+                    "FailoverGroups"
+                ],
+                "description": "Gets the failover group with the given name.",
+                "operationId": "FailoverGroups_Get",
+                "x-ms-examples": {
+                  "Get failover group": { "$ref": "../examples/FailoverGroupGet.json" }
+                },
+                "parameters": [
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ResourceGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ServerParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/FailoverGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved the specified failover group.",
+                        "schema": {
+                            "$ref": "#/definitions/FailoverGroupResource"
+                        }
+                    },
+                    "default": {
+                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
+                        "schema": {
+                            "$ref": "#/definitions/ArmErrorResponseMessage"
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "put": {
+                "tags": [
+                    "FailoverGroups"
+                ],
+                "description": "Creates or updates the failover group with the given name.",
+                "operationId": "FailoverGroups_CreateOrUpdate",
+                "x-ms-examples": {
+                  "Create failover group": { "$ref": "../examples/FailoverGroupCreateOrUpdate.json" }
+                },
+                "parameters": [
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ResourceGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ServerParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/FailoverGroupParameter"
+                    },
+                    {
+                        "name": "failoverGroup",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/FailoverGroupResource"
+                        }
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated the failover group.",
+                        "schema": {
+                            "$ref": "#/definitions/FailoverGroupResource"
+                        }
+                    },
+                    "201": {
+                        "description": "Successfully created the failover group.",
+                        "schema": {
+                            "$ref": "#/definitions/FailoverGroupResource"
+                        }
+                    },
+                    "default": {
+                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 400 FailoverGroupCreateOrUpdatePartiallySucceeded - Some databases could not be added or removed.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 409 FailoverGroupUnableToPerformGroupOperationOnDatabases - The list of databases to add/remove to/from Failover Group contains errors that are preventing operation to complete.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
+                        "schema": {
+                            "$ref": "#/definitions/ArmErrorResponseMessage"
+                        }
+                    }
+                },
+                "deprecated": false,
+                "x-ms-long-running-operation": true
+            },
+            "delete": {
+                "tags": [
+                    "FailoverGroups"
+                ],
+                "description": "Deletes the failover group with the given name.",
+                "operationId": "FailoverGroups_Delete",
+                "x-ms-examples": {
+                  "Delete failover group": { "$ref": "../examples/FailoverGroupDelete.json" }
+                },
+                "parameters": [
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ResourceGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ServerParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/FailoverGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted the failover group."
+                    },
+                    "204": {
+                        "description": "The specified failover group does not exist."
+                    },
+                    "default": {
+                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
+                        "schema": {
+                            "$ref": "#/definitions/ArmErrorResponseMessage"
+                        }
+                    }
+                },
+                "deprecated": false,
+                "x-ms-long-running-operation": true
+            },
+            "patch": {
+                "tags": [
+                    "FailoverGroups"
+                ],
+                "description": "Partially updates the failover group with the given name.",
+                "operationId": "FailoverGroups_Update",
+                "x-ms-examples": {
+                  "Update failover group": { "$ref": "../examples/FailoverGroupUpdate.json" }
+                },
+                "parameters": [
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ResourceGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ServerParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/FailoverGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated the failover group.",
+                        "schema": {
+                            "$ref": "#/definitions/FailoverGroupResource"
+                        }
+                    },
+                    "default": {
+                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 400 FailoverGroupCreateOrUpdatePartiallySucceeded - Some databases could not be added or removed.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 409 FailoverGroupUnableToPerformGroupOperationOnDatabases - The list of databases to add/remove to/from Failover Group contains errors that are preventing operation to complete.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
+                        "schema": {
+                            "$ref": "#/definitions/ArmErrorResponseMessage"
+                        }
+                    }
+                },
+                "deprecated": false,
+                "x-ms-long-running-operation": true
+            }
+        },
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups": {
+            "get": {
+                "tags": [
+                    "FailoverGroups"
+                ],
+                "description": "Lists the failover groups on the given server.",
+                "operationId": "FailoverGroups_List",
+                "x-ms-examples": {
+                  "List failover group": { "$ref": "../examples/FailoverGroupList.json" }
+                },
+                "parameters": [
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ResourceGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ServerParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved the failover groups.",
+                        "schema": {
+                            "$ref": "#/definitions/FailoverGroupResourceList"
+                        }
+                    },
+                    "default": {
+                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
+                        "schema": {
+                            "$ref": "#/definitions/ArmErrorResponseMessage"
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}/failover": {
+            "post": {
+                "tags": [
+                    "FailoverGroups"
+                ],
+                "description": "Starts planned failover operation for the failover group.",
+                "operationId": "FailoverGroups_Failover",
+                "x-ms-examples": {
+                  "Planned failover failover group": { "$ref": "../examples/FailoverGroupFailover.json" }
+                },
+                "parameters": [
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ResourceGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ServerParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/FailoverGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully failed over.",
+                        "schema": {
+                            "$ref": "#/definitions/FailoverGroupResource"
+                        }
+                    },
+                    "default": {
+                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
+                        "schema": {
+                            "$ref": "#/definitions/ArmErrorResponseMessage"
+                        }
+                    }
+                },
+                "deprecated": false,
+                "x-ms-long-running-operation": true
+            }
+        },
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}/forceFailoverAllowDataLoss": {
+            "post": {
+                "tags": [
+                    "FailoverGroups"
+                ],
+                "description": "Starts forced failover operation for the given failover group.",
+                "operationId": "FailoverGroups_ForceFailoverAllowDataLoss",
+                "x-ms-examples": {
+                  "Forced failover failover group": { "$ref": "../examples/FailoverGroupForceFailoverAllowDataLoss.json" }
+                },
+                "parameters": [
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ResourceGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ServerParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/FailoverGroupParameter"
+                    },
+                    {
+                        "required": true,
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully failed over.",
+                        "schema": {
+                            "$ref": "#/definitions/FailoverGroupResource"
+                        }
+                    },
+                    "default": {
+                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
+                        "schema": {
+                            "$ref": "#/definitions/ArmErrorResponseMessage"
+                        }
+                    }
+                },
+                "deprecated": false,
+                "x-ms-long-running-operation": true
+            }
+        }
+    },
+    "definitions": {
+        "ArmErrorResponseMessage": {
+            "description": "Contains information about the error that occured.",
+            "type": "object",
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/ArmErrorResponseExtendedErrorInfo",
+                    "description": "Contains the information about the error."
+                }
+            }
+        },
+        "ArmErrorResponseExtendedErrorInfo": {
+            "description": "Contains additional information about the error that occured.",
+            "type": "object",
+            "properties": {
+                "details": {
+                    "description": "A list of error details.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ArmErrorResponseErrorDetail"
+                    }
+                },
+                "innerError": {
+                    "description": "The inner error if available."
+                },
+                "code": {
+                    "description": "The error code associated with the failure.",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "The error message associated with the failure.",
+                    "type": "string"
+                },
+                "target": {
+                    "description": "The target of the particular error.",
+                    "type": "string"
+                }
+            }
+        },
+        "ArmErrorResponseErrorDetail": {
+            "description": "Contains detailed information about the error that occured.",
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "The error code associated with the failure.",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "The error message associated with the failure.",
+                    "type": "string"
+                },
+                "target": {
+                    "description": "The target of the particular error.",
+                    "type": "string"
+                }
+            }
+        },
+        "FailoverGroupResource": {
+            "description": "Contains information about an Azure SQL Server Failover Group.",
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "sku": {
+                    "$ref": "#/definitions/ArmResourceSku"
+                },
+                "kind": {
+                    "enum": [
+                        "None",
+                        "V2",
+                        "V12",
+                        "User",
+                        "System",
+                        "Datawarehouse"
+                    ],
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/FailoverGroupResourceProperties"
+                }
+            }
+        },
+        "ArmResourceSku": {
+            "description": "Represents an ARM Resource SKU.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the SKU, typically, a letter + Number code, e.g. P3.",
+                    "type": "string"
+                },
+                "tier": {
+                    "description": "The tier of the particular SKU, e.g. Basic, Premium.",
+                    "type": "string"
+                },
+                "size": {
+                    "type": "string"
+                },
+                "family": {
+                    "type": "string"
+                },
+                "capacity": {
+                    "format": "int32",
+                    "type": "integer"
+                }
+            }
+        },
+        "FailoverGroupResourceProperties": {
+            "description": "Properties for an Azure SQL Database Failover Group",
+            "type": "object",
+            "properties": {
+                "readWriteEndpoint": {
+                    "$ref": "#/definitions/FailoverGroupReadWriteEndpoint",
+                    "description": "Read-write endpoint of the failover group instance."
+                },
+                "readOnlyEndpoint": {
+                    "$ref": "#/definitions/FailoverGroupReadOnlyEndpoint",
+                    "description": "Read-only endpoint of the failover group instance."
+                },
+                "replicationRole": {
+                    "description": "Local replication role of the failover group instance.",
+                    "enum": [
+                        "Primary",
+                        "Secondary"
+                    ],
+                    "type": "string"
+                },
+                "replicationState": {
+                    "description": "Replication state of the failover group instance.",
+                    "type": "string"
+                },
+                "partnerServers": {
+                    "description": "List of partner server information for the failover group.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PartnerInfo"
+                    }
+                },
+                "databases": {
+                    "description": "List of databases in the failover group.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "FailoverGroupReadWriteEndpoint": {
+            "type": "object",
+            "properties": {
+                "failoverPolicy": {
+                    "description": "Failover policy of the read-write endpoint for the failover group.",
+                    "enum": [
+                        "Manual",
+                        "Automatic"
+                    ],
+                    "type": "string"
+                },
+                "failoverWithDataLossGracePeriodMinutes": {
+                    "format": "int32",
+                    "description": "Grace period before failover with data loss is attempted for the read-write endpoint.",
+                    "type": "integer"
+                }
+            }
+        },
+        "FailoverGroupReadOnlyEndpoint": {
+            "type": "object",
+            "properties": {
+                "failoverPolicy": {
+                    "description": "Failover policy of the read-only endpoint for the failover group.",
+                    "enum": [
+                        "Disabled",
+                        "Enabled"
+                    ],
+                    "type": "string"
+                }
+            }
+        },
+        "PartnerInfo": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Resource identifier of the partner server.",
+                    "type": "string"
+                },
+                "location": {
+                    "description": "Geo location of the partner server.",
+                    "type": "string"
+                },
+                "replicationRole": {
+                    "description": "Replication role of the partner server.",
+                    "enum": [
+                        "Primary",
+                        "Secondary"
+                    ],
+                    "type": "string"
+                }
+            }
+        },
+        "FailoverGroupResourceList": {
+            "description": "A list of failover groups.",
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FailoverGroupResource"
+                    }
+                },
+                "nextLink": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "parameters": {
+        "SubscriptionIdParameter": {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The subscription credentials which uniquely identify Microsoft Azure subscription.",
+            "required": true,
+            "type": "string"
+        },
+        "ApiVersionParameter": {
+            "name": "api-version",
+            "in": "query",
+            "description": "Client Api Version.",
+            "required": true,
+            "x-ms-parameter-location": "client",
+            "type": "string"
+        },
+        "ResourceGroupParameter": {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the resource group to which the resource belongs.",
+            "required": true,
+            "x-ms-parameter-location": "method",
+            "type": "string"
+        },
+        "ServerParameter": {
+            "name": "serverName",
+            "in": "path",
+            "description": "The name of the server on which the Failover Group is hosted.",
+            "required": true,
+            "x-ms-parameter-location": "method",
+            "type": "string"
+        },
+        "FailoverGroupParameter": {
+            "name": "failoverGroupName",
+            "in": "path",
+            "description": "The name of the failover group.",
+            "required": true,
+            "x-ms-parameter-location": "method",
+            "type": "string"
+        }
+    }
+}

--- a/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
+++ b/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
@@ -567,14 +567,14 @@
         "SubscriptionIdParameter": {
             "name": "subscriptionId",
             "in": "path",
-            "description": "The subscription credentials which uniquely identify Microsoft Azure subscription.",
+            "description": "The subscription ID that identifies an Azure subscription.",
             "required": true,
             "type": "string"
         },
         "ApiVersionParameter": {
             "name": "api-version",
             "in": "query",
-            "description": "Client Api Version.",
+            "description": "The API version to use for the request.",
             "required": true,
             "x-ms-parameter-location": "client",
             "type": "string"
@@ -582,7 +582,7 @@
         "ResourceGroupParameter": {
             "name": "resourceGroupName",
             "in": "path",
-            "description": "The name of the resource group to which the resource belongs.",
+            "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
             "required": true,
             "x-ms-parameter-location": "method",
             "type": "string"
@@ -590,7 +590,7 @@
         "ServerParameter": {
             "name": "serverName",
             "in": "path",
-            "description": "The name of the server on which the Failover Group is hosted.",
+            "description": "The name of the server.",
             "required": true,
             "x-ms-parameter-location": "method",
             "type": "string"

--- a/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
+++ b/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
@@ -1,616 +1,600 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "version": "2015-05-01-preview",
-        "title": "SqlManagementClient",
-        "description": "The Azure SQL Database management API provides a RESTful set of web APIs that interact with Azure SQL Database services to manage your databases. The API enables users to create, retrieve, update, and delete databases, servers, and other entities."
-    },
-    "host": "management.azure.com",
-    "schemes": [
-        "https"
-    ],
-    "consumes": [
-        "application/json"
-    ],
-    "produces": [
-        "application/json"
-    ],
-    "paths": {
-        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}": {
-            "get": {
-                "tags": [
-                    "FailoverGroups"
-                ],
-                "description": "Gets the failover group with the given name.",
-                "operationId": "FailoverGroups_Get",
-                "x-ms-examples": {
-                  "Get failover group": { "$ref": "../examples/FailoverGroupGet.json" }
-                },
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/SubscriptionIdParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ResourceGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ServerParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/FailoverGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ApiVersionParameter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully retrieved the specified failover group.",
-                        "schema": {
-                            "$ref": "#/definitions/FailoverGroupResource"
-                        }
-                    },
-                    "default": {
-                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
-                        "schema": {
-                            "$ref": "#/definitions/ArmErrorResponseMessage"
-                        }
-                    }
-                },
-                "deprecated": false
-            },
-            "put": {
-                "tags": [
-                    "FailoverGroups"
-                ],
-                "description": "Creates or updates the failover group with the given name.",
-                "operationId": "FailoverGroups_CreateOrUpdate",
-                "x-ms-examples": {
-                  "Create failover group": { "$ref": "../examples/FailoverGroupCreateOrUpdate.json" }
-                },
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/SubscriptionIdParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ResourceGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ServerParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/FailoverGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ApiVersionParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/FailoverGroupBodyParameter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully updated the failover group.",
-                        "schema": {
-                            "$ref": "#/definitions/FailoverGroupResource"
-                        }
-                    },
-                    "201": {
-                        "description": "Successfully created the failover group.",
-                        "schema": {
-                            "$ref": "#/definitions/FailoverGroupResource"
-                        }
-                    },
-                    "default": {
-                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 400 FailoverGroupCreateOrUpdatePartiallySucceeded - Some databases could not be added or removed.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 409 FailoverGroupUnableToPerformGroupOperationOnDatabases - The list of databases to add/remove to/from Failover Group contains errors that are preventing operation to complete.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
-                        "schema": {
-                            "$ref": "#/definitions/ArmErrorResponseMessage"
-                        }
-                    }
-                },
-                "deprecated": false,
-                "x-ms-long-running-operation": true
-            },
-            "delete": {
-                "tags": [
-                    "FailoverGroups"
-                ],
-                "description": "Deletes the failover group with the given name.",
-                "operationId": "FailoverGroups_Delete",
-                "x-ms-examples": {
-                  "Delete failover group": { "$ref": "../examples/FailoverGroupDelete.json" }
-                },
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/SubscriptionIdParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ResourceGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ServerParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/FailoverGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ApiVersionParameter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully deleted the failover group."
-                    },
-                    "204": {
-                        "description": "The specified failover group does not exist."
-                    },
-                    "default": {
-                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
-                        "schema": {
-                            "$ref": "#/definitions/ArmErrorResponseMessage"
-                        }
-                    }
-                },
-                "deprecated": false,
-                "x-ms-long-running-operation": true
-            },
-            "patch": {
-                "tags": [
-                    "FailoverGroups"
-                ],
-                "description": "Partially updates the failover group with the given name.",
-                "operationId": "FailoverGroups_Update",
-                "x-ms-examples": {
-                  "Update failover group": { "$ref": "../examples/FailoverGroupUpdate.json" }
-                },
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/SubscriptionIdParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ResourceGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ServerParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/FailoverGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ApiVersionParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/FailoverGroupBodyParameter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully updated the failover group.",
-                        "schema": {
-                            "$ref": "#/definitions/FailoverGroupResource"
-                        }
-                    },
-                    "default": {
-                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 400 FailoverGroupCreateOrUpdatePartiallySucceeded - Some databases could not be added or removed.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 409 FailoverGroupUnableToPerformGroupOperationOnDatabases - The list of databases to add/remove to/from Failover Group contains errors that are preventing operation to complete.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
-                        "schema": {
-                            "$ref": "#/definitions/ArmErrorResponseMessage"
-                        }
-                    }
-                },
-                "deprecated": false,
-                "x-ms-long-running-operation": true
-            }
+  "swagger": "2.0",
+  "info": {
+    "version": "2015-05-01-preview",
+    "title": "SqlManagementClient",
+    "description": "The Azure SQL Database management API provides a RESTful set of web APIs that interact with Azure SQL Database services to manage your databases. The API enables users to create, retrieve, update, and delete databases, servers, and other entities."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}": {
+      "get": {
+        "tags": [
+          "FailoverGroups"
+        ],
+        "description": "Gets a failover group.",
+        "operationId": "FailoverGroups_Get",
+        "x-ms-examples": {
+          "Get failover group": {
+            "$ref": "../examples/FailoverGroupGet.json"
+          }
         },
-        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups": {
-            "get": {
-                "tags": [
-                    "FailoverGroups"
-                ],
-                "description": "Lists the failover groups on the given server.",
-                "operationId": "FailoverGroups_List",
-                "x-ms-examples": {
-                  "List failover group": { "$ref": "../examples/FailoverGroupList.json" }
-                },
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/SubscriptionIdParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ResourceGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ServerParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ApiVersionParameter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully retrieved the failover groups.",
-                        "schema": {
-                            "$ref": "#/definitions/FailoverGroupResourceList"
-                        }
-                    },
-                    "default": {
-                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
-                        "schema": {
-                            "$ref": "#/definitions/ArmErrorResponseMessage"
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}/failover": {
-            "post": {
-                "tags": [
-                    "FailoverGroups"
-                ],
-                "description": "Starts planned failover operation for the failover group.",
-                "operationId": "FailoverGroups_Failover",
-                "x-ms-examples": {
-                  "Planned failover failover group": { "$ref": "../examples/FailoverGroupFailover.json" }
-                },
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/SubscriptionIdParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ResourceGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ServerParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/FailoverGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ApiVersionParameter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully failed over.",
-                        "schema": {
-                            "$ref": "#/definitions/FailoverGroupResource"
-                        }
-                    },
-                    "default": {
-                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
-                        "schema": {
-                            "$ref": "#/definitions/ArmErrorResponseMessage"
-                        }
-                    }
-                },
-                "deprecated": false,
-                "x-ms-long-running-operation": true
-            }
-        },
-        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}/forceFailoverAllowDataLoss": {
-            "post": {
-                "tags": [
-                    "FailoverGroups"
-                ],
-                "description": "Starts forced failover operation for the given failover group.",
-                "operationId": "FailoverGroups_ForceFailoverAllowDataLoss",
-                "x-ms-examples": {
-                  "Forced failover failover group": { "$ref": "../examples/FailoverGroupForceFailoverAllowDataLoss.json" }
-                },
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/SubscriptionIdParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ResourceGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ServerParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/FailoverGroupParameter"
-                    },
-                    {
-                        "$ref": "#/parameters/ApiVersionParameter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully failed over.",
-                        "schema": {
-                            "$ref": "#/definitions/FailoverGroupResource"
-                        }
-                    },
-                    "default": {
-                        "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout.",
-                        "schema": {
-                            "$ref": "#/definitions/ArmErrorResponseMessage"
-                        }
-                    }
-                },
-                "deprecated": false,
-                "x-ms-long-running-operation": true
-            }
-        }
-    },
-    "definitions": {
-        "ArmErrorResponseMessage": {
-            "description": "Contains information about the error that occured.",
-            "type": "object",
-            "properties": {
-                "error": {
-                    "$ref": "#/definitions/ArmErrorResponseExtendedErrorInfo",
-                    "description": "Contains the information about the error."
-                }
-            }
-        },
-        "ArmErrorResponseExtendedErrorInfo": {
-            "description": "Contains additional information about the error that occured.",
-            "type": "object",
-            "properties": {
-                "details": {
-                    "description": "A list of error details.",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ArmErrorResponseErrorDetail"
-                    }
-                },
-                "innerError": {
-                    "description": "The inner error if available."
-                },
-                "code": {
-                    "description": "The error code associated with the failure.",
-                    "type": "string"
-                },
-                "message": {
-                    "description": "The error message associated with the failure.",
-                    "type": "string"
-                },
-                "target": {
-                    "description": "The target of the particular error.",
-                    "type": "string"
-                }
-            }
-        },
-        "ArmErrorResponseErrorDetail": {
-            "description": "Contains detailed information about the error that occured.",
-            "type": "object",
-            "properties": {
-                "code": {
-                    "description": "The error code associated with the failure.",
-                    "type": "string"
-                },
-                "message": {
-                    "description": "The error message associated with the failure.",
-                    "type": "string"
-                },
-                "target": {
-                    "description": "The target of the particular error.",
-                    "type": "string"
-                }
-            }
-        },
-        "FailoverGroupResource": {
-            "description": "Contains information about an Azure SQL Server Failover Group.",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "location": {
-                    "type": "string"
-                },
-                "sku": {
-                    "$ref": "#/definitions/ArmResourceSku"
-                },
-                "kind": {
-                    "enum": [
-                        "None",
-                        "V2",
-                        "V12",
-                        "User",
-                        "System",
-                        "Datawarehouse"
-                    ],
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "properties": {
-                    "$ref": "#/definitions/FailoverGroupResourceProperties"
-                }
-            }
-        },
-        "ArmResourceSku": {
-            "description": "Represents an ARM Resource SKU.",
-            "type": "object",
-            "properties": {
-                "name": {
-                    "description": "The name of the SKU, typically, a letter + Number code, e.g. P3.",
-                    "type": "string"
-                },
-                "tier": {
-                    "description": "The tier of the particular SKU, e.g. Basic, Premium.",
-                    "type": "string"
-                },
-                "size": {
-                    "type": "string"
-                },
-                "family": {
-                    "type": "string"
-                },
-                "capacity": {
-                    "format": "int32",
-                    "type": "integer"
-                }
-            }
-        },
-        "FailoverGroupResourceProperties": {
-            "description": "Properties for a failover group",
-            "type": "object",
-            "properties": {
-                "readWriteEndpoint": {
-                    "$ref": "#/definitions/FailoverGroupReadWriteEndpoint",
-                    "description": "Read-write endpoint of the failover group instance."
-                },
-                "readOnlyEndpoint": {
-                    "$ref": "#/definitions/FailoverGroupReadOnlyEndpoint",
-                    "description": "Read-only endpoint of the failover group instance."
-                },
-                "replicationRole": {
-                    "description": "Local replication role of the failover group instance.",
-                    "enum": [
-                        "Primary",
-                        "Secondary"
-                    ],
-                    "type": "string"
-                },
-                "replicationState": {
-                    "description": "Replication state of the failover group instance.",
-                    "type": "string"
-                },
-                "partnerServers": {
-                    "description": "List of partner server information for the failover group.",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/PartnerInfo"
-                    }
-                },
-                "databases": {
-                    "description": "List of databases in the failover group.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "FailoverGroupReadWriteEndpoint": {
-            "type": "object",
-            "properties": {
-                "failoverPolicy": {
-                    "description": "Failover policy of the read-write endpoint for the failover group.",
-                    "enum": [
-                        "Manual",
-                        "Automatic"
-                    ],
-                    "type": "string"
-                },
-                "failoverWithDataLossGracePeriodMinutes": {
-                    "format": "int32",
-                    "description": "Grace period before failover with data loss is attempted for the read-write endpoint.",
-                    "type": "integer"
-                }
-            }
-        },
-        "FailoverGroupReadOnlyEndpoint": {
-            "type": "object",
-            "properties": {
-                "failoverPolicy": {
-                    "description": "Failover policy of the read-only endpoint for the failover group.",
-                    "enum": [
-                        "Disabled",
-                        "Enabled"
-                    ],
-                    "type": "string"
-                }
-            }
-        },
-        "PartnerInfo": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "Resource identifier of the partner server.",
-                    "type": "string"
-                },
-                "location": {
-                    "description": "Geo location of the partner server.",
-                    "type": "string"
-                },
-                "replicationRole": {
-                    "description": "Replication role of the partner server.",
-                    "enum": [
-                        "Primary",
-                        "Secondary"
-                    ],
-                    "type": "string"
-                }
-            }
-        },
-        "FailoverGroupResourceList": {
-            "description": "A list of failover groups.",
-            "type": "object",
-            "properties": {
-                "value": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/FailoverGroupResource"
-                    }
-                },
-                "nextLink": {
-                    "type": "string"
-                }
-            }
-        }
-    },
-    "parameters": {
-        "SubscriptionIdParameter": {
-            "name": "subscriptionId",
-            "in": "path",
-            "description": "The subscription ID that identifies an Azure subscription.",
-            "required": true,
-            "type": "string"
-        },
-        "ApiVersionParameter": {
-            "name": "api-version",
-            "in": "query",
-            "description": "The API version to use for the request.",
-            "required": true,
-            "x-ms-parameter-location": "client",
-            "type": "string"
-        },
-        "ResourceGroupParameter": {
-            "name": "resourceGroupName",
-            "in": "path",
-            "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
-            "required": true,
-            "x-ms-parameter-location": "method",
-            "type": "string"
-        },
-        "ServerParameter": {
-            "name": "serverName",
-            "in": "path",
-            "description": "The name of the server.",
-            "required": true,
-            "x-ms-parameter-location": "method",
-            "type": "string"
-        },
-        "FailoverGroupParameter": {
-            "name": "failoverGroupName",
-            "in": "path",
-            "description": "The name of the failover group.",
-            "required": true,
-            "x-ms-parameter-location": "method",
-            "type": "string"
-        },
-        "FailoverGroupBodyParameter": {
-            "name": "failoverGroup",
-            "in": "body",
-            "required": true,
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ServerParameter"
+          },
+          {
+            "$ref": "#/parameters/FailoverGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the specified failover group.",
             "schema": {
               "$ref": "#/definitions/FailoverGroupResource"
-            },
-            "description": "The failover group."
-        }
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout."
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "FailoverGroups"
+        ],
+        "description": "Creates or updates a failover group.",
+        "operationId": "FailoverGroups_CreateOrUpdate",
+        "x-ms-examples": {
+          "Create failover group": {
+            "$ref": "../examples/FailoverGroupCreateOrUpdate.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ServerParameter"
+          },
+          {
+            "$ref": "#/parameters/FailoverGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/FailoverGroupBodyParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated the failover group.",
+            "schema": {
+              "$ref": "#/definitions/FailoverGroupResource"
+            }
+          },
+          "201": {
+            "description": "Successfully created the failover group.",
+            "schema": {
+              "$ref": "#/definitions/FailoverGroupResource"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 400 FailoverGroupCreateOrUpdatePartiallySucceeded - Some databases could not be added or removed.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 409 FailoverGroupUnableToPerformGroupOperationOnDatabases - The list of databases to add/remove to/from Failover Group contains errors that are preventing operation to complete.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout."
+          }
+        },
+        "deprecated": false,
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "tags": [
+          "FailoverGroups"
+        ],
+        "description": "Deletes a failover group.",
+        "operationId": "FailoverGroups_Delete",
+        "x-ms-examples": {
+          "Delete failover group": {
+            "$ref": "../examples/FailoverGroupDelete.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ServerParameter"
+          },
+          {
+            "$ref": "#/parameters/FailoverGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted the failover group."
+          },
+          "204": {
+            "description": "The specified failover group does not exist."
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout."
+          }
+        },
+        "deprecated": false,
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "FailoverGroups"
+        ],
+        "description": "Updates a failover group.",
+        "operationId": "FailoverGroups_Update",
+        "x-ms-examples": {
+          "Update failover group": {
+            "$ref": "../examples/FailoverGroupUpdate.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ServerParameter"
+          },
+          {
+            "$ref": "#/parameters/FailoverGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/FailoverGroupBodyParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated the failover group.",
+            "schema": {
+              "$ref": "#/definitions/FailoverGroupResource"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 400 FailoverGroupCreateOrUpdatePartiallySucceeded - Some databases could not be added or removed.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 409 FailoverGroupUnableToPerformGroupOperationOnDatabases - The list of databases to add/remove to/from Failover Group contains errors that are preventing operation to complete.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout."
+          }
+        },
+        "deprecated": false,
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups": {
+      "get": {
+        "tags": [
+          "FailoverGroups"
+        ],
+        "description": "Lists the failover groups in a server.",
+        "operationId": "FailoverGroups_ListByServer",
+        "x-ms-examples": {
+          "List failover group": {
+            "$ref": "../examples/FailoverGroupList.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ServerParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the failover groups.",
+            "schema": {
+              "$ref": "#/definitions/FailoverGroupResourceList"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout."
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}/failover": {
+      "post": {
+        "tags": [
+          "FailoverGroups"
+        ],
+        "description": "Sets which server is primary by failing over from the current primary server.",
+        "operationId": "FailoverGroups_Failover",
+        "x-ms-examples": {
+          "Planned failover failover group": {
+            "$ref": "../examples/FailoverGroupFailover.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ServerParameter"
+          },
+          {
+            "$ref": "#/parameters/FailoverGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully failed over.",
+            "schema": {
+              "$ref": "#/definitions/FailoverGroupResource"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout."
+          }
+        },
+        "deprecated": false,
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}/forceFailoverAllowDataLoss": {
+      "post": {
+        "tags": [
+          "FailoverGroups"
+        ],
+        "description": "Sets which server is primary by failing over from the current primary server. This operation might result in data loss.",
+        "operationId": "FailoverGroups_ForceFailoverAllowDataLoss",
+        "x-ms-examples": {
+          "Forced failover failover group": {
+            "$ref": "../examples/FailoverGroupForceFailoverAllowDataLoss.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ServerParameter"
+          },
+          {
+            "$ref": "#/parameters/FailoverGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully failed over.",
+            "schema": {
+              "$ref": "#/definitions/FailoverGroupResource"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabases - The provided databases in the request are not valid database resource IDs.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidPartner - The given partners field in create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupCreateOrUpdateRequestDuplicatePartner - One or more of the provided partner servers are already part of the failover group. Please make sure the primary server and all of the given partner servers are unique.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidDatabaseServer - One or more of the provided databases do not exist on the primary server of the failover group. Please make sure that all the databases exist on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestUnsupportedPartnerCount - Only one partner server is supported.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpoint - The readWriteEndpoint field is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalid - The create or update failover group request body is empty or invalid.\n\n * 400 FailoverGroupUpdateOrDeleteRequestOnSecondary - Modifications to the failover group are not allowed on a secondary server. Execute the request on the primary server.\n\n * 400 FailoverGroupCreateOrUpdateRequestNegativeGracePeriodValues - Grace period value for the read-write endpoint must be non-negative.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFields - The property failoverWithDataLossGracePeriodMinutes must be provided when failover policy Automatic is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteFailoverPolicy - The failoverPolicy field for the read-write endpoint is required for create or update requests.\n\n * 400 FailoverGroupCreateOrUpdateRequestInvalidReadWriteEndpointFieldsForManualPolicy - Grace period value should not be provided when failover policy Manual is selected for the read-write endpoint.\n\n * 400 FailoverGroupCreateOrUpdateRequestReadOnlyPropertyModified - The create or update failover group request body should not modify the read-only property '{0}'.\n\n * 400 FailoverGroupFailoverRequestOnPrimary - The failover request should be initiated on the secondary server of failover group.\n\n * 400 FailoverGroupPartnerServerFromDifferentSubscription - Primary server and the partner servers of failover group are from different subscriptions. Cross subscription for servers of failover group is not allowed.\n\n * 400 UnableToResolveRemoteServer - The remote partner server name could not be resolved due to an invalid server name or DNS connectivity issues.\n\n * 400 RemoteDatabaseCopyPermission - User does not have sufficient permission to create a database copy on the specified server.\n\n * 400 InvalidFailoverGroupRegion - Servers specified in a Failover Group need to reside in different regions to provide isolation.\n\n * 400 ServerNotFound - The requested server was not found.\n\n * 400 FailoverGroupDoesNotExist - Failover group does not exist on a server.\n\n * 400 FailoverGroupNotSecondary - Failover cannot be initiated from the primary server in a Failover Group.\n\n * 400 PlannedFailoverTimedOutForDatabase - User invoked planned failover, it timed out, and a specific database appears to be to blame.\n\n * 400 PlannedFailoverTimedOut - User invoked planned failover, and it timed out while trying to contact the partner management service.\n\n * 400 DatabaseInFailoverGroupNotPrimary - GeoDR link for the database already exists, but its role is not 'Primary' or it is not continuous copy link.\n\n * 400 InvalidAddSecondaryPermission - User does not have sufficient permission to add secondary on the specified server.\n\n * 400 InvalidSku - The user specified an invalid sku.\n\n * 400 FeatureDisabledOnSelectedEdition - User attempted to use a feature which is disabled on current database edition.\n\n * 400 InvalidTargetSubregion - The target server of a non-readable secondary is not in a DR paired Azure region.\n\n * 400 PartnerServerNotCompetible - The user is attempting to copy a database from a SAWA V1 server to a Sterling server or vice versa.\n\n * 400 IncorrectReplicationLinkState - The operation expects the database to be in an expected state on the replication link.\n\n * 400 ResourcePoolNotFound - Specified elastic pool does not exist in the specified logical server.\n\n * 400 GeoReplicationDatabaseNotSecondary - The operation expects the database to be a replication target.\n\n * 400 GeoReplicaLimitReached - The per-replica replication limit was reached.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ResourceNotFound - The requested resource was not found.\n\n * 404 OperationIdNotFound - The operation with Id does not exist.\n\n * 404 ServerNotInSubscriptionResourceGroup - Specified server does not exist in the specified resource group and subscription.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 ServerNotInSubscription - Specified server does not exist on the specified subscription.\n\n * 405 UnsupportedReplicationOperation - An unsupported replication operation was initiated on the database.\n\n * 409 OperationCancelled - The operation has been cancelled by user.\n\n * 409 OperationInterrupted - The operation on the resource could not be completed because it was interrupted by another operation on the same resource.\n\n * 409 UpdateSloInProgress - User tried to initiate an incompatible operation while a SLO update was in progress.\n\n * 409 RemoteDatabaseExists - The destination database name already exists on the destination server.\n\n * 409 FailoverGroupAlreadyExists - Failover group already exists on a given server.\n\n * 409 FailoverGroupBusy - Failover Group is busy with another operation.\n\n * 409 DatabaseBelongsToOtherFailoverGroup - Database belongs to other Failover Group and cannot be consider a part of this one.\n\n * 409 DatabaseBeingAddedToFailoverGroup - The database is currently being added to Failover Group, customer needs to wait for this operation to finish to issue remove.\n\n * 409 DatabaseBeingRemovedFromFailoverGroup - The database is currently being removed from failover group, customer needs to wait for this operation to finish to issue add.\n\n * 409 FailoverGroupDnsRecordInUse - A duplicate DNS record exists for the requested endpoint.\n\n * 409 InvalidFailoverGroupName - Invalid Failover Group name was supplied.\n\n * 409 SubscriptionDisabled - Subscription is disabled.\n\n * 409 ConflictingSystemOperationInProgress - A system maintenance operation is in progress on the database and further operations need to wait until it is completed.\n\n * 409 InvalidOperationForDatabaseNotInReplicationRelationship - A replication seeding operation was performed on a database that is already in a replication relationship.\n\n * 409 InvalidDatabaseStateForOperation - The operation is not allowed on the database in its current replication state.\n\n * 409 DuplicateGeoDrRelation - The databases are already in a replication relation. This is a duplicate request.\n\n * 409 GeoReplicationCannotBecomePrimaryDuringUndo - User attempted to failover or force-terminate a geo-link while the secondary is in a state where it may not be physically consistent and so cannot enter the primary role.\n\n * 429 SubscriptionTooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 ConflictingServerOperation - An operation is currently in progress for the server.\n\n * 429 TooManyRequests - Requests beyond max requests that can be processed by available resources.\n\n * 429 SubscriptionTooManyCreateUpdateRequests - Requests beyond max requests that can be processed by available resources.\n\n * 500 OperationTimedOut - The operation timed out and automatically rolled back. Please retry the operation.\n\n * 504 RequestTimeout - Service request exceeded the allowed timeout."
+          }
+        },
+        "deprecated": false,
+        "x-ms-long-running-operation": true
+      }
     }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "ARM resource.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TrackedResource": {
+      "description": "ARM tracked top level resource.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create",
+            "update"
+          ],
+          "description": "Resource tags."
+        },
+        "location": {
+          "type": "string",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "description": "Resource location."
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ]
+    },
+    "ProxyResource": {
+      "description": "ARM proxy resource.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ]
+    },
+    "FailoverGroupResource": {
+      "description": "Contains information about failover group.",
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "description": "The geo-location where the resource lives."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create",
+            "update"
+          ],
+          "description": "Resource tags."
+        },
+        "properties": {
+          "$ref": "#/definitions/FailoverGroupProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "FailoverGroupProperties": {
+      "description": "Properties of a failover group.",
+      "type": "object",
+      "properties": {
+        "readWriteEndpoint": {
+          "$ref": "#/definitions/FailoverGroupReadWriteEndpoint",
+          "description": "Read-write endpoint of the failover group instance."
+        },
+        "readOnlyEndpoint": {
+          "$ref": "#/definitions/FailoverGroupReadOnlyEndpoint",
+          "description": "Read-only endpoint of the failover group instance."
+        },
+        "replicationRole": {
+          "description": "Local replication role of the failover group instance.",
+          "enum": [
+            "Primary",
+            "Secondary"
+          ],
+          "readOnly": true,
+          "type": "string",
+          "x-ms-enum": {
+            "name": "FailoverGroupReplicationRole"
+          }
+        },
+        "replicationState": {
+          "description": "Replication state of the failover group instance.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "partnerServers": {
+          "description": "List of partner server information for the failover group.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PartnerInfo"
+          }
+        },
+        "databases": {
+          "description": "List of databases in the failover group.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FailoverGroupReadWriteEndpoint": {
+      "type": "object",
+      "properties": {
+        "failoverPolicy": {
+          "description": "Failover policy of the read-write endpoint for the failover group.",
+          "enum": [
+            "Manual",
+            "Automatic"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ReadWriteEndpointFailoverPolicy"
+          }
+        },
+        "failoverWithDataLossGracePeriodMinutes": {
+          "format": "int32",
+          "description": "Grace period before failover with data loss is attempted for the read-write endpoint.",
+          "type": "integer"
+        }
+      }
+    },
+    "FailoverGroupReadOnlyEndpoint": {
+      "type": "object",
+      "properties": {
+        "failoverPolicy": {
+          "description": "Failover policy of the read-only endpoint for the failover group.",
+          "enum": [
+            "Disabled",
+            "Enabled"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ReadOnlyEndpointFailoverPolicy"
+          }
+        }
+      }
+    },
+    "PartnerInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Resource identifier of the partner server.",
+          "type": "string"
+        },
+        "location": {
+          "description": "Geo location of the partner server.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "replicationRole": {
+          "description": "Replication role of the partner server.",
+          "readOnly": true,
+          "enum": [
+            "Primary",
+            "Secondary"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "FailoverGroupReplicationRole"
+          }
+        }
+      }
+    },
+    "FailoverGroupResourceList": {
+      "description": "A list of failover groups.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FailoverGroupResource"
+          }
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "The subscription ID that identifies an Azure subscription.",
+      "required": true,
+      "type": "string"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for the request.",
+      "required": true,
+      "x-ms-parameter-location": "client",
+      "type": "string"
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
+      "required": true,
+      "x-ms-parameter-location": "method",
+      "type": "string"
+    },
+    "ServerParameter": {
+      "name": "serverName",
+      "in": "path",
+      "description": "The name of the server.",
+      "required": true,
+      "x-ms-parameter-location": "method",
+      "type": "string"
+    },
+    "FailoverGroupParameter": {
+      "name": "failoverGroupName",
+      "in": "path",
+      "description": "The name of the failover group.",
+      "required": true,
+      "x-ms-parameter-location": "method",
+      "type": "string"
+    },
+    "FailoverGroupBodyParameter": {
+      "name": "failoverGroup",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/FailoverGroupResource"
+      },
+      "description": "The failover group."
+    }
+  }
 }

--- a/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
+++ b/arm-sql/2015-05-01-preview/swagger/failoverGroups.json
@@ -1,7 +1,7 @@
 {
     "swagger": "2.0",
     "info": {
-        "version": "2.0",
+        "version": "2015-05-01-preview",
         "title": "SqlManagementClient",
         "description": "The Azure SQL Database management API provides a RESTful set of web APIs that interact with Azure SQL Database services to manage your databases. The API enables users to create, retrieve, update, and delete databases, servers, and other entities."
     },
@@ -28,23 +28,18 @@
                 },
                 "parameters": [
                     {
-                        "required": true,
                         "$ref": "#/parameters/SubscriptionIdParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ResourceGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ServerParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/FailoverGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ApiVersionParameter"
                     }
                 ],
@@ -75,32 +70,22 @@
                 },
                 "parameters": [
                     {
-                        "required": true,
                         "$ref": "#/parameters/SubscriptionIdParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ResourceGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ServerParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/FailoverGroupParameter"
                     },
                     {
-                        "name": "failoverGroup",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/FailoverGroupResource"
-                        }
+                        "$ref": "#/parameters/ApiVersionParameter"
                     },
                     {
-                        "required": true,
-                        "$ref": "#/parameters/ApiVersionParameter"
+                        "$ref": "#/parameters/FailoverGroupBodyParameter"
                     }
                 ],
                 "responses": {
@@ -137,23 +122,18 @@
                 },
                 "parameters": [
                     {
-                        "required": true,
                         "$ref": "#/parameters/SubscriptionIdParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ResourceGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ServerParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/FailoverGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ApiVersionParameter"
                     }
                 ],
@@ -185,24 +165,22 @@
                 },
                 "parameters": [
                     {
-                        "required": true,
                         "$ref": "#/parameters/SubscriptionIdParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ResourceGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ServerParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/FailoverGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/FailoverGroupBodyParameter"
                     }
                 ],
                 "responses": {
@@ -235,19 +213,15 @@
                 },
                 "parameters": [
                     {
-                        "required": true,
                         "$ref": "#/parameters/SubscriptionIdParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ResourceGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ServerParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ApiVersionParameter"
                     }
                 ],
@@ -280,23 +254,18 @@
                 },
                 "parameters": [
                     {
-                        "required": true,
                         "$ref": "#/parameters/SubscriptionIdParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ResourceGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ServerParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/FailoverGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ApiVersionParameter"
                     }
                 ],
@@ -330,23 +299,18 @@
                 },
                 "parameters": [
                     {
-                        "required": true,
                         "$ref": "#/parameters/SubscriptionIdParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ResourceGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ServerParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/FailoverGroupParameter"
                     },
                     {
-                        "required": true,
                         "$ref": "#/parameters/ApiVersionParameter"
                     }
                 ],
@@ -492,7 +456,7 @@
             }
         },
         "FailoverGroupResourceProperties": {
-            "description": "Properties for an Azure SQL Database Failover Group",
+            "description": "Properties for a failover group",
             "type": "object",
             "properties": {
                 "readWriteEndpoint": {
@@ -638,6 +602,15 @@
             "required": true,
             "x-ms-parameter-location": "method",
             "type": "string"
+        },
+        "FailoverGroupBodyParameter": {
+            "name": "failoverGroup",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FailoverGroupResource"
+            },
+            "description": "The failover group."
         }
     }
 }

--- a/arm-sql/compositeSql.json
+++ b/arm-sql/compositeSql.json
@@ -10,6 +10,7 @@
     "./2014-04-01/swagger/replicationLinks.json",
     "./2014-04-01/swagger/sql.core.json",
     "./2014-04-01/swagger/databaseSecurityAlertPolicies.json",
-    "./2015-05-01-preview/swagger/blobAuditingPolicies.json"
+    "./2015-05-01-preview/swagger/blobAuditingPolicies.json",
+    "./2015-05-01-preview/swagger/failoverGroups.json"
   ]
 }


### PR DESCRIPTION
Adding Azure SQL Database Failover Group REST API specifications as the feature will be in public preview soon.

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
