### PR TITLE
Use singleton enum pattern for sql server administrator name

### DIFF
--- a/arm-sql/2014-04-01/swagger/serverAzureADAdministrators.json
+++ b/arm-sql/2014-04-01/swagger/serverAzureADAdministrators.json
@@ -69,7 +69,7 @@
                },
                "202":{
                   "description":"Accepted",
-		  "schema":{
+                  "schema":{
                      "$ref":"#/definitions/ServerAzureADAdministrator"
                   }
                }
@@ -221,12 +221,12 @@
             "sid":{
                "type":"string",
                "description":"The server administrator Sid (Secure ID).",
-			   "format": "uuid"
+               "format": "uuid"
             },
             "tenantId":{
                "type":"string",
                "description":"The server Active Directory Administrator tenant id.",
-			   "format": "uuid"
+               "format": "uuid"
             }
          },
          "required":[

--- a/arm-sql/2014-04-01/swagger/serverAzureADAdministrators.json
+++ b/arm-sql/2014-04-01/swagger/serverAzureADAdministrators.json
@@ -16,7 +16,7 @@
       "application/json"
    ],
    "paths":{
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/administrators/activedirectory":{
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/administrators/{administratorName}":{
          "put":{
             "tags":[
                "ServerAdministrators"
@@ -40,6 +40,9 @@
                },
                {
                   "$ref":"#/parameters/ServerNameParameter"
+               },
+               {
+                  "$ref":"#/parameters/AdministratorNameParameter"
                },
                {
                   "name":"properties",
@@ -96,6 +99,9 @@
                },
                {
                   "$ref":"#/parameters/ServerNameParameter"
+               },
+               {
+                  "$ref":"#/parameters/AdministratorNameParameter"
                }
             ],
             "responses":{
@@ -312,6 +318,20 @@
          "type":"string",
          "description":"A comma separated list of child objects to expand in the response. Possible properties: serviceTierAdvisors, transparentDataEncryption.",
          "x-ms-parameter-location":"method"
+      },
+      "AdministratorNameParameter":{
+          "name": "administratorName",
+          "in": "path",
+          "description": "Name of the server administrator resource.",
+          "required": true,
+          "type": "string",
+          "enum": [
+            "activeDirectory"
+          ],
+          "x-ms-enum": {
+            "name": "ServerAdministratorName"
+          },
+          "x-ms-parameter-location": "method"
       }
    },
   "securityDefinitions": {


### PR DESCRIPTION
This pattern is required for autorest --azureresourceschema to work.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
