### PR TITLE
IotHub nested resource: certificates

### DIFF
--- a/specification/iothub/resource-manager/Microsoft.Devices/2017-01-19/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/2017-01-19/iothub.json
@@ -964,9 +964,452 @@
         },
         "deprecated": false
       }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/certificates": {
+      "get": {
+        "tags": [ "GET" ],
+        "summary": "Get the certificate list.",
+        "description": "Get the certificate list.",
+        "operationId": "IotHubResource_ListCertificates",
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "description": "The name of the resource group that contains the IoT hub.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the IoT hub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The body contains all the certificate list.",
+            "schema": {
+              "$ref": "#/definitions/CertificateListDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/certificates/{certificateName}": {
+      "get": {
+        "tags": [ "GET" ],
+        "summary": "Get the certificate.",
+        "description": "Returns the certificate.",
+        "operationId": "Certificate_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "description": "The name of the resource group that contains the IoT hub.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the IoT hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in":"path",
+            "description":"The name of the certificate",
+            "required":true,
+            "type":"string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The body contains the certificate.",
+            "schema": {
+              "$ref": "#/definitions/CertificateDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [ "PUT" ],
+        "summary": "Upload the certificate to the IoT hub.",
+        "description": "Adds new or replaces existing certificate.",
+        "operationId": "Certificate_CreateOrUpdate",
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the resource group that contains the IoT hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the IoT hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in":"path",
+            "description":"The name of the certificate create or update.",
+            "required":true,
+            "type":"string",
+			"maxLength": 256
+          },
+          {
+            "name": "certificateDescription",
+            "in": "body",
+            "description": "The certificate body.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CertificateBodyDescription"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "If certificate didn't exist creation was successful, the operation returns HTTP status code of 201 (OK).",
+            "schema": {
+              "$ref": "#/definitions/CertificateDescription"
+            }
+          },
+          "200": {
+            "description": "If certificate already exist and update was successful, the operation returns HTTP status code of 201 (OK).",
+            "schema": {
+              "$ref": "#/definitions/CertificateDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [ "DELETE" ],
+        "summary": "Delete an X509 certificate.",
+        "description": "Deletes an existing X509 certificate or does nothing if it does not exist.",
+        "operationId": "Certificate_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "description": "The name of the resource group that contains the IoT hub.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the IoT hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in":"path",
+            "description":"The name of the certificate to delete.",
+            "required":true,
+            "type":"string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Certificate has been deleted."
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/certificates/{certificateName}/generateVerificationCode": {
+      "post": {
+        "tags": [ "POST" ],
+        "summary": "Generate verification code for proof of posession flow.",
+        "description": "Generates verification code for proof of posession flow. The verifification code will be used to generate a leaf certificate.",
+        "operationId": "Certificate_GenerateVerificationCode",
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "description": "The name of the resource group that contains the IoT hub.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the IoT hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in":"path",
+            "description":"The name of the certificate",
+            "required":true,
+            "type":"string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The body contains the certificate.",
+            "schema": {
+              "$ref": "#/definitions/CertificateWithNonceDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/certificates/{certificateName}/verify": {
+      "post": {
+        "tags": [ "POST" ],
+        "summary": "Verify certificate's private key posession.",
+        "description": "Verifies the certificate's private key posession by providing the leaf cert issued by the verifying pre uploaded certificate.",
+        "operationId": "Certificate_Verify",
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "description": "The name of the resource group that contains the IoT hub.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the IoT hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in":"path",
+            "description":"The name of the certificate",
+            "required":true,
+            "type":"string"
+          },
+          {
+            "name": "certificateVerificationBody",
+            "in":"body",
+            "description":"The name of the certificate",
+            "required":true,
+            "schema": {
+              "$ref": "#/definitions/CertificateVerificationDescription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The body contains the certificate.",
+            "schema": {
+              "$ref": "#/definitions/CertificateDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
     }
   },
   "definitions": {
+    "CertificateVerificationDescription":{
+      "description": "The JSON-serialized leaf certificate",
+      "type": "object",
+      "properties": {
+        "certificate": {
+          "description": "base-64 representation of X509 certificate .cer file or just .pem file content.",
+          "type": "string"
+        }
+      }
+    },
+    "CertificateBodyDescription":{
+      "description": "The JSON-serialized X509 Certificate.",
+      "type": "object",
+      "properties": {
+        "certificate": {
+          "description": "base-64 representation of the X509 leaf certificate .cer file or just .pem file content.",
+          "type": "string"
+        }
+      }
+    },
+    "CertificateListDescription": {
+      "description": "The JSON-serialized array of Certificate objects.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The array of Certificate objects.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CertificateDescription"
+          }
+        }
+      }
+    },
+    "CertificateDescription": {
+      "description": "The X509 Certificate.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the certificate.",
+          "type": "string"
+        },
+        "etag": {
+          "description": "The entity tag.",
+          "type": "string"
+        },
+        "subject": {
+          "description": "The certificate's subject name.",
+          "type": "string"
+        },
+        "expiry": {
+          "description": "The certificate's expiration date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123"
+        },
+        "thumbprint": {
+          "description": "The certificate's thumbprint.",
+          "type": "string"
+        },
+        "isVerified": {
+          "description": "Determines wether certificate has been verified.",
+          "type": "boolean"
+        },
+        "created": {
+          "description": "The certificate's create date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123"
+        },
+        "updated": {
+          "description": "The certificate's last update date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123"
+        }
+      },
+	  "x-ms-azure-resource": true
+    },
+    "CertificateWithNonceDescription": {
+      "description": "The X509 Certificate.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the certificate.",
+          "type": "string"
+        },
+        "etag": {
+          "description": "The entity tag.",
+          "type": "string"
+        },
+        "subject": {
+          "description": "The certificate's subject name.",
+          "type": "string"
+        },
+        "expiry": {
+          "description": "The certificate's expiration date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123"
+        },
+        "thumbprint": {
+          "description": "The certificate's thumbprint.",
+          "type": "string"
+        },
+        "isVerified": {
+          "description": "Determines wether certificate has been verified.",
+          "type": "boolean"
+        },
+        "created": {
+          "description": "The certificate's create date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123"
+        },
+        "updated": {
+          "description": "The certificate's last update date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123"
+        },
+        "verificationCode": {
+          "description": "The certificate's verification code that will be used for proof of posession.",
+          "type": "string"
+        }
+      }
+    },
     "SharedAccessSignatureAuthorizationRule": {
       "description": "The properties of an IoT hub shared access policy.",
       "type": "object",


### PR DESCRIPTION
It is time to enable this feature finally. I have already got sign off on original commit and it was merged, then I had to revert it because the feature wan't announce yet. 
So I'd like to get the sign off again to be ready to just push the button and merge it in a few days.

Revert "Revert "IotHub nested resource: certificates""

This reverts commit 0019c1f4214368226d8edea4303adc949b1f2769.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
