### PR TITLE
BatchAI. Getting rid of legacy "learning" brand.

### DIFF
--- a/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/BatchAI.json
+++ b/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/BatchAI.json
@@ -1865,7 +1865,7 @@
             "$ref": "#/definitions/EnvironmentSetting"
           },
           "title": "Additional environment variables to set on the job.",
-          "description": "Batch AI service sets the following environment variables for all jobs: AZ_LEARNING_INPUT_id, AZ_LEARNING_OUTPUT_id, AZ_LEARNING_NUM_GPUS_PER_NODE. For distributed TensorFlow jobs, following additional environment variables are set by the Batch AI Service: AZ_LEARNING_PS_HOSTS, AZ_LEARNING_WORKER_HOSTS"
+          "description": "Batch AI service sets the following environment variables for all jobs: AZ_BATCHAI_INPUT_id, AZ_BATCHAI_OUTPUT_id, AZ_BATCHAI_NUM_GPUS_PER_NODE. For distributed TensorFlow jobs, following additional environment variables are set by the Batch AI Service: AZ_BATCHAI_PS_HOSTS, AZ_BATCHAI_WORKER_HOSTS"
         },
         "constraints": {
           "properties": {
@@ -1993,7 +1993,7 @@
             "$ref": "#/definitions/EnvironmentSetting"
           },
           "title": "Additional environment variables to be passed to the job.",
-          "description": "Batch AI services sends the following environment variables for all jobs: AZ_LEARNING_INPUT_id, AZ_LEARNING_OUTPUT_id, AZ_LEARNING_NUM_GPUS_PER_NODE, For distributed TensorFlow jobs, following additional environment variables are set by the Batch AI Service: AZ_LEARNING_PS_HOSTS, AZ_LEARNING_WORKER_HOSTS"
+          "description": "Batch AI services sends the following environment variables for all jobs: AZ_BATCHAI_INPUT_id, AZ_BATCHAI_OUTPUT_id, AZ_BATCHAI_NUM_GPUS_PER_NODE, For distributed TensorFlow jobs, following additional environment variables are set by the Batch AI Service: AZ_BATCHAI_PS_HOSTS, AZ_BATCHAI_WORKER_HOSTS"
         },
         "constraints": {
           "properties": {
@@ -2391,7 +2391,7 @@
         "id": {
           "type": "string",
           "title": "The id for the input directory.",
-          "description": "It will be available for the job as an environment variable under AZ_LEARNING_INPUT_id. The learning service will also provide the following  environment variable: AZ_LEARNING_PREV_OUTPUT_Name. The value of the variable will be populated if the job is being retried after a previous failure, otherwise it will be set to nothing."
+          "description": "It will be available for the job as an environment variable under AZ_BATCHAI_INPUT_id. The service will also provide the following  environment variable: AZ_BATCHAI_PREV_OUTPUT_Name. The value of the variable will be populated if the job is being retried after a previous failure, otherwise it will be set to nothing."
         },
         "path": {
           "type": "string",
@@ -2409,17 +2409,17 @@
         "id": {
           "type": "string",
           "title": "The name for the output directory.",
-          "description": "It will be available for the job as an environment variable under AZ_LEARNING_OUTPUT_id."
+          "description": "It will be available for the job as an environment variable under AZ_BATCHAI_OUTPUT_id."
         },
         "pathPrefix": {
           "type": "string",
           "title": "The prefix path where the output directory will be created.",
-          "description": "NOTE: This is an absolute path to prefix. E.g. $AZ_LEARNING_MOUNT_ROOT/MyNFS/MyLearningLogs."
+          "description": "NOTE: This is an absolute path to prefix. E.g. $AZ_BATCHAI_MOUNT_ROOT/MyNFS/MyLogs."
         },
         "pathSuffix": {
           "type": "string",
-          "title": "The path of the directory to create.",
-          "description": "The learning system will create the following directory on user's behalf: PathPrefix/JobID/jobVersion/directoryName, where the JobID is a unique name created by the Batch AI Service and jobVersion is the version of the job. The Batch AI Service will also populate a file under this the PathPrefix/JobID/jobVersion directory, which maps the directory to a job ARM resource ID."
+          "title": "The suffix path where the output directory will be created.",
+          "description": "The suffix path where the output directory will be created."
         },
         "type": {
           "type": "string",
@@ -2482,7 +2482,7 @@
         "relativeMountPath": {
           "type": "string",
           "title": "Specifies the relative path on the compute node where the Azure file share will be mounted.",
-          "description": "Note that all file shares will be mounted under $AZ_LEARNING_MOUNT_ROOT location."
+          "description": "Note that all file shares will be mounted under $AZ_BATCHAI_MOUNT_ROOT location."
         },
         "fileMode": {
           "type": "string",
@@ -2522,7 +2522,7 @@
         "relativeMountPath": {
           "type": "string",
           "title": "Specifies the relative path on the compute node where the Azure Blob file system will be mounted.",
-          "description": "Note that all blob file systems will be mounted under $AZ_LEARNING_MOUNT_ROOT location."
+          "description": "Note that all blob file systems will be mounted under $AZ_BATCHAI_MOUNT_ROOT location."
         },
         "mountOptions": {
           "type": "string",
@@ -2551,7 +2551,7 @@
         "relativeMountPath": {
           "type": "string",
           "title": "Specifies the relative path on the compute node where the file server will be mounted.",
-          "description": "Note that all file shares will be mounted under $AZ_LEARNING_MOUNT_ROOT location."
+          "description": "Note that all file shares will be mounted under $AZ_BATCHAI_MOUNT_ROOT location."
         },
         "mountOptions": {
           "type": "string",
@@ -2573,7 +2573,7 @@
         "relativeMountPath": {
           "type": "string",
           "title": "Specifies the relative path on the compute cluster node where the file system will be mounted.",
-          "description": "Note that all file shares will be mounted under $AZ_LEARNING_MOUNT_ROOT location."
+          "description": "Note that all file shares will be mounted under $AZ_BATCHAI_MOUNT_ROOT location."
         }
       },
       "description": "Details of the file system to mount on the compute cluster.",
@@ -2732,7 +2732,7 @@
       "properties": {
         "commandLine": {
           "type": "string",
-          "title": "The command line to execute the custom toolkit learning Job."
+          "title": "The command line to execute the custom toolkit Job."
         }
       },
       "description": "Specifies the settings for a custom tool kit job."

--- a/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/examples/GetJob.json
+++ b/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/examples/GetJob.json
@@ -24,19 +24,19 @@
           },
           "toolType": "custom",
           "customToolkitSettings": {
-            "commandLine": "echo hi | tee $AZ_LEARNING_OUTPUT_OUTPUTS/hi.txt"
+            "commandLine": "echo hi | tee $AZ_BATCHAI_OUTPUT_OUTPUTS/hi.txt"
           },
-          "stdOutErrPathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles",
+          "stdOutErrPathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles",
           "inputDirectories": [
             {
               "id": "INPUT",
-              "path": "$AZ_LEARNING_MOUNT_ROOT/azfiles/input"
+              "path": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/input"
             }
           ],
           "outputDirectories": [
             {
               "id": "OUTPUTS",
-              "pathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles/",
+              "pathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/",
               "pathSuffix": "files",
               "type": "custom",
               "createNew": true

--- a/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/examples/ListJob.json
+++ b/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/examples/ListJob.json
@@ -24,19 +24,19 @@
               },
               "toolType": "custom",
               "customToolkitSettings": {
-                "commandLine": "echo hi | tee $AZ_LEARNING_OUTPUT_OUTPUTS/hi.txt"
+                "commandLine": "echo hi | tee $AZ_BATCHAI_OUTPUT_OUTPUTS/hi.txt"
               },
-              "stdOutErrPathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles",
+              "stdOutErrPathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles",
               "inputDirectories": [
                 {
                   "id": "INPUT",
-                  "path": "$AZ_LEARNING_MOUNT_ROOT/azfiles/input"
+                  "path": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/input"
                 }
               ],
               "outputDirectories": [
                 {
                   "id": "OUTPUTS",
-                  "pathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles/",
+                  "pathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/",
                   "pathSuffix": "files",
                   "type": "custom",
                   "createNew": true

--- a/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/examples/ListJobByResourceGroup.json
+++ b/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/examples/ListJobByResourceGroup.json
@@ -25,19 +25,19 @@
               },
               "toolType": "custom",
               "customToolkitSettings": {
-                "commandLine": "echo hi | tee $AZ_LEARNING_OUTPUT_OUTPUTS/hi.txt"
+                "commandLine": "echo hi | tee $AZ_BATCHAI_OUTPUT_OUTPUTS/hi.txt"
               },
-              "stdOutErrPathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles",
+              "stdOutErrPathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles",
               "inputDirectories": [
                 {
                   "id": "INPUT",
-                  "path": "$AZ_LEARNING_MOUNT_ROOT/azfiles/input"
+                  "path": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/input"
                 }
               ],
               "outputDirectories": [
                 {
                   "id": "OUTPUTS",
-                  "pathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles/",
+                  "pathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/",
                   "pathSuffix": "files",
                   "type": "custom",
                   "createNew": true

--- a/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/examples/PutJob.json
+++ b/specification/batchai/resource-manager/Microsoft.BatchAI/2017-09-01-preview/examples/PutJob.json
@@ -7,18 +7,18 @@
     "parameters": {
       "location": "eastus",
       "properties": {
-        "stdOutErrPathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles",
+        "stdOutErrPathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles",
         "cluster": {
           "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/demo_resource_group/providers/Microsoft.BatchAI/clusters/demo_cluster"
         },
         "nodeCount": 1,
         "customToolkitSettings": {
-          "commandLine": "echo hi | tee $AZ_LEARNING_OUTPUT_OUTPUTS/hi.txt"
+          "commandLine": "echo hi | tee $AZ_BATCHAI_OUTPUT_OUTPUTS/hi.txt"
         },
         "inputDirectories": [
           {
             "id": "INPUT",
-            "path": "$AZ_LEARNING_MOUNT_ROOT/azfiles/input"
+            "path": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/input"
           }
         ],
         "priority": 0,
@@ -29,7 +29,7 @@
         },
         "outputDirectories": [
           {
-            "pathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles/",
+            "pathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/",
             "type": "custom",
             "id": "OUTPUTS",
             "pathSuffix": "files",
@@ -64,19 +64,19 @@
           },
           "toolType": "custom",
           "customToolkitSettings": {
-            "commandLine": "echo hi | tee $AZ_LEARNING_OUTPUT_OUTPUTS/hi.txt"
+            "commandLine": "echo hi | tee $AZ_BATCHAI_OUTPUT_OUTPUTS/hi.txt"
           },
-          "stdOutErrPathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles",
+          "stdOutErrPathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles",
           "inputDirectories": [
             {
               "id": "INPUT",
-              "path": "$AZ_LEARNING_MOUNT_ROOT/azfiles/input"
+              "path": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/input"
             }
           ],
           "outputDirectories": [
             {
               "id": "OUTPUTS",
-              "pathPrefix": "$AZ_LEARNING_MOUNT_ROOT/azfiles/",
+              "pathPrefix": "$AZ_BATCHAI_MOUNT_ROOT/azfiles/",
               "pathSuffix": "files",
               "type": "custom",
               "createNew": true


### PR DESCRIPTION
Originally the service was called "Batch AI learning service", now it's
just "Batch AI". So, we need to get rid of legacy "learning" everywhere.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
