### PR TITLE
ADLA Catalog updates

### DIFF
--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogGetPackage.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogGetPackage.json
@@ -1,0 +1,16 @@
+{
+    "parameters": {
+        "api-version": "2016-11-01",
+        "databaseName": "master",
+        "schemaName": "dbo",
+        "packageName": "catalog_item_8",
+        "accountName": "contosoadla"
+    },
+    "responses": {
+        "200": {
+            "body": {                
+                "computeAccountName":"contosoadla","databaseName":"master","schemaName":"dbo","packageName":"catalog_item_8","definition":"this is a placeholder string that would define the package","version":"776b9091-8916-4638-87f7-9c989a38da98"
+            }
+        }
+    }
+}

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogGetPackage.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogGetPackage.json
@@ -9,7 +9,12 @@
     "responses": {
         "200": {
             "body": {                
-                "computeAccountName":"contosoadla","databaseName":"master","schemaName":"dbo","packageName":"catalog_item_8","definition":"this is a placeholder string that would define the package","version":"776b9091-8916-4638-87f7-9c989a38da98"
+                "computeAccountName":"contosoadla",
+                "databaseName":"master",
+                "schemaName":"dbo",
+                "packageName":"catalog_item_8",
+                "definition":"this is a placeholder string that would define the package",
+                "version":"776b9091-8916-4638-87f7-9c989a38da98"
             }
         }
     }

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListPackages.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListPackages.json
@@ -1,0 +1,20 @@
+{
+    "parameters": {
+        "api-version": "2016-11-01",
+        "databaseName": "master",
+        "schemaName": "dbo",
+        "accountName": "contosoadla"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value":[
+                    {
+                        "computeAccountName":"contosoadla","databaseName":"master","schemaName":"dbo","packageName":"catalog_item_8","definition":"this is a placeholder string that would define the package","version":"776b9091-8916-4638-87f7-9c989a38da98"
+
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListPackages.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListPackages.json
@@ -10,7 +10,12 @@
             "body": {
                 "value":[
                     {
-                        "computeAccountName":"contosoadla","databaseName":"master","schemaName":"dbo","packageName":"catalog_item_8","definition":"this is a placeholder string that would define the package","version":"776b9091-8916-4638-87f7-9c989a38da98"
+                        "computeAccountName":"contosoadla",
+                        "databaseName":"master",
+                        "schemaName":"dbo",
+                        "packageName":"catalog_item_8",
+                        "definition":"this is a placeholder string that would define the package",
+                        "version":"776b9091-8916-4638-87f7-9c989a38da98"
 
                     }
                 ]

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListPackages.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListPackages.json
@@ -18,7 +18,8 @@
                         "version":"776b9091-8916-4638-87f7-9c989a38da98"
 
                     }
-                ]
+                ],
+                "nextLink":"https://contosoadl.datalakeanalytics.net/catalog/usql/databases/master/schemas/dbo/packages?api-version=2016-11-01&%24skiptoken=<token>"
             }
         }
     }

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListStatisticsInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListStatisticsInDatabase.json
@@ -1,0 +1,34 @@
+{
+    "parameters": {
+        "api-version": "2016-11-01",
+        "databaseName": "master",
+        "accountName": "contosoadla"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value":[
+                    {
+                        "computeAccountName":"contosoadla",
+                        "databaseName":"master",
+                        "schemaName":"dbo",
+                        "tableName":"catalog_item_8",
+                        "statisticsName": "testStats",
+                        "userStatName": "fake stat name",
+                        "statDataPath": "fake data",
+                        "createTime": "2017-04-14T13:21:56.6819037-07:00",
+                        "updateTime": "2017-04-14T13:21:56.6819037-07:00",
+                        "isUserCreated": true,
+                        "isAutoCreated": false,
+                        "hasFilter": true,
+                        "filterDefinition": "fake data",
+                        "colNames": [
+                            "fake col1",
+                            "fake col2"
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListStatisticsInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListStatisticsInDatabase.json
@@ -27,7 +27,8 @@
                             "fake col2"
                         ]
                     }
-                ]
+                ],
+                "nextLink":"https://contosoadla.datalakeanalytics.net/catalog/usql/databases/master/statistics?api-version=2016-11-01&%24skiptoken=<token>"
             }
         }
     }

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListStatisticsInDatabaseSchema.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListStatisticsInDatabaseSchema.json
@@ -1,0 +1,35 @@
+{
+    "parameters": {
+        "api-version": "2016-11-01",
+        "databaseName": "master",
+        "schemaName": "dbo",
+        "accountName": "contosoadla"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value":[
+                    {
+                        "computeAccountName":"contosoadla",
+                        "databaseName":"master",
+                        "schemaName":"dbo",
+                        "tableName":"catalog_item_8",
+                        "statisticsName": "testStats",
+                        "userStatName": "fake stat name",
+                        "statDataPath": "fake data",
+                        "createTime": "2017-04-14T13:21:56.6819037-07:00",
+                        "updateTime": "2017-04-14T13:21:56.6819037-07:00",
+                        "isUserCreated": true,
+                        "isAutoCreated": false,
+                        "hasFilter": true,
+                        "filterDefinition": "fake data",
+                        "colNames": [
+                            "fake col1",
+                            "fake col2"
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListStatisticsInDatabaseSchema.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListStatisticsInDatabaseSchema.json
@@ -28,7 +28,8 @@
                             "fake col2"
                         ]
                     }
-                ]
+                ],
+                "nextLink":"https://contosoadla.datalakeanalytics.net/catalog/usql/databases/master/schema/dbo/statistics?api-version=2016-11-01&%24skiptoken=<token>"
             }
         }
     }

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTableValuedFunctionsInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTableValuedFunctionsInDatabase.json
@@ -9,7 +9,12 @@
             "body": {
                 "value":[
                     {
-                        "computeAccountName":"contosoadla","databaseName":"master","schemaName":"dbo","tvfName":"WeblogsView","definition":"//create TVF WeblogsView on space-delimited website log data\nCREATE FUNCTION master.dbo.WeblogsView()\nRETURNS @result TABLE\n(\n    s_date DateTime,\n    s_time string,\n    s_sitename string,\n    cs_method string, \n    cs_uristem string,\n    cs_uriquery string,\n    s_port int,\n    cs_username string, \n    c_ip string,\n    cs_useragent string,\n    cs_cookie string,\n    cs_referer string, \n    cs_host string,\n    sc_status int,\n    sc_substatus int,\n    sc_win32status int, \n    sc_bytes int,\n    cs_bytes int,\n    s_timetaken int\n)\nAS\nBEGIN\n\n    @result = EXTRACT\n        s_date DateTime,\n        s_time string,\n        s_sitename string,\n        cs_method string,\n        cs_uristem string,\n        cs_uriquery string,\n        s_port int,\n        cs_username string,\n        c_ip string,\n        cs_useragent string,\n        cs_cookie string,\n        cs_referer string,\n        cs_host string,\n        sc_status int,\n        sc_substatus int,\n        sc_win32status int,\n        sc_bytes int,\n        cs_bytes int,\n        s_timetaken int\n    FROM @\"/Samples/Data/WebLog.log\"\n    USING Extractors.Text(delimiter:' ');\n\nEND;","version":"7884a35b-a2b8-4375-9a47-54c367cf346e"
+                        "computeAccountName":"contosoadla",
+                        "databaseName":"master",
+                        "schemaName":"dbo",
+                        "tvfName":"WeblogsView",
+                        "definition":"fake data",
+                        "version":"7884a35b-a2b8-4375-9a47-54c367cf346e"
                     }
                 ]
             }

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTableValuedFunctionsInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTableValuedFunctionsInDatabase.json
@@ -1,0 +1,18 @@
+{
+    "parameters": {
+        "api-version": "2016-11-01",
+        "databaseName": "master",
+        "accountName": "contosoadla"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value":[
+                    {
+                        "computeAccountName":"contosoadla","databaseName":"master","schemaName":"dbo","tvfName":"WeblogsView","definition":"//create TVF WeblogsView on space-delimited website log data\nCREATE FUNCTION master.dbo.WeblogsView()\nRETURNS @result TABLE\n(\n    s_date DateTime,\n    s_time string,\n    s_sitename string,\n    cs_method string, \n    cs_uristem string,\n    cs_uriquery string,\n    s_port int,\n    cs_username string, \n    c_ip string,\n    cs_useragent string,\n    cs_cookie string,\n    cs_referer string, \n    cs_host string,\n    sc_status int,\n    sc_substatus int,\n    sc_win32status int, \n    sc_bytes int,\n    cs_bytes int,\n    s_timetaken int\n)\nAS\nBEGIN\n\n    @result = EXTRACT\n        s_date DateTime,\n        s_time string,\n        s_sitename string,\n        cs_method string,\n        cs_uristem string,\n        cs_uriquery string,\n        s_port int,\n        cs_username string,\n        c_ip string,\n        cs_useragent string,\n        cs_cookie string,\n        cs_referer string,\n        cs_host string,\n        sc_status int,\n        sc_substatus int,\n        sc_win32status int,\n        sc_bytes int,\n        cs_bytes int,\n        s_timetaken int\n    FROM @\"/Samples/Data/WebLog.log\"\n    USING Extractors.Text(delimiter:' ');\n\nEND;","version":"7884a35b-a2b8-4375-9a47-54c367cf346e"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTableValuedFunctionsInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTableValuedFunctionsInDatabase.json
@@ -16,7 +16,8 @@
                         "definition":"fake data",
                         "version":"7884a35b-a2b8-4375-9a47-54c367cf346e"
                     }
-                ]
+                ],
+                "nextLink":"https://contosoadla.datalakeanalytics.net/catalog/usql/databases/master/tablevaluedfunctions?api-version=2016-11-01&%24skiptoken=<token>"
             }
         }
     }

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTablesInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTablesInDatabase.json
@@ -1,0 +1,56 @@
+{
+    "parameters": {
+        "api-version": "2016-11-01",
+        "databaseName": "master",
+        "accountName": "contosoadla"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value":[
+                    {
+                        "computeAccountName":"contosoadla","databaseName":"master","schemaName":"dbo","tableName":"CUSTOMER","columnList":[
+                            {
+                            "name":"C_CUSTKEY","type":"System.Int64"
+                            },{
+                            "name":"C_NAME","type":"System.String"
+                            },{
+                            "name":"C_ADDRESS","type":"System.String"
+                            },{
+                            "name":"C_NATIONKEY","type":"System.Int64"
+                            },{
+                            "name":"C_PHONE","type":"System.String"
+                            },{
+                            "name":"C_ACCTBAL","type":"System.Decimal?"
+                            },{
+                            "name":"C_MKTSEGMENT","type":"System.String"
+                            },{
+                            "name":"C_COMMENT","type":"System.String"
+                            }
+                        ],"indexList":[
+                            {
+                            "name":"idx_customer","indexKeys":[
+                                {
+                                "name":"C_CUSTKEY","descending":false
+                                }
+                            ],"columns":[
+                                "C_CUSTKEY"
+                            ],"distributionInfo":{
+                                "type":5,"keys":[
+                                {
+                                    "name":"C_CUSTKEY","descending":false
+                                }
+                                ],"count":0,"dynamicCount":0
+                            },"partitionFunction":"a23ede66-3132-49ea-a568-b2dba2595319","partitionKeyList":[
+                                
+                            ],"isColumnstore":false,"indexId":1,"isUnique":false
+                            }
+                        ],"partitionKeyList":[
+                            
+                        ],"externalTable":null,"distributionInfo":null,"version":"847b96bf-95a3-4c71-a09c-b432c3d6df24"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTablesInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListTablesInDatabase.json
@@ -49,7 +49,8 @@
                             
                         ],"externalTable":null,"distributionInfo":null,"version":"847b96bf-95a3-4c71-a09c-b432c3d6df24"
                     }
-                ]
+                ],
+                "nextLink":"https://contosoadla.datalakeanalytics.net/catalog/usql/databases/master/tables?api-version=2016-11-01&%24skiptoken=<token>"
             }
         }
     }

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListViewsInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListViewsInDatabase.json
@@ -17,7 +17,8 @@
                         "version":"776b9091-8916-4638-87f7-9c989a38da98"
 
                     }
-                ]
+                ],
+                "nextLink":"https://contosoadla.datalakeanalytics.net/catalog/usql/databases/master/views?api-version=2016-11-01&%24skiptoken=<token>"
             }
         }
     }

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListViewsInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListViewsInDatabase.json
@@ -9,7 +9,12 @@
             "body": {
                 "value":[
                     {
-                        "computeAccountName":"contosoadla","databaseName":"master","schemaName":"dbo","viewName":"catalog_item_8","definition":"CREATE VIEW master.dbo.catalog_item_8 AS SELECT * FROM (VALUES(1,2),(2,4)) AS T(a, b);","version":"776b9091-8916-4638-87f7-9c989a38da98"
+                        "computeAccountName":"contosoadla",
+                        "databaseName":"master",
+                        "schemaName":"dbo",
+                        "viewName":"catalog_item_8",
+                        "definition":"CREATE VIEW master.dbo.catalog_item_8 AS SELECT * FROM (VALUES(1,2),(2,4)) AS T(a, b);",
+                        "version":"776b9091-8916-4638-87f7-9c989a38da98"
 
                     }
                 ]

--- a/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListViewsInDatabase.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/examples/AdlCatalogListViewsInDatabase.json
@@ -1,0 +1,19 @@
+{
+    "parameters": {
+        "api-version": "2016-11-01",
+        "databaseName": "master",
+        "accountName": "contosoadla"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value":[
+                    {
+                        "computeAccountName":"contosoadla","databaseName":"master","schemaName":"dbo","viewName":"catalog_item_8","definition":"CREATE VIEW master.dbo.catalog_item_8 AS SELECT * FROM (VALUES(1,2),(2,4)) AS T(a, b);","version":"776b9091-8916-4638-87f7-9c989a38da98"
+
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/arm-datalake-analytics/catalog/2016-11-01/swagger/catalog.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/swagger/catalog.json
@@ -833,8 +833,11 @@
         "tags": [
           "Catalog"
         ],
-        "operationId": "Catalog_ListStatisticsByDatabaseAndSchema",
+        "operationId": "Catalog_ListTableStatisticsByDatabaseAndSchema",
         "description": "Retrieves the list of all table statistics within the specified schema from the Data Lake Analytics catalog.",
+        "x-ms-examples": {
+          "List all table statistics in a database and schema": { "$ref": "../examples/AdlCatalogListStatisticsInDatabaseSchema.json" }
+        },
         "parameters": [
           {
             "name": "databaseName",
@@ -1050,6 +1053,9 @@
         ],
         "operationId": "Catalog_GetPackage",
         "description": "Retrieves the specified package from the Data Lake Analytics catalog.",
+        "x-ms-examples": {
+          "Get a specific package": { "$ref": "../examples/AdlCatalogGetPackage.json" }
+        },
         "parameters": [
           {
             "name": "databaseName",
@@ -1093,6 +1099,9 @@
         ],
         "operationId": "Catalog_ListPackages",
         "description": "Retrieves the list of packages from the Data Lake Analytics catalog.",
+        "x-ms-examples": {
+          "List all packages in a database and schema": { "$ref": "../examples/AdlCatalogListPackages.json" }
+        },
         "parameters": [
           {
             "name": "databaseName",
@@ -2037,8 +2046,11 @@
         "tags": [
           "Catalog"
         ],
-        "operationId": "Catalog_ListStatisticsByDatabase",
+        "operationId": "Catalog_ListTableStatisticsByDatabase",
         "description": "Retrieves the list of all statistics in a database from the Data Lake Analytics catalog.",
+        "x-ms-examples": {
+          "List all table statistics in a database": { "$ref": "../examples/AdlCatalogListStatisticsInDatabase.json" }
+        },
         "parameters": [
           {
             "name": "databaseName",
@@ -2118,6 +2130,9 @@
         ],
         "operationId": "Catalog_ListTablesByDatabase",
         "description": "Retrieves the list of all tables in a database from the Data Lake Analytics catalog.",
+        "x-ms-examples": {
+          "List all tables in a database": { "$ref": "../examples/AdlCatalogListTablesInDatabase.json" }
+        },
         "parameters": [
           {
             "name": "databaseName",
@@ -2197,6 +2212,9 @@
         ],
         "operationId": "Catalog_ListTableValuedFunctionsByDatabase",
         "description": "Retrieves the list of all table valued functions in a database from the Data Lake Analytics catalog.",
+        "x-ms-examples": {
+          "List all table valued functions in a database": { "$ref": "../examples/AdlCatalogListTableValuedFunctionsInDatabase.json" }
+        },
         "parameters": [
           {
             "name": "databaseName",
@@ -2276,6 +2294,9 @@
         ],
         "operationId": "Catalog_ListViewsByDatabase",
         "description": "Retrieves the list of all views in a database from the Data Lake Analytics catalog.",
+        "x-ms-examples": {
+          "List all views in a database": { "$ref": "../examples/AdlCatalogListViewsInDatabase.json" }
+        },
         "parameters": [
           {
             "name": "databaseName",

--- a/arm-datalake-analytics/catalog/2016-11-01/swagger/catalog.json
+++ b/arm-datalake-analytics/catalog/2016-11-01/swagger/catalog.json
@@ -828,6 +828,92 @@
         "x-ms-odata": "#/definitions/USqlTable"
       }
     },
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/statistics": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListStatisticsByDatabaseAndSchema",
+        "description": "Retrieves the list of all table statistics within the specified schema from the Data Lake Analytics catalog.",
+        "parameters": [
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database containing the statistics."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema containing the statistics."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OrderBy clause. One or more comma-separated expressions with an optional \"asc\" (the default) or \"desc\" depending on the order you'd like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of all table statistics in the specified database and schema.",
+            "schema": {
+              "$ref": "#/definitions/USqlTableStatisticsList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/USqlTableStatistics"
+      }
+    },
     "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/tabletypes/{tableTypeName}": {
       "get": {
         "tags": [
@@ -955,6 +1041,135 @@
           "nextLinkName": "nextLink"
         },
         "x-ms-odata": "#/definitions/USqlTableType"
+      }
+    },
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/packages/{packageName}": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_GetPackage",
+        "description": "Retrieves the specified package from the Data Lake Analytics catalog.",
+        "parameters": [
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database containing the package."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema containing the package."
+          },
+          {
+            "name": "packageName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the package."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the specified package from the underying database and schema combination",
+            "schema": {
+              "$ref": "#/definitions/USqlPackage"
+            }
+          }
+        }
+      }
+    },
+    "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/packages": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListPackages",
+        "description": "Retrieves the list of packages from the Data Lake Analytics catalog.",
+        "parameters": [
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database containing the packages."
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the schema containing the packages."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OrderBy clause. One or more comma-separated expressions with an optional \"asc\" (the default) or \"desc\" depending on the order you'd like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of packages in the specified database and schema.",
+            "schema": {
+              "$ref": "#/definitions/USqlPackageList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/USqlPackage"
       }
     },
     "/catalog/usql/databases/{databaseName}/schemas/{schemaName}/views/{viewName}": {
@@ -1817,6 +2032,322 @@
         "x-ms-odata": "#/definitions/USqlSchema"
       }
     },
+    "/catalog/usql/databases/{databaseName}/statistics": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListStatisticsByDatabase",
+        "description": "Retrieves the list of all statistics in a database from the Data Lake Analytics catalog.",
+        "parameters": [
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database containing the table statistics."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OrderBy clause. One or more comma-separated expressions with an optional \"asc\" (the default) or \"desc\" depending on the order you'd like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of all table statistics in the specified database.",
+            "schema": {
+              "$ref": "#/definitions/USqlTableStatisticsList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/USqlTableStatistics"
+      }
+    },
+    "/catalog/usql/databases/{databaseName}/tables": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListTablesByDatabase",
+        "description": "Retrieves the list of all tables in a database from the Data Lake Analytics catalog.",
+        "parameters": [
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database containing the tables."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OrderBy clause. One or more comma-separated expressions with an optional \"asc\" (the default) or \"desc\" depending on the order you'd like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of all tables in the specified database.",
+            "schema": {
+              "$ref": "#/definitions/USqlTableList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/USqlTable"
+      }
+    },
+    "/catalog/usql/databases/{databaseName}/tablevaluedfunctions": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListTableValuedFunctionsByDatabase",
+        "description": "Retrieves the list of all table valued functions in a database from the Data Lake Analytics catalog.",
+        "parameters": [
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database containing the table valued functions."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OrderBy clause. One or more comma-separated expressions with an optional \"asc\" (the default) or \"desc\" depending on the order you'd like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of all table valued functions in the specified database.",
+            "schema": {
+              "$ref": "#/definitions/USqlTableValuedFunctionList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/USqlTableValuedFunction"
+      }
+    },
+    "/catalog/usql/databases/{databaseName}/views": {
+      "get": {
+        "tags": [
+          "Catalog"
+        ],
+        "operationId": "Catalog_ListViewsByDatabase",
+        "description": "Retrieves the list of all views in a database from the Data Lake Analytics catalog.",
+        "parameters": [
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database containing the views."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData filter. Optional."
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to return. Optional."
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "The number of items to skip over before returning elements. Optional."
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OData Select statement. Limits the properties on each entry to just those requested, e.g. Categories?$select=CategoryName,Description. Optional."
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OrderBy clause. One or more comma-separated expressions with an optional \"asc\" (the default) or \"desc\" depending on the order you'd like the values sorted, e.g. Categories?$orderby=CategoryName desc. Optional."
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "The Boolean value of true or false to request a count of the matching resources included with the resources in the response, e.g. Categories?$count=true. Optional."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of all views in the specified database.",
+            "schema": {
+              "$ref": "#/definitions/USqlViewList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/USqlView"
+      }
+    },
     "/catalog/usql/databases/{databaseName}": {
       "get": {
         "tags": [
@@ -2474,6 +3005,51 @@
       },
       "description": "A Data Lake Analytics catalog U-SQL view item list."
     },
+    "USqlPackage": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CatalogItem"
+        }
+      ],
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "the name of the database containing the package."
+        },
+        "schemaName": {
+          "type": "string",
+          "description": "the name of the schema associated with this package and database."
+        },
+        "packageName": {
+          "type": "string",
+          "x-ms-client-name": "name",
+          "description": "the name of the package."
+        },
+        "definition": {
+          "type": "string",
+          "description": "the definition of the package."
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL package item."
+    },
+    "USqlPackageList": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CatalogItemList"
+        }
+      ],
+      "properties": {
+        "value": {
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/USqlPackage"
+          },
+          "description": "the list of packages in the database and schema combination"
+        }
+      },
+      "description": "A Data Lake Analytics catalog U-SQL package item list."
+    },
     "USqlTablePartition": {
       "allOf": [
         {
@@ -2767,11 +3343,12 @@
           "description": "the assembly file type.",
           "enum": [
             "Assembly",
-            "Resource"
+            "Resource",
+            "Nodeploy"
           ],
           "x-ms-enum": {
             "name": "FileType",
-            "modelAsString": false
+            "modelAsString": true
           }
         },
         "originalPath": {


### PR DESCRIPTION
Inclusion of USqlPackages
(BREAKING) Switch FileType enum to be modeled as a string. This is
important since this field changes frequently and we don't want to break
the SDK for this read-only property
Add support for listing various catalog elements from higher level
nodes:
tables, views, statistics and tvfs from within a database (no schema
required)
statistics from within a schema (no table required).

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
