### PR TITLE
[arm-authorization] Adding / before providers

### DIFF
--- a/arm-authorization/2015-07-01/swagger/authorization.json
+++ b/arm-authorization/2015-07-01/swagger/authorization.json
@@ -246,7 +246,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}providers/Microsoft.Authorization/roleAssignments": {
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}/providers/Microsoft.Authorization/roleAssignments": {
       "get": {
         "tags": [
           "RoleAssignments"


### PR DESCRIPTION
Seems suspicious to not have `/` int he path. 

Feel free to comment if you have any prior knowledge on why it may be right. 