### PR TITLE
Code changes around resource folder

### DIFF
--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -31,6 +31,45 @@ openapi-type: arm
 tag: package-2017-05
 ```
 
+### Tag: package-features
+These settings apply only when `--tag=package-features` is specified on the command line.
+
+``` yaml $(tag) == 'package-features'
+input-file:
+- Microsoft.Features/2015-12-01/features.json
+```
+
+### Tag: package-locks
+These settings apply only when `--tag=package-locks` is specified on the command line.
+
+``` yaml $(tag) == 'package-locks'
+input-file:
+- Microsoft.Authorization/2016-09-01/locks.json
+```
+
+### Tag: package-policy
+These settings apply only when `--tag=package-policy` is specified on the command line.
+
+``` yaml $(tag) == 'package-policy'
+input-file:
+- Microsoft.Authorization/2016-12-01/policy.json
+```
+
+### Tag: package-resources
+These settings apply only when `--tag=package-resources` is specified on the command line.
+
+``` yaml $(tag) == 'package-resources'
+input-file:
+- Microsoft.Resources/2017-05-10/resources.json
+```
+
+### Tag: package-subscriptions
+These settings apply only when `--tag=package-subscriptions` is specified on the command line.
+
+``` yaml $(tag) == 'package-subscriptions'
+input-file:
+- Microsoft.Resources/2016-06-01/subscriptions.json
+```
 
 ### Tag: package-2017-05
 

--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -31,42 +31,42 @@ openapi-type: arm
 tag: package-2017-05
 ```
 
-### Tag: package-features
-These settings apply only when `--tag=package-features` is specified on the command line.
+### Tag: package-features-2015-12
+These settings apply only when `--tag=package-features-2015-12` is specified on the command line.
 
-``` yaml $(tag) == 'package-features'
+``` yaml $(tag) == 'package-features-2015-12'
 input-file:
 - Microsoft.Features/2015-12-01/features.json
 ```
 
-### Tag: package-locks
-These settings apply only when `--tag=package-locks` is specified on the command line.
+### Tag: package-locks-2016-09
+These settings apply only when `--tag=package-locks-2016-09` is specified on the command line.
 
-``` yaml $(tag) == 'package-locks'
+``` yaml $(tag) == 'package-locks-2016-09'
 input-file:
 - Microsoft.Authorization/2016-09-01/locks.json
 ```
 
-### Tag: package-policy
-These settings apply only when `--tag=package-policy` is specified on the command line.
+### Tag: package-policy-2016-12
+These settings apply only when `--tag=package-policy-2016-12` is specified on the command line.
 
-``` yaml $(tag) == 'package-policy'
+``` yaml $(tag) == 'package-policy-2016-12'
 input-file:
 - Microsoft.Authorization/2016-12-01/policy.json
 ```
 
-### Tag: package-resources
-These settings apply only when `--tag=package-resources` is specified on the command line.
+### Tag: package-resources-2017-05
+These settings apply only when `--tag=package-resources-2017-05` is specified on the command line.
 
-``` yaml $(tag) == 'package-resources'
+``` yaml $(tag) == 'package-resources-2017-05'
 input-file:
 - Microsoft.Resources/2017-05-10/resources.json
 ```
 
-### Tag: package-subscriptions
-These settings apply only when `--tag=package-subscriptions` is specified on the command line.
+### Tag: package-subscriptions-2016-06
+These settings apply only when `--tag=package-subscriptions-2016-06` is specified on the command line.
 
-``` yaml $(tag) == 'package-subscriptions'
+``` yaml $(tag) == 'package-subscriptions-2016-06'
 input-file:
 - Microsoft.Resources/2016-06-01/subscriptions.json
 ```


### PR DESCRIPTION
This PR is to modify the readme file of the resources folder. Earlier (legacy branch) arm-resources is a special case folder where swagger files for features, locks,policy, resources, subscriptions and resources were included (Why? No idea!!!!!) But the files were accessed seperately. None of them is a composite file. 

So, In the latest model, each of them could have a seperate folder or (as discussed with @fearthecowboy ) they could have seperate tag in the readme file. I have chosen the latter approach.

Please review and approve. 

