### PR TITLE
resourceGroupName must have x-ms-parameter-location - method extension

### DIFF
--- a/arm-storageimportexport/2016-11-01/swagger/storageimportexport.json
+++ b/arm-storageimportexport/2016-11-01/swagger/storageimportexport.json
@@ -1193,7 +1193,8 @@
       "in": "path",
       "description": "The resource group name uniquely identifies the resource group within the user subscription.",
       "required": true,
-      "type": "string"
+      "type": "string",
+      "x-ms-parameter-location": "method"
     },
     "Accept-Language": {
       "name": "Accept-Language",


### PR DESCRIPTION
If this extension is not applied then resourceGroupName ends up being a property on the client. This is incorrect based on the current convention.