### PR TITLE
Fix incorrect declaration of 'tags' in Microsoft.Cache/redis swagger

### DIFF
--- a/specification/redis/resource-manager/Microsoft.Cache/2016-04-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/2016-04-01/redis.json
@@ -1017,13 +1017,6 @@
         "sku": {
           "$ref": "#/definitions/Sku",
           "description": "The SKU of the Redis cache to deploy."
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Resource tags."
         }
       },
       "allOf": [
@@ -1092,6 +1085,13 @@
           "x-ms-client-flatten": true,
           "$ref": "#/definitions/RedisUpdateProperties",
           "description": "Redis cache properties."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags."
         }
       },
       "description": "Parameters supplied to the Update Redis operation."

--- a/specification/redis/resource-manager/Microsoft.Cache/2017-02-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/2017-02-01/redis.json
@@ -1215,13 +1215,6 @@
         "sku": {
           "$ref": "#/definitions/Sku",
           "description": "The SKU of the Redis cache to deploy."
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Resource tags."
         }
       },
       "allOf": [
@@ -1317,6 +1310,13 @@
           "x-ms-client-flatten": true,
           "$ref": "#/definitions/RedisUpdateProperties",
           "description": "Redis cache properties."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags."
         }
       },
       "description": "Parameters supplied to the Update Redis operation."


### PR DESCRIPTION
Fix incorrect declaration of 'tags' in the Microsoft.Cache/redis swagger specs (declared in wrong scope). To address #1152.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
