### PR TITLE
[Network-2017-10-01] Fix syntax errors

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/2017-10-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/2017-10-01/applicationGateway.json
@@ -394,7 +394,7 @@
             "required": false,
             "type": "string",
             "description": "Expands BackendAddressPool and BackendHttpSettings referenced in backend health."
-          }		  
+          }
         ],
         "responses": {
           "200": {
@@ -535,19 +535,19 @@
       "properties": {
         "backendAddressPools": {
           "type": "array",
-	        "items": {
+          "items": {
             "$ref": "#/definitions/ApplicationGatewayBackendHealthPool"
-	        }
-	      }
-	    },
-	    "description": "List of ApplicationGatewayBackendHealthPool resources."
-	},	
+          }
+        }
+      },
+      "description": "List of ApplicationGatewayBackendHealthPool resources."
+    },
     "ApplicationGatewayBackendHealthPool": {
       "properties": {
         "backendAddressPool": {
           "$ref": "#/definitions/ApplicationGatewayBackendAddressPool",
           "description": "Reference of an ApplicationGatewayBackendAddressPool resource."
-        },	  
+        },
         "backendHttpSettingsCollection": {
           "type": "array",
           "items": {
@@ -563,7 +563,7 @@
         "backendHttpSettings": {
           "$ref": "#/definitions/ApplicationGatewayBackendHttpSettings",
           "description": "Reference of an ApplicationGatewayBackendHttpSettings resource."
-        },	  
+        },
         "servers": {
           "type": "array",
           "items": {
@@ -573,17 +573,17 @@
         }
       },
       "description": "Application gateway BackendHealthHttp settings."
-    },	
+    },
     "ApplicationGatewayBackendHealthServer": {
       "properties": {
         "address": {
         "type": "string",
         "description": "IP address or FQDN of backend server."
-        },	  
+        },
         "ipConfiguration": {
           "$ref": "./networkInterface.json#/definitions/NetworkInterfaceIPConfiguration",
           "description": "Reference of IP configuration of backend server."
-        },	  
+        },
         "health": {
           "type": "string",
           "description": "Health of backend server.",
@@ -599,9 +599,9 @@
             "modelAsString": true
           }
         }
-      },	
+      },
       "description": "Application gateway backendhealth http settings."
-    },  
+    },
     "ApplicationGatewaySku": {
       "properties": {
         "name": {

--- a/specification/network/resource-manager/Microsoft.Network/2017-10-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/2017-10-01/virtualNetworkGateway.json
@@ -543,7 +543,7 @@
         "x-ms-long-running-operation": true
       }
     },
-	"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/supportedvpndevices": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/supportedvpndevices": {
       "post": {
         "tags": [
           "VirtualNetworkGateways"
@@ -675,7 +675,7 @@
         "x-ms-long-running-operation": true
       }
     },
-	"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/vpndeviceconfigurationscript": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/vpndeviceconfigurationscript": {
       "post": {
         "tags": [
           "VirtualNetworkGateways"


### PR DESCRIPTION
### Description

Removes tabs introduced in the previous API version that is causing syntax errors in AutoRest.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
