### PR TITLE
[Network] Fix bug in SecurityRule - Address prefixes non-required since 2017-06-01

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/2017-06-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/2017-06-01/networkSecurityGroup.json
@@ -684,8 +684,6 @@
       },
       "required": [
         "protocol",
-        "sourceAddressPrefix",
-        "destinationAddressPrefix",
         "access",
         "direction"
       ],

--- a/specification/network/resource-manager/Microsoft.Network/2017-08-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/2017-08-01/networkSecurityGroup.json
@@ -660,8 +660,6 @@
       },
       "required": [
         "protocol",
-        "sourceAddressPrefix",
-        "destinationAddressPrefix",
         "access",
         "direction"
       ],

--- a/specification/network/resource-manager/Microsoft.Network/2017-09-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/2017-09-01/networkSecurityGroup.json
@@ -674,8 +674,6 @@
       },
       "required": [
         "protocol",
-        "sourceAddressPrefix",
-        "destinationAddressPrefix",
         "access",
         "direction"
       ],

--- a/specification/network/resource-manager/Microsoft.Network/2017-10-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/2017-10-01/networkSecurityGroup.json
@@ -674,8 +674,6 @@
       },
       "required": [
         "protocol",
-        "sourceAddressPrefix",
-        "destinationAddressPrefix",
         "access",
         "direction"
       ],


### PR DESCRIPTION
### Description

This change is required as we added multivalued rules (sourceAddressPrefixes/destinationAddressPrefixes)  and ASGs (sourceApplicationSecurityGroups/destinationApplicationSecurityGroups) as part of the SecurityRule. This is a bug fix as this parameter should have been made non-mandatory since v2017-06-01.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
