### PR TITLE
Fix RDBMS constructor x-ms-parameter-location - method after #1773 + name as required for CheckNameAvailability

### DIFF
--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/2017-04-30-preview/mysql.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/2017-04-30-preview/mysql.json
@@ -1888,7 +1888,8 @@
       "in": "path",
       "description": "The name of the virtual network rule.",
       "required": true,
-      "type": "string"
+      "type": "string",
+      "x-ms-parameter-location": "method"
     },
     "DatabaseNameParameter": {
       "name": "databaseName",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/2017-04-30-preview/mysql.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/2017-04-30-preview/mysql.json
@@ -1814,6 +1814,9 @@
       "description": "A list of performance tiers."
     },
     "NameAvailabilityRequest": {
+        "required": [
+            "name"
+        ],
         "properties": {
             "name": {
                 "type": "string",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/2017-04-30-preview/postgresql.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/2017-04-30-preview/postgresql.json
@@ -1887,7 +1887,8 @@
       "in": "path",
       "description": "The name of the virtual network rule.",
       "required": true,
-      "type": "string"
+      "type": "string",
+      "x-ms-parameter-location": "method"
     },
     "DatabaseNameParameter": {
       "name": "databaseName",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/2017-04-30-preview/postgresql.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/2017-04-30-preview/postgresql.json
@@ -1813,6 +1813,9 @@
       "description": "A list of performance tiers."
     },
     "NameAvailabilityRequest": {
+      "required": [
+          "name"
+      ],
       "properties": {
           "name": {
               "type": "string",


### PR DESCRIPTION
This PR https://github.com/Azure/azure-rest-api-specs/pull/1773 incorrectly introduces a parameter at the global level, breaking all constructors in SDK.

This is fixing the initial PR. Assigning @jianghaolu since he reviewed the initial PR.

See for reference:
https://github.com/Azure/azure-openapi-validator/issues/84