### PR TITLE
Fix geoBackupPolicies swagger

### DIFF
--- a/arm-sql/2014-04-01/swagger/geoBackupPolicies.json
+++ b/arm-sql/2014-04-01/swagger/geoBackupPolicies.json
@@ -47,16 +47,7 @@
             "description": "The name of the database."
           },
           {
-            "name": "geoBackupPolicyName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "enum": ["Default"],
-            "description": "The name of the geo backup policy.",
-            "x-ms-enum":{
-              "modelAsString": true,
-              "name": "GeoBackupPolicyName"
-            }
+            "$ref": "#/parameters/GeoBackupPolicyName"
           },
           {
             "name": "parameters",
@@ -113,11 +104,7 @@
             "description": "The name of the database."
           },
           {
-            "name": "geoBackupPolicyName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the geo backup policy."
+            "$ref": "#/parameters/GeoBackupPolicyName"
           }
         ],
         "responses": {
@@ -296,6 +283,18 @@
       "type": "string",
       "description": "The name of the server.",
       "x-ms-parameter-location": "method"
+    },
+    "GeoBackupPolicyNameParameter": {
+      "name": "geoBackupPolicyName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "enum": ["Default"],
+      "description": "The name of the geo backup policy.",
+      "x-ms-enum":{
+        "modelAsString": true,
+        "name": "GeoBackupPolicyName"
+      }
     }
   },
   "securityDefinitions": {

--- a/arm-sql/2014-04-01/swagger/geoBackupPolicies.json
+++ b/arm-sql/2014-04-01/swagger/geoBackupPolicies.json
@@ -47,7 +47,7 @@
             "description": "The name of the database."
           },
           {
-            "$ref": "#/parameters/GeoBackupPolicyName"
+            "$ref": "#/parameters/GeoBackupPolicyNameParameter"
           },
           {
             "name": "parameters",
@@ -104,7 +104,7 @@
             "description": "The name of the database."
           },
           {
-            "$ref": "#/parameters/GeoBackupPolicyName"
+            "$ref": "#/parameters/GeoBackupPolicyNameParameter"
           }
         ],
         "responses": {


### PR DESCRIPTION
Minor fix to create a common parameter in geoBackupPolicies swagger.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
