### PR TITLE
Pluaralize ComputePolicies operation group

### DIFF
--- a/arm-datalake-analytics/account/2016-11-01/swagger/account.json
+++ b/arm-datalake-analytics/account/2016-11-01/swagger/account.json
@@ -40,9 +40,9 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}/computePolicies/{computePolicyName}": {
       "put": {
         "tags": [
-          "ComputePolicy"
+          "ComputePolicies"
         ],
-        "operationId": "ComputePolicy_CreateOrUpdate",
+        "operationId": "ComputePolicies_CreateOrUpdate",
         "description": "Creates or updates the specified compute policy. During update, the compute policy with the specified name will be replaced with this new compute policy. An account supports, at most, 50 policies",
         "parameters": [
           {
@@ -93,9 +93,9 @@
       },
       "patch": {
         "tags": [
-          "ComputePolicy"
+          "ComputePolicies"
         ],
-        "operationId": "ComputePolicy_Update",
+        "operationId": "ComputePolicies_Update",
         "description": "Updates the specified compute policy.",
         "parameters": [
           {
@@ -146,9 +146,9 @@
       },
       "delete": {
         "tags": [
-          "ComputePolicy"
+          "ComputePolicies"
         ],
-        "operationId": "ComputePolicy_Delete",
+        "operationId": "ComputePolicies_Delete",
         "description": "Deletes the specified compute policy from the specified Data Lake Analytics account",
         "parameters": [
           {
@@ -190,9 +190,9 @@
       },
       "get": {
         "tags": [
-          "ComputePolicy"
+          "ComputePolicies"
         ],
-        "operationId": "ComputePolicy_Get",
+        "operationId": "ComputePolicies_Get",
         "description": "Gets the specified Data Lake Analytics compute policy.",
         "parameters": [
           {
@@ -236,9 +236,9 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}/computePolicies": {
       "get": {
         "tags": [
-          "ComputePolicy"
+          "ComputePolicies"
         ],
-        "operationId": "ComputePolicy_ListByAccount",
+        "operationId": "ComputePolicies_ListByAccount",
         "description": "Lists the Data Lake Analytics compute policies within the specified Data Lake Analytics account. An account supports, at most, 50 policies",
         "parameters": [
           {


### PR DESCRIPTION
This was missed during initial swagger review. This new group should by
pluralized since it also contains an object called "ComputePolicy"

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
