### PR TITLE
[#ApplicationGateway] Next link in PredefinedPolicies, predefinedPoliciesParam correction and version reverted

### DIFF
--- a/arm-network/2017-06-01/swagger/applicationGateway.json
+++ b/arm-network/2017-06-01/swagger/applicationGateway.json
@@ -462,7 +462,11 @@
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/PredefinedPolicyNameParameter"
+            "name": "predefinedPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Name of Ssl predefined policy."
           }
         ],
         "responses": {
@@ -1828,6 +1832,10 @@
             "$ref": "#/definitions/ApplicationGatewaySslPredefinedPolicy"
           },
           "description": "List of available Ssl predefined policy."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
         }
       },
       "description": "Response for ApplicationGatewayAvailableSslOptions API service call."
@@ -1955,13 +1963,6 @@
       "required": true,
       "type": "string",
       "description": "Client API version."
-    },
-    "PredefinedPolicyNameParameter": {
-      "name": "predefinedPolicyName",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "Name of Ssl predefined policy."
     }
   }
 }

--- a/arm-network/2017-06-01/swagger/networkWatcher.json
+++ b/arm-network/2017-06-01/swagger/networkWatcher.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NetworkManagementClient",
     "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
-    "version": "2017-06-01"
+    "version": "2017-03-01"
   },
   "host": "management.azure.com",
   "schemes": [

--- a/arm-network/2017-06-01/swagger/virtualNetwork.json
+++ b/arm-network/2017-06-01/swagger/virtualNetwork.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NetworkManagementClient",
     "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
-    "version": "2017-06-01"
+    "version": "2017-03-01"
   },
   "host": "management.azure.com",
   "schemes": [

--- a/arm-network/2017-06-01/swagger/vmssPublicIpAddress.json
+++ b/arm-network/2017-06-01/swagger/vmssPublicIpAddress.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NetworkManagementClient",
     "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
-    "version": "2017-06-01"
+    "version": "2017-03-01"
   },
   "host": "management.azure.com",
   "schemes": [


### PR DESCRIPTION
### Description

* Added Next link field in PredefinedPolicies
* Corrected predefined Policies Param which are defined in global context to local context
* Reverted some versions of the file that were created in previous pull request to 2017-03-01 as they should be only updated by the team maintaining them.

… 

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
