### PR TITLE
Title extraction from Composite

### DIFF
--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -32,7 +32,7 @@ These are the global settings for the Compute API.
 
 ``` yaml
 # common 
-title: Compute
+title: ComputeManagementClient
 description: Compute Client
 openapi-type: arm
 tag: package-2017-03

--- a/specification/graphrbac/data-plane/readme.md
+++ b/specification/graphrbac/data-plane/readme.md
@@ -26,8 +26,8 @@ These are the global settings for the GraphRbac API.
 
 ``` yaml
 # common 
-title: Graph Rbac
-description: Graph Rbac Client
+title: GraphRbacManagementClient
+description: Azure Active Directory Graph RBAC management client.
 openapi-type: data-plane
 tag: 1.6
 

--- a/specification/monitor/data-plane/readme.md
+++ b/specification/monitor/data-plane/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the MonitorClient API.
 
 ``` yaml
 # common 
-title: Monitor Client
+title: MonitorClient
 description: Monitor Client
 openapi-type: data-plane
 tag: package-2016-09

--- a/specification/monitor/resource-manager/readme.md
+++ b/specification/monitor/resource-manager/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the MonitorClient API.
 
 ``` yaml
 # common 
-title: Monitor Management Client
+title: MonitorManagementClient
 description: Monitor Management Client
 openapi-type: arm
 tag: package-2017-03

--- a/specification/network/resource-manager/readme.md
+++ b/specification/network/resource-manager/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the Network API.
 
 ``` yaml
 # common 
-title: Network
+title: NetworkManagementClient
 description: Network Client
 openapi-type: arm
 tag: package-2017-06

--- a/specification/sql/resource-manager/readme.md
+++ b/specification/sql/resource-manager/readme.md
@@ -26,8 +26,8 @@ These are the global settings for the Sql API.
 
 ``` yaml
 # common 
-title: Sql
-description: Sql Client
+title: SqlManagementClient
+description: The Azure SQL Database management API provides a RESTful set of web services that interact with Azure SQL Database services to manage your databases. The API enables you to create, retrieve, update, and delete databases.
 openapi-type: arm
 tag: package-2015-05-preview
 

--- a/specification/web/resource-manager/readme.md
+++ b/specification/web/resource-manager/readme.md
@@ -32,8 +32,8 @@ These are the global settings for the Web API.
 
 ``` yaml
 # common 
-title: Web
-description: Web App Client
+title: WebSiteManagementClient
+description: WebSite Management Client
 openapi-type: arm
 tag: package-2016-09
 


### PR DESCRIPTION
@olydis This is the title/description extraction from the initial Composite files (at least the ones I used in Python). This avoid client breaking change, and set the description to what it was.

The only difference is I removed "Composite Swagger for" from the description. Otherwise, this is what was in the composite.