### PR TITLE
Small update to message from linter CI

### DIFF
--- a/test/linter.js
+++ b/test/linter.js
@@ -114,7 +114,7 @@ describe('AutoRest Linter validation:', function () {
             prFile += '';
             return prFile.startsWith(configDir) && prFile.indexOf('examples') === -1 && prFile.endsWith('.json');
           }).forEach(prFileInConfigFile => {
-            console.warn(`Configuration file not found for file: ${prFileInConfigFile}, running validation rules against it in individual context.`);
+            console.warn(`WARNING: Configuration file not found for file: ${prFileInConfigFile}, running validation rules against it in individual context.`);
             execLinterCommand(`--input-file=${prFileInConfigFile}`);
           });
         }


### PR DESCRIPTION
Updating warning message to be a bit more noticeable, as I missed it once already (PR validation fell back to single file, which was fine for that case, but should have realized this was there due to a typo in name of the file that was pointed from the readme.md).