### PR TITLE
Batches for validation and C# code generation

### DIFF
--- a/specification/analysisservices/resource-manager/readme.md
+++ b/specification/analysisservices/resource-manager/readme.md
@@ -53,5 +53,6 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Analysis
   output-folder: $(csharp-sdks-folder)/AnalysisServices/Management.Analysis/Generated
+  clear-output-folder: true
 ```
 

--- a/specification/authorization/resource-manager/readme.md
+++ b/specification/authorization/resource-manager/readme.md
@@ -56,4 +56,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Authorization
   output-folder: $(csharp-sdks-folder)/Authorization/Management.Authorization/Generated
+  clear-output-folder: true
 ```

--- a/specification/automation/resource-manager/readme.md
+++ b/specification/automation/resource-manager/readme.md
@@ -75,5 +75,6 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Automation
   output-folder: $(csharp-sdks-folder)/Automation/Management.Automation/Generated
+  clear-output-folder: true
 ```
 

--- a/specification/batch/data-plane/readme.md
+++ b/specification/batch/data-plane/readme.md
@@ -102,4 +102,5 @@ csharp:
   payload-flattening-threshold: 1
   namespace: Microsoft.Azure.Batch
   output-folder: $(csharp-sdks-folder)/Batch/DataPlane/Azure.Batch/GeneratedProtocol
+  clear-output-folder: true
 ```

--- a/specification/batch/resource-manager/readme.md
+++ b/specification/batch/resource-manager/readme.md
@@ -76,4 +76,5 @@ csharp:
   namespace: Microsoft.Azure.Management.Batch
   payload-flattening-threshold: 1
   output-folder: $(csharp-sdks-folder)/Batch/Management/Management.Batch/Generated
+  clear-output-folder: true
 ```

--- a/specification/billing/resource-manager/readme.md
+++ b/specification/billing/resource-manager/readme.md
@@ -60,4 +60,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Billing
   output-folder: $(csharp-sdks-folder)/Billing/Management.Billing/Generated
+  clear-output-folder: true
 ```

--- a/specification/cdn/resource-manager/readme.md
+++ b/specification/cdn/resource-manager/readme.md
@@ -75,4 +75,5 @@ csharp:
   namespace: Microsoft.Azure.Management.Cdn
   payload-flattening-threshold: 2
   output-folder: $(csharp-sdks-folder)/Cdn/Management.Cdn/Generated
+  clear-output-folder: true
 ```

--- a/specification/cognitiveservices/resource-manager/readme.md
+++ b/specification/cognitiveservices/resource-manager/readme.md
@@ -65,4 +65,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.CognitiveServices
   output-folder: $(csharp-sdks-folder)/CognitiveServices/Management.CognitiveServices/Generated
+  clear-output-folder: true
 ```

--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -146,6 +146,7 @@ csharp:
   namespace: Microsoft.Azure.Management.Compute
   payload-flattening-threshold: 1
   output-folder: $(csharp-sdks-folder)/Compute/Management.Compute/Generated
+  clear-output-folder: true
 ```
 
 

--- a/specification/consumption/resource-manager/readme.md
+++ b/specification/consumption/resource-manager/readme.md
@@ -55,4 +55,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Consumption
   output-folder: $(csharp-sdks-folder)/Consumption/Management.Consumption/Generated
+  clear-output-folder: true
 ```

--- a/specification/containerregistry/resource-manager/readme.md
+++ b/specification/containerregistry/resource-manager/readme.md
@@ -75,4 +75,5 @@ csharp:
   namespace: Microsoft.Azure.Management.ContainerRegistry
   payload-flattening-threshold: 2
   output-folder: $(csharp-sdks-folder)/ContainerRegistry/Management.ContainerRegistry/Generated
+  clear-output-folder: true
 ```

--- a/specification/customer-insights/resource-manager/readme.md
+++ b/specification/customer-insights/resource-manager/readme.md
@@ -65,4 +65,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.CustomerInsights
   output-folder: $(csharp-sdks-folder)/CustomerInsights/Management.CustomerInsights/Generated
+  clear-output-folder: true
 ```

--- a/specification/datalake-analytics/data-plane/readme.md
+++ b/specification/datalake-analytics/data-plane/readme.md
@@ -103,3 +103,13 @@ csharp:
   namespace: Microsoft.Azure.Management.DataLake.Analytics
   output-folder: $(csharp-sdks-folder)/DataLake.Analytics/Management.DataLake.Analytics/Generated
 ```
+
+# Validation
+
+Since this RP has no unique default package, iterate over all of them for validation:
+
+``` yaml $(validation)
+batch:
+  - package-catalog: true
+  - package-job: true
+```

--- a/specification/datalake-analytics/data-plane/readme.md
+++ b/specification/datalake-analytics/data-plane/readme.md
@@ -94,14 +94,9 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.DataLake.Analytics
   output-folder: $(csharp-sdks-folder)/DataLake.Analytics/Management.DataLake.Analytics/Generated
-```
-
-``` yaml $(csharp)
-csharp:
-  azure-arm: true
-  license-header: MICROSOFT_MIT
-  namespace: Microsoft.Azure.Management.DataLake.Analytics
-  output-folder: $(csharp-sdks-folder)/DataLake.Analytics/Management.DataLake.Analytics/Generated
+batch:
+  - package-catalog: true
+  - package-job: true
 ```
 
 # Validation

--- a/specification/datalake-analytics/resource-manager/readme.md
+++ b/specification/datalake-analytics/resource-manager/readme.md
@@ -64,4 +64,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.DataLake.Analytics
   output-folder: $(csharp-sdks-folder)/DataLake.Analytics/Management.DataLake.Analytics/Generated
+  clear-output-folder: true
 ```

--- a/specification/datalake-store/resource-manager/readme.md
+++ b/specification/datalake-store/resource-manager/readme.md
@@ -65,4 +65,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.DataLake.Store
   output-folder: $(csharp-sdks-folder)/DataLake.Store/Management.DataLake.Store/Generated
+  clear-output-folder: true
 ```

--- a/specification/devtestlabs/resource-manager/readme.md
+++ b/specification/devtestlabs/resource-manager/readme.md
@@ -64,4 +64,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.DevTestLabs
   output-folder: $(csharp-sdks-folder)/DevTestLabs/Management.DevTestLabs/Generated
+  clear-output-folder: true
 ```

--- a/specification/dns/resource-manager/readme.md
+++ b/specification/dns/resource-manager/readme.md
@@ -65,4 +65,5 @@ csharp:
   namespace: Microsoft.Azure.Management.Dns
   payload-flattening-threshold: 2
   output-folder: $(csharp-sdks-folder)/Dns/Management.Dns/Generated
+  clear-output-folder: true
 ```

--- a/specification/eventhub/resource-manager/readme.md
+++ b/specification/eventhub/resource-manager/readme.md
@@ -65,4 +65,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.EventHub
   output-folder: $(csharp-sdks-folder)/EventHub/Management.EventHub/Generated
+  clear-output-folder: true
 ```

--- a/specification/graphrbac/data-plane/readme.md
+++ b/specification/graphrbac/data-plane/readme.md
@@ -53,6 +53,7 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Graph.RBAC
   output-folder: $(csharp-sdks-folder)/Graph.RBAC/Graph.RBAC/Generated
+  clear-output-folder: true
 ```
 
 ## Python

--- a/specification/intune/resource-manager/readme.md
+++ b/specification/intune/resource-manager/readme.md
@@ -62,4 +62,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Intune
   output-folder: $(csharp-sdks-folder)/Intune/Intune/Generated
+  clear-output-folder: true
 ```

--- a/specification/iothub/resource-manager/readme.md
+++ b/specification/iothub/resource-manager/readme.md
@@ -63,4 +63,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.IotHub
   output-folder: $(csharp-sdks-folder)/IotHub/Management.IotHub/Generated
+  clear-output-folder: true
 ```

--- a/specification/keyvault/data-plane/readme.md
+++ b/specification/keyvault/data-plane/readme.md
@@ -62,4 +62,5 @@ csharp:
   namespace: Microsoft.Azure.KeyVault
   sync-methods: None
   output-folder: $(csharp-sdks-folder)/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Generated
+  clear-output-folder: true
 ```

--- a/specification/keyvault/resource-manager/readme.md
+++ b/specification/keyvault/resource-manager/readme.md
@@ -62,4 +62,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.KeyVault
   output-folder: $(csharp-sdks-folder)/KeyVault/Management/Management.KeyVault/Generated
+  clear-output-folder: true
 ```

--- a/specification/logic/resource-manager/readme.md
+++ b/specification/logic/resource-manager/readme.md
@@ -72,4 +72,5 @@ csharp:
   azure-arm: true
   namespace: Microsoft.Azure.Management.Logic
   output-folder: $(csharp-sdks-folder)/Logic/Management.Logic/Generated
+  clear-output-folder: true
 ```

--- a/specification/machinelearning/resource-manager/readme.md
+++ b/specification/machinelearning/resource-manager/readme.md
@@ -80,16 +80,16 @@ csharp:
   license-header: MICROSOFT_MIT
 ```
 
-```yaml $(csharp) && $(package-commitmentPlans)
+```yaml $(csharp)
 csharp:
-  namespace: Microsoft.Azure.Management.MachineLearning.CommitmentPlans
-  output-folder: $(csharp-sdks-folder)/MachineLearning/Management.MachineLearning/Generated/CommitmentPlans
-```
-
-```yaml $(csharp) && $(package-webservices)
-csharp:
-  namespace: Microsoft.Azure.Management.MachineLearning.WebServices
-  output-folder: $(csharp-sdks-folder)/MachineLearning/Management.MachineLearning/Generated/WebServices
+  clear-output-folder: true
+batch:
+  - package-webservices: true
+    namespace: Microsoft.Azure.Management.MachineLearning.WebServices
+    output-folder: $(csharp-sdks-folder)/MachineLearning/Management.MachineLearning/Generated/WebServices
+  - package-commitmentPlans: true
+    namespace: Microsoft.Azure.Management.MachineLearning.CommitmentPlans
+    output-folder: $(csharp-sdks-folder)/MachineLearning/Management.MachineLearning/Generated/CommitmentPlans
 ```
 
 # Validation

--- a/specification/machinelearning/resource-manager/readme.md
+++ b/specification/machinelearning/resource-manager/readme.md
@@ -91,3 +91,13 @@ csharp:
   namespace: Microsoft.Azure.Management.MachineLearning.WebServices
   output-folder: $(csharp-sdks-folder)/MachineLearning/Management.MachineLearning/Generated/WebServices
 ```
+
+# Validation
+
+Since this RP has no unique default package, iterate over all of them for validation:
+
+``` yaml $(validation)
+batch:
+  - package-webservices: true
+  - package-commitmentPlans: true
+```

--- a/specification/mediaservices/resource-manager/readme.md
+++ b/specification/mediaservices/resource-manager/readme.md
@@ -56,4 +56,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Media
   output-folder: $(csharp-sdks-folder)/Media/Management.Media/Generated
+  clear-output-folder: true
 ```

--- a/specification/monitor/data-plane/readme.md
+++ b/specification/monitor/data-plane/readme.md
@@ -62,6 +62,7 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Monitor
   output-folder: $(csharp-sdks-folder)/Monitor/Management.Monitor/Generated/Monitor
+  clear-output-folder: true
 ```
 
 

--- a/specification/monitor/resource-manager/readme.md
+++ b/specification/monitor/resource-manager/readme.md
@@ -63,6 +63,7 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Monitor.Management
   output-folder: $(csharp-sdks-folder)/Monitor/Management.Monitor/Generated/Management/Monitor
+  clear-output-folder: true
 ```
 
 

--- a/specification/network/resource-manager/readme.md
+++ b/specification/network/resource-manager/readme.md
@@ -201,6 +201,7 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Network
   output-folder: $(csharp-sdks-folder)/Network/Management.Network/Generated
+  clear-output-folder: true
 ```
 
 

--- a/specification/notificationhubs/resource-manager/readme.md
+++ b/specification/notificationhubs/resource-manager/readme.md
@@ -72,4 +72,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.NotificationHubs
   output-folder: $(csharp-sdks-folder)/NotificationHubs/Management.NotificationHubs/Generated
+  clear-output-folder: true
 ```

--- a/specification/operationalinsights/resource-manager/readme.md
+++ b/specification/operationalinsights/resource-manager/readme.md
@@ -68,4 +68,5 @@ csharp:
   payload-flattening-threshold: 1
   license-header: MICROSOFT_MIT
   output-folder: $(csharp-sdks-folder)/OperationalInsights/Management.OperationalInsights/Generated
+  clear-output-folder: true
 ```

--- a/specification/powerbiembedded/resource-manager/readme.md
+++ b/specification/powerbiembedded/resource-manager/readme.md
@@ -56,4 +56,5 @@ csharp:
   namespace: Microsoft.Azure.Management.PowerBIEmbedded
   payload-flattening-threshold: 2
   output-folder: $(csharp-sdks-folder)/PowerBIEmbedded/Management.PowerBIEmbedded/Generated
+  clear-output-folder: true
 ```

--- a/specification/recoveryservices/resource-manager/readme.md
+++ b/specification/recoveryservices/resource-manager/readme.md
@@ -71,5 +71,6 @@ csharp:
   payload-flattening-threshold: 1
   namespace: Microsoft.Azure.Management.RecoveryServices
   output-folder: $(csharp-sdks-folder)/RecoveryServices/Management.RecoveryServices/Generated
+  clear-output-folder: true
 ```
 

--- a/specification/recoveryservicesbackup/resource-manager/readme.md
+++ b/specification/recoveryservicesbackup/resource-manager/readme.md
@@ -71,6 +71,7 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.RecoveryServices.Backup
   output-folder: $(csharp-sdks-folder)/RecoveryServices.Backup/Management.RecoveryServices.Backup/Generated
+  clear-output-folder: true
 ```
 
 ## Python

--- a/specification/recoveryservicessiterecovery/resource-manager/readme.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.md
@@ -54,4 +54,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.RecoveryServices.SiteRecovery
   output-folder: $(csharp-sdks-folder)/RecoveryServices.SiteRecovery/Management.RecoveryServices.SiteRecovery/Generated
+  clear-output-folder: true
 ```

--- a/specification/redis/resource-manager/readme.md
+++ b/specification/redis/resource-manager/readme.md
@@ -75,4 +75,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Redis
   output-folder: $(csharp-sdks-folder)/RedisCache/Management.Redis/Generated
+  clear-output-folder: true
 ```

--- a/specification/relay/resource-manager/readme.md
+++ b/specification/relay/resource-manager/readme.md
@@ -65,4 +65,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Relay
   output-folder: $(csharp-sdks-folder)/Relay/Management.Relay/Generated
+  clear-output-folder: true
 ```

--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -183,6 +183,15 @@ csharp:
   namespace: Microsoft.Azure.Management.ResourceManager
   license-header: MICROSOFT_MIT
   output-folder: $(csharp-sdks-folder)/Resource/Management.ResourceManager/Generated
+batch:
+  - package-features: true
+    clear-output-folder: true # clear output folder on first run
+  - package-locks: true
+  - package-policy: true
+  - package-resources: true
+  - package-subscriptions: true
+  - package-links: true
+#  - package-managedapplications: true
 ```
 
 # Validation

--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -184,3 +184,18 @@ csharp:
   license-header: MICROSOFT_MIT
   output-folder: $(csharp-sdks-folder)/Resource/Management.ResourceManager/Generated
 ```
+
+# Validation
+
+Since this RP has no unique default package, iterate over all of them for validation:
+
+``` yaml $(validation)
+batch:
+  - package-features: true
+  - package-locks: true
+  - package-policy: true
+  - package-resources: true
+  - package-subscriptions: true
+  - package-links: true
+  - package-managedapplications: true
+```

--- a/specification/scheduler/resource-manager/readme.md
+++ b/specification/scheduler/resource-manager/readme.md
@@ -70,4 +70,5 @@ csharp:
   license-header: NONE
   namespace: Microsoft.Azure.Management.Scheduler
   output-folder: $(csharp-sdks-folder)/Scheduler/Management.Scheduler/Generated
+  clear-output-folder: true
 ```

--- a/specification/search/data-plane/readme.md
+++ b/specification/search/data-plane/readme.md
@@ -75,4 +75,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Search
   output-folder: $(csharp-sdks-folder)/Search/DataPlane/Microsoft.Azure.Search/GeneratedSearchIndex
+  clear-output-folder: true
 ```

--- a/specification/search/resource-manager/readme.md
+++ b/specification/search/resource-manager/readme.md
@@ -61,4 +61,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Search
   output-folder: $(csharp-sdks-folder)/Search/Management/Management.Search/Generated
+  clear-output-folder: true
 ```

--- a/specification/servermanagement/resource-manager/readme.md
+++ b/specification/servermanagement/resource-manager/readme.md
@@ -64,4 +64,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.ServerManagement
   output-folder: $(csharp-sdks-folder)/ServerManagement/Management.ServerManagement/Generated
+  clear-output-folder: true
 ```

--- a/specification/servicebus/resource-manager/readme.md
+++ b/specification/servicebus/resource-manager/readme.md
@@ -65,4 +65,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.ServiceBus
   output-folder: $(csharp-sdks-folder)/ServiceBus/Management.ServiceBus/Generated
+  clear-output-folder: true
 ```

--- a/specification/servicefabric/resource-manager/readme.md
+++ b/specification/servicefabric/resource-manager/readme.md
@@ -55,4 +55,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.ServiceFabric
   output-folder: $(csharp-sdks-folder)/ServiceFabric/Management.ServiceFabric/Generated
+  clear-output-folder: true
 ```

--- a/specification/sql/resource-manager/readme.md
+++ b/specification/sql/resource-manager/readme.md
@@ -93,6 +93,7 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.Sql
   output-folder: $(csharp-sdks-folder)/SqlManagement/Management.Sql/Generated
+  clear-output-folder: true
 ```
 
 

--- a/specification/storage/resource-manager/readme.md
+++ b/specification/storage/resource-manager/readme.md
@@ -102,4 +102,5 @@ csharp:
   namespace: Microsoft.Azure.Management.Storage
   payload-flattening-threshold: 2
   output-folder: $(csharp-sdks-folder)/Storage/Management.Storage/Generated
+  clear-output-folder: true
 ```

--- a/specification/storsimple8000series/resource-manager/readme.md
+++ b/specification/storsimple8000series/resource-manager/readme.md
@@ -54,4 +54,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.StorSimple8000Series
   output-folder: $(csharp-sdks-folder)/StorSimple8000Series/Management.StorSimple8000Series/Generated
+  clear-output-folder: true
 ```

--- a/specification/streamanalytics/resource-manager/readme.md
+++ b/specification/streamanalytics/resource-manager/readme.md
@@ -62,4 +62,5 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.StreamAnalytics
   output-folder: $(csharp-sdks-folder)/StreamAnalytics/Management.StreamAnalytics/Generated
+  clear-output-folder: true
 ```

--- a/specification/trafficmanager/resource-manager/readme.md
+++ b/specification/trafficmanager/resource-manager/readme.md
@@ -76,4 +76,5 @@ csharp:
   namespace: Microsoft.Azure.Management.TrafficManager
   payload-flattening-threshold: 2
   output-folder: $(csharp-sdks-folder)/TrafficManager/Management.TrafficManager/Generated
+  clear-output-folder: true
 ```

--- a/specification/web/resource-manager/readme.md
+++ b/specification/web/resource-manager/readme.md
@@ -84,6 +84,7 @@ csharp:
   license-header: MICROSOFT_MIT
   namespace: Microsoft.Azure.Management.WebSites
   output-folder: $(csharp-sdks-folder)/WebSites/Management.WebSites/Generated
+  clear-output-folder: true
 ```
 
 


### PR DESCRIPTION
Uses `batch` mode to:
- reenable validation for RPs like `resources` (where it really needs multiple invocations of the validation tools)
- allow consistent C# code generation! Any RP (except one, that relies on a weird `Fix-....ps1` script) can now be regenerated with a single, simple `autorest --csharp <RP config>`