### PR TITLE
removing resourcetype parameter from global prameters as it is not referenced anywhere.

### DIFF
--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/2015-01-01/resourcehealth.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/2015-01-01/resourcehealth.json
@@ -548,13 +548,6 @@
       "description": "The name of the resource group.",
       "x-ms-parameter-location": "method"
     },
-    "ResourceTypeParameter": {
-      "name": "resourceType",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "The name of the resource type."
-    },
     "FilterParameter": {
       "name": "$filter",
       "in": "query",

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/2017-07-01/resourcehealth.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/2017-07-01/resourcehealth.json
@@ -564,13 +564,6 @@
       "description": "The name of the resource group.",
       "x-ms-parameter-location": "method"
     },
-    "ResourceTypeParameter": {
-      "name": "resourceType",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "The name of the resource type."
-    },
     "FilterParameter": {
       "name": "$filter",
       "in": "query",


### PR DESCRIPTION
The changes in this PR were originally made in #1753.
However, that PR had similar changes for ServiceFabric and RecoveryServicesSiteRecovery. Splitting this so that ResourceHealth changes are standalone.