### PR TITLE
[Travis CI] Azure PR Bot CI job must fail on the JSON.parse error from linter output

### DIFF
--- a/scripts/momentOfTruth.js
+++ b/scripts/momentOfTruth.js
@@ -74,18 +74,9 @@ async function getLinterResult(swaggerPath) {
     let resultString = stderr;
     if (resultString.indexOf('{') !== -1) {
         resultString = "[" + resultString.substring(resultString.indexOf('{')).trim().replace(/\}\n\{/g, "},\n{") + "]";
-        //console.log('>>>>>> Trimmed Result...');
-        //console.log(resultString);
-        try {
-            jsonResult = JSON.parse(resultString);
-            //console.log('>>>>>> Parsed Result...');
-            //console.dir(resultObject, {depth: null, colors: true});
-            return jsonResult;
-        } catch (e) {
-            console.log(`An error occurred while executing JSON.parse() on the linter output for ${swaggerPath}:`);
-            console.dir(resultString);
-            console.dir(e, { depth: null, colors: true });
-        }
+        // Do not catch the JSON parse error
+        jsonResult = JSON.parse(resultString);
+        return jsonResult;
     }
     return [];
 };


### PR DESCRIPTION
As of today we catch the JSON.parse error on the linter output for the Azure Bot to report status. With this we are having trouble that Azure Bot reports there were no errors but that is not true.

Example PR: https://github.com/Azure/azure-rest-api-specs/pull/1788#issuecomment-333996892
CI Bot Error: https://travis-ci.org/Azure/azure-rest-api-specs/jobs/282957467#L607

By not catching this error, we'll fail the CI job and make Azure Bot not report the invalid report. 