### PR TITLE
added missing name parameters

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetFromACustomImage.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetFromACustomImage.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>", 
+    "vmScaleSetName": "myVMSS", 
     "api-version": "2017-03-30", 
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithAMarketplaceImagePlan.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithAMarketplaceImagePlan.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>", 
+    "vmScaleSetName": "myVMSS", 
     "api-version": "2017-03-30", 
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithAPublicIpAddressPerVm.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithAPublicIpAddressPerVm.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>",
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>",
+    "vmScaleSetName": "myVMSS",
     "api-version": "2017-03-30",
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithAnAzureApplicationGateway.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithAnAzureApplicationGateway.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>", 
+    "vmScaleSetName": "myVMSS", 
     "api-version": "2017-03-30", 
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithAnAzureLoadBalancer.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithAnAzureLoadBalancer.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>", 
+    "vmScaleSetName": "myVMSS", 
     "api-version": "2017-03-30", 
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithBootDiagnostics.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithBootDiagnostics.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>", 
+    "vmScaleSetName": "myVMSS", 
     "api-version": "2017-03-30", 
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithEmptyDataDisksOnEachVm.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithEmptyDataDisksOnEachVm.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>", 
+    "vmScaleSetName": "myVMSS", 
     "api-version": "2017-03-30", 
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithPasswordAuthentication.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithPasswordAuthentication.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>", 
+    "vmScaleSetName": "myVMSS", 
     "api-version": "2017-03-30", 
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithPremiumStorage.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithPremiumStorage.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>", 
+    "vmScaleSetName": "myVMSS", 
     "api-version": "2017-03-30", 
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithSshAuthentication.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAScaleSetWithSshAuthentication.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vmss-name>", 
+    "vmScaleSetName": "myVMSS", 
     "api-version": "2017-03-30", 
     "parameters": {
       "sku": {

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmFromACustomImage.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmFromACustomImage.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vm-name>", 
+    "vmName": "myVM", 
     "api-version": "2017-03-30", 
     "parameters": {
       "location": "westus", 

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmInAnAvailabilitySet.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmInAnAvailabilitySet.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vm-name>", 
+    "vmName": "myVM", 
     "api-version": "2017-03-30", 
     "parameters": {
       "location": "westus", 

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithAMarketplaceImagePlan.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithAMarketplaceImagePlan.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vm-name>", 
+    "vmName": "myVM", 
     "api-version": "2017-03-30", 
     "parameters": {
       "location": "westus", 

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithBootDiagnostics.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithBootDiagnostics.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vm-name>", 
+    "vmName": "myVM", 
     "api-version": "2017-03-30", 
     "parameters": {
       "location": "westus", 

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithEmptyDataDisks.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithEmptyDataDisks.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vm-name>", 
+    "vmName": "myVM", 
     "api-version": "2017-03-30", 
     "parameters": {
       "location": "westus", 

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithPasswordAuthentication.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithPasswordAuthentication.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vm-name>", 
+    "vmName": "myVM", 
     "api-version": "2017-03-30", 
     "parameters": {
       "location": "westus", 

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithPremiumStorage.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithPremiumStorage.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vm-name>", 
+    "vmName": "myVM", 
     "api-version": "2017-03-30", 
     "parameters": {
       "location": "westus", 

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithSshAuthentication.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAVmWithSshAuthentication.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
-    "name": "<vm-name>", 
+    "vmName": "myVM", 
     "api-version": "2017-03-30", 
     "parameters": {
       "location": "westus", 

--- a/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAnAvailabilitySet.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/2017-03-30/examples/CreateAnAvailabilitySet.json
@@ -3,6 +3,7 @@
     "subscriptionId": "<subscription-id>", 
     "resourceGroupName": "myRG",
     "api-version": "2017-03-30", 
+    "availabilitySetName": "myAvailabilitySet",
     "parameters": {
       "location": "westus", 
       "properties": {


### PR DESCRIPTION
Fixes an issue where instead of the true parameter names (like "vmName", "availabilitySetName", and "vmScaleSetName"), just had "name"