### PR TITLE
Revert "Added support for ECC to Key Vault"

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/2016-10-01/keyvault.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/2016-10-01/keyvault.json
@@ -2923,8 +2923,8 @@
         },
         "kty": {
           "type": "string",
-          "description": "JsonWebKey key type (kty).",
-          "enum": [ "EC", "EC-HSM", "RSA", "RSA-HSM", "oct" ],
+          "description": "Supported JsonWebKey key types (kty) for Elliptic Curve, RSA, HSM, Octet. Kty is usually set to RSA",
+          "enum": [ "EC", "RSA", "RSA-HSM", "oct" ],
           "x-ms-enum": {
             "name": "JsonWebKeyType",
             "modelAsString": true
@@ -2935,15 +2935,6 @@
           "items": {
             "type": "string",
             "description": "Supported key operations."
-          }
-        },
-        "crv": {
-          "type": "string",
-          "description": "Elliptic curve name. For valid values, see JsonWebKeyECName.",
-          "enum": [ "P-256", "P-384", "P-521", "SECP256K1" ],
-          "x-ms-enum": {
-            "name": "JsonWebKeyECName",
-            "modelAsString": true
           }
         },
         "n": {
@@ -2959,7 +2950,7 @@
         "d": {
           "type": "string",
           "format": "base64url",
-          "description": "RSA private exponent, or the D component of an EC private key."
+          "description": "RSA private exponent."
         },
         "dp": {
           "x-ms-client-name": "DP",
@@ -2988,16 +2979,6 @@
           "type": "string",
           "format": "base64url",
           "description": "RSA secret prime, with p < q."
-        },
-        "x": {
-          "type": "string",
-          "format": "base64url",
-          "description": "X component of an EC public key."
-        },
-        "y": {
-          "type": "string",
-          "format": "base64url",
-          "description": "Y component of an EC public key."
         },
         "k": {
           "type": "string",
@@ -3834,20 +3815,10 @@
         "kty": {
           "type": "string",
           "minLength": 1,
-          "description": "The type of key to create. For valid values, see JsonWebKeyType.",
-          "enum": [ "EC", "EC-HSM", "RSA", "RSA-HSM", "oct" ],
+          "description": "The type of key to create. For valid key types, see JsonWebKeyType. Supported JsonWebKey key types (kty) for Elliptic Curve, RSA, HSM, Octet",
+          "enum": [ "EC", "RSA", "RSA-HSM", "oct" ],
           "x-ms-enum": {
             "name": "JsonWebKeyType",
-            "modelAsString": true
-          }
-        },
-        "crv": {
-          "x-ms-client-name": "curve",
-          "type": "string",
-          "description": "Elliptic curve name. For valid values, see JsonWebKeyECName.",
-          "enum": [ "P-256", "P-384", "P-521", "SECP256K1" ],
-          "x-ms-enum": {
-            "name": "JsonWebKeyECName",
             "modelAsString": true
           }
         },
@@ -3937,7 +3908,7 @@
           "type": "string",
           "minLength": 1,
           "description": "The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.",
-          "enum": [ "PS256", "PS384", "PS512", "RS256", "RS384", "RS512", "RSNULL", "ES256", "ES384", "ES512", "ECDSA256" ],
+          "enum": [ "PS256", "PS384", "PS512", "RS256", "RS384", "RS512", "RSNULL" ],
           "x-ms-enum": {
             "name": "JsonWebKeySignatureAlgorithm",
             "modelAsString": true
@@ -3958,7 +3929,7 @@
           "type": "string",
           "minLength": 1,
           "description": "The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.",
-          "enum": [ "PS256", "PS384", "PS512", "RS256", "RS384", "RS512", "RSNULL", "ES256", "ES384", "ES512", "ECDSA256" ],
+          "enum": [ "PS256", "PS384", "PS512", "RS256", "RS384", "RS512", "RSNULL" ],
           "x-ms-enum": {
             "name": "JsonWebKeySignatureAlgorithm",
             "modelAsString": true


### PR DESCRIPTION
Reverting Azure/azure-rest-api-specs#1538 as it results in non backwards compatible generated code in the SDK.