### PR TITLE
[compute] Removing x-ms-azure-resource extension from invalid model ResourceUpdate

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/2016-04-30-preview/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2016-04-30-preview/disk.json
@@ -669,8 +669,7 @@
           },
           "description": "Resource tags"
         }
-      },
-      "x-ms-azure-resource": true
+      }
     },
     "Disk": {
       "properties": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/disk.json
@@ -674,8 +674,7 @@
         "sku": {
           "$ref": "#/definitions/DiskSku"
         }
-      },
-      "x-ms-azure-resource": true
+      }
     },
     "Disk": {
       "properties": {


### PR DESCRIPTION
Model `ResourceUpdate` is not a valid Azure resource. It should not be marked as `x-ms-azure-resource: true`. 

cc:
@veronicagg @sarangan12