### PR TITLE
Changed use of title property to description in recently added type

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/2017-03-01/apimapis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/2017-03-01/apimapis.json
@@ -1499,15 +1499,15 @@
         },
         "wsdlSelector": {
           "type": "object",
-          "title": "Criteria to limit import of WSDL to a subset of the document.",
+          "description": "Criteria to limit import of WSDL to a subset of the document.",
           "properties": {
             "wsdlServiceName": {
               "type": "string",
-              "title": "Name of service to import from WSDL"
+              "description": "Name of service to import from WSDL"
             },
             "wsdlEndpointName": {
               "type": "string",
-              "title": "Name of endpoint(port) to import from WSDL"
+              "description": "Name of endpoint(port) to import from WSDL"
             }
           }
         }


### PR DESCRIPTION
The validation hints in AutoREST suggested that using title was more appropriate, however @fearthecowboy clarified that for documentation purposes, `description` was the correct property to use.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x ] The title of the PR is clear and informative.
- [ x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [ x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ x] My spec meets the review criteria:
  - [ x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [ x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
