### PR TITLE
Fix VMSS path

### DIFF
--- a/specification/network/resource-manager/readme.md
+++ b/specification/network/resource-manager/readme.md
@@ -114,7 +114,7 @@ These settings apply only when `--tag=package-2016-09` is specified on the comma
 
 ``` yaml $(tag) == 'package-2016-09'
 input-file:
-- microsoft.Network/2016-09-01/vmssNetworkInterface.json
+- Microsoft.Network/2016-09-01/vmssNetworkInterface.json
 - Microsoft.Network/2016-09-01/applicationGateway.json
 - Microsoft.Network/2016-09-01/checkDnsAvailability.json
 - Microsoft.Network/2016-09-01/expressRouteCircuit.json


### PR DESCRIPTION
Travis is case sensitive, this breaks build:
https://travis-ci.org/Azure/azure-rest-api-specs/jobs/255692708

```shell
FATAL: swagger-document-override/md-override-loader - FAILED
FATAL: Error: Failed to read 'file:///git-restapi/specification/network/resource-manager/microsoft.Network/2016-09-01/vmssNetworkInterface.json'. Key not found.
```

Seen in https://github.com/Azure/azure-rest-api-specs/pull/1442