### PR TITLE
Adding license header constant in SiteRecovery spec

### DIFF
--- a/arm-recoveryservicessiterecovery/2016-08-10/swagger/service.json
+++ b/arm-recoveryservicessiterecovery/2016-08-10/swagger/service.json
@@ -2,7 +2,10 @@
   "swagger": "2.0",
   "info": {
     "version": "2016-08-10",
-    "title": "SiteRecoveryManagementClient"
+    "title": "SiteRecoveryManagementClient",
+    "x-ms-code-generation-settings": {
+      "header": "MICROSOFT_MIT_NO_VERSION"
+    }
   },
   "host": "management.azure.com",
   "schemes": [

--- a/arm-recoveryservicessiterecovery/2016-08-10/swagger/service.json
+++ b/arm-recoveryservicessiterecovery/2016-08-10/swagger/service.json
@@ -6858,7 +6858,7 @@
       "description": "Input details specific to fabrics during Network Mapping.",
       "type": "object",
       "properties": {
-        "InstanceType": {
+        "instanceType": {
           "description": "The instance type.",
           "type": "string"
         }
@@ -9178,10 +9178,6 @@
         "primaryNetworkId": {
           "description": "The primary azure vnet Id.",
           "type": "string"
-        },
-        "InstanceType": {
-          "description": "The instance type.",
-          "type": "string"
         }
       },
       "x-ms-discriminator-value": "AzureToAzure"
@@ -9194,12 +9190,7 @@
           "$ref": "#/definitions/FabricSpecificUpdateNetworkMappingInput"
         }
       ],
-      "properties": {
-        "InstanceType": {
-          "description": "The instance type.",
-          "type": "string"
-        }
-      },
+      "properties": {},
       "x-ms-discriminator-value": "VmmToAzure"
     },
     "VmmToVmmUpdateNetworkMappingInput": {
@@ -9210,12 +9201,7 @@
           "$ref": "#/definitions/FabricSpecificUpdateNetworkMappingInput"
         }
       ],
-      "properties": {
-        "InstanceType": {
-          "description": "The instance type.",
-          "type": "string"
-        }
-      },
+      "properties": {},
       "x-ms-discriminator-value": "VmmToVmm"
     },
     "AzureFabricSpecificDetails": {


### PR DESCRIPTION
Change is to address the comment on PR: https://github.com/Azure/azure-sdk-for-net/pull/3194

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-rest-api-specs/1227)
<!-- Reviewable:end -->
