### PR TITLE
Fixing the PostgreSQL Swagger

### DIFF
--- a/arm-postgresql/2017-04-30-preview/swagger/postgresql.json
+++ b/arm-postgresql/2017-04-30-preview/swagger/postgresql.json
@@ -39,11 +39,11 @@
         "tags": [
           "Servers"
         ],
-        "operationId": "Servers_CreateOrUpdate",
+        "operationId": "Servers_Create",
         "x-ms-examples": {
           "ServerCreate": { "$ref": "../examples/ServerCreate.json" }
         },
-        "description": "Creates a new server or updates an existing server. The update action will overwrite the existing server.",
+        "description": "Creates a new server, or will overwrite an existing server.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"


### PR DESCRIPTION
~The [following code is generated from the Swagger currently in Master when using AutoRest to generate the Go SDK](https://github.com/mcardosos/azure-sdk-for-go/blob/v10.2/arm/postgresql/models.go#L214) - which doesn't allow for setting the `administratorLogin` and `administratorLoginPassword` fields, which [are defined in the Examples](https://github.com/Azure/azure-rest-api-specs/blob/master/arm-postgresql/2017-04-30-preview/examples/ServerCreate.json#L11).~

~This PR adds support for setting the `administratorLogin` and `administratorLoginPassword`~ - and also renames `CreateOrUpdate` to `Create` for the Create Servers method, since there's a separate Update method available.

---

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 