### PR TITLE
Service Bus: Adding Location to the Response Models

### DIFF
--- a/arm-servicebus/2015-08-01/swagger/servicebus.json
+++ b/arm-servicebus/2015-08-01/swagger/servicebus.json
@@ -1694,6 +1694,10 @@
           "type": "string",
           "description": "Resource name"
         },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
         "type": {
           "readOnly": true,
           "type": "string",


### PR DESCRIPTION
The Location field is [in the Request Models](https://github.com/Azure/azure-sdk-for-go/blob/master/arm/servicebus/models.go#L217) for the Go SDK, but [not in the Response Models](https://github.com/Azure/azure-sdk-for-go/blob/master/arm/servicebus/models.go#L551) - meaning it's possible to set but not retrieve this value.

This PR adds this field back in, as it's [still exposed in the HTTP Response](https://gist.github.com/tombuildsstuff/814f512639389dadceef598fd3fcbc68) - and is a required field when Creating/Updating - so I believe this has been incorrectly deprecated.

[This Gist shows the diff between the generated Go code between Master and this change](https://gist.github.com/tombuildsstuff/bea9b8a5ac35840b716c839555d4f4de) when running the following command:
```
dotnet AutoRest.dll -Namespace servicebus -CodeGenerator Go -Modeler Swagger -Input ~/code/src/github.com/Azure/azure-rest-api-specs/arm-servicebus/2015-08-01/swagger/servicebus.json
```

---

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 