### PR TITLE
AzureStack: Fixed incorrect return type and set to long running operation

### DIFF
--- a/specification/azsadmin/resource-manager/fabric/Microsoft.Fabric.Admin/2016-05-01/IpPool.json
+++ b/specification/azsadmin/resource-manager/fabric/Microsoft.Fabric.Admin/2016-05-01/IpPool.json
@@ -83,13 +83,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/IpPool"
+                            "$ref": "Operations.json#/definitions/OperationStatus"
                         }
                     },
                     "202": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/IpPool"
+                            "$ref": "Operations.json#/definitions/OperationStatus"
                         }
                     }
                 },

--- a/specification/azsadmin/resource-manager/fabric/Microsoft.Fabric.Admin/2016-05-01/IpPool.json
+++ b/specification/azsadmin/resource-manager/fabric/Microsoft.Fabric.Admin/2016-05-01/IpPool.json
@@ -85,8 +85,15 @@
                         "schema": {
                             "$ref": "#/definitions/IpPool"
                         }
+                    },
+                    "202": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/IpPool"
+                        }
                     }
-                }
+                },
+                "x-ms-long-running-operation": true
             }
         },
         "/subscriptions/{subscriptionId}/resourceGroups/System.{location}/providers/Microsoft.Fabric.Admin/fabricLocations/{location}/ipPools": {


### PR DESCRIPTION
Two changes:

1.  Fixed wrong return type
2.  Added long running operation flag

Before when executed the return type was IpPool which contained no initialized fields.
In addition, this is a long running operation.

Could not test before because RP was unstable when creating Ip Pools and would crash duh to exception.

