### PR TITLE
Add 200 code for import APIs

### DIFF
--- a/arm-sql/2014-04-01/examples/DatabaseCreateImportMaxSasKey.json
+++ b/arm-sql/2014-04-01/examples/DatabaseCreateImportMaxSasKey.json
@@ -19,6 +19,24 @@
     }
   },
   "responses": {
+    "200": {
+      "body":{
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+        "name": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+        "type": "Microsoft.Sql/servers/importExportOperationResults",
+        "properties": {
+            "requestId": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+            "requestType": "Import",
+            "queuedTime": "3/1/2017 12:14:25 AM",
+            "lastModifiedTime": "3/1/2017 12:16:33 AM",
+            "blobUri": "https://test.blob.core.windows.net/bacpacs/test.bacpac",
+            "serverName": "test",
+            "databaseName": "testdb",
+            "status": "Completed",
+            "errorMessage": null
+        }
+      }
+    },
     "201": {
       "body":{
         "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",

--- a/arm-sql/2014-04-01/examples/DatabaseCreateImportMaxSasKey.json
+++ b/arm-sql/2014-04-01/examples/DatabaseCreateImportMaxSasKey.json
@@ -37,24 +37,6 @@
         }
       }
     },
-    "201": {
-      "body":{
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-        "name": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-        "type": "Microsoft.Sql/servers/importExportOperationResults",
-        "properties": {
-            "requestId": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-            "requestType": "Import",
-            "queuedTime": "3/1/2017 12:14:25 AM",
-            "lastModifiedTime": "3/1/2017 12:16:33 AM",
-            "blobUri": "https://test.blob.core.windows.net/bacpacs/test.bacpac",
-            "serverName": "test",
-            "databaseName": "testdb",
-            "status": "Completed",
-            "errorMessage": null
-        }
-      }
-    },
     "202": {}
   }
 }

--- a/arm-sql/2014-04-01/examples/DatabaseCreateImportMaxStorageKey.json
+++ b/arm-sql/2014-04-01/examples/DatabaseCreateImportMaxStorageKey.json
@@ -19,6 +19,24 @@
     }
   },
   "responses": {
+    "200": {
+      "body":{
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+        "name": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+        "type": "Microsoft.Sql/servers/importExportOperationResults",
+        "properties": {
+            "requestId": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+            "requestType": "Import",
+            "queuedTime": "3/1/2017 12:14:25 AM",
+            "lastModifiedTime": "3/1/2017 12:16:33 AM",
+            "blobUri": "https://test.blob.core.windows.net/bacpacs/test.bacpac",
+            "serverName": "test",
+            "databaseName": "testdb",
+            "status": "Completed",
+            "errorMessage": null
+        }
+      }
+    },
     "201": {
       "body":{
         "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",

--- a/arm-sql/2014-04-01/examples/DatabaseCreateImportMaxStorageKey.json
+++ b/arm-sql/2014-04-01/examples/DatabaseCreateImportMaxStorageKey.json
@@ -37,24 +37,6 @@
         }
       }
     },
-    "201": {
-      "body":{
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-        "name": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-        "type": "Microsoft.Sql/servers/importExportOperationResults",
-        "properties": {
-            "requestId": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-            "requestType": "Import",
-            "queuedTime": "3/1/2017 12:14:25 AM",
-            "lastModifiedTime": "3/1/2017 12:16:33 AM",
-            "blobUri": "https://test.blob.core.windows.net/bacpacs/test.bacpac",
-            "serverName": "test",
-            "databaseName": "testdb",
-            "status": "Completed",
-            "errorMessage": null
-        }
-      }
-    },
     "202": {}
   }
 }

--- a/arm-sql/2014-04-01/examples/DatabaseCreateImportMinSasKey.json
+++ b/arm-sql/2014-04-01/examples/DatabaseCreateImportMinSasKey.json
@@ -36,24 +36,6 @@
         }
       }
     },
-    "201": {
-      "body":{
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-        "name": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-        "type": "Microsoft.Sql/servers/importExportOperationResults",
-        "properties": {
-            "requestId": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-            "requestType": "Import",
-            "queuedTime": "3/1/2017 12:14:25 AM",
-            "lastModifiedTime": "3/1/2017 12:16:33 AM",
-            "blobUri": "https://test.blob.core.windows.net/bacpacs/test.bacpac",
-            "serverName": "test",
-            "databaseName": "testdb",
-            "status": "Completed",
-            "errorMessage": null
-        }
-      }
-    },
     "202": {}
   }
 }

--- a/arm-sql/2014-04-01/examples/DatabaseCreateImportMinSasKey.json
+++ b/arm-sql/2014-04-01/examples/DatabaseCreateImportMinSasKey.json
@@ -18,6 +18,24 @@
     }
   },
   "responses": {
+    "200": {
+      "body":{
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+        "name": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+        "type": "Microsoft.Sql/servers/importExportOperationResults",
+        "properties": {
+            "requestId": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+            "requestType": "Import",
+            "queuedTime": "3/1/2017 12:14:25 AM",
+            "lastModifiedTime": "3/1/2017 12:16:33 AM",
+            "blobUri": "https://test.blob.core.windows.net/bacpacs/test.bacpac",
+            "serverName": "test",
+            "databaseName": "testdb",
+            "status": "Completed",
+            "errorMessage": null
+        }
+      }
+    },
     "201": {
       "body":{
         "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",

--- a/arm-sql/2014-04-01/examples/DatabaseCreateImportMinStorageKey.json
+++ b/arm-sql/2014-04-01/examples/DatabaseCreateImportMinStorageKey.json
@@ -36,24 +36,6 @@
         }
       }
     },
-    "201": {
-      "body":{
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-        "name": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-        "type": "Microsoft.Sql/servers/importExportOperationResults",
-        "properties": {
-            "requestId": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
-            "requestType": "Import",
-            "queuedTime": "3/1/2017 12:14:25 AM",
-            "lastModifiedTime": "3/1/2017 12:16:33 AM",
-            "blobUri": "https://test.blob.core.windows.net/bacpacs/test.bacpac",
-            "serverName": "test",
-            "databaseName": "testdb",
-            "status": "Completed",
-            "errorMessage": null
-        }
-      }
-    },
     "202": {}
   }
 }

--- a/arm-sql/2014-04-01/examples/DatabaseCreateImportMinStorageKey.json
+++ b/arm-sql/2014-04-01/examples/DatabaseCreateImportMinStorageKey.json
@@ -18,6 +18,24 @@
     }
   },
   "responses": {
+    "200": {
+      "body":{
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+        "name": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+        "type": "Microsoft.Sql/servers/importExportOperationResults",
+        "properties": {
+            "requestId": "f01d7bfe-7162-44e7-9350-f1c85ce83e4c",
+            "requestType": "Import",
+            "queuedTime": "3/1/2017 12:14:25 AM",
+            "lastModifiedTime": "3/1/2017 12:16:33 AM",
+            "blobUri": "https://test.blob.core.windows.net/bacpacs/test.bacpac",
+            "serverName": "test",
+            "databaseName": "testdb",
+            "status": "Completed",
+            "errorMessage": null
+        }
+      }
+    },
     "201": {
       "body":{
         "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/sqlcrudtest-4799/providers/Microsoft.Sql/servers/sqlcrudtest-5961/importExportOperationResult/f01d7bfe-7162-44e7-9350-f1c85ce83e4c",

--- a/arm-sql/2014-04-01/swagger/importExport.json
+++ b/arm-sql/2014-04-01/swagger/importExport.json
@@ -47,6 +47,12 @@
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                        "$ref": "#/definitions/ImportExportResponse"
+                        }
+                    },
                     "201": {
                         "description": "Created",
                         "schema": {

--- a/arm-sql/2014-04-01/swagger/importExport.json
+++ b/arm-sql/2014-04-01/swagger/importExport.json
@@ -53,12 +53,6 @@
                         "$ref": "#/definitions/ImportExportResponse"
                         }
                     },
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                        "$ref": "#/definitions/ImportExportResponse"
-                        }
-                    },
                     "202": {
                         "description": "Accepted"
                     }


### PR DESCRIPTION
Import was returning 201 when this swagger was updated to return 201, and SDK tests were passing.

Import just returned 200 and caused SDK tests to fail, so leaving both 200 and 201 documented.

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
