### PR TITLE
updating spec for file type to comply with schema

### DIFF
--- a/specification/cognitiveservices/data-plane/Face/v1.0/Face.json
+++ b/specification/cognitiveservices/data-plane/Face/v1.0/Face.json
@@ -2645,7 +2645,8 @@
    "x-ms-parameter-location": "method",
    "description": "An image stream.",
    "schema": {
-    "type": "file"
+    "type": "object",
+    "format": "file"
    }
   },
   "ImageUrl": {


### PR DESCRIPTION
Face.json is currently not complying with swagger 2.0 spec (per schema), which is currently breaking CI in the repo. 
Swagger 2.0 Schema: https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v2.0/schema.json
which is the base for the extended one we use at https://github.com/Azure/autorest/blob/master/schema/swagger-extensions.json

See related thread: https://github.com/OAI/OpenAPI-Specification/issues/1226

Making an update to an equivalent type/format, which produces the same generated code via AutoRest.

