### PR TITLE
Fix wrong scope for parameter in DTL after #1829

### DIFF
--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/2016-05-15/DTL.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/2016-05-15/DTL.json
@@ -8642,7 +8642,8 @@
       "in": "path",
       "description": "The name of the location.",
       "required": true,
-      "type": "string"
+      "type": "string",
+      "x-ms-parameter-location": "method"
     }
   },
   "securityDefinitions": {


### PR DESCRIPTION
This PR https://github.com/Azure/azure-rest-api-specs/pull/1829 incorrectly introduces a parameter at the global level, breaking all constructors in SDK.

This is fixing the initial PR. Assigning @anuchandy since he reviewed the initial PR.

See for reference:
https://github.com/Azure/azure-openapi-validator/issues/84