### PR TITLE
Improvements to Key Vault REST spec

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/2016-10-01/keyvault.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/2016-10-01/keyvault.json
@@ -2939,10 +2939,10 @@
         },
         "crv": {
           "type": "string",
-          "description": "Elliptic curve name. For valid values, see JsonWebKeyECName.",
+          "description": "Elliptic curve name. For valid values, see JsonWebKeyCurveName.",
           "enum": [ "P-256", "P-384", "P-521", "SECP256K1" ],
           "x-ms-enum": {
-            "name": "JsonWebKeyECName",
+            "name": "JsonWebKeyCurveName",
             "modelAsString": true
           }
         },
@@ -3841,16 +3841,6 @@
             "modelAsString": true
           }
         },
-        "crv": {
-          "x-ms-client-name": "curve",
-          "type": "string",
-          "description": "Elliptic curve name. For valid values, see JsonWebKeyECName.",
-          "enum": [ "P-256", "P-384", "P-521", "SECP256K1" ],
-          "x-ms-enum": {
-            "name": "JsonWebKeyECName",
-            "modelAsString": true
-          }
-        },
         "key_size": {
           "type": "integer",
           "format": "int32",
@@ -3878,6 +3868,16 @@
             "type": "string"
           },
           "description": "Application specific metadata in the form of key-value pairs."
+        },
+        "crv": {
+          "x-ms-client-name": "curve",
+          "type": "string",
+          "description": "Elliptic curve name. For valid values, see JsonWebKeyCurveName.",
+          "enum": [ "P-256", "P-384", "P-521", "SECP256K1" ],
+          "x-ms-enum": {
+            "name": "JsonWebKeyCurveName",
+            "modelAsString": true
+          }
         }
       },
       "description": "The key create parameters.",


### PR DESCRIPTION
### Summary
- Renamed JsonWebKeyECName to JsonWebKeyCurveName.
- Restored order of key creation parameters to reduce compatibility issues.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - x ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
