### PR TITLE
Code changes to fix issues with swagger

### DIFF
--- a/specification/datalake-analytics/resource-manager/readme.md
+++ b/specification/datalake-analytics/resource-manager/readme.md
@@ -39,8 +39,6 @@ These settings apply only when `--tag=package-2016-11` is specified on the comma
 ``` yaml $(tag) == 'package-2016-11'
 input-file:
 - Microsoft.DataLakeAnalytics/2016-11-01/account.json
-- Microsoft.DataLakeAnalytics/2016-11-01/catalog.json
-- Microsoft.DataLakeAnalytics/2016-11-01/job.json
 ```
  
 ### Tag: package-2016-03-preview

--- a/specification/datalake-store/resource-manager/readme.md
+++ b/specification/datalake-store/resource-manager/readme.md
@@ -40,7 +40,6 @@ These settings apply only when `--tag=package-2016-11` is specified on the comma
 ``` yaml $(tag) == 'package-2016-11'
 input-file:
 - Microsoft.DataLakeStore/2016-11-01/account.json
-- Microsoft.DataLakeStore/2016-11-01/filesystem.json
 ```
  
 ### Tag: package-2015-10-preview

--- a/specification/machinelearning/resource-manager/readme.md
+++ b/specification/machinelearning/resource-manager/readme.md
@@ -38,7 +38,6 @@ These settings apply only when `--tag=package-2017-01` is specified on the comma
 
 ``` yaml $(tag) == 'package-2017-01'
 input-file:
-- Microsoft.MachineLearning/2016-05-01-preview/commitmentPlans.json
 - Microsoft.MachineLearning/2017-01-01/webservices.json
 ```
  

--- a/specification/network/resource-manager/readme.md
+++ b/specification/network/resource-manager/readme.md
@@ -54,8 +54,8 @@ input-file:
 - Microsoft.Network/2017-06-01/usage.json
 - Microsoft.Network/2017-06-01/virtualNetwork.json
 - Microsoft.Network/2017-06-01/virtualNetworkGateway.json
-- Microsoft.Compute/2017-06-01/vmssNetworkInterface.json
-- Microsoft.Compute/2017-06-01/vmssPublicIpAddress.json
+- Microsoft.Network/2017-06-01/vmssNetworkInterface.json
+- Microsoft.Network/2017-06-01/vmssPublicIpAddress.json
 ```
 
 


### PR DESCRIPTION
For Azure Management Datalake Analytics, We use only the [account.json](https://github.com/Azure/azure-sdk-for-ruby/blob/master/Rakefile#L184) file. 
We do not use the catalog.json & job.json files.

For Azure Management Datalake Store, We use only the [account.json](https://github.com/Azure/azure-sdk-for-ruby/blob/master/Rakefile#L190) file. 
We do not use the filesystem.json file.     

For Azure Management Machine Learning, We use only [webservices.json](https://github.com/Azure/azure-sdk-for-ruby/blob/master/Rakefile#L265). 
We do not use commitmentPlans.json file.

For Azure Management Network Service, the files are mislabeled. 