### PR TITLE
[Travis-ci] Oad in ci status

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@microsoft.azure/literate":"^1.0.21",
     "@microsoft.azure/async-io":"^1.0.21",
     "@microsoft.azure/polyfill":"^1.0.17",
-    "oad": "^0.1.6"
+    "oad": "vishrutshah/openapi-diff#chain-result"
   },
   "homepage": "https://github.com/azure/azure-rest-api-specs",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@microsoft.azure/literate":"^1.0.21",
     "@microsoft.azure/async-io":"^1.0.21",
     "@microsoft.azure/polyfill":"^1.0.17",
-    "oad": "vishrutshah/openapi-diff#chain-result"
+    "oad": "^0.1.7"
   },
   "homepage": "https://github.com/azure/azure-rest-api-specs",
   "repository": {

--- a/scripts/breaking-change.js
+++ b/scripts/breaking-change.js
@@ -37,7 +37,15 @@ function runOad(oldSpec, newSpec) {
   console.log(`New Spec: "${newSpec}"`);
   console.log(`>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`);
 
-  return Promise.resolve(oad.compare(oldSpec, newSpec, { consoleLogLevel: 'warn', json: true }));
+  return oad.compare(oldSpec, newSpec, { consoleLogLevel: 'warn', json: true }).then((result) => {
+    if (result !== undefined && typeof result.valueOf() === 'string' && result.indexOf(`"type": "Error"`) > -1) {
+      console.log(`There are potential breaking changes in this PR. Please review before moving forward. Thanks!`);
+      process.exitCode = 1;
+    }
+    return Promise.resolve();
+  }).catch(err => {
+    console.log(err);
+  });
 }
 
 /**
@@ -99,8 +107,13 @@ async function runScript() {
   console.dir(resolvedMapForNewSpecs);
 
   for (const swagger of swaggersToProcess) {
-    let outputFileNameWithExt = path.basename(swagger);
+    // If file does not exists in the previous commits then we ignore it as it's new file
+    if (!fs.existsSync(swagger)) {
+      console.log(`File: "${swagger}" looks to be newly added in this PR.`);
+      continue;
+    }
 
+    let outputFileNameWithExt = path.basename(swagger);
     console.log(outputFileNameWithExt);
     if (resolvedMapForNewSpecs[outputFileNameWithExt]) {
       await runOad(swagger, resolvedMapForNewSpecs[outputFileNameWithExt]);
@@ -110,8 +123,9 @@ async function runScript() {
 
 // magic starts here
 runScript().then(success => {
-  process.exit(0);
+  console.log(`Thanks for using breaking change tool to review.`);
+  console.log(`If you encounter any issue(s), please open issue(s) at https://github.com/Azure/openapi-diff/issues .`);
 }).catch(err => {
   console.log(err);
-  process.exit(1);
+  process.exitCode = 1;
 })

--- a/scripts/breaking-change.js
+++ b/scripts/breaking-change.js
@@ -38,6 +38,7 @@ function runOad(oldSpec, newSpec) {
   console.log(`>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`);
 
   return oad.compare(oldSpec, newSpec, { consoleLogLevel: 'warn', json: true }).then((result) => {
+    console.log(result);
     if (result !== undefined && typeof result.valueOf() === 'string' && result.indexOf(`"type": "Error"`) > -1) {
       console.log(`There are potential breaking changes in this PR. Please review before moving forward. Thanks!`);
       process.exitCode = 1;

--- a/scripts/momentOfTruth.js
+++ b/scripts/momentOfTruth.js
@@ -139,8 +139,9 @@ async function runScript() {
     for (const configFile of configsToProcess) {
         await runTools(configFile, 'after');
     }
-    execSync(`${gitCheckoutCmd}`, { encoding: 'utf8' });
-    execSync(`${gitLogCmd}`, { encoding: 'utf8' });
+
+    utils.checkoutTargetBranch();
+
     for (const configFile of configsToProcess) {
         await runTools(configFile, 'before');
     }

--- a/specification/storage/resource-manager/Microsoft.Storage/2017-06-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/2017-06-01/storage.json
@@ -1711,11 +1711,6 @@
           "type": "string",
           "x-ms-client-name": "ContentLanguage",
           "description": "The response header override for content language."
-        },
-        "rsct": {
-          "type": "string",
-          "x-ms-client-name": "ContentType",
-          "description": "The response header override for content type."
         }
       },
       "required": [

--- a/specification/storage/resource-manager/Microsoft.Storage/2017-06-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/2017-06-01/storage.json
@@ -1711,6 +1711,11 @@
           "type": "string",
           "x-ms-client-name": "ContentLanguage",
           "description": "The response header override for content language."
+        },
+        "rsct": {
+          "type": "string",
+          "x-ms-client-name": "ContentType",
+          "description": "The response header override for content type."
         }
       },
       "required": [

--- a/test/util/utils.js
+++ b/test/util/utils.js
@@ -82,6 +82,8 @@ exports.checkoutTargetBranch = function checkoutTargetBranch() {
   execSync(`git remote -vv`, { encoding: 'utf8' });
   execSync(`git branch --all`, { encoding: 'utf8' });
   execSync(`git fetch origin ${targetBranch}`, { encoding: 'utf8' });
+  execSync(`git diff`, { encoding: 'utf8' });
+  execSync(`git stash`, { encoding: 'utf8' });
   execSync(`git checkout ${targetBranch}`, { encoding: 'utf8' });
   execSync(`git log -3`, { encoding: 'utf8' });
 }


### PR DESCRIPTION
Part of https://github.com/Azure/openapi-diff/issues/88

**TODO**
- [x] Revert the file for storage changes used for testing
- [x] Use the released version of `oad` instead of my fork