### PR TITLE
Remove duplicate path among composite swaggers

### DIFF
--- a/arm-recoveryservices/2016-06-01/swagger/backup.json
+++ b/arm-recoveryservices/2016-06-01/swagger/backup.json
@@ -18,41 +18,6 @@
     "application/json"
   ],
   "paths": {
-    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Returns the list of available operations.",
-        "operationId": "Operations_List",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/SubscriptionId"
-          },
-          {
-            "$ref": "#/parameters/ApiVersion"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupName"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "./vaults.json#/definitions/ClientDiscoveryResponse"
-            }
-          }
-        },
-        "deprecated": false,
-        "x-ms-pageable": {
-          "nextLinkName": "NextLink"
-        }
-      }
-    },
     "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupconfig/vaultconfig": {
       "get": {
         "tags": [

--- a/arm-recoveryservices/2016-06-01/swagger/registeredidentities.json
+++ b/arm-recoveryservices/2016-06-01/swagger/registeredidentities.json
@@ -18,41 +18,6 @@
     "application/json"
   ],
   "paths": {
-    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Returns the list of available operations.",
-        "operationId": "Operations_List",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/SubscriptionId"
-          },
-          {
-            "$ref": "#/parameters/ApiVersion"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupName"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "./vaults.json#/definitions/ClientDiscoveryResponse"
-            }
-          }
-        },
-        "deprecated": false,
-        "x-ms-pageable": {
-          "nextLinkName": "NextLink"
-        }
-      }
-    },
     "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/certificates/{certificateName}": {
       "put": {
         "tags": [

--- a/arm-recoveryservices/2016-06-01/swagger/replicationusages.json
+++ b/arm-recoveryservices/2016-06-01/swagger/replicationusages.json
@@ -18,41 +18,6 @@
     "application/json"
   ],
   "paths": {
-    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Returns the list of available operations.",
-        "operationId": "Operations_List",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/SubscriptionId"
-          },
-          {
-            "$ref": "#/parameters/ApiVersion"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupName"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "../../2016-06-01/swagger/vaults.json#/definitions/ClientDiscoveryResponse"
-            }
-          }
-        },
-        "deprecated": false,
-        "x-ms-pageable": {
-          "nextLinkName": "NextLink"
-        }
-      }
-    },
     "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/replicationUsages": {
       "get": {
         "tags": [

--- a/arm-recoveryservices/2016-06-01/swagger/vaults.json
+++ b/arm-recoveryservices/2016-06-01/swagger/vaults.json
@@ -50,6 +50,41 @@
         }
       }
     },
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "description": "Returns the list of available operations.",
+        "operationId": "Operations_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionId"
+          },
+          {
+            "$ref": "#/parameters/ApiVersion"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ClientDiscoveryResponse"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-pageable": {
+          "nextLinkName": "NextLink"
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults": {
       "get": {
         "tags": [

--- a/arm-recoveryservices/2016-06-01/swagger/vaults.json
+++ b/arm-recoveryservices/2016-06-01/swagger/vaults.json
@@ -50,41 +50,6 @@
         }
       }
     },
-    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Returns the list of available operations.",
-        "operationId": "Operations_List",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/SubscriptionId"
-          },
-          {
-            "$ref": "#/parameters/ApiVersion"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupName"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/ClientDiscoveryResponse"
-            }
-          }
-        },
-        "deprecated": false,
-        "x-ms-pageable": {
-          "nextLinkName": "NextLink"
-        }
-      }
-    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults": {
       "get": {
         "tags": [

--- a/arm-recoveryservices/2016-06-01/swagger/vaultusages.json
+++ b/arm-recoveryservices/2016-06-01/swagger/vaultusages.json
@@ -18,41 +18,6 @@
     "application/json"
   ],
   "paths": {
-    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Returns the list of available operations.",
-        "operationId": "Operations_List",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/SubscriptionId"
-          },
-          {
-            "$ref": "#/parameters/ApiVersion"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupName"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "./vaults.json#/definitions/ClientDiscoveryResponse"
-            }
-          }
-        },
-        "deprecated": false,
-        "x-ms-pageable": {
-          "nextLinkName": "NextLink"
-        }
-      }
-    },
     "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/usages": {
       "get": {
         "tags": [


### PR DESCRIPTION
This PR is to fix the issue with the arm-recoveryservices swagger. This is a composite swagger that points to 5 swagger files. The Operations path with 'get' operation is defined in each one of them that causes the autorest core to error out. You will see the following error:

```
C:\workspace\azure-rest-api-specs>"C:\Program Files\nodejs\node.exe" C:\workspace\autorest\src\core\AutoRest\bin\Debug\netcoreapp1.0\node_modules\autorest-core\app.js -i C:\workspace\azure-rest-api-specs\arm-recoveryservices\compositeRecoveryServicesClient.json -pv 0.10.0 -n Azure::ARM::RecoveryServices -pn azure_mgmt_recovery_services -g Azure.Ruby -o C:\workspace\lib -m CompositeSwagger
FATAL: swagger-document/compose - FAILED
Process() Cancelled due to exception : '$.paths["/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/operations"].get.parameters' has incomaptible values (---
- $ref: '#/parameters/SubscriptionId'
- name: api-version
  in: query
  description: Client Api Version.
  required: true
  type: string
  enum:
    - '2016-12-01'
- $ref: '#/parameters/ResourceGroupName'
, ---
- $ref: '#/parameters/SubscriptionId'
- name: api-version
  in: query
  description: Client Api Version.
  required: true
  type: string
  enum:
    - '2016-06-01'
- $ref: '#/parameters/ResourceGroupName'
).
Error: '$.paths["/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/operations"].get.parameters' has incomaptible values (---
- $ref: '#/parameters/SubscriptionId'
- name: api-version
  in: query
  description: Client Api Version.
  required: true
  type: string
  enum:
    - '2016-12-01'
- $ref: '#/parameters/ResourceGroupName'
, ---
- $ref: '#/parameters/SubscriptionId'
- name: api-version
  in: query
  description: Client Api Version.
  required: true
  type: string
  enum:
    - '2016-06-01'
- $ref: '#/parameters/ResourceGroupName'
).
    at Merge (C:\workspace\autorest\src\autorest-core\lib\source-map\merging.ts:64:9)
    at Merge (C:\workspace\autorest\src\autorest-core\lib\source-map\merging.ts:58:23)
    at Merge (C:\workspace\autorest\src\autorest-core\lib\source-map\merging.ts:58:23)
    at Merge (C:\workspace\autorest\src\autorest-core\lib\source-map\merging.ts:58:23)
    at Merge (C:\workspace\autorest\src\autorest-core\lib\source-map\merging.ts:58:23)
    at Object.MergeYamls (C:\workspace\autorest\src\autorest-core\lib\source-map\merging.ts:212:20)
    at Object.<anonymous> (C:\workspace\autorest\src\autorest-core\lib\pipeline\swagger-loader.ts:418:24)
    at next (native)
    at fulfilled (C:\workspace\autorest\src\autorest-core\lib\polyfill.min.js:27:62)
    at process._tickCallback (internal/process/next_tick.js:103:7)

```
Now with this PR, the issue is resolved and the SDK is generated successfully.


