### PR TITLE
Updating EntitySearch readme to include correct namespace and add-credentials flag

### DIFF
--- a/specification/cognitiveservices/data-plane/EntitySearch/readme.md
+++ b/specification/cognitiveservices/data-plane/EntitySearch/readme.md
@@ -18,13 +18,14 @@ These settings apply only when `--tag=release_1_0` is specified on the command l
 
 ``` yaml $(tag) == 'release_1_0'
 input-file: v1.0/EntitySearch.json
+add-credentials: y
 ```
 
 ## CSharp Settings
 These settings apply only when `--csharp` is specified on the command line.
 ``` yaml $(csharp) 
 csharp: 
-  namespace: Microsoft.CognitiveServices.EntitySearch
+  namespace: Microsoft.Azure.CognitiveServices.Search.EntitySearch
   output-folder: $(csharp-sdks-folder)/CognitiveServices/dataPlane/Search/Search/Generated/EntitySearch
 ```
 

--- a/specification/cognitiveservices/data-plane/EntitySearch/readme.md
+++ b/specification/cognitiveservices/data-plane/EntitySearch/readme.md
@@ -18,7 +18,6 @@ These settings apply only when `--tag=release_1_0` is specified on the command l
 
 ``` yaml $(tag) == 'release_1_0'
 input-file: v1.0/EntitySearch.json
-add-credentials: y
 ```
 
 ## CSharp Settings
@@ -27,5 +26,6 @@ These settings apply only when `--csharp` is specified on the command line.
 csharp: 
   namespace: Microsoft.Azure.CognitiveServices.Search.EntitySearch
   output-folder: $(csharp-sdks-folder)/CognitiveServices/dataPlane/Search/Search/Generated/EntitySearch
+  add-credentials: true
 ```
 


### PR DESCRIPTION
Note, not sure what the appropriate way to include the --add-credentials flag when running generate.cmd in the SDK directory is. Apparently this readme config file expects key value pairs on params, so I threw in a dummy value of y to get the generation to work.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
