### PR TITLE
less misleading tags (due to repeated confusion at the consumer side)

### DIFF
--- a/specification/advisor/resource-manager/readme.md
+++ b/specification/advisor/resource-manager/readme.md
@@ -29,36 +29,36 @@ These are the global settings for the Advisor API.
 title: Advisor
 description: Advisor Client
 openapi-type: arm
-tag: 2017-04-19
+tag: package-2017-04
 
 ```
 
 
-# Tag: 2017-04-19
+# Tag: package-2017-04
 
-These settings apply only when `--tag=2017-04-19` is specified on the command line.
+These settings apply only when `--tag=package-2017-04` is specified on the command line.
 
-``` yaml $(tag) == '2017-04-19'
+``` yaml $(tag) == 'package-2017-04'
 input-file:
 - Microsoft.Advisor/2017-04-19/advisor.json
 
 ```
  
-# Tag: 2017-03-31
+# Tag: package-2017-03
 
-These settings apply only when `--tag=2017-03-31` is specified on the command line.
+These settings apply only when `--tag=package-2017-03` is specified on the command line.
 
-``` yaml $(tag) == '2017-03-31'
+``` yaml $(tag) == 'package-2017-03'
 input-file:
 - Microsoft.Advisor/2017-03-31/advisor.json
 
 ```
  
-# Tag: 2016-07-12-preview
+# Tag: package-2016-07-preview
 
-These settings apply only when `--tag=2016-07-12-preview` is specified on the command line.
+These settings apply only when `--tag=package-2016-07-preview` is specified on the command line.
 
-``` yaml $(tag) == '2016-07-12-preview'
+``` yaml $(tag) == 'package-2016-07-preview'
 input-file:
 - Microsoft.Advisor/2016-07-12-preview/advisor.json
 

--- a/specification/analysisservices/resource-manager/readme.md
+++ b/specification/analysisservices/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the AnalysisServices API.
 title: Analysis Services
 description: Analysis Services Client
 openapi-type: arm
-tag: 2016-05-16
+tag: package-2016-05
 
 ```
 
 
-# Tag: 2016-05-16
+# Tag: package-2016-05
 
-These settings apply only when `--tag=2016-05-16` is specified on the command line.
+These settings apply only when `--tag=package-2016-05` is specified on the command line.
 
-``` yaml $(tag) == '2016-05-16'
+``` yaml $(tag) == 'package-2016-05'
 input-file:
 - Microsoft.AnalysisServices/2016-05-16/analysisservices.json
 

--- a/specification/apimanagement/resource-manager/readme.md
+++ b/specification/apimanagement/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the ApiManagement API.
 title: ApiManagementClient
 description: ApiManagement Client
 openapi-type: arm
-tag: 2016-10-10
+tag: package-2016-10
 
 ```
 
 
-# Tag: 2016-10-10
+# Tag: package-2016-10
 
-These settings apply only when `--tag=2016-10-10` is specified on the command line.
+These settings apply only when `--tag=package-2016-10` is specified on the command line.
 
-``` yaml $(tag) == '2016-10-10'
+``` yaml $(tag) == 'package-2016-10'
 input-file:
 - Microsoft.ApiManagement/2016-10-10/apimanagement.json
 - Microsoft.ApiManagement/2016-10-10/apimapis.json
@@ -61,11 +61,11 @@ input-file:
 
 ```
  
-# Tag: 2016-07-07
+# Tag: package-2016-07
 
-These settings apply only when `--tag=2016-07-07` is specified on the command line.
+These settings apply only when `--tag=package-2016-07` is specified on the command line.
 
-``` yaml $(tag) == '2016-07-07'
+``` yaml $(tag) == 'package-2016-07'
 input-file:
 - Microsoft.ApiManagement/2016-07-07/apimanagement.json
 - Microsoft.ApiManagement/2016-07-07/apimdeployment.json

--- a/specification/appinsights/resource-manager/readme.md
+++ b/specification/appinsights/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the AppInsights API.
 title: AppInsights
 description: AppInsights Client
 openapi-type: arm
-tag: 2015-05-01
+tag: package-2015-05
 
 ```
 
 
-# Tag: 2015-05-01
+# Tag: package-2015-05
 
-These settings apply only when `--tag=2015-05-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-05` is specified on the command line.
 
-``` yaml $(tag) == '2015-05-01'
+``` yaml $(tag) == 'package-2015-05'
 input-file:
 - microsoft.insights/2015-05-01/aiOperations_API.json
 - microsoft.insights/2015-05-01/components_API.json

--- a/specification/authorization/resource-manager/readme.md
+++ b/specification/authorization/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the Authorization API.
 title: Authorization
 description: Authorization Client
 openapi-type: arm
-tag: 2015-07-01
+tag: package-2015-07
 
 ```
 
 
-# Tag: 2015-07-01
+# Tag: package-2015-07
 
-These settings apply only when `--tag=2015-07-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-07` is specified on the command line.
 
-``` yaml $(tag) == '2015-07-01'
+``` yaml $(tag) == 'package-2015-07'
 input-file:
 - Microsoft.Authorization/2015-07-01/authorization.json
 

--- a/specification/automation/resource-manager/readme.md
+++ b/specification/automation/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the Automation API.
 title: Azure Automation
 description: Automation Client
 openapi-type: arm
-tag: 2015-10-31
+tag: package-2015-10
 
 ```
 
 
-# Tag: 2015-10-31
+# Tag: package-2015-10
 
-These settings apply only when `--tag=2015-10-31` is specified on the command line.
+These settings apply only when `--tag=package-2015-10` is specified on the command line.
 
-``` yaml $(tag) == '2015-10-31'
+``` yaml $(tag) == 'package-2015-10'
 input-file:
 - Microsoft.Automation/2015-10-31/account.json
 - Microsoft.Automation/2015-10-31/certificate.json

--- a/specification/batch/data-plane/readme.md
+++ b/specification/batch/data-plane/readme.md
@@ -29,68 +29,68 @@ These are the global settings for the Batch API.
 title: Batch
 description: Batch Client
 openapi-type: data-plane
-tag: 2017-06-01.5.1
+tag: package-2017-06.5.1
 
 ```
 
 
-# Tag: 2017-06-01.5.1
+# Tag: package-2017-06.5.1
 
-These settings apply only when `--tag=2017-06-01.5.1` is specified on the command line.
+These settings apply only when `--tag=package-2017-06.5.1` is specified on the command line.
 
-``` yaml $(tag) == '2017-06-01.5.1'
+``` yaml $(tag) == 'package-2017-06.5.1'
 input-file:
 - Microsoft.Batch/2017-06-01.5.1/BatchService.json
 
 ```
 
 
-# Tag: 2017-05-01.5.0
+# Tag: package-2017-05.5.0
 
-These settings apply only when `--tag=2017-05-01.5.0` is specified on the command line.
+These settings apply only when `--tag=package-2017-05.5.0` is specified on the command line.
 
-``` yaml $(tag) == '2017-05-01.5.0'
+``` yaml $(tag) == 'package-2017-05.5.0'
 input-file:
 - Microsoft.Batch/2017-05-01.5.0/BatchService.json
 
 ```
 
 
-# Tag: 2017-01-01.4.0
+# Tag: package-2017-01.4.0
 
-These settings apply only when `--tag=2017-01-01.4.0` is specified on the command line.
+These settings apply only when `--tag=package-2017-01.4.0` is specified on the command line.
 
-``` yaml $(tag) == '2017-01-01.4.0'
+``` yaml $(tag) == 'package-2017-01.4.0'
 input-file:
 - Microsoft.Batch/2017-01-01.4.0/BatchService.json
 
 ```
  
-# Tag: 2016-07-01.3.1
+# Tag: package-2016-07.3.1
 
-These settings apply only when `--tag=2016-07-01.3.1` is specified on the command line.
+These settings apply only when `--tag=package-2016-07.3.1` is specified on the command line.
 
-``` yaml $(tag) == '2016-07-01.3.1'
+``` yaml $(tag) == 'package-2016-07.3.1'
 input-file:
 - Microsoft.Batch/2016-07-01.3.1/BatchService.json
 
 ```
  
-# Tag: 2016-02-01.3.0
+# Tag: package-2016-02.3.0
 
-These settings apply only when `--tag=2016-02-01.3.0` is specified on the command line.
+These settings apply only when `--tag=package-2016-02.3.0` is specified on the command line.
 
-``` yaml $(tag) == '2016-02-01.3.0'
+``` yaml $(tag) == 'package-2016-02.3.0'
 input-file:
 - Microsoft.Batch/2016-02-01.3.0/BatchService.json
 
 ```
  
-# Tag: 2015-12-01.2.2
+# Tag: package-2015-12.2.2
 
-These settings apply only when `--tag=2015-12-01.2.2` is specified on the command line.
+These settings apply only when `--tag=package-2015-12.2.2` is specified on the command line.
 
-``` yaml $(tag) == '2015-12-01.2.2'
+``` yaml $(tag) == 'package-2015-12.2.2'
 input-file:
 - Microsoft.Batch/2015-12-01.2.2/BatchService.json
 

--- a/specification/batch/resource-manager/readme.md
+++ b/specification/batch/resource-manager/readme.md
@@ -29,37 +29,37 @@ These are the global settings for the Batch API.
 title: Batch
 description: Batch Client
 openapi-type: arm
-tag: 2017-05-01
+tag: package-2017-05
 
 ```
 
 
-# Tag: 2017-05-01
+# Tag: package-2017-05
 
-These settings apply only when `--tag=2017-05-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-05` is specified on the command line.
 
-``` yaml $(tag) == '2017-05-01'
+``` yaml $(tag) == 'package-2017-05'
 input-file:
 - Microsoft.Batch/2017-05-01/BatchManagement.json
 
 ```
 
 
-# Tag: 2017-01-01
+# Tag: package-2017-01
 
-These settings apply only when `--tag=2017-01-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-01` is specified on the command line.
 
-``` yaml $(tag) == '2017-01-01'
+``` yaml $(tag) == 'package-2017-01'
 input-file:
 - Microsoft.Batch/2017-01-01/BatchManagement.json
 
 ```
  
-# Tag: 2015-12-01
+# Tag: package-2015-12
 
-These settings apply only when `--tag=2015-12-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-12` is specified on the command line.
 
-``` yaml $(tag) == '2015-12-01'
+``` yaml $(tag) == 'package-2015-12'
 input-file:
 - Microsoft.Batch/2015-12-01/BatchManagement.json
 

--- a/specification/billing/resource-manager/readme.md
+++ b/specification/billing/resource-manager/readme.md
@@ -29,26 +29,26 @@ These are the global settings for the Billing API.
 title: Billing
 description: Billing Client
 openapi-type: arm
-tag: 2017-04-24-preview
+tag: package-2017-04-preview
 
 ```
 
 
-# Tag: 2017-04-24-preview
+# Tag: package-2017-04-preview
 
-These settings apply only when `--tag=2017-04-24-preview` is specified on the command line.
+These settings apply only when `--tag=package-2017-04-preview` is specified on the command line.
 
-``` yaml $(tag) == '2017-04-24-preview'
+``` yaml $(tag) == 'package-2017-04-preview'
 input-file:
 - Microsoft.Billing/2017-04-24-preview/billing.json
 
 ```
  
-# Tag: 2017-02-27-preview
+# Tag: package-2017-02-preview
 
-These settings apply only when `--tag=2017-02-27-preview` is specified on the command line.
+These settings apply only when `--tag=package-2017-02-preview` is specified on the command line.
 
-``` yaml $(tag) == '2017-02-27-preview'
+``` yaml $(tag) == 'package-2017-02-preview'
 input-file:
 - Microsoft.Billing/2017-02-27-preview/billing.json
 

--- a/specification/cdn/resource-manager/readme.md
+++ b/specification/cdn/resource-manager/readme.md
@@ -29,36 +29,36 @@ These are the global settings for the Cdn API.
 title: CDN
 description: CDN Client
 openapi-type: arm
-tag: 2016-10-02
+tag: package-2016-10
 
 ```
 
 
-# Tag: 2016-10-02
+# Tag: package-2016-10
 
-These settings apply only when `--tag=2016-10-02` is specified on the command line.
+These settings apply only when `--tag=package-2016-10` is specified on the command line.
 
-``` yaml $(tag) == '2016-10-02'
+``` yaml $(tag) == 'package-2016-10'
 input-file:
 - Microsoft.Cdn/2016-10-02/cdn.json
 
 ```
  
-# Tag: 2016-04-02
+# Tag: package-2016-04
 
-These settings apply only when `--tag=2016-04-02` is specified on the command line.
+These settings apply only when `--tag=package-2016-04` is specified on the command line.
 
-``` yaml $(tag) == '2016-04-02'
+``` yaml $(tag) == 'package-2016-04'
 input-file:
 - Microsoft.Cdn/2016-04-02/cdn.json
 
 ```
  
-# Tag: 2015-06-01
+# Tag: package-2015-06
 
-These settings apply only when `--tag=2015-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-06` is specified on the command line.
 
-``` yaml $(tag) == '2015-06-01'
+``` yaml $(tag) == 'package-2015-06'
 input-file:
 - Microsoft.Cdn/2015-06-01/cdn.json
 

--- a/specification/cognitiveservices/resource-manager/readme.md
+++ b/specification/cognitiveservices/resource-manager/readme.md
@@ -30,26 +30,26 @@ These are the global settings for the CognitiveServices API.
 title: Cognitive Services
 description: Cognitive Services Client
 openapi-type: arm
-tag: 2017-04-18
+tag: package-2017-04
 
 ```
 
 
-# Tag: 2017-04-18
+# Tag: package-2017-04
 
-These settings apply only when `--tag=2017-04-18` is specified on the command line.
+These settings apply only when `--tag=package-2017-04` is specified on the command line.
 
-``` yaml $(tag) == '2017-04-18'
+``` yaml $(tag) == 'package-2017-04'
 input-file:
 - Microsoft.CognitiveServices/2017-04-18/cognitiveservices.json
 
 ```
  
-# Tag: 2016-02-01-preview
+# Tag: package-2016-02-preview
 
-These settings apply only when `--tag=2016-02-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2016-02-preview` is specified on the command line.
 
-``` yaml $(tag) == '2016-02-01-preview'
+``` yaml $(tag) == 'package-2016-02-preview'
 input-file:
 - Microsoft.CognitiveServices/2016-02-01-preview/cognitiveservices.json
 

--- a/specification/commerce/resource-manager/readme.md
+++ b/specification/commerce/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the Commerce API.
 title: Commerce
 description: Commerce Client
 openapi-type: arm
-tag: 2015-06-01-preview
+tag: package-2015-06-preview
 
 ```
 
 
-# Tag: 2015-06-01-preview
+# Tag: package-2015-06-preview
 
-These settings apply only when `--tag=2015-06-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-06-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-06-01-preview'
+``` yaml $(tag) == 'package-2015-06-preview'
 input-file:
 - Microsoft.Commerce/2015-06-01-preview/commerce.json
 

--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -35,16 +35,16 @@ These are the global settings for the Compute API.
 title: Compute
 description: Compute Client
 openapi-type: arm
-tag: 2017-03-30
+tag: package-2017-03
 
 ```
 
 
-# Tag: 2017-03-30
+# Tag: package-2017-03
 
-These settings apply only when `--tag=2017-03-30` is specified on the command line.
+These settings apply only when `--tag=package-2017-03` is specified on the command line.
 
-``` yaml $(tag) == '2017-03-30'
+``` yaml $(tag) == 'package-2017-03'
 input-file:
 - Microsoft.Compute/2017-03-30/compute.json
 - Microsoft.Compute/2017-03-30/disk.json
@@ -54,11 +54,11 @@ input-file:
 ```
 
 
-# Tag: 2016-04-30-preview
+# Tag: package-2016-04-preview
 
-These settings apply only when `--tag=2016-04-30-preview` is specified on the command line.
+These settings apply only when `--tag=package-2016-04-preview` is specified on the command line.
 
-``` yaml $(tag) == '2016-04-30-preview'
+``` yaml $(tag) == 'package-2016-04-preview'
 input-file:
 - Microsoft.Compute/2016-04-30-preview/compute.json
 - Microsoft.Compute/2016-04-30-preview/disk.json
@@ -66,22 +66,22 @@ input-file:
 
 ```
  
-# Tag: 2016-03-30
+# Tag: package-2016-03
 
-These settings apply only when `--tag=2016-03-30` is specified on the command line.
+These settings apply only when `--tag=package-2016-03` is specified on the command line.
 
-``` yaml $(tag) == '2016-03-30'
+``` yaml $(tag) == 'package-2016-03'
 input-file:
 - Microsoft.Compute/2016-03-30/compute.json
 - Microsoft.ContainerService/2016-03-30/containerService.json
 
 ```
  
-# Tag: 2015-06-15-preview
+# Tag: package-2015-06-preview
 
-These settings apply only when `--tag=2015-06-15-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-06-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-06-15-preview'
+``` yaml $(tag) == 'package-2015-06-preview'
 input-file:
 - Microsoft.Compute/2015-06-15/compute.json
 - Microsoft.ContainerService/2015-11-01-preview/containerService.json

--- a/specification/consumption/resource-manager/readme.md
+++ b/specification/consumption/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the Consumption API.
 title: Consumption
 description: Consumption Client
 openapi-type: arm
-tag: 2017-04-24-preview
+tag: package-2017-04-preview
 
 ```
 
 
-# Tag: 2017-04-24-preview
+# Tag: package-2017-04-preview
 
-These settings apply only when `--tag=2017-04-24-preview` is specified on the command line.
+These settings apply only when `--tag=package-2017-04-preview` is specified on the command line.
 
-``` yaml $(tag) == '2017-04-24-preview'
+``` yaml $(tag) == 'package-2017-04-preview'
 input-file:
 - Microsoft.Consumption/2017-04-24-preview/consumption.json
 

--- a/specification/containerregistry/resource-manager/readme.md
+++ b/specification/containerregistry/resource-manager/readme.md
@@ -29,36 +29,36 @@ These are the global settings for the ContainerRegistry API.
 title: Container Registry
 description: Container Registry Client
 openapi-type: arm
-tag: 2017-06-01-preview
+tag: package-2017-06-preview
 
 ```
 
 
-# Tag: 2017-06-01-preview
+# Tag: package-2017-06-preview
 
-These settings apply only when `--tag=2017-06-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2017-06-preview` is specified on the command line.
 
-``` yaml $(tag) == '2017-06-01-preview'
+``` yaml $(tag) == 'package-2017-06-preview'
 input-file:
 - Microsoft.ContainerRegistry/2017-06-01-preview/containerregistry.json
 
 ```
  
-# Tag: 2017-03-01
+# Tag: package-2017-03
 
-These settings apply only when `--tag=2017-03-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-03` is specified on the command line.
 
-``` yaml $(tag) == '2017-03-01'
+``` yaml $(tag) == 'package-2017-03'
 input-file:
 - Microsoft.ContainerRegistry/2017-03-01/containerregistry.json
 
 ```
  
-# Tag: 2016-06-27-preview
+# Tag: package-2016-06-preview
 
-These settings apply only when `--tag=2016-06-27-preview` is specified on the command line.
+These settings apply only when `--tag=package-2016-06-preview` is specified on the command line.
 
-``` yaml $(tag) == '2016-06-27-preview'
+``` yaml $(tag) == 'package-2016-06-preview'
 input-file:
 - Microsoft.ContainerRegistry/2016-06-27-preview/containerregistry.json
 

--- a/specification/customer-insights/resource-manager/readme.md
+++ b/specification/customer-insights/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the CustomerInsights API.
 title: Customer Insights
 description: Customer Insights Client
 openapi-type: arm
-tag: 2017-01-01
+tag: package-2017-01
 
 ```
 
 
-# Tag: 2017-01-01
+# Tag: package-2017-01
 
-These settings apply only when `--tag=2017-01-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-01` is specified on the command line.
 
-``` yaml $(tag) == '2017-01-01'
+``` yaml $(tag) == 'package-2017-01'
 input-file:
 - Microsoft.CustomerInsights/2017-01-01/customer-insights.json
 

--- a/specification/datalake-analytics/resource-manager/readme.md
+++ b/specification/datalake-analytics/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the DataLakeAnalytics API.
 title: DataLake Analytics
 description: DataLake Analytics Client
 openapi-type: arm
-tag: 2016-11-01
+tag: package-2016-11
 
 ```
 
 
-# Tag: 2016-11-01
+# Tag: package-2016-11
 
-These settings apply only when `--tag=2016-11-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-11` is specified on the command line.
 
-``` yaml $(tag) == '2016-11-01'
+``` yaml $(tag) == 'package-2016-11'
 input-file:
 - Microsoft.DataLakeAnalytics/2016-11-01/account.json
 - Microsoft.DataLakeAnalytics/2016-11-01/catalog.json
@@ -46,11 +46,11 @@ input-file:
 
 ```
  
-# Tag: 2016-03-20-preview
+# Tag: package-2016-03-preview
 
-These settings apply only when `--tag=2016-03-20-preview` is specified on the command line.
+These settings apply only when `--tag=package-2016-03-preview` is specified on the command line.
 
-``` yaml $(tag) == '2016-03-20-preview'
+``` yaml $(tag) == 'package-2016-03-preview'
 input-file:
 - Microsoft.DataLakeAnalytics/2015-10-01-preview/account.json
 - Microsoft.DataLakeAnalytics/2015-10-01-preview/catalog.json
@@ -58,11 +58,11 @@ input-file:
 
 ```
  
-# Tag: 2015-11-01-preview
+# Tag: package-2015-11-preview
 
-These settings apply only when `--tag=2015-11-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-11-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-11-01-preview'
+``` yaml $(tag) == 'package-2015-11-preview'
 input-file:
 - Microsoft.DataLakeAnalytics/2015-10-01-preview/account.json
 - Microsoft.DataLakeAnalytics/2015-10-01-preview/catalog.json

--- a/specification/datalake-store/resource-manager/readme.md
+++ b/specification/datalake-store/resource-manager/readme.md
@@ -29,27 +29,27 @@ These are the global settings for the DataLakeStore API.
 title: DataLake Store
 description: DataLake Store Client
 openapi-type: arm
-tag: 2016-11-01
+tag: package-2016-11
 
 ```
 
 
-# Tag: 2016-11-01
+# Tag: package-2016-11
 
-These settings apply only when `--tag=2016-11-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-11` is specified on the command line.
 
-``` yaml $(tag) == '2016-11-01'
+``` yaml $(tag) == 'package-2016-11'
 input-file:
 - Microsoft.DataLakeStore/2016-11-01/account.json
 - Microsoft.DataLakeStore/2016-11-01/filesystem.json
 
 ```
  
-# Tag: 2015-10-01-preview
+# Tag: package-2015-10-preview
 
-These settings apply only when `--tag=2015-10-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-10-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-10-01-preview'
+``` yaml $(tag) == 'package-2015-10-preview'
 input-file:
 - Microsoft.DataLakeStore/2015-10-01-preview/account.json
 - Microsoft.DataLakeStore/2015-10-01-preview/filesystem.json

--- a/specification/devtestlabs/resource-manager/readme.md
+++ b/specification/devtestlabs/resource-manager/readme.md
@@ -29,26 +29,26 @@ These are the global settings for the DevTestLab API.
 title: Dev Test Lab
 description: Dev Test Lab Client
 openapi-type: arm
-tag: 2016-05-15
+tag: package-2016-05
 
 ```
 
 
-# Tag: 2016-05-15
+# Tag: package-2016-05
 
-These settings apply only when `--tag=2016-05-15` is specified on the command line.
+These settings apply only when `--tag=package-2016-05` is specified on the command line.
 
-``` yaml $(tag) == '2016-05-15'
+``` yaml $(tag) == 'package-2016-05'
 input-file:
 - Microsoft.DevTestLab/2016-05-15/DTL.json
 
 ```
  
-# Tag: 2015-05-21-preview
+# Tag: package-2015-05-preview
 
-These settings apply only when `--tag=2015-05-21-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-05-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-05-21-preview'
+``` yaml $(tag) == 'package-2015-05-preview'
 input-file:
 - Microsoft.DevTestLab/2015-05-21-preview/DTL.json
 

--- a/specification/dns/resource-manager/readme.md
+++ b/specification/dns/resource-manager/readme.md
@@ -29,26 +29,26 @@ These are the global settings for the DNS API.
 title: DNS
 description: DNS Client
 openapi-type: arm
-tag: 2016-04-01
+tag: package-2016-04
 
 ```
 
 
-# Tag: 2016-04-01
+# Tag: package-2016-04
 
-These settings apply only when `--tag=2016-04-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-04` is specified on the command line.
 
-``` yaml $(tag) == '2016-04-01'
+``` yaml $(tag) == 'package-2016-04'
 input-file:
 - Microsoft.Network/2016-04-01/dns.json
 
 ```
  
-# Tag: 2015-05-04-preview
+# Tag: package-2015-05-preview
 
-These settings apply only when `--tag=2015-05-04-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-05-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-05-04-preview'
+``` yaml $(tag) == 'package-2015-05-preview'
 input-file:
 - Microsoft.Network/2015-05-04-preview/dns.json
 

--- a/specification/documentdb/resource-manager/readme.md
+++ b/specification/documentdb/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the DocumentDB API.
 title: Document DB
 description: Document DB Client
 openapi-type: arm
-tag: 2015-04-08
+tag: package-2015-04
 
 ```
 
 
-# Tag: 2015-04-08
+# Tag: package-2015-04
 
-These settings apply only when `--tag=2015-04-08` is specified on the command line.
+These settings apply only when `--tag=package-2015-04` is specified on the command line.
 
-``` yaml $(tag) == '2015-04-08'
+``` yaml $(tag) == 'package-2015-04'
 input-file:
 - Microsoft.DocumentDB/2015-04-08/documentdb.json
 

--- a/specification/eventhub/resource-manager/readme.md
+++ b/specification/eventhub/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the EventHub API.
 title: Event Hub
 description: Event Hub Client
 openapi-type: arm
-tag: 2015-08-01
+tag: package-2015-08
 
 ```
 
 
-# Tag: 2015-08-01
+# Tag: package-2015-08
 
-These settings apply only when `--tag=2015-08-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-08` is specified on the command line.
 
-``` yaml $(tag) == '2015-08-01'
+``` yaml $(tag) == 'package-2015-08'
 input-file:
 - Microsoft.EventHub/2015-08-01/EventHub.json
 

--- a/specification/hdinsight/resource-manager/readme.md
+++ b/specification/hdinsight/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the HDInsight API.
 title: HDInsight Management
 description: HDInsight Management Client
 openapi-type: arm
-tag: 2015-03-01-preview
+tag: package-2015-03-preview
 
 ```
 
 
-# Tag: 2015-03-01-preview
+# Tag: package-2015-03-preview
 
-These settings apply only when `--tag=2015-03-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-03-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-03-01-preview'
+``` yaml $(tag) == 'package-2015-03-preview'
 input-file:
 - Microsoft.HDInsight/2015-03-01-preview/cluster.json
 - Microsoft.HDInsight/2015-03-01-preview/applications.json

--- a/specification/intune/resource-manager/readme.md
+++ b/specification/intune/resource-manager/readme.md
@@ -29,26 +29,26 @@ These are the global settings for the Intune API.
 title: Intune
 description: Intune Client
 openapi-type: arm
-tag: 2015-01-14-preview
+tag: package-2015-01-preview
 
 ```
 
 
-# Tag: 2015-01-14-preview
+# Tag: package-2015-01-preview
 
-These settings apply only when `--tag=2015-01-14-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-01-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-01-14-preview'
+``` yaml $(tag) == 'package-2015-01-preview'
 input-file:
 - Microsoft.Intune/2015-01-14-preview/intune.json
 
 ```
  
-# Tag: 2015-01-14-privatepreview
+# Tag: package-2015-01-privatepreview
 
-These settings apply only when `--tag=2015-01-14-privatepreview` is specified on the command line.
+These settings apply only when `--tag=package-2015-01-privatepreview` is specified on the command line.
 
-``` yaml $(tag) == '2015-01-14-privatepreview'
+``` yaml $(tag) == 'package-2015-01-privatepreview'
 input-file:
 - Microsoft.Intune/2015-01-14-privatepreview/intune.json
 

--- a/specification/iothub/resource-manager/readme.md
+++ b/specification/iothub/resource-manager/readme.md
@@ -29,26 +29,26 @@ These are the global settings for the IotHub API.
 title: IOT Hub
 description: IOT Hub Client
 openapi-type: arm
-tag: 2017-01-19
+tag: package-2017-01
 
 ```
 
 
-# Tag: 2017-01-19
+# Tag: package-2017-01
 
-These settings apply only when `--tag=2017-01-19` is specified on the command line.
+These settings apply only when `--tag=package-2017-01` is specified on the command line.
 
-``` yaml $(tag) == '2017-01-19'
+``` yaml $(tag) == 'package-2017-01'
 input-file:
 - Microsoft.Devices/2017-01-19/iothub.json
 
 ```
  
-# Tag: 2016-02-03
+# Tag: package-2016-02
 
-These settings apply only when `--tag=2016-02-03` is specified on the command line.
+These settings apply only when `--tag=package-2016-02` is specified on the command line.
 
-``` yaml $(tag) == '2016-02-03'
+``` yaml $(tag) == 'package-2016-02'
 input-file:
 - Microsoft.Devices/2016-02-03/iothub.json
 

--- a/specification/keyvault/data-plane/readme.md
+++ b/specification/keyvault/data-plane/readme.md
@@ -29,26 +29,26 @@ These are the global settings for the KeyVault API.
 title: Key Vault
 description: Key Vault Client
 openapi-type: data-plane
-tag: 2016-10-01
+tag: package-2016-10
 
 ```
 
 
-# Tag: 2016-10-01
+# Tag: package-2016-10
 
-These settings apply only when `--tag=2016-10-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-10` is specified on the command line.
 
-``` yaml $(tag) == '2016-10-01'
+``` yaml $(tag) == 'package-2016-10'
 input-file:
 - Microsoft.KeyVault/2016-10-01/keyvault.json
 
 ```
  
-# Tag: 2015-06-01
+# Tag: package-2015-06
 
-These settings apply only when `--tag=2015-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-06` is specified on the command line.
 
-``` yaml $(tag) == '2015-06-01'
+``` yaml $(tag) == 'package-2015-06'
 input-file:
 - Microsoft.KeyVault/2015-06-01/keyvault.json
 

--- a/specification/keyvault/resource-manager/readme.md
+++ b/specification/keyvault/resource-manager/readme.md
@@ -29,27 +29,27 @@ These are the global settings for the KeyVault API.
 title: Key Vault
 description: Key Vault Client
 openapi-type: arm
-tag: 2016-10-01
+tag: package-2016-10
 
 ```
 
 
-# Tag: 2016-10-01
+# Tag: package-2016-10
 
-These settings apply only when `--tag=2016-10-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-10` is specified on the command line.
 
-``` yaml $(tag) == '2016-10-01'
+``` yaml $(tag) == 'package-2016-10'
 input-file:
 - Microsoft.KeyVault/2016-10-01/keyvault.json
 
 ```
 
 
-# Tag: 2015-06-01
+# Tag: package-2015-06
 
-These settings apply only when `--tag=2015-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-06` is specified on the command line.
 
-``` yaml $(tag) == '2015-06-01'
+``` yaml $(tag) == 'package-2015-06'
 input-file:
 - Microsoft.KeyVault/2015-06-01/keyvault.json
 

--- a/specification/logic/resource-manager/readme.md
+++ b/specification/logic/resource-manager/readme.md
@@ -29,36 +29,36 @@ These are the global settings for the Logic API.
 title: Logic
 description: Logic Client
 openapi-type: arm
-tag: 2016-06-01
+tag: package-2016-06
 
 ```
 
 
-# Tag: 2016-06-01
+# Tag: package-2016-06
 
-These settings apply only when `--tag=2016-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-06` is specified on the command line.
 
-``` yaml $(tag) == '2016-06-01'
+``` yaml $(tag) == 'package-2016-06'
 input-file:
 - Microsoft.Logic/2016-06-01/logic.json
 
 ```
  
-# Tag: 2015-08-01-preview
+# Tag: package-2015-08-preview
 
-These settings apply only when `--tag=2015-08-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-08-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-08-01-preview'
+``` yaml $(tag) == 'package-2015-08-preview'
 input-file:
 - Microsoft.Logic/2015-08-01-preview/logic.json
 
 ```
  
-# Tag: 2015-02-01-preview
+# Tag: package-2015-02-preview
 
-These settings apply only when `--tag=2015-02-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-02-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-02-01-preview'
+``` yaml $(tag) == 'package-2015-02-preview'
 input-file:
 - Microsoft.Logic/2015-02-01-preview/logic.json
 

--- a/specification/machinelearning/resource-manager/readme.md
+++ b/specification/machinelearning/resource-manager/readme.md
@@ -29,27 +29,27 @@ These are the global settings for the MachineLearning API.
 title: Machine Learning
 description: Machine Learning Client
 openapi-type: arm
-tag: 2017-01-01
+tag: package-2017-01
 
 ```
 
 
-# Tag: 2017-01-01
+# Tag: package-2017-01
 
-These settings apply only when `--tag=2017-01-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-01` is specified on the command line.
 
-``` yaml $(tag) == '2017-01-01'
+``` yaml $(tag) == 'package-2017-01'
 input-file:
 - Microsoft.MachineLearning/2016-05-01-preview/commitmentPlans.json
 - Microsoft.MachineLearning/2017-01-01/webservices.json
 
 ```
  
-# Tag: 2016-05-01-preview
+# Tag: package-2016-05-preview
 
-These settings apply only when `--tag=2016-05-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2016-05-preview` is specified on the command line.
 
-``` yaml $(tag) == '2016-05-01-preview'
+``` yaml $(tag) == 'package-2016-05-preview'
 input-file:
 - Microsoft.MachineLearning/2016-05-01-preview/commitmentPlans.json
 - Microsoft.MachineLearning/2016-05-01-preview/webservices.json

--- a/specification/mediaservices/resource-manager/readme.md
+++ b/specification/mediaservices/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the MediaServices API.
 title: Media Services
 description: Media Services Client
 openapi-type: arm
-tag: 2015-10-01
+tag: package-2015-10
 
 ```
 
 
-# Tag: 2015-10-01
+# Tag: package-2015-10
 
-These settings apply only when `--tag=2015-10-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-10` is specified on the command line.
 
-``` yaml $(tag) == '2015-10-01'
+``` yaml $(tag) == 'package-2015-10'
 input-file:
 - Microsoft.Media/2015-10-01/media.json
 

--- a/specification/mobileengagement/resource-manager/readme.md
+++ b/specification/mobileengagement/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the MobileEngagement API.
 title: Mobile Engagement
 description: Mobile Engagement Client
 openapi-type: arm
-tag: 2014-12-01
+tag: package-2014-12
 
 ```
 
 
-# Tag: 2014-12-01
+# Tag: package-2014-12
 
-These settings apply only when `--tag=2014-12-01` is specified on the command line.
+These settings apply only when `--tag=package-2014-12` is specified on the command line.
 
-``` yaml $(tag) == '2014-12-01'
+``` yaml $(tag) == 'package-2014-12'
 input-file:
 - Microsoft.MobileEngagement/2014-12-01/mobile-engagement.json
 

--- a/specification/monitor/data-plane/readme.md
+++ b/specification/monitor/data-plane/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the MonitorClient API.
 title: Monitor Client
 description: Monitor Client
 openapi-type: data-plane
-tag: 2016-09-01
+tag: package-2016-09
 
 ```
 
 
-# Tag: 2016-09-01
+# Tag: package-2016-09
 
-These settings apply only when `--tag=2016-09-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-09` is specified on the command line.
 
-``` yaml $(tag) == '2016-09-01'
+``` yaml $(tag) == 'package-2016-09'
 input-file:
 - microsoft.insights/2014-04-01/usageMetrics_API.json
 - microsoft.insights/2015-04-01/activityLogs_API.json

--- a/specification/monitor/resource-manager/readme.md
+++ b/specification/monitor/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the MonitorClient API.
 title: Monitor Management Client
 description: Monitor Management Client
 openapi-type: arm
-tag: 2017-03-01
+tag: package-2017-03
 
 ```
 
 
-# Tag: 2017-03-01
+# Tag: package-2017-03
 
-These settings apply only when `--tag=2017-03-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-03` is specified on the command line.
 
-``` yaml $(tag) == '2017-03-01'
+``` yaml $(tag) == 'package-2017-03'
 input-file:
 - microsoft.insights/2015-04-01/autoscale_API.json
 - microsoft.insights/2016-03-01/alertRulesIncidents_API.json

--- a/specification/network/resource-manager/readme.md
+++ b/specification/network/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the Network API.
 title: Network
 description: Network Client
 openapi-type: arm
-tag: 2017-03-01
+tag: package-2017-03
 
 ```
 
 
-# Tag: 2017-03-01
+# Tag: package-2017-03
 
-These settings apply only when `--tag=2017-03-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-03` is specified on the command line.
 
-``` yaml $(tag) == '2017-03-01'
+``` yaml $(tag) == 'package-2017-03'
 input-file:
 - Microsoft.Network/2017-03-01/applicationGateway.json
 - Microsoft.Network/2017-03-01/checkDnsAvailability.json
@@ -59,11 +59,11 @@ input-file:
 - Microsoft.Compute/2017-03-01/vmssPublicIpAddress.json
 ```
  
-# Tag: 2016-12-01
+# Tag: package-2016-12
 
-These settings apply only when `--tag=2016-12-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-12` is specified on the command line.
 
-``` yaml $(tag) == '2016-12-01'
+``` yaml $(tag) == 'package-2016-12'
 input-file:
 - microsoft.Compute/2016-12-01/vmssNetworkInterface.json
 - Microsoft.Network/2016-12-01/applicationGateway.json
@@ -84,11 +84,11 @@ input-file:
 
 ```
  
-# Tag: 2016-09-01
+# Tag: package-2016-09
 
-These settings apply only when `--tag=2016-09-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-09` is specified on the command line.
 
-``` yaml $(tag) == '2016-09-01'
+``` yaml $(tag) == 'package-2016-09'
 input-file:
 - microsoft.Compute/2016-09-01/vmssNetworkInterface.json
 - Microsoft.Network/2016-09-01/applicationGateway.json
@@ -107,32 +107,32 @@ input-file:
 
 ```
  
-# Tag: 2016-06-01
+# Tag: package-2016-06
 
-These settings apply only when `--tag=2016-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-06` is specified on the command line.
 
-``` yaml $(tag) == '2016-06-01'
+``` yaml $(tag) == 'package-2016-06'
 input-file:
 - Microsoft.Network/2016-06-01/network.json
 
 
 ```
  
-# Tag: 2016-03-30
+# Tag: package-2016-03
 
-These settings apply only when `--tag=2016-03-30` is specified on the command line.
+These settings apply only when `--tag=package-2016-03` is specified on the command line.
 
-``` yaml $(tag) == '2016-03-30'
+``` yaml $(tag) == 'package-2016-03'
 input-file:
 - Microsoft.Network/2016-03-30/network.json
 
 ```
  
-# Tag: 2015-06-15split
+# Tag: package-2015-06split
 
-These settings apply only when `--tag=2015-06-15split` is specified on the command line.
+These settings apply only when `--tag=package-2015-06split` is specified on the command line.
 
-``` yaml $(tag) == '2015-06-15split'
+``` yaml $(tag) == 'package-2015-06split'
 input-file:
 - Microsoft.Network/2015-06-15/applicationGateway.json
 - Microsoft.Network/2015-06-15/checkDnsAvailability.json
@@ -148,20 +148,20 @@ input-file:
 - microsoft.Compute/2015-06-15/vmssNetworkInterface.json
 ```
  
-# Tag: 2015-06-15
+# Tag: package-2015-06
 
-These settings apply only when `--tag=2015-06-15` is specified on the command line.
+These settings apply only when `--tag=package-2015-06` is specified on the command line.
 
-``` yaml $(tag) == '2015-06-15'
+``` yaml $(tag) == 'package-2015-06'
 input-file:
 - Microsoft.Network/2015-06-15/network.json
 ```
  
-# Tag: 2015-05-01-preview
+# Tag: package-2015-05-preview
 
-These settings apply only when `--tag=2015-05-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-05-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-05-01-preview'
+``` yaml $(tag) == 'package-2015-05-preview'
 input-file:
 - Microsoft.Network/2015-05-01-preview/network.json
 

--- a/specification/notificationhubs/resource-manager/readme.md
+++ b/specification/notificationhubs/resource-manager/readme.md
@@ -29,36 +29,36 @@ These are the global settings for the NotificationHubs API.
 title: Notification Hubs
 description: Notification Hubs Client
 openapi-type: arm
-tag: 2017-04-01
+tag: package-2017-04
 
 ```
 
 
-# Tag: 2017-04-01
+# Tag: package-2017-04
 
-These settings apply only when `--tag=2017-04-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-04` is specified on the command line.
 
-``` yaml $(tag) == '2017-04-01'
+``` yaml $(tag) == 'package-2017-04'
 input-file:
 - Microsoft.NotificationHubs/2017-04-01/notificationhubs.json
 
 ```
  
-# Tag: 2016-03-01
+# Tag: package-2016-03
 
-These settings apply only when `--tag=2016-03-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-03` is specified on the command line.
 
-``` yaml $(tag) == '2016-03-01'
+``` yaml $(tag) == 'package-2016-03'
 input-file:
 - Microsoft.NotificationHubs/2016-03-01/notificationhubs.json
 
 ```
  
-# Tag: 2014-09-01
+# Tag: package-2014-09
 
-These settings apply only when `--tag=2014-09-01` is specified on the command line.
+These settings apply only when `--tag=package-2014-09` is specified on the command line.
 
-``` yaml $(tag) == '2014-09-01'
+``` yaml $(tag) == 'package-2014-09'
 input-file:
 - Microsoft.NotificationHubs/2014-09-01/notificationhubs.json
 

--- a/specification/operationalinsights/resource-manager/readme.md
+++ b/specification/operationalinsights/resource-manager/readme.md
@@ -29,27 +29,27 @@ These are the global settings for the OperationalInsights API.
 title: Operational Insights
 description: Operational Insights Client
 openapi-type: arm
-tag: 2015-11-01-preview
+tag: package-2015-11-preview
 
 ```
 
 
-# Tag: 2015-11-01-preview
+# Tag: package-2015-11-preview
 
-These settings apply only when `--tag=2015-11-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-11-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-11-01-preview'
+``` yaml $(tag) == 'package-2015-11-preview'
 input-file:
 - Microsoft.OperationalInsights/2015-11-01-preview/OperationalInsights.json
 - Microsoft.OperationalInsights/2015-03-20/OperationalInsights.json
 
 ```
  
-# Tag: 2015-03-20
+# Tag: package-2015-03
 
-These settings apply only when `--tag=2015-03-20` is specified on the command line.
+These settings apply only when `--tag=package-2015-03` is specified on the command line.
 
-``` yaml $(tag) == '2015-03-20'
+``` yaml $(tag) == 'package-2015-03'
 input-file:
 - Microsoft.OperationalInsights/2015-03-20/OperationalInsights.json
 

--- a/specification/powerbiembedded/resource-manager/readme.md
+++ b/specification/powerbiembedded/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the PowerBI API.
 title: Power BI
 description: Power BI Client
 openapi-type: arm
-tag: 2016-01-29
+tag: package-2016-01
 
 ```
 
 
-# Tag: 2016-01-29
+# Tag: package-2016-01
 
-These settings apply only when `--tag=2016-01-29` is specified on the command line.
+These settings apply only when `--tag=package-2016-01` is specified on the command line.
 
-``` yaml $(tag) == '2016-01-29'
+``` yaml $(tag) == 'package-2016-01'
 input-file:
 - Microsoft.PowerBI/2016-01-29/powerbiembedded.json
 

--- a/specification/recoveryservices/resource-manager/readme.md
+++ b/specification/recoveryservices/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the RecoveryServices API.
 title: Recovery Services
 description: Recovery Services Client
 openapi-type: arm
-tag: 2016-12-01
+tag: package-2016-12
 
 ```
 
 
-# Tag: 2016-12-01
+# Tag: package-2016-12
 
-These settings apply only when `--tag=2016-12-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-12` is specified on the command line.
 
-``` yaml $(tag) == '2016-12-01'
+``` yaml $(tag) == 'package-2016-12'
 input-file:
 - Microsoft.RecoveryServices/2016-12-01/backup.json
 - Microsoft.RecoveryServices/2016-06-01/registeredidentities.json
@@ -48,11 +48,11 @@ input-file:
 
 ```
  
-# Tag: 2016-06-01
+# Tag: package-2016-06
 
-These settings apply only when `--tag=2016-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-06` is specified on the command line.
 
-``` yaml $(tag) == '2016-06-01'
+``` yaml $(tag) == 'package-2016-06'
 input-file:
 - Microsoft.RecoveryServices/2016-06-01/registeredidentities.json
 - Microsoft.RecoveryServices/2016-06-01/replicationusages.json

--- a/specification/recoveryservicesbackup/resource-manager/readme.md
+++ b/specification/recoveryservicesbackup/resource-manager/readme.md
@@ -29,29 +29,29 @@ These are the global settings for the RecoveryServicesBackup API.
 title: Recovery Services Backup
 description: Open API 2.0 Specs for Azure RecoveryServices Backup service
 openapi-type: arm
-tag: 2016-12-01
+tag: package-2016-12
 
 azure-arm: true
 license-header: MICROSOFT_MIT
 ```
 
 
-# Tag: 2016-12-01
+# Tag: package-2016-12
 
-These settings apply only when `--tag=2016-12-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-12` is specified on the command line.
 
-``` yaml $(tag) == '2016-12-01'
+``` yaml $(tag) == 'package-2016-12'
 input-file:
 - Microsoft.RecoveryServices/2016-12-01/backupManagement.json
 - Microsoft.RecoveryServices/2016-08-10/operations.json
 
 ```
  
-# Tag: 2016-06-01
+# Tag: package-2016-06
 
-These settings apply only when `--tag=2016-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-06` is specified on the command line.
 
-``` yaml $(tag) == '2016-06-01'
+``` yaml $(tag) == 'package-2016-06'
 input-file:
 - Microsoft.RecoveryServices/2016-06-01/recoveryservicesbackup.json
 - Microsoft.RecoveryServices/2016-06-01/registeredIdentities.json

--- a/specification/recoveryservicessiterecovery/resource-manager/readme.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the RecoveryServicesSiteRecovery API.
 title: Recovery Services Site Recovery
 description: Recovery Services Site Recovery Client
 openapi-type: arm
-tag: 2016-08-10
+tag: package-2016-08
 
 ```
 
 
-# Tag: 2016-08-10
+# Tag: package-2016-08
 
-These settings apply only when `--tag=2016-08-10` is specified on the command line.
+These settings apply only when `--tag=package-2016-08` is specified on the command line.
 
-``` yaml $(tag) == '2016-08-10'
+``` yaml $(tag) == 'package-2016-08'
 input-file:
 - Microsoft.RecoveryServices/2016-08-10/service.json
 

--- a/specification/redis/resource-manager/readme.md
+++ b/specification/redis/resource-manager/readme.md
@@ -29,37 +29,37 @@ These are the global settings for the Redis API.
 title: Redis
 description: Redis Client
 openapi-type: arm
-tag: 2017-02-01
+tag: package-2017-02
 
 ```
 
 
-# Tag: 2017-02-01
+# Tag: package-2017-02
 
-These settings apply only when `--tag=2017-02-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-02` is specified on the command line.
 
-``` yaml $(tag) == '2017-02-01'
+``` yaml $(tag) == 'package-2017-02'
 input-file:
 - Microsoft.Cache/2017-02-01/redis.json
 
 ```
 
 
-# Tag: 2016-04-01
+# Tag: package-2016-04
 
-These settings apply only when `--tag=2016-04-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-04` is specified on the command line.
 
-``` yaml $(tag) == '2016-04-01'
+``` yaml $(tag) == 'package-2016-04'
 input-file:
 - Microsoft.Cache/2016-04-01/redis.json
 
 ```
  
-# Tag: 2015-08-01
+# Tag: package-2015-08
 
-These settings apply only when `--tag=2015-08-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-08` is specified on the command line.
 
-``` yaml $(tag) == '2015-08-01'
+``` yaml $(tag) == 'package-2015-08'
 input-file:
 - Microsoft.Cache/2015-08-01/redis.json
 

--- a/specification/relay/resource-manager/readme.md
+++ b/specification/relay/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the Relay API.
 title: Relay
 description: Relay Client
 openapi-type: arm
-tag: 2016-07-01
+tag: package-2016-07
 
 ```
 
 
-# Tag: 2016-07-01
+# Tag: package-2016-07
 
-These settings apply only when `--tag=2016-07-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-07` is specified on the command line.
 
-``` yaml $(tag) == '2016-07-01'
+``` yaml $(tag) == 'package-2016-07'
 input-file:
 - Microsoft.Relay/2016-07-01/relay.json
 

--- a/specification/resourcehealth/resource-manager/readme.md
+++ b/specification/resourcehealth/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the ResourceHealth API.
 title: Resource Health
 description: Resource Health Client
 openapi-type: arm
-tag: 2015-01-01
+tag: package-2015-01
 
 ```
 
 
-# Tag: 2015-01-01
+# Tag: package-2015-01
 
-These settings apply only when `--tag=2015-01-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-01` is specified on the command line.
 
-``` yaml $(tag) == '2015-01-01'
+``` yaml $(tag) == 'package-2015-01'
 input-file:
 - Microsoft.ResourceHealth/2015-01-01/resourcehealth.json
 

--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the Resource API.
 title: Resource
 description: Resource Client
 openapi-type: arm
-tag: 2017-05-10
+tag: package-2017-05
 
 ```
 
 
-# Tag: 2017-05-10
+# Tag: package-2017-05
 
-These settings apply only when `--tag=2017-05-10` is specified on the command line.
+These settings apply only when `--tag=package-2017-05` is specified on the command line.
 
-``` yaml $(tag) == '2017-05-10'
+``` yaml $(tag) == 'package-2017-05'
 input-file:
 - Microsoft.Authorization/2016-09-01/locks.json
 - Microsoft.Authorization/2016-12-01/policy.json
@@ -50,11 +50,11 @@ input-file:
 
 ```
  
-# Tag: 2016-09-01
+# Tag: package-2016-09
 
-These settings apply only when `--tag=2016-09-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-09` is specified on the command line.
 
-``` yaml $(tag) == '2016-09-01'
+``` yaml $(tag) == 'package-2016-09'
 input-file:
 - Microsoft.Authorization/2016-09-01/locks.json
 - Microsoft.Authorization/2016-04-01/policy.json
@@ -65,11 +65,11 @@ input-file:
 
 ```
  
-# Tag: 2016-07-01
+# Tag: package-2016-07
 
-These settings apply only when `--tag=2016-07-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-07` is specified on the command line.
 
-``` yaml $(tag) == '2016-07-01'
+``` yaml $(tag) == 'package-2016-07'
 input-file:
 - Microsoft.Authorization/2015-01-01/locks.json
 - Microsoft.Authorization/2016-04-01/policy.json
@@ -79,11 +79,11 @@ input-file:
 
 ```
  
-# Tag: 2016-06-01
+# Tag: package-2016-06
 
-These settings apply only when `--tag=2016-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-06` is specified on the command line.
 
-``` yaml $(tag) == '2016-06-01'
+``` yaml $(tag) == 'package-2016-06'
 input-file:
 - Microsoft.Authorization/2015-01-01/locks.json
 - Microsoft.Authorization/2016-04-01/policy.json
@@ -93,11 +93,11 @@ input-file:
 
 ```
  
-# Tag: 2016-04-01
+# Tag: package-2016-04
 
-These settings apply only when `--tag=2016-04-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-04` is specified on the command line.
 
-``` yaml $(tag) == '2016-04-01'
+``` yaml $(tag) == 'package-2016-04'
 input-file:
 - Microsoft.Authorization/2015-01-01/locks.json
 - Microsoft.Authorization/2016-04-01/policy.json
@@ -107,11 +107,11 @@ input-file:
 
 ```
  
-# Tag: 2016-02-01
+# Tag: package-2016-02
 
-These settings apply only when `--tag=2016-02-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-02` is specified on the command line.
 
-``` yaml $(tag) == '2016-02-01'
+``` yaml $(tag) == 'package-2016-02'
 input-file:
 - Microsoft.Authorization/2015-01-01/locks.json
 - Microsoft.Authorization/2015-10-01-preview/policy.json
@@ -121,11 +121,11 @@ input-file:
 
 ```
  
-# Tag: 2015-12-01
+# Tag: package-2015-12
 
-These settings apply only when `--tag=2015-12-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-12` is specified on the command line.
 
-``` yaml $(tag) == '2015-12-01'
+``` yaml $(tag) == 'package-2015-12'
 input-file:
 - Microsoft.Authorization/2015-01-01/locks.json
 - Microsoft.Authorization/2015-10-01-preview/policy.json

--- a/specification/scheduler/resource-manager/readme.md
+++ b/specification/scheduler/resource-manager/readme.md
@@ -29,36 +29,36 @@ These are the global settings for the Scheduler API.
 title: Scheduler
 description: Scheduler Client
 openapi-type: arm
-tag: 2016-03-01
+tag: package-2016-03
 
 ```
 
 
-# Tag: 2016-03-01
+# Tag: package-2016-03
 
-These settings apply only when `--tag=2016-03-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-03` is specified on the command line.
 
-``` yaml $(tag) == '2016-03-01'
+``` yaml $(tag) == 'package-2016-03'
 input-file:
 - Microsoft.Scheduler/2016-03-01/scheduler.json
 
 ```
  
-# Tag: 2016-01-01
+# Tag: package-2016-01
 
-These settings apply only when `--tag=2016-01-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-01` is specified on the command line.
 
-``` yaml $(tag) == '2016-01-01'
+``` yaml $(tag) == 'package-2016-01'
 input-file:
 - Microsoft.Scheduler/2016-01-01/scheduler.json
 
 ```
  
-# Tag: 2014-08-01-preview
+# Tag: package-2014-08-preview
 
-These settings apply only when `--tag=2014-08-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2014-08-preview` is specified on the command line.
 
-``` yaml $(tag) == '2014-08-01-preview'
+``` yaml $(tag) == 'package-2014-08-preview'
 input-file:
 - Microsoft.Scheduler/2014-08-01-preview/scheduler.json
 

--- a/specification/search/data-plane/readme.md
+++ b/specification/search/data-plane/readme.md
@@ -29,38 +29,38 @@ These are the global settings for the SearchClient API.
 title: Search
 description: Search Client
 openapi-type: data-plane
-tag: 2016-09-01
+tag: package-2016-09
 
 ```
 
 
-# Tag: 2016-09-01
+# Tag: package-2016-09
 
-These settings apply only when `--tag=2016-09-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-09` is specified on the command line.
 
-``` yaml $(tag) == '2016-09-01'
+``` yaml $(tag) == 'package-2016-09'
 input-file:
 - Microsoft.Search/2016-09-01/searchindex.json
 - Microsoft.Search/2016-09-01/searchservice.json
 
 ```
  
-# Tag: 2015-02-28-preview
+# Tag: package-2015-02-preview
 
-These settings apply only when `--tag=2015-02-28-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-02-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-02-28-preview'
+``` yaml $(tag) == 'package-2015-02-preview'
 input-file:
 - Microsoft.Search/2015-02-28-preview/searchindex.json
 - Microsoft.Search/2015-02-28-preview/searchservice.json
 
 ```
  
-# Tag: 2015-02-28
+# Tag: package-2015-02
 
-These settings apply only when `--tag=2015-02-28` is specified on the command line.
+These settings apply only when `--tag=package-2015-02` is specified on the command line.
 
-``` yaml $(tag) == '2015-02-28'
+``` yaml $(tag) == 'package-2015-02'
 input-file:
 - Microsoft.Search/2015-02-28/searchindex.json
 - Microsoft.Search/2015-02-28/searchservice.json

--- a/specification/search/resource-manager/readme.md
+++ b/specification/search/resource-manager/readme.md
@@ -29,26 +29,26 @@ These are the global settings for the SearchClient API.
 title: Search
 description: Search Client
 openapi-type: arm
-tag: 2015-08-19
+tag: package-2015-08
 
 ```
 
 
-# Tag: 2015-08-19
+# Tag: package-2015-08
 
-These settings apply only when `--tag=2015-08-19` is specified on the command line.
+These settings apply only when `--tag=package-2015-08` is specified on the command line.
 
-``` yaml $(tag) == '2015-08-19'
+``` yaml $(tag) == 'package-2015-08'
 input-file:
 - Microsoft.Search/2015-08-19/search.json
 
 ```
  
-# Tag: 2015-02-28
+# Tag: package-2015-02
 
-These settings apply only when `--tag=2015-02-28` is specified on the command line.
+These settings apply only when `--tag=package-2015-02` is specified on the command line.
 
-``` yaml $(tag) == '2015-02-28'
+``` yaml $(tag) == 'package-2015-02'
 input-file:
 - Microsoft.Search/2015-02-28/search.json
 

--- a/specification/servermanagement/resource-manager/readme.md
+++ b/specification/servermanagement/resource-manager/readme.md
@@ -29,26 +29,26 @@ These are the global settings for the ServerManagement API.
 title: Server Management
 description: Server Management Client
 openapi-type: arm
-tag: 2016-07-01-preview
+tag: package-2016-07-preview
 
 ```
 
 
-# Tag: 2016-07-01-preview
+# Tag: package-2016-07-preview
 
-These settings apply only when `--tag=2016-07-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2016-07-preview` is specified on the command line.
 
-``` yaml $(tag) == '2016-07-01-preview'
+``` yaml $(tag) == 'package-2016-07-preview'
 input-file:
 - Microsoft.ServerManagement/2016-07-01-preview/servermanagement.json
 
 ```
  
-# Tag: 2015-07-01-preview
+# Tag: package-2015-07-preview
 
-These settings apply only when `--tag=2015-07-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-07-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-07-01-preview'
+``` yaml $(tag) == 'package-2015-07-preview'
 input-file:
 - Microsoft.ServerManagement/2015-07-01-preview/servermanagement.json
 

--- a/specification/service-map/resource-manager/readme.md
+++ b/specification/service-map/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the ServiceMap API.
 title: Service Map
 description: Service Map Client
 openapi-type: arm
-tag: 2015-11-01-preview
+tag: package-2015-11-preview
 
 ```
 
 
-# Tag: 2015-11-01-preview
+# Tag: package-2015-11-preview
 
-These settings apply only when `--tag=2015-11-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-11-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-11-01-preview'
+``` yaml $(tag) == 'package-2015-11-preview'
 input-file:
 - Microsoft.OperationalInsights/2015-11-01-preview/arm-service-map.json
 

--- a/specification/servicebus/resource-manager/readme.md
+++ b/specification/servicebus/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the ServiceBus API.
 title: Service Bus
 description: Service Bus Client
 openapi-type: arm
-tag: 2015-08-01
+tag: package-2015-08
 
 ```
 
 
-# Tag: 2015-08-01
+# Tag: package-2015-08
 
-These settings apply only when `--tag=2015-08-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-08` is specified on the command line.
 
-``` yaml $(tag) == '2015-08-01'
+``` yaml $(tag) == 'package-2015-08'
 input-file:
 - Microsoft.ServiceBus/2015-08-01/servicebus.json
 

--- a/specification/servicefabric/resource-manager/readme.md
+++ b/specification/servicefabric/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the ServiceFabricClient API.
 title: Service Fabric
 description: Service Fabric Client
 openapi-type: arm
-tag: 2016-09-01
+tag: package-2016-09
 
 ```
 
 
-# Tag: 2016-09-01
+# Tag: package-2016-09
 
-These settings apply only when `--tag=2016-09-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-09` is specified on the command line.
 
-``` yaml $(tag) == '2016-09-01'
+``` yaml $(tag) == 'package-2016-09'
 input-file:
 - Microsoft.ServiceFabric/2016-09-01/servicefabric.json
 

--- a/specification/sql/resource-manager/readme.md
+++ b/specification/sql/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the Sql API.
 title: Sql
 description: Sql Client
 openapi-type: arm
-tag: 2015-05-01-preview
+tag: package-2015-05-preview
 
 ```
 
 
-# Tag: 2015-05-01-preview
+# Tag: package-2015-05-preview
 
-These settings apply only when `--tag=2015-05-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-05-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-05-01-preview'
+``` yaml $(tag) == 'package-2015-05-preview'
 input-file:
 - Microsoft.Sql/2014-04-01/backups.json
 - Microsoft.Sql/2014-04-01/capabilities.json
@@ -63,11 +63,11 @@ input-file:
 
 ```
  
-# Tag: 2014-04-01
+# Tag: package-2014-04
 
-These settings apply only when `--tag=2014-04-01` is specified on the command line.
+These settings apply only when `--tag=package-2014-04` is specified on the command line.
 
-``` yaml $(tag) == '2014-04-01'
+``` yaml $(tag) == 'package-2014-04'
 input-file:
 - Microsoft.Sql/2014-04-01/firewallRules.json
 - Microsoft.Sql/2014-04-01/importExport.json

--- a/specification/storage/resource-manager/readme.md
+++ b/specification/storage/resource-manager/readme.md
@@ -29,67 +29,67 @@ These are the global settings for the Storage API.
 title: Storage
 description: Storage Client
 openapi-type: arm
-tag: 2017-06-01
+tag: package-2017-06
 
 ```
 
 
-# Tag: 2017-06-01
+# Tag: package-2017-06
 
-These settings apply only when `--tag=2017-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-06` is specified on the command line.
 
-``` yaml $(tag) == '2017-06-01'
+``` yaml $(tag) == 'package-2017-06'
 input-file:
 - Microsoft.Storage/2017-06-01/storage.json
 
 ```
 
 
-# Tag: 2016-12-01
+# Tag: package-2016-12
 
-These settings apply only when `--tag=2016-12-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-12` is specified on the command line.
 
-``` yaml $(tag) == '2016-12-01'
+``` yaml $(tag) == 'package-2016-12'
 input-file:
 - Microsoft.Storage/2016-12-01/storage.json
 
 ```
  
-# Tag: 2016-05-01
+# Tag: package-2016-05
 
-These settings apply only when `--tag=2016-05-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-05` is specified on the command line.
 
-``` yaml $(tag) == '2016-05-01'
+``` yaml $(tag) == 'package-2016-05'
 input-file:
 - Microsoft.Storage/2016-05-01/storage.json
 
 ```
  
-# Tag: 2016-01-01
+# Tag: package-2016-01
 
-These settings apply only when `--tag=2016-01-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-01` is specified on the command line.
 
-``` yaml $(tag) == '2016-01-01'
+``` yaml $(tag) == 'package-2016-01'
 input-file:
 - Microsoft.Storage/2016-01-01/storage.json
 
 ```
  
-# Tag: 2015-06-15
+# Tag: package-2015-06
 
-These settings apply only when `--tag=2015-06-15` is specified on the command line.
+These settings apply only when `--tag=package-2015-06` is specified on the command line.
 
-``` yaml $(tag) == '2015-06-15'
+``` yaml $(tag) == 'package-2015-06'
 input-file:
 - Microsoft.Storage/2015-06-15/storage.json
 
 ```
  
-# Tag: 2015-05-01-preview
+# Tag: package-2015-05-preview
 
-These settings apply only when `--tag=2015-05-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-05-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-05-01-preview'
+``` yaml $(tag) == 'package-2015-05-preview'
 input-file:
 - Microsoft.Storage/2015-05-01-preview/storage.json
 

--- a/specification/storageimportexport/resource-manager/readme.md
+++ b/specification/storageimportexport/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the StorageImportExport API.
 title: Storage Import Export
 description: Storage Import Export Client
 openapi-type: arm
-tag: 2016-11-01
+tag: package-2016-11
 
 ```
 
 
-# Tag: 2016-11-01
+# Tag: package-2016-11
 
-These settings apply only when `--tag=2016-11-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-11` is specified on the command line.
 
-``` yaml $(tag) == '2016-11-01'
+``` yaml $(tag) == 'package-2016-11'
 input-file:
 - Microsoft.ImportExport/2016-11-01/storageimportexport.json
 

--- a/specification/storsimple8000series/resource-manager/readme.md
+++ b/specification/storsimple8000series/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the StorSimple API.
 title: StorSimple 8000 Series
 description: StorSimple 8000 Series Client
 openapi-type: arm
-tag: 2017-06-01
+tag: package-2017-06
 
 ```
 
 
-# Tag: 2017-06-01
+# Tag: package-2017-06
 
-These settings apply only when `--tag=2017-06-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-06` is specified on the command line.
 
-``` yaml $(tag) == '2017-06-01'
+``` yaml $(tag) == 'package-2017-06'
 input-file:
 - Microsoft.StorSimple/2017-06-01/storsimple.json
 

--- a/specification/streamanalytics/resource-manager/readme.md
+++ b/specification/streamanalytics/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the StreamAnalytics API.
 title: Stream Analytics Management Client
 description: Stream Analytics Client
 openapi-type: arm
-tag: 2016-03-01
+tag: package-2016-03
 
 ```
 
 
-# Tag: 2016-03-01
+# Tag: package-2016-03
 
-These settings apply only when `--tag=2016-03-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-03` is specified on the command line.
 
-``` yaml $(tag) == '2016-03-01'
+``` yaml $(tag) == 'package-2016-03'
 input-file:
 - Microsoft.StreamAnalytics/2016-03-01/streamingjobs.json
 - Microsoft.StreamAnalytics/2016-03-01/inputs.json

--- a/specification/timeseriesinsights/resource-manager/readme.md
+++ b/specification/timeseriesinsights/resource-manager/readme.md
@@ -29,16 +29,16 @@ These are the global settings for the TimeSeriesInsights API.
 title: Time Series Insights
 description: Time Series Insights Client
 openapi-type: arm
-tag: 2017-02-28-preview
+tag: package-2017-02-preview
 
 ```
 
 
-# Tag: 2017-02-28-preview
+# Tag: package-2017-02-preview
 
-These settings apply only when `--tag=2017-02-28-preview` is specified on the command line.
+These settings apply only when `--tag=package-2017-02-preview` is specified on the command line.
 
-``` yaml $(tag) == '2017-02-28-preview'
+``` yaml $(tag) == 'package-2017-02-preview'
 input-file:
 - Microsoft.TimeSeriesInsights/2017-02-28-preview/timeseriesinsights.json
 

--- a/specification/trafficmanager/resource-manager/readme.md
+++ b/specification/trafficmanager/resource-manager/readme.md
@@ -29,37 +29,37 @@ These are the global settings for the TrafficManager API.
 title: Traffic Manager
 description: Traffic Manager Client
 openapi-type: arm
-tag: 2017-05-01
+tag: package-2017-05
 
 ```
 
 
-# Tag: 2017-05-01
+# Tag: package-2017-05
 
-These settings apply only when `--tag=2017-05-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-05` is specified on the command line.
 
-``` yaml $(tag) == '2017-05-01'
+``` yaml $(tag) == 'package-2017-05'
 input-file:
 - Microsoft.Network/2017-05-01/trafficmanager.json
 
 ```
 
 
-# Tag: 2017-03-01
+# Tag: package-2017-03
 
-These settings apply only when `--tag=2017-03-01` is specified on the command line.
+These settings apply only when `--tag=package-2017-03` is specified on the command line.
 
-``` yaml $(tag) == '2017-03-01'
+``` yaml $(tag) == 'package-2017-03'
 input-file:
 - Microsoft.Network/2017-03-01/trafficmanager.json
 
 ```
  
-# Tag: 2015-11-01
+# Tag: package-2015-11
 
-These settings apply only when `--tag=2015-11-01` is specified on the command line.
+These settings apply only when `--tag=package-2015-11` is specified on the command line.
 
-``` yaml $(tag) == '2015-11-01'
+``` yaml $(tag) == 'package-2015-11'
 input-file:
 - Microsoft.Network/2015-11-01/trafficmanager.json
 

--- a/specification/web/resource-manager/readme.md
+++ b/specification/web/resource-manager/readme.md
@@ -35,16 +35,16 @@ These are the global settings for the Web API.
 title: Web
 description: Web App Client
 openapi-type: arm
-tag: 2016-09-01
+tag: package-2016-09
 
 ```
 
 
-# Tag: 2016-09-01
+# Tag: package-2016-09
 
-These settings apply only when `--tag=2016-09-01` is specified on the command line.
+These settings apply only when `--tag=package-2016-09` is specified on the command line.
 
-``` yaml $(tag) == '2016-09-01'
+``` yaml $(tag) == 'package-2016-09'
 input-file:
 - Microsoft.CertificateRegistration/2015-08-01/AppServiceCertificateOrders.json
 - Microsoft.DomainRegistration/2015-04-01/Domains.json
@@ -60,11 +60,11 @@ input-file:
 
 ```
  
-# Tag: 2015-08-01-preview
+# Tag: package-2015-08-preview
 
-These settings apply only when `--tag=2015-08-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2015-08-preview` is specified on the command line.
 
-``` yaml $(tag) == '2015-08-01-preview'
+``` yaml $(tag) == 'package-2015-08-preview'
 input-file:
 - Microsoft.Web/2015-08-01/service.json
 - Microsoft.Web/2015-08-01-preview/logicAppsManagementClient.json


### PR DESCRIPTION
- adding `package` to emphasize that this is intended packaging granularity by the team
- reducing precision of date (checked: no collisions) to not suggest strong relationship with API version