### PR TITLE
Added GetSupportedOptimizationTypes API and changed the optimizationtype to an enum

### DIFF
--- a/arm-cdn/2016-10-02/swagger/cdn.json
+++ b/arm-cdn/2016-10-02/swagger/cdn.json
@@ -343,6 +343,47 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/getSupportedOptimizationTypes": {
+      "post": {
+        "tags": [
+          "Profiles"
+        ],
+        "description": "Gets the supported optimization types for the current profile. A user can create an endpoint using the listed values.",
+        "operationId": "Profiles_GetSupportedOptimizationTypes",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "Name of the CDN profile which is unique within the resource group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/SupportedOptimizationTypesResult"
+            }
+          },
+          "default": {
+            "description": "CDN error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/checkResourceUsage": {
       "post": {
         "tags": [
@@ -1729,6 +1770,19 @@
         }
       }
     },
+    "SupportedOptimizationTypesResult": {
+      "description": "The result of the GetSupportedOptimizationTypes API",
+      "type": "object",
+      "properties": {
+        "supportedOptimizationTypes": {
+          "description": "Supported optimization types for a profile.",
+          "items": {
+            "$ref": "#/definitions/OptimizationType"
+          },
+          "type": "array"
+        }
+      }
+    },
     "Endpoint": {
       "description": "CDN endpoint is the entity within a CDN profile containing configuration information such as origin, protocol, content caching and delivery behavior. The CDN endpoint uses the URL format <endpointname>.azureedge.net.",
       "type": "object",
@@ -1861,7 +1915,7 @@
         },
         "optimizationType": {
           "description": "Customer can specify what scenario they want this CDN endpoint to optimize, e.g. Download, Media services. With this information we can apply scenario driven optimization.",
-          "type": "string"
+          "$ref": "#/definitions/OptimizationType"
         },
         "geoFilters": {
           "description": "List of rules defining user geo access within a CDN endpoint. Each geo filter defines an acess rule to a specified path or content, e.g. block APAC for path /pictures/",
@@ -2516,6 +2570,21 @@
         }
       },
       "type": "object"
+    },
+    "OptimizationType": {
+      "description": "Customer can specify what scenario they want this CDN endpoint to optimize, e.g. Download, Media services. With this information we can apply scenario driven optimization.",
+      "enum": [
+        "GeneralWebDelivery",
+        "GeneralMediaStreaming",
+        "VideoOnDemandMediaStreaming",
+        "LargeFileDownload",
+        "DynamicSiteAcceleration"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "OptimizationType",
+        "modelAsString": true
+      }
     },
     "ErrorResponse": {
       "description": "Error reponse indicates CDN service is not able to process the incoming request. The reason is provided in the error message.",


### PR DESCRIPTION
In this PR, we have updated the swagger for the API version 2016-10-02. 

The changes include the following:
1. Added GetSupportedOptimizationTypes API
2. Changed the optimization type from a string to an enum

For these changes in the swagger, we do not plan to generate the SDK and write test cases as we'll soon generate the SDK using the 2017-04-02 version of swagger.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
