### PR TITLE
Remove semantic validation for PR only files from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ env:
   - MODE=python
   - MODE=node
   - MODE=ruby
+  - MODE=semantic PR_ONLY=true
   # - MODE=linter PR_ONLY=false Disabling to save travis-ci resource for now
   - MODE=semantic PR_ONLY=false
   - MODE=model PR_ONLY=false
   - MODE=linter PR_ONLY=true
-  - MODE=semantic PR_ONLY=true
   - MODE=model PR_ONLY=true
   - MODE=BreakingChange PR_ONLY=true
   - MODE=azurebot PR_ONLY=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
     - env: MODE=semantic PR_ONLY=false
     - env: MODE=model PR_ONLY=false
     - env: MODE=linter PR_ONLY=true
-    - env: MODE=semantic PR_ONLY=true
     - env: MODE=model PR_ONLY=true
     - env: MODE=BreakingChange PR_ONLY=true
     - env: MODE=azurebot PR_ONLY=true


### PR DESCRIPTION
Remove semantic validation for PR only files from allowed failures, should always be green.
Addressing https://github.com/Azure/azure-rest-api-specs/issues/1536