### PR TITLE
[ACS] add AKS (managed Kubernetes clusters)

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/containerService.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/containerService.json
@@ -1,0 +1,842 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServiceClient",
+    "description": "The Container Service Client.",
+    "version": "2017-07-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/containerServices": {
+      "get": {
+        "tags": [
+          "ContainerServices"
+        ],
+        "operationId": "ContainerServices_List",
+        "summary": "Gets a list of container services in the specified subscription.",
+        "description": "Gets a list of container services in the specified subscription. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ContainerServiceListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}": {
+      "put": {
+        "tags": [
+          "ContainerService"
+        ],
+        "operationId": "ContainerServices_CreateOrUpdate",
+        "summary": "Creates or updates a container service.",
+        "description": "Creates or updates a container service with the specified configuration of orchestrator, masters, and agents.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "containerServiceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the container service in the specified subscription and resource group."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            },
+            "description": "Parameters supplied to the Create or Update a Container Service operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "ContainerService"
+        ],
+        "operationId": "ContainerServices_Get",
+        "summary": "Gets the properties of the specified container service.",
+        "description": "Gets the properties of the specified container service in the specified subscription and resource group. The operation returns the properties including state, orchestrator, number of masters and agents, and FQDNs of masters and agents. ",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "containerServiceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the container service in the specified subscription and resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ContainerService"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ContainerService"
+        ],
+        "operationId": "ContainerServices_Delete",
+        "summary": "Deletes the specified container service.",
+        "description": "Deletes the specified container service in the specified subscription and resource group. The operation does not delete other resources created as part of creating a container service, including storage accounts, VMs, and availability sets. All the other resources created with the container service are part of the same resource group and can be deleted individually.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "containerServiceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the container service in the specified subscription and resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "204": {
+            "description": "Not found"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices": {
+      "get": {
+        "tags": [
+          "ContainerServices"
+        ],
+        "operationId": "ContainerServices_ListByResourceGroup",
+        "summary": "Gets a list of container services in the specified resource group.",
+        "description": "Gets a list of container services in the specified subscription and resource group. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ContainerServiceListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "ContainerServiceOSDisk": {
+      "type": "integer",
+      "format": "int32",
+      "maximum": 1023,
+      "minimum": 0,
+      "description": "OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+    },
+    "ContainerServiceStorageProfile": {
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ContainerServiceStorageProfileTypes",
+        "modelAsString": true
+      },
+      "enum": [
+        "StorageAccount",
+        "ManagedDisks"
+      ],
+      "description": "Storage profile specifies what kind of storage used. Choose from StorageAccount and ManagedDisks. Leave it empty, we will choose for you based on the orchestrator choice."
+    },
+    "ContainerServiceVnetSubnetID": {
+      "type": "string",
+      "description": "VNet SubnetID specifies the vnet's subnet identifier. If you specify either master VNet Subnet, or agent VNet Subnet, you need to specify both. And they have to be in the same VNet."
+    },
+    "ContainerServiceVMSize": {
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ContainerServiceVMSizeTypes",
+        "modelAsString": true
+      },
+      "description": "Size of agent VMs.",
+      "enum": [
+        "Standard_A0",
+        "Standard_A1",
+        "Standard_A10",
+        "Standard_A11",
+        "Standard_A1_v2",
+        "Standard_A2",
+        "Standard_A2_v2",
+        "Standard_A2m_v2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A4_v2",
+        "Standard_A4m_v2",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_A8",
+        "Standard_A8_v2",
+        "Standard_A8m_v2",
+        "Standard_A9",
+        "Standard_D1",
+        "Standard_D11",
+        "Standard_D11_v2",
+        "Standard_D11_v2_Promo",
+        "Standard_D12",
+        "Standard_D12_v2",
+        "Standard_D12_v2_Promo",
+        "Standard_D13",
+        "Standard_D13_v2",
+        "Standard_D13_v2_Promo",
+        "Standard_D14",
+        "Standard_D14_v2",
+        "Standard_D14_v2_Promo",
+        "Standard_D15_v2",
+        "Standard_D16_v3",
+        "Standard_D16s_v3",
+        "Standard_D1_v2",
+        "Standard_D2",
+        "Standard_D2_v2",
+        "Standard_D2_v2_Promo",
+        "Standard_D2_v3",
+        "Standard_D2s_v3",
+        "Standard_D3",
+        "Standard_D3_v2",
+        "Standard_D3_v2_Promo",
+        "Standard_D4",
+        "Standard_D4_v2",
+        "Standard_D4_v2_Promo",
+        "Standard_D4_v3",
+        "Standard_D4s_v3",
+        "Standard_D5_v2",
+        "Standard_D5_v2_Promo",
+        "Standard_D8_v3",
+        "Standard_D8s_v3",
+        "Standard_DS1",
+        "Standard_DS11",
+        "Standard_DS11_v2",
+        "Standard_DS11_v2_Promo",
+        "Standard_DS12",
+        "Standard_DS12_v2",
+        "Standard_DS12_v2_Promo",
+        "Standard_DS13",
+        "Standard_DS13_v2",
+        "Standard_DS13_v2_Promo",
+        "Standard_DS14",
+        "Standard_DS14_v2",
+        "Standard_DS14_v2_Promo",
+        "Standard_DS15_v2",
+        "Standard_DS1_v2",
+        "Standard_DS2",
+        "Standard_DS2_v2",
+        "Standard_DS2_v2_Promo",
+        "Standard_DS3",
+        "Standard_DS3_v2",
+        "Standard_DS3_v2_Promo",
+        "Standard_DS4",
+        "Standard_DS4_v2",
+        "Standard_DS4_v2_Promo",
+        "Standard_DS5_v2",
+        "Standard_DS5_v2_Promo",
+        "Standard_E16_v3",
+        "Standard_E16s_v3",
+        "Standard_E2_v3",
+        "Standard_E2s_v3",
+        "Standard_E32_v3",
+        "Standard_E32s_v3",
+        "Standard_E4_v3",
+        "Standard_E4s_v3",
+        "Standard_E64_v3",
+        "Standard_E64s_v3",
+        "Standard_E8_v3",
+        "Standard_E8s_v3",
+        "Standard_F1",
+        "Standard_F16",
+        "Standard_F16s",
+        "Standard_F1s",
+        "Standard_F2",
+        "Standard_F2s",
+        "Standard_F4",
+        "Standard_F4s",
+        "Standard_F8",
+        "Standard_F8s",
+        "Standard_G1",
+        "Standard_G2",
+        "Standard_G3",
+        "Standard_G4",
+        "Standard_G5",
+        "Standard_GS1",
+        "Standard_GS2",
+        "Standard_GS3",
+        "Standard_GS4",
+        "Standard_GS5",
+        "Standard_H16",
+        "Standard_H16m",
+        "Standard_H16mr",
+        "Standard_H16r",
+        "Standard_H8",
+        "Standard_H8m",
+        "Standard_L16s",
+        "Standard_L32s",
+        "Standard_L4s",
+        "Standard_L8s",
+        "Standard_M128s",
+        "Standard_M64ms",
+        "Standard_NC12",
+        "Standard_NC24",
+        "Standard_NC24r",
+        "Standard_NC6",
+        "Standard_NV12",
+        "Standard_NV24",
+        "Standard_NV6"
+      ]
+    },
+    "ContainerServiceCustomProfile": {
+      "properties": {
+        "orchestrator": {
+          "type": "string",
+          "description": "The name of the custom orchestrator to use."
+        }
+      },
+      "description": "Properties to configure a custom container service cluster.",
+      "required": [
+        "orchestrator"
+      ]
+    },
+    "KeyVaultSecretRef": {
+      "properties": {
+        "vaultID": {
+          "type": "string",
+          "description": "Key vault identifier."
+        },
+        "secretName": {
+          "type": "string",
+          "description": "The secret name."
+        },
+        "version": {
+          "type": "string",
+          "description": "The secret version."
+        }
+      },
+      "description": "Reference to a secret stored in Azure Key Vault.",
+      "required": [
+        "vaultID",
+        "secretName"
+      ]
+    },
+    "ContainerServiceServicePrincipalProfile": {
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The ID for the service principal."
+        },
+        "secret": {
+          "type": "string",
+          "description": "The secret password associated with the service principal in plain text."
+        },
+        "keyVaultSecretRef": {
+          "$ref": "#/definitions/KeyVaultSecretRef",
+          "description": "Reference to a secret stored in Azure Key Vault."
+        }
+      },
+      "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs. Either secret or keyVaultSecretRef must be specified.",
+      "required": [
+        "clientId"
+      ]
+    },
+    "ContainerServiceOrchestratorProfile": {
+      "properties": {
+        "orchestratorType": {
+          "type": "string",
+          "enum": [
+            "Kubernetes",
+            "Swarm",
+            "DCOS",
+            "DockerCE",
+            "Custom"
+          ],
+          "x-ms-enum": {
+            "name": "ContainerServiceOrchestratorTypes",
+            "modelAsString": true
+          },
+          "description": "The orchestrator to use to manage container service cluster resources. Valid values are Kubernetes, Swarm, DCOS, DockerCE and Custom."
+        },
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "The version of the orchestrator to use. You can specify the major.minor.patch part of the actual version.For example, you can specify version as \"1.6.11\"."
+        }
+      },
+      "description": "Profile for the container service orchestrator.",
+      "required": [
+        "orchestratorType"
+      ]
+    },
+    "ContainerServiceMasterProfile": {
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "enum": [
+            1,
+            3,
+            5
+          ],
+          "x-ms-enum": {
+            "name": "Count",
+            "modelAsString": false
+          },
+          "description": "Number of masters (VMs) in the container service cluster. Allowed values are 1, 3, and 5. The default value is 1.",
+          "default": 1
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix to be used to create the FQDN for the master pool."
+        },
+        "vmSize": {
+          "$ref": "#/definitions/ContainerServiceVMSize",
+          "description": "Size of agent VMs."
+        },
+        "osDiskSizeGB": {
+          "$ref": "#/definitions/ContainerServiceOSDisk",
+          "description": "OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+        },
+        "vnetSubnetID": {
+          "$ref": "#/definitions/ContainerServiceVnetSubnetID",
+          "description": "VNet SubnetID specifies the vnet's subnet identifier. If you specify either master VNet Subnet, or agent VNet Subnet, you need to specify both. And they have to be in the same VNet."
+        },
+        "firstConsecutiveStaticIP": {
+          "type": "string",
+          "description": "FirstConsecutiveStaticIP used to specify the first static ip of masters.",
+          "default": "10.240.255.5"
+        },
+        "storageProfile": {
+          "$ref": "#/definitions/ContainerServiceStorageProfile",
+          "description": "Storage profile specifies what kind of storage used. Choose from StorageAccount and ManagedDisks. Leave it empty, we will choose for you based on the orchestrator choice."
+        },
+        "fqdn": {
+          "readOnly": true,
+          "type": "string",
+          "description": "FDQN for the master pool."
+        }
+      },
+      "required": [
+        "dnsPrefix",
+        "vmSize"
+      ],
+      "description": "Profile for the container service master."
+    },
+    "ContainerServiceAgentPoolProfile": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name of the agent pool profile in the context of the subscription and resource group."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 100,
+          "minimum": 1,
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. ",
+          "default": 1
+        },
+        "vmSize": {
+          "$ref": "#/definitions/ContainerServiceVMSize",
+          "description": "Size of agent VMs."
+        },
+        "osDiskSizeGB": {
+          "$ref": "#/definitions/ContainerServiceOSDisk",
+          "description": "OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix to be used to create the FQDN for the agent pool."
+        },
+        "fqdn": {
+          "readOnly": true,
+          "type": "string",
+          "description": "FDQN for the agent pool."
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "description": "Ports number array used to expose on this agent pool. The default opened ports are different based on your choice of orchestrator."
+        },
+        "storageProfile": {
+          "$ref": "#/definitions/ContainerServiceStorageProfile",
+          "description": "Storage profile specifies what kind of storage used. Choose from StorageAccount and ManagedDisks. Leave it empty, we will choose for you based on the orchestrator choice."
+        },
+        "vnetSubnetID": {
+          "$ref": "#/definitions/ContainerServiceVnetSubnetID",
+          "description": "VNet SubnetID specifies the vnet's subnet identifier. If you specify either master VNet Subnet, or agent VNet Subnet, you need to specify both. And they have to be in the same VNet."
+        },
+        "osType": {
+          "type": "string",
+          "default": "Linux",
+          "enum": [
+            "Linux",
+            "Windows"
+          ],
+          "x-ms-enum": {
+            "name": "OSType"
+          },
+          "description": "OsType to be used to specify os type. Choose from Linux and Windows. Default to Linux."
+        }
+      },
+      "required": [
+        "name",
+        "vmSize"
+      ],
+      "description": "Profile for the container service agent pool."
+    },
+    "ContainerServiceWindowsProfile": {
+      "properties": {
+        "adminUsername": {
+          "type": "string",
+          "description": "The administrator username to use for Windows VMs.",
+          "pattern": "^[a-zA-Z0-9]+([._]?[a-zA-Z0-9]+)*$"
+        },
+        "adminPassword": {
+          "type": "string",
+          "description": "The administrator password to use for Windows VMs.",
+          "pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%\\^&\\*\\(\\)])[a-zA-Z\\d!@#$%\\^&\\*\\(\\)]{12,123}$"
+        }
+      },
+      "required": [
+        "adminUsername",
+        "adminPassword"
+      ],
+      "description": "Profile for Windows VMs in the container service cluster."
+    },
+    "ContainerServiceLinuxProfile": {
+      "properties": {
+        "adminUsername": {
+          "type": "string",
+          "description": "The administrator username to use for Linux VMs.",
+          "pattern": "^[a-z][a-z0-9_-]*$"
+        },
+        "ssh": {
+          "$ref": "#/definitions/ContainerServiceSshConfiguration",
+          "description": "SSH configuration for Linux-based VMs running on Azure."
+        }
+      },
+      "required": [
+        "adminUsername",
+        "ssh"
+      ],
+      "description": "Profile for Linux VMs in the container service cluster."
+    },
+    "ContainerServiceSshConfiguration": {
+      "properties": {
+        "publicKeys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContainerServiceSshPublicKey"
+          },
+          "description": "The list of SSH public keys used to authenticate with Linux-based VMs. Only expect one key specified."
+        }
+      },
+      "description": "SSH configuration for Linux-based VMs running on Azure.",
+      "required": [
+        "publicKeys"
+      ]
+    },
+    "ContainerServiceSshPublicKey": {
+      "properties": {
+        "keyData": {
+          "type": "string",
+          "description": "Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers."
+        }
+      },
+      "required": [
+        "keyData"
+      ],
+      "description": "Contains information about SSH certificate public key data."
+    },
+    "ContainerServiceDiagnosticsProfile": {
+      "properties": {
+        "vmDiagnostics": {
+          "$ref": "#/definitions/ContainerServiceVMDiagnostics",
+          "description": "Profile for diagnostics on the container service VMs."
+        }
+      },
+      "description": "Profile for diagnostics on the container service cluster.",
+      "required": [
+        "vmDiagnostics"
+      ]
+    },
+    "ContainerServiceVMDiagnostics": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the VM diagnostic agent is provisioned on the VM."
+        },
+        "storageUri": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URI of the storage account where diagnostics are stored."
+        }
+      },
+      "description": "Profile for diagnostics on the container service VMs.",
+      "required": [
+        "enabled"
+      ]
+    },
+    "ContainerService": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        },
+        {
+          "properties": {
+            "properties": {
+              "description": "Properties of the container service.",
+              "$ref": "#/definitions/ContainerServiceProperties",
+              "x-ms-client-flatten": true
+            }
+          }
+        }
+      ],
+      "description": "Container service."
+    },
+    "ContainerServiceListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContainerService"
+          },
+          "description": "The list of container services."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of container service results.",
+          "readOnly": true
+        }
+      },
+      "description": "The response from the List Container Services operation."
+    },
+    "ContainerServiceProperties": {
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The current deployment or provisioning state, which only appears in the response."
+        },
+        "orchestratorProfile": {
+          "$ref": "#/definitions/ContainerServiceOrchestratorProfile",
+          "description": "Profile for the container service orchestrator."
+        },
+        "customProfile": {
+          "$ref": "#/definitions/ContainerServiceCustomProfile",
+          "description": "Properties to configure a custom container service cluster."
+        },
+        "servicePrincipalProfile": {
+          "$ref": "#/definitions/ContainerServiceServicePrincipalProfile",
+          "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs. Exact one of secret or keyVaultSecretRef need to be specified."
+        },
+        "masterProfile": {
+          "$ref": "#/definitions/ContainerServiceMasterProfile",
+          "description": "Profile for the container service master."
+        },
+        "agentPoolProfiles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContainerServiceAgentPoolProfile"
+          },
+          "description": "Properties of the agent pool."
+        },
+        "windowsProfile": {
+          "$ref": "#/definitions/ContainerServiceWindowsProfile",
+          "description": "Profile for Windows VMs in the container service cluster."
+        },
+        "linuxProfile": {
+          "$ref": "#/definitions/ContainerServiceLinuxProfile",
+          "description": "Profile for Linux VMs in the container service cluster."
+        },
+        "diagnosticsProfile": {
+          "$ref": "#/definitions/ContainerServiceDiagnosticsProfile",
+          "description": "Profile for diagnostics in the container service cluster."
+        }
+      },
+      "required": [
+        "orchestratorProfile",
+        "masterProfile",
+        "linuxProfile"
+      ],
+      "description": "Properties of the container service."
+    },
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+      "x-ms-parameter-location": "client"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version.",
+      "x-ms-parameter-location": "client"
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the resource group.",
+      "x-ms-parameter-location": "method"
+    },
+    "ResourceNameParameter": {
+      "name": "resourceName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the resource.",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/containerService.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/containerService.json
@@ -60,6 +60,11 @@
         },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List Container Services": {
+            "$ref": "./examples/ContainerServicesList.json"
+          }
         }
       }
     },
@@ -118,7 +123,12 @@
             }
           }
         },
-        "x-ms-long-running-operation": true
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Create/Update Container Service": {
+            "$ref": "./examples/ContainerServiceCreate_Update.json"
+          }
+        }
       },
       "get": {
         "tags": [
@@ -151,6 +161,11 @@
             "schema": {
               "$ref": "#/definitions/ContainerService"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container Service": {
+            "$ref": "./examples/ContainerServicesGet.json"
           }
         }
       },
@@ -187,7 +202,12 @@
             "description": "Not found"
           }
         },
-        "x-ms-long-running-operation": true
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Delete Container Service": {
+            "$ref": "./examples/ContainerServiceDelete.json"
+          }
+        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices": {
@@ -219,6 +239,11 @@
         },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List Container Services by Resource Group": {
+            "$ref": "./examples/ContainerServicesListByResourceGroup.json"
+          }
         }
       }
     }

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/containerService.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/containerService.json
@@ -803,7 +803,7 @@
         "linuxProfile"
       ],
       "description": "Properties of the container service."
-    },
+    }
   },
   "parameters": {
     "SubscriptionIdParameter": {

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServiceCreate_Update.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServiceCreate_Update.json
@@ -1,0 +1,151 @@
+{
+  "parameters": {
+    "api-version": "2017-07-01",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "containerServiceName": "acs1",
+    "parameters": {
+      "location": "location1"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.ContainerService/ContainerServices",
+        "location": "location1",
+        "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.ContainerService/containerServices/acs1",
+        "name": "acs1",
+        "properties": {
+          "provisioningState": "Creating",
+          "orchestratorProfile": {
+            "orchestratorType": "DCOS"
+          },
+          "masterProfile": {
+            "count": 1,
+            "dnsPrefix": "acs1-rg1-e240e5mgmt",
+            "fqdn": "acs1-rg1-e240e5mgmt.location1.cloudapp.azure.com",
+            "vmSize": "Standard_D2_v2"
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "agentpool0",
+              "count": 3,
+              "vmSize": "Standard_D2_v2",
+              "dnsPrefix": "acs1-rg1-e240e5agent",
+              "fqdn": "acs1-rg1-e240e5agent.location1.cloudapp.azure.com",
+              "osType": "Linux"
+            }
+          ],
+          "linuxProfile": {
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "ssh-rsa AAAAB3NzaC1y...+0vNzo1FAdQ== user@hostname.local\n"
+                }
+              ]
+            },
+            "adminUsername": "azureuser"
+          },
+          "diagnosticsProfile": {
+            "vmDiagnostics": {
+              "enabled": true,
+              "storageUri": "https://mjwjtrv73stvgdiag0.blob.core.windows.net/"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.ContainerService/ContainerServices",
+        "location": "location1",
+        "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.ContainerService/containerServices/acs1",
+        "name": "acs1",
+        "properties": {
+          "provisioningState": "Creating",
+          "orchestratorProfile": {
+            "orchestratorType": "DCOS"
+          },
+          "masterProfile": {
+            "count": 1,
+            "dnsPrefix": "acs1-rg1-e240e5mgmt",
+            "fqdn": "acs1-rg1-e240e5mgmt.location1.cloudapp.azure.com",
+            "vmSize": "Standard_D2_v2"
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "agentpool0",
+              "count": 3,
+              "vmSize": "Standard_D2_v2",
+              "dnsPrefix": "acs1-rg1-e240e5agent",
+              "fqdn": "acs1-rg1-e240e5agent.location1.cloudapp.azure.com",
+              "osType": "Linux"
+            }
+          ],
+          "linuxProfile": {
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "ssh-rsa AAAAB3NzaC1y...+0vNzo1FAdQ== user@hostname.local\n"
+                }
+              ]
+            },
+            "adminUsername": "azureuser"
+          },
+          "diagnosticsProfile": {
+            "vmDiagnostics": {
+              "enabled": true,
+              "storageUri": "https://mjwjtrv73stvgdiag0.blob.core.windows.net/"
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "type": "Microsoft.ContainerService/ContainerServices",
+        "location": "location1",
+        "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.ContainerService/containerServices/acs1",
+        "name": "acs1",
+        "properties": {
+          "provisioningState": "Creating",
+          "orchestratorProfile": {
+            "orchestratorType": "DCOS"
+          },
+          "masterProfile": {
+            "count": 1,
+            "dnsPrefix": "acs1-rg1-e240e5mgmt",
+            "fqdn": "acs1-rg1-e240e5mgmt.location1.cloudapp.azure.com",
+            "vmSize": "Standard_D2_v2"
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "agentpool0",
+              "count": 3,
+              "vmSize": "Standard_D2_v2",
+              "dnsPrefix": "acs1-rg1-e240e5agent",
+              "fqdn": "acs1-rg1-e240e5agent.location1.cloudapp.azure.com",
+              "osType": "Linux"
+            }
+          ],
+          "linuxProfile": {
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "ssh-rsa AAAAB3NzaC1y...+0vNzo1FAdQ== user@hostname.local\n"
+                }
+              ]
+            },
+            "adminUsername": "azureuser"
+          },
+          "diagnosticsProfile": {
+            "vmDiagnostics": {
+              "enabled": true,
+              "storageUri": "https://mjwjtrv73stvgdiag0.blob.core.windows.net/"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServiceDelete.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServiceDelete.json
@@ -1,0 +1,12 @@
+{
+  "parameters": {
+    "api-version": "2017-07-01",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "containerServiceName": "acs1"
+  },
+  "responses": {
+    "202": {},
+    "204": {}
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServicesGet.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServicesGet.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2017-07-01",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "containerServiceName": "acs1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.ContainerService/ContainerServices",
+        "location": "location1",
+        "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.ContainerService/containerServices/acs1",
+        "name": "acs1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "orchestratorProfile": {
+            "orchestratorType": "DCOS"
+          },
+          "masterProfile": {
+            "count": 1,
+            "dnsPrefix": "acs1-rg1-e240e5mgmt",
+            "fqdn": "acs1-rg1-e240e5mgmt.location1.cloudapp.azure.com",
+            "vmSize": "Standard_D2_v2"
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "agentpool0",
+              "count": 3,
+              "vmSize": "Standard_D2_v2",
+              "dnsPrefix": "acs1-rg1-e240e5agent",
+              "fqdn": "acs1-rg1-e240e5agent.location1.cloudapp.azure.com",
+              "osType": "Linux"
+            }
+          ],
+          "linuxProfile": {
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "ssh-rsa AAAAB3NzaC1y...+0vNzo1FAdQ== user@hostname.local\n"
+                }
+              ]
+            },
+            "adminUsername": "azureuser"
+          },
+          "diagnosticsProfile": {
+            "vmDiagnostics": {
+              "enabled": true,
+              "storageUri": "https://mjwjtrv73stvgdiag0.blob.core.windows.net/"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServicesList.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServicesList.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "api-version": "2017-07-01",
+    "subscriptionId": "subid1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.ContainerService/ContainerServices",
+            "location": "location1",
+            "id": "/subscriptions/subid1/resourceGroups/RG1/providers/Microsoft.ContainerService/containerServices/acs1",
+            "name": "acs1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "orchestratorProfile": {
+                "orchestratorType": "DCOS"
+              },
+              "masterProfile": {
+                "count": 1,
+                "dnsPrefix": "acs1-rg1-e240e5mgmt",
+                "fqdn": "acs1-rg1-e240e5mgmt.location1.cloudapp.azure.com",
+                "vmSize": "Standard_D2_v2"
+              },
+              "agentPoolProfiles": [
+                {
+                  "name": "agentpool0",
+                  "count": 3,
+                  "vmSize": "Standard_D2_v2",
+                  "dnsPrefix": "acs1-rg1-e240e5agent",
+                  "fqdn": "acs1-rg1-e240e5agent.location1.cloudapp.azure.com",
+                  "osType": "Linux"
+                }
+              ],
+              "linuxProfile": {
+                "ssh": {
+                  "publicKeys": [
+                    {
+                      "keyData": "ssh-rsa AAAAB3NzaC1y...+0vNzo1FAdQ== user@hostname.local\n"
+                    }
+                  ]
+                },
+                "adminUsername": "azureuser"
+              },
+              "diagnosticsProfile": {
+                "vmDiagnostics": {
+                  "enabled": true,
+                  "storageUri": "https://mjwjtrv73stvgdiag0.blob.core.windows.net/"
+                }
+              }
+            }
+          },
+          {
+            "type": "Microsoft.ContainerService/ContainerServices",
+            "location": "location1",
+            "id": "/subscriptions/subid1/resourceGroups/RG1/providers/Microsoft.ContainerService/containerServices/acs2",
+            "name": "acs2",
+            "properties": {
+              "provisioningState": "Creating",
+              "orchestratorProfile": {
+                "orchestratorType": "DCOS"
+              },
+              "masterProfile": {
+                "count": 1,
+                "dnsPrefix": "acs2-rg1-e240e5mgmt",
+                "vmSize": "Standard_D2_v2"
+              },
+              "agentPoolProfiles": [
+                {
+                  "name": "agentpool0",
+                  "count": 3,
+                  "vmSize": "Standard_D2_v2",
+                  "dnsPrefix": "acs2-rg1-e240e5agent",
+                  "osType": "Linux"
+                }
+              ],
+              "linuxProfile": {
+                "ssh": {
+                  "publicKeys": [
+                    {
+                      "keyData": "ssh-rsa AAAAB3NzaC1y...+0vNzo1FAdQ== user@hostname.local\n"
+                    }
+                  ]
+                },
+                "adminUsername": "azureuser"
+              },
+              "diagnosticsProfile": {
+                "vmDiagnostics": {
+                  "enabled": true
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServicesListByResourceGroup.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-07-01/examples/ContainerServicesListByResourceGroup.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+  "api-version": "2017-07-01",
+  "subscriptionId": "subid1",
+  "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.ContainerService/ContainerServices",
+            "location": "location1",
+            "id": "/subscriptions/subid1/resourceGroups/RG1/providers/Microsoft.ContainerService/containerServices/acs1",
+            "name": "acs1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "orchestratorProfile": {
+                "orchestratorType": "DCOS"
+              },
+              "masterProfile": {
+                "count": 1,
+                "dnsPrefix": "acs1-rg1-e240e5mgmt",
+                "fqdn": "acs1-rg1-e240e5mgmt.location1.cloudapp.azure.com",
+                "vmSize": "Standard_D2_v2"
+              },
+              "agentPoolProfiles": [
+                {
+                  "name": "agentpool0",
+                  "count": 3,
+                  "vmSize": "Standard_D2_v2",
+                  "dnsPrefix": "acs1-rg1-e240e5agent",
+                  "fqdn": "acs1-rg1-e240e5agent.location1.cloudapp.azure.com",
+                  "osType": "Linux"
+                }
+              ],
+              "linuxProfile": {
+                "ssh": {
+                  "publicKeys": [
+                    {
+                      "keyData": "ssh-rsa AAAAB3NzaC1y...+0vNzo1FAdQ== user@hostname.local\n"
+                    }
+                  ]
+                },
+                "adminUsername": "azureuser"
+              },
+              "diagnosticsProfile": {
+                "vmDiagnostics": {
+                  "enabled": true,
+                  "storageUri": "https://mjwjtrv73stvgdiag0.blob.core.windows.net/"
+                }
+              }
+            }
+          },
+          {
+            "type": "Microsoft.ContainerService/ContainerServices",
+            "location": "location1",
+            "id": "/subscriptions/subid1/resourceGroups/RG1/providers/Microsoft.ContainerService/containerServices/acs2",
+            "name": "acs2",
+            "properties": {
+              "provisioningState": "Creating",
+              "orchestratorProfile": {
+                "orchestratorType": "DCOS"
+              },
+              "masterProfile": {
+                "count": 1,
+                "dnsPrefix": "acs2-rg1-e240e5mgmt",
+                "vmSize": "Standard_D2_v2"
+              },
+              "agentPoolProfiles": [
+                {
+                  "name": "agentpool0",
+                  "count": 3,
+                  "vmSize": "Standard_D2_v2",
+                  "dnsPrefix": "acs2-rg1-e240e5agent",
+                  "osType": "Linux"
+                }
+              ],
+              "linuxProfile": {
+                "ssh": {
+                  "publicKeys": [
+                    {
+                      "keyData": "ssh-rsa AAAAB3NzaC1y...+0vNzo1FAdQ== user@hostname.local\n"
+                    }
+                  ]
+                },
+                "adminUsername": "azureuser"
+              },
+              "diagnosticsProfile": {
+                "vmDiagnostics": {
+                  "enabled": true
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersAccessProfilesGet.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersAccessProfilesGet.json
@@ -4,7 +4,7 @@
     "subscriptionId": "subid1",
     "resourceGroupName": "rg1",
     "resourceName": "clustername1",
-    "accessProfileRoleName": "clusterUser"
+    "roleName": "clusterUser"
   },
   "responses": {
     "200": {
@@ -12,7 +12,7 @@
         "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/accessProfiles/clusterUser",
         "location": "location1",
         "name": "clusterUser",
-        "AccessProfile": {
+        "properties": {
           "kubeConfig": "kubeConfig1"
         },
         "type": "Microsoft.ContainerService/ManagedClusters/AccessProfiles"

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersAccessProfilesGet.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersAccessProfilesGet.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2017-08-31",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "accessProfileRoleName": "clusterUser"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/accessProfiles/clusterUser",
+        "location": "location1",
+        "name": "clusterUser",
+        "AccessProfile": {
+          "kubeConfig": "kubeConfig1"
+        },
+        "type": "Microsoft.ContainerService/ManagedClusters/AccessProfiles"
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersCreate_Update.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersCreate_Update.json
@@ -1,0 +1,112 @@
+{
+  "parameters": {
+    "api-version": "2017-08-31",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "dnsPrefix": "dnsprefix1",
+        "agentPoolProfiles": [
+          {
+            "count": 1,
+            "name": "agentpool1",
+            "vmSize": "Standard_D2_v2"
+          }
+        ],
+        "kubernetesVersion": "1.7.7"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "name": "mycluster1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "count": 1,
+              "dnsPrefix": "agentpool1dnsPrefix",
+              "fqdn": "agentpool1fqdn",
+              "name": "agentpool1",
+              "osType": "Linux",
+              "ports": [
+                1
+              ],
+              "storageProfile": "ManagedDisks",
+              "vmSize": "Standard_D2_v2"
+            }
+          ],
+          "dnsPrefix": "dnsprefix1",
+          "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
+          "kubernetesVersion": "1.7.7",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid",
+            "keyVaultSecretRef": null,
+            "secret": "secret"
+          }
+        },
+        "tags": "managedcluster",
+        "type": "Microsoft.ContainerService/ManagedClusters"
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "name": "mycluster1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "count": 1,
+              "dnsPrefix": "agentpool1dnsPrefix",
+              "fqdn": "agentpool1fqdn",
+              "name": "agentpool1",
+              "osType": "Linux",
+              "ports": [
+                1
+              ],
+              "storageProfile": "ManagedDisks",
+              "vmSize": "Standard_D2_v2"
+            }
+          ],
+          "dnsPrefix": "dnsprefix1",
+          "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
+          "kubernetesVersion": "1.7.7",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid",
+            "keyVaultSecretRef": null,
+            "secret": "secret"
+          }
+        },
+        "tags": "managedcluster",
+        "type": "Microsoft.ContainerService/ManagedClusters"
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersDelete.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersDelete.json
@@ -1,0 +1,12 @@
+{
+  "parameters": {
+    "api-version": "2017-08-31",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1"
+  },
+  "responses": {
+    "202": {},
+    "204": {}
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersGet.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersGet.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2017-08-31",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "name": "mycluster1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "count": 1,
+              "dnsPrefix": "agentpool1dnsPrefix",
+              "fqdn": "agentpool1fqdn",
+              "name": "agentpool1",
+              "osType": "Linux",
+              "ports": [
+                1
+              ],
+              "storageProfile": "ManagedDisks",
+              "vmSize": "Standard_D2_v2"
+            }
+          ],
+          "dnsPrefix": "dnsprefix1",
+          "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
+          "kubernetesVersion": "1.7.7",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid",
+            "keyVaultSecretRef": null,
+            "secret": "secret"
+          }
+        },
+        "tags": "managed-cluster",
+        "type": "Microsoft.ContainerService/ManagedClusters"
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersGetUpgradeProfile.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersGetUpgradeProfile.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2017-08-31",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/upgradeprofiles/default",
+        "name": "default",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "kubernetesVersion": "1.7.7",
+              "name": "agent",
+              "osType": "Linux",
+              "upgrades": [
+                "1.8.1"
+              ]
+            }
+          ],
+          "controlPlaneProfile": {
+            "kubernetesVersion": "1.7.7",
+            "name": "master",
+            "osType": "Linux",
+            "upgrades": [
+              "1.8.1"
+            ]
+          }
+        },
+        "type": "Microsoft.ContainerService/managedClusters/upgradeprofiles"
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersList.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersList.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2017-08-31",
+    "subscriptionId": "subid1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid1/providers/Microsoft.ContainerService/managedClusters",
+            "location": "location1",
+            "name": "mycluster1",
+            "properties": {
+              "agentPoolProfiles": [
+                {
+                  "count": 1,
+                  "dnsPrefix": "agentpool1dnsPrefix",
+                  "fqdn": "agentpool1fqdn",
+                  "name": "agentpool1",
+                  "osType": "Linux",
+                  "ports": [
+                    1
+                  ],
+                  "storageProfile": "ManagedDisks",
+                  "vmSize": "Standard_D2_v2"
+                }
+              ],
+              "dnsPrefix": "dnsprefix1",
+              "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
+              "kubernetesVersion": "1.7.7",
+              "linuxProfile": {
+                "adminUsername": "azureuser",
+                "ssh": {
+                  "publicKeys": [
+                    {
+                      "keyData": "keydata"
+                    }
+                  ]
+                }
+              },
+              "provisioningState": "Succeeded",
+              "servicePrincipalProfile": {
+                "clientId": "clientid",
+                "keyVaultSecretRef": null,
+                "secret": "secret"
+              }
+            },
+            "tags": "managed-cluster",
+            "type": "Microsoft.ContainerService/ManagedClusters"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersListByResourceGroup.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/examples/ManagedClustersListByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2017-08-31",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters",
+            "location": "location1",
+            "name": "mycluster1",
+            "properties": {
+              "agentPoolProfiles": [
+                {
+                  "count": 1,
+                  "dnsPrefix": "agentpool1dnsPrefix",
+                  "fqdn": "agentpool1fqdn",
+                  "name": "agentpool1",
+                  "osType": "Linux",
+                  "ports": [
+                    1
+                  ],
+                  "storageProfile": "ManagedDisks",
+                  "vmSize": "Standard_D2_v2"
+                }
+              ],
+              "dnsPrefix": "dnsprefix1",
+              "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
+              "kubernetesVersion": "1.7.7",
+              "linuxProfile": {
+                "adminUsername": "azureuser",
+                "ssh": {
+                  "publicKeys": [
+                    {
+                      "keyData": "keydata"
+                    }
+                  ]
+                }
+              },
+              "provisioningState": "Succeeded",
+              "servicePrincipalProfile": {
+                "clientId": "clientid",
+                "keyVaultSecretRef": null,
+                "secret": "secret"
+              }
+            },
+            "tags": "managed-cluster",
+            "type": "Microsoft.ContainerService/ManagedClusters"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-08-31/managedClusters.json
@@ -1,0 +1,1040 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServiceClient",
+    "description": "The Container Service Client.",
+    "version": "2017-08-31"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/managedClusters": {
+      "get": {
+        "tags": [
+          "ManagedClusters"
+        ],
+        "operationId": "ManagedClusters_List",
+        "summary": "Gets a list of managed clusters in the specified subscription.",
+        "description": "Gets a list of managed clusters in the specified subscription. The operation returns properties of each managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List Managed Clusters": {
+            "$ref": "./examples/ManagedClustersList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters": {
+      "get": {
+        "tags": [
+          "ManagedClusters"
+        ],
+        "operationId": "ManagedClusters_ListByResourceGroup",
+        "summary": "Lists managed clusters in the specified subscription and resource group.",
+        "description": "Lists managed clusters in the specified subscription and resource group. The operation returns properties of each managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get Managed Clusters by Resource Group": {
+            "$ref": "./examples/ManagedClustersListByResourceGroup.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/upgradeProfiles/default": {
+      "get": {
+        "tags": [
+          "ManagedClusters"
+        ],
+        "operationId": "ManagedClusters_GetUpgradeProfile",
+        "summary": "Gets upgrade profile for a managed cluster.",
+        "description": "Gets the details of the upgrade profile for a managed cluster with a specified resource group and name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the managed cluster resource."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterUpgradeProfile"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Upgrade Profile for Managed Cluster": {
+            "$ref": "./examples/ManagedClustersGetUpgradeProfile.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/accessProfiles/{roleName}": {
+      "get": {
+        "tags": [
+          "ManagedClusters"
+        ],
+        "operationId": "ManagedClusters_GetAccessProfiles",
+        "summary": "Gets access profile of a managed cluster.",
+        "description": "Gets the accessProfile for the specified role name of the managed cluster with a specified resource group and name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the managed cluster resource."
+          },
+          {
+            "name": "roleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the role for managed cluster accessProfile resource."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterAccessProfile"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Managed Cluster": {
+            "$ref": "./examples/ManagedClustersAccessProfilesGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}": {
+      "get": {
+        "tags": [
+          "ManagedClusters"
+        ],
+        "operationId": "ManagedClusters_Get",
+        "summary": "Gets a managed cluster.",
+        "description": "Gets the details of the managed cluster with a specified resource group and name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the managed cluster resource."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Managed Cluster": {
+            "$ref": "./examples/ManagedClustersGet.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ManagedClusters"
+        ],
+        "operationId": "ManagedClusters_CreateOrUpdate",
+        "summary": "Creates or updates a managed cluster.",
+        "description": "Creates or updates a managed cluster with the specified configuration for agents and Kubernetes version.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the managed cluster resource."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            },
+            "description": "Parameters supplied to the Create or Update a Managed Cluster operation."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Create/Update Managed Cluster": {
+            "$ref": "./examples/ManagedClustersCreate_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ManagedClusters"
+        ],
+        "operationId": "ManagedClusters_Delete",
+        "summary": "Deletes a managed cluster.",
+        "description": "Deletes the managed cluster with a specified resource group and name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the managed cluster resource."
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "204": {
+            "description": "NoContent"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Delete Managed Cluster": {
+            "$ref": "./examples/ManagedClustersDelete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "ContainerServiceOSDisk": {
+      "type": "integer",
+      "format": "int32",
+      "maximum": 1023,
+      "minimum": 0,
+      "description": "OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+    },
+    "ContainerServiceStorageProfile": {
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ContainerServiceStorageProfileTypes",
+        "modelAsString": true
+      },
+      "enum": [
+        "StorageAccount",
+        "ManagedDisks"
+      ],
+      "description": "Storage profile specifies what kind of storage used. Choose from StorageAccount and ManagedDisks. Leave it empty, we will choose for you based on the orchestrator choice."
+    },
+    "ContainerServiceVnetSubnetID": {
+      "type": "string",
+      "description": "VNet SubnetID specifies the vnet's subnet identifier. If you specify either master VNet Subnet, or agent VNet Subnet, you need to specify both. And they have to be in the same VNet."
+    },
+    "ContainerServiceVMSize": {
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ContainerServiceVMSizeTypes",
+        "modelAsString": true
+      },
+      "description": "Size of agent VMs.",
+      "enum": [
+        "Standard_A0",
+        "Standard_A1",
+        "Standard_A10",
+        "Standard_A11",
+        "Standard_A1_v2",
+        "Standard_A2",
+        "Standard_A2_v2",
+        "Standard_A2m_v2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A4_v2",
+        "Standard_A4m_v2",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_A8",
+        "Standard_A8_v2",
+        "Standard_A8m_v2",
+        "Standard_A9",
+        "Standard_D1",
+        "Standard_D11",
+        "Standard_D11_v2",
+        "Standard_D11_v2_Promo",
+        "Standard_D12",
+        "Standard_D12_v2",
+        "Standard_D12_v2_Promo",
+        "Standard_D13",
+        "Standard_D13_v2",
+        "Standard_D13_v2_Promo",
+        "Standard_D14",
+        "Standard_D14_v2",
+        "Standard_D14_v2_Promo",
+        "Standard_D15_v2",
+        "Standard_D16_v3",
+        "Standard_D16s_v3",
+        "Standard_D1_v2",
+        "Standard_D2",
+        "Standard_D2_v2",
+        "Standard_D2_v2_Promo",
+        "Standard_D2_v3",
+        "Standard_D2s_v3",
+        "Standard_D3",
+        "Standard_D3_v2",
+        "Standard_D3_v2_Promo",
+        "Standard_D4",
+        "Standard_D4_v2",
+        "Standard_D4_v2_Promo",
+        "Standard_D4_v3",
+        "Standard_D4s_v3",
+        "Standard_D5_v2",
+        "Standard_D5_v2_Promo",
+        "Standard_D8_v3",
+        "Standard_D8s_v3",
+        "Standard_DS1",
+        "Standard_DS11",
+        "Standard_DS11_v2",
+        "Standard_DS11_v2_Promo",
+        "Standard_DS12",
+        "Standard_DS12_v2",
+        "Standard_DS12_v2_Promo",
+        "Standard_DS13",
+        "Standard_DS13_v2",
+        "Standard_DS13_v2_Promo",
+        "Standard_DS14",
+        "Standard_DS14_v2",
+        "Standard_DS14_v2_Promo",
+        "Standard_DS15_v2",
+        "Standard_DS1_v2",
+        "Standard_DS2",
+        "Standard_DS2_v2",
+        "Standard_DS2_v2_Promo",
+        "Standard_DS3",
+        "Standard_DS3_v2",
+        "Standard_DS3_v2_Promo",
+        "Standard_DS4",
+        "Standard_DS4_v2",
+        "Standard_DS4_v2_Promo",
+        "Standard_DS5_v2",
+        "Standard_DS5_v2_Promo",
+        "Standard_E16_v3",
+        "Standard_E16s_v3",
+        "Standard_E2_v3",
+        "Standard_E2s_v3",
+        "Standard_E32_v3",
+        "Standard_E32s_v3",
+        "Standard_E4_v3",
+        "Standard_E4s_v3",
+        "Standard_E64_v3",
+        "Standard_E64s_v3",
+        "Standard_E8_v3",
+        "Standard_E8s_v3",
+        "Standard_F1",
+        "Standard_F16",
+        "Standard_F16s",
+        "Standard_F1s",
+        "Standard_F2",
+        "Standard_F2s",
+        "Standard_F4",
+        "Standard_F4s",
+        "Standard_F8",
+        "Standard_F8s",
+        "Standard_G1",
+        "Standard_G2",
+        "Standard_G3",
+        "Standard_G4",
+        "Standard_G5",
+        "Standard_GS1",
+        "Standard_GS2",
+        "Standard_GS3",
+        "Standard_GS4",
+        "Standard_GS5",
+        "Standard_H16",
+        "Standard_H16m",
+        "Standard_H16mr",
+        "Standard_H16r",
+        "Standard_H8",
+        "Standard_H8m",
+        "Standard_L16s",
+        "Standard_L32s",
+        "Standard_L4s",
+        "Standard_L8s",
+        "Standard_M128s",
+        "Standard_M64ms",
+        "Standard_NC12",
+        "Standard_NC24",
+        "Standard_NC24r",
+        "Standard_NC6",
+        "Standard_NV12",
+        "Standard_NV24",
+        "Standard_NV6"
+      ]
+    },
+    "KeyVaultSecretRef": {
+      "properties": {
+        "vaultID": {
+          "type": "string",
+          "description": "Key vault identifier."
+        },
+        "secretName": {
+          "type": "string",
+          "description": "The secret name."
+        },
+        "version": {
+          "type": "string",
+          "description": "The secret version."
+        }
+      },
+      "description": "Reference to a secret stored in Azure Key Vault.",
+      "required": [
+        "vaultID",
+        "secretName"
+      ]
+    },
+    "ContainerServiceServicePrincipalProfile": {
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The ID for the service principal."
+        },
+        "secret": {
+          "type": "string",
+          "description": "The secret password associated with the service principal in plain text."
+        },
+        "keyVaultSecretRef": {
+          "$ref": "#/definitions/KeyVaultSecretRef",
+          "description": "Reference to a secret stored in Azure Key Vault."
+        }
+      },
+      "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs. Either secret or keyVaultSecretRef must be specified.",
+      "required": [
+        "clientId"
+      ]
+    },
+    "ContainerServiceMasterProfile": {
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "enum": [
+            1,
+            3,
+            5
+          ],
+          "x-ms-enum": {
+            "name": "Count",
+            "modelAsString": false
+          },
+          "description": "Number of masters (VMs) in the container service cluster. Allowed values are 1, 3, and 5. The default value is 1.",
+          "default": 1
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix to be used to create the FQDN for the master pool."
+        },
+        "vmSize": {
+          "$ref": "#/definitions/ContainerServiceVMSize",
+          "description": "Size of agent VMs."
+        },
+        "osDiskSizeGB": {
+          "$ref": "#/definitions/ContainerServiceOSDisk",
+          "description": "OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+        },
+        "vnetSubnetID": {
+          "$ref": "#/definitions/ContainerServiceVnetSubnetID",
+          "description": "VNet SubnetID specifies the vnet's subnet identifier. If you specify either master VNet Subnet, or agent VNet Subnet, you need to specify both. And they have to be in the same VNet."
+        },
+        "firstConsecutiveStaticIP": {
+          "type": "string",
+          "description": "FirstConsecutiveStaticIP used to specify the first static ip of masters.",
+          "default": "10.240.255.5"
+        },
+        "storageProfile": {
+          "$ref": "#/definitions/ContainerServiceStorageProfile",
+          "description": "Storage profile specifies what kind of storage used. Choose from StorageAccount and ManagedDisks. Leave it empty, we will choose for you based on the orchestrator choice."
+        },
+        "fqdn": {
+          "readOnly": true,
+          "type": "string",
+          "description": "FDQN for the master pool."
+        }
+      },
+      "required": [
+        "dnsPrefix",
+        "vmSize"
+      ],
+      "description": "Profile for the container service master."
+    },
+    "ContainerServiceAgentPoolProfile": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name of the agent pool profile in the context of the subscription and resource group."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 100,
+          "minimum": 1,
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. ",
+          "default": 1
+        },
+        "vmSize": {
+          "$ref": "#/definitions/ContainerServiceVMSize",
+          "description": "Size of agent VMs."
+        },
+        "osDiskSizeGB": {
+          "$ref": "#/definitions/ContainerServiceOSDisk",
+          "description": "OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix to be used to create the FQDN for the agent pool."
+        },
+        "fqdn": {
+          "readOnly": true,
+          "type": "string",
+          "description": "FDQN for the agent pool."
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "description": "Ports number array used to expose on this agent pool. The default opened ports are different based on your choice of orchestrator."
+        },
+        "storageProfile": {
+          "$ref": "#/definitions/ContainerServiceStorageProfile",
+          "description": "Storage profile specifies what kind of storage used. Choose from StorageAccount and ManagedDisks. Leave it empty, we will choose for you based on the orchestrator choice."
+        },
+        "vnetSubnetID": {
+          "$ref": "#/definitions/ContainerServiceVnetSubnetID",
+          "description": "VNet SubnetID specifies the vnet's subnet identifier. If you specify either master VNet Subnet, or agent VNet Subnet, you need to specify both. And they have to be in the same VNet."
+        },
+        "osType": {
+          "$ref": "#/definitions/OSType",
+          "description": "OsType to be used to specify os type. Choose from Linux and Windows. Default to Linux."
+        }
+      },
+      "required": [
+        "name",
+        "vmSize"
+      ],
+      "description": "Profile for the container service agent pool."
+    },
+    "ContainerServiceWindowsProfile": {
+      "properties": {
+        "adminUsername": {
+          "type": "string",
+          "description": "The administrator username to use for Windows VMs.",
+          "pattern": "^[a-zA-Z0-9]+([._]?[a-zA-Z0-9]+)*$"
+        },
+        "adminPassword": {
+          "type": "string",
+          "description": "The administrator password to use for Windows VMs.",
+          "pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%\\^&\\*\\(\\)])[a-zA-Z\\d!@#$%\\^&\\*\\(\\)]{12,123}$"
+        }
+      },
+      "required": [
+        "adminUsername",
+        "adminPassword"
+      ],
+      "description": "Profile for Windows VMs in the container service cluster."
+    },
+    "ContainerServiceLinuxProfile": {
+      "properties": {
+        "adminUsername": {
+          "type": "string",
+          "description": "The administrator username to use for Linux VMs.",
+          "pattern": "^[a-z][a-z0-9_-]*$"
+        },
+        "ssh": {
+          "$ref": "#/definitions/ContainerServiceSshConfiguration",
+          "description": "SSH configuration for Linux-based VMs running on Azure."
+        }
+      },
+      "required": [
+        "adminUsername",
+        "ssh"
+      ],
+      "description": "Profile for Linux VMs in the container service cluster."
+    },
+    "ContainerServiceSshConfiguration": {
+      "properties": {
+        "publicKeys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContainerServiceSshPublicKey"
+          },
+          "description": "The list of SSH public keys used to authenticate with Linux-based VMs. Only expect one key specified."
+        }
+      },
+      "description": "SSH configuration for Linux-based VMs running on Azure.",
+      "required": [
+        "publicKeys"
+      ]
+    },
+    "ContainerServiceSshPublicKey": {
+      "properties": {
+        "keyData": {
+          "type": "string",
+          "description": "Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers."
+        }
+      },
+      "required": [
+        "keyData"
+      ],
+      "description": "Contains information about SSH certificate public key data."
+    },
+    "ContainerServiceDiagnosticsProfile": {
+      "properties": {
+        "vmDiagnostics": {
+          "$ref": "#/definitions/ContainerServiceVMDiagnostics",
+          "description": "Profile for diagnostics on the container service VMs."
+        }
+      },
+      "description": "Profile for diagnostics on the container service cluster.",
+      "required": [
+        "vmDiagnostics"
+      ]
+    },
+    "ContainerServiceVMDiagnostics": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the VM diagnostic agent is provisioned on the VM."
+        },
+        "storageUri": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URI of the storage account where diagnostics are stored."
+        }
+      },
+      "description": "Profile for diagnostics on the container service VMs.",
+      "required": [
+        "enabled"
+      ]
+    },
+    "ManagedClusterListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ManagedCluster"
+          },
+          "description": "The list of managed clusters."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of managed cluster results.",
+          "readOnly": true
+        }
+      },
+      "description": "The response from the List Managed Clusters operation."
+    },
+    "ManagedCluster": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        },
+        {
+          "properties": {
+            "properties": {
+              "description": "Properties of a managed cluster.",
+              "$ref": "#/definitions/ManagedClusterProperties",
+              "x-ms-client-flatten": true
+            }
+          }
+        }
+      ],
+      "description": "Managed cluster."
+    },
+    "ManagedClusterProperties": {
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The current deployment or provisioning state, which only appears in the response."
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix specified when creating the managed cluster."
+        },
+        "fqdn": {
+          "readOnly": true,
+          "type": "string",
+          "description": "FDQN for the master pool."
+        },
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "Version of Kubernetes specified when creating the managed cluster."
+        },
+        "agentPoolProfiles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContainerServiceAgentPoolProfile"
+          },
+          "description": "Properties of the agent pool."
+        },
+        "linuxProfile": {
+          "$ref": "#/definitions/ContainerServiceLinuxProfile",
+          "description": "Profile for Linux VMs in the container service cluster."
+        },
+        "servicePrincipalProfile": {
+          "$ref": "#/definitions/ContainerServiceServicePrincipalProfile",
+          "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs. Either secret or keyVaultSecretRef must be specified."
+        }
+      },
+      "description": "Properties of the managed cluster."
+    },
+    "OrchestratorProfile": {
+      "properties": {
+        "orchestratorType": {
+          "type": "string",
+          "description": "Orchestrator type."
+        },
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "Orchestrator version (major, minor, patch)."
+        }
+      },
+      "required": [
+        "orchestratorType",
+        "orchestratorVersion"
+      ],
+      "description": "Contains information about orchestrator."
+    },
+    "ManagedClusterAccessProfile": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        },
+        {
+          "properties": {
+            "properties": {
+              "description": "AccessProfile of a managed cluster.",
+              "$ref": "#/definitions/AccessProfile",
+              "x-ms-client-flatten": true
+            }
+          }
+        }
+      ],
+      "description": "Managed cluster Access Profile."
+    },
+    "AccessProfile": {
+      "type": "object",
+      "properties": {
+        "kubeConfig": {
+          "type": "string",
+          "description": "Base64-encoded Kubernetes configuration file."
+        }
+      },
+      "description": "Profile for enabling a user to access a managed cluster."
+    },
+    "ManagedClusterPoolUpgradeProfile": {
+      "properties": {
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "Kubernetes version (major, minor, patch)."
+        },
+        "name": {
+          "type": "string",
+          "description": "Pool name."
+        },
+        "osType": {
+          "$ref": "#/definitions/OSType",
+          "enum": [
+            "Linux",
+            "Windows"
+          ],
+          "x-ms-enum": {
+            "name": "ContainerServiceOSTypes",
+            "modelAsString": true
+          },
+          "description": "OsType to be used to specify os type. Choose from Linux and Windows. Default to Linux."
+        },
+        "upgrades": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of orchestrator types and versions available for upgrade."
+        }
+      },
+      "required": [
+        "kubernetesVersion",
+        "osType"
+      ],
+      "description": "The list of available upgrade versions."
+    },
+    "ManagedClusterUpgradeProfileProperties": {
+      "properties": {
+        "controlPlaneProfile": {
+          "$ref": "#/definitions/ManagedClusterPoolUpgradeProfile",
+          "description": "The list of available upgrade versions for the control plane."
+        },
+        "agentPoolProfiles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterPoolUpgradeProfile"
+          },
+          "description": "The list of available upgrade versions for agent pools."
+        }
+      },
+      "required": [
+        "controlPlaneProfile",
+        "agentPoolProfiles"
+      ],
+      "description": "Control plane and agent pool upgrade profiles."
+    },
+    "ManagedClusterUpgradeProfile": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Id of upgrade profile."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Name of upgrade profile."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Type of upgrade profile."
+        },
+        "properties": {
+          "$ref": "#/definitions/ManagedClusterUpgradeProfileProperties",
+          "description": "Properties of upgrade profile.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "description": "The list of available upgrades for compute pools."
+    },
+    "OSType": {
+      "type": "string",
+      "default": "Linux",
+      "enum": [
+        "Linux",
+        "Windows"
+      ],
+      "x-ms-enum": {
+        "name": "OSType",
+        "modelAsString": true
+      },
+      "description": "OsType to be used to specify os type. Choose from Linux and Windows. Default to Linux."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+      "x-ms-parameter-location": "client"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version.",
+      "x-ms-parameter-location": "client"
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-09-30/examples/ContainerServiceListOrchestrators.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-09-30/examples/ContainerServiceListOrchestrators.json
@@ -1,0 +1,204 @@
+{
+  "parameters": {
+    "api-version": "2017-09-30",
+    "subscriptionId": "subid1",
+    "location": "location1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "\/subscriptions\/e240e532-1923-4fe0-86da-28abc43fc4c7\/providers\/Microsoft.ContainerService\/locations\/centralus\/orchestrators",
+        "name": "default",
+        "type": "Microsoft.ContainerService\/locations\/orchestrators",
+        "properties": {
+          "orchestrators": [
+            {
+              "orchestratorType": "DCOS",
+              "orchestratorVersion": "1.10.0"
+            },
+            {
+              "orchestratorType": "DCOS",
+              "orchestratorVersion": "1.9.0",
+              "default": true
+            },
+            {
+              "orchestratorType": "DCOS",
+              "orchestratorVersion": "1.8.8"
+            },
+            {
+              "orchestratorType": "Swarm",
+              "orchestratorVersion": "swarm:1.1.0"
+            },
+            {
+              "orchestratorType": "DockerCE",
+              "orchestratorVersion": "17.03.*"
+            },
+            {
+              "orchestratorType": "Kubernetes",
+              "orchestratorVersion": "1.8.1",
+              "upgrades": [
+                {
+                  "orchestratorVersion": "1.8.4"
+                },
+                {
+                  "orchestratorVersion": "1.8.2"
+                }
+              ]
+            },
+            {
+              "orchestratorType": "Kubernetes",
+              "orchestratorVersion": "1.8.2",
+              "upgrades": [
+                {
+                  "orchestratorVersion": "1.8.4"
+                }
+              ]
+            },
+            {
+              "orchestratorType": "Kubernetes",
+              "orchestratorVersion": "1.6.11",
+              "upgrades": [
+                {
+                  "orchestratorVersion": "1.7.4"
+                },
+                {
+                  "orchestratorVersion": "1.7.9"
+                },
+                {
+                  "orchestratorVersion": "1.6.12"
+                },
+                {
+                  "orchestratorVersion": "1.7.1"
+                },
+                {
+                  "orchestratorVersion": "1.7.0"
+                },
+                {
+                  "orchestratorVersion": "1.7.5"
+                },
+                {
+                  "orchestratorVersion": "1.7.10"
+                },
+                {
+                  "orchestratorVersion": "1.6.13"
+                },
+                {
+                  "orchestratorVersion": "1.7.2"
+                },
+                {
+                  "orchestratorVersion": "1.7.7"
+                }
+              ]
+            },
+            {
+              "orchestratorType": "Kubernetes",
+              "orchestratorVersion": "1.7.7",
+              "upgrades": [
+                {
+                  "orchestratorVersion": "1.7.9"
+                },
+                {
+                  "orchestratorVersion": "1.8.4"
+                },
+                {
+                  "orchestratorVersion": "1.8.0"
+                },
+                {
+                  "orchestratorVersion": "1.7.10"
+                },
+                {
+                  "orchestratorVersion": "1.8.1"
+                },
+                {
+                  "orchestratorVersion": "1.8.2"
+                }
+              ]
+            },
+            {
+              "orchestratorType": "Kubernetes",
+              "orchestratorVersion": "1.5.8",
+              "upgrades": [
+                {
+                  "orchestratorVersion": "1.6.11"
+                },
+                {
+                  "orchestratorVersion": "1.6.13"
+                },
+                {
+                  "orchestratorVersion": "1.6.9"
+                },
+                {
+                  "orchestratorVersion": "1.6.6"
+                },
+                {
+                  "orchestratorVersion": "1.6.12"
+                }
+              ]
+            },
+            {
+              "orchestratorType": "Kubernetes",
+              "orchestratorVersion": "1.6.9",
+              "upgrades": [
+                {
+                  "orchestratorVersion": "1.7.4"
+                },
+                {
+                  "orchestratorVersion": "1.7.9"
+                },
+                {
+                  "orchestratorVersion": "1.6.12"
+                },
+                {
+                  "orchestratorVersion": "1.7.1"
+                },
+                {
+                  "orchestratorVersion": "1.7.0"
+                },
+                {
+                  "orchestratorVersion": "1.7.5"
+                },
+                {
+                  "orchestratorVersion": "1.7.10"
+                },
+                {
+                  "orchestratorVersion": "1.6.11"
+                },
+                {
+                  "orchestratorVersion": "1.6.13"
+                },
+                {
+                  "orchestratorVersion": "1.7.2"
+                },
+                {
+                  "orchestratorVersion": "1.7.7"
+                }
+              ]
+            },
+            {
+              "orchestratorType": "Kubernetes",
+              "orchestratorVersion": "1.7.9",
+              "default": true,
+              "upgrades": [
+                {
+                  "orchestratorVersion": "1.8.1"
+                },
+                {
+                  "orchestratorVersion": "1.8.2"
+                },
+                {
+                  "orchestratorVersion": "1.8.4"
+                },
+                {
+                  "orchestratorVersion": "1.8.0"
+                },
+                {
+                  "orchestratorVersion": "1.7.10"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-09-30/location.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-09-30/location.json
@@ -1,0 +1,193 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServiceClient",
+    "description": "The Container Service Client.",
+    "version": "2017-09-30"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/locations/{location}/orchestrators": {
+      "get": {
+        "tags": [
+          "ContainerServices"
+        ],
+        "operationId": "ContainerServices_ListOrchestrators",
+        "summary": "Gets a list of supported orchestrators in the specified subscription.",
+        "description": "Gets a list of supported orchestrators in the specified subscription. The operation returns properties of each orchestrator including verison and available upgrades.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/LocationParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceTypeParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OrchestratorVersionProfileListResult"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "OrchestratorProfile": {
+      "properties": {
+        "orchestratorType": {
+          "type": "string",
+          "description": "Orchestrator type."
+        },
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "Orchestrator version (major, minor, patch)."
+        }
+      },
+      "required": [
+        "orchestratorType",
+        "orchestratorVersion"
+      ],
+      "description": "Contains information about orchestrator."
+    },
+    "OrchestratorVersionProfile": {
+      "properties": {
+        "orchestratorType": {
+          "type": "string",
+          "description": "Orchestrator type."
+        },
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "Orchestrator version (major, minor, patch)."
+        },
+        "default": {
+          "type": "boolean",
+          "description": "Installed by default if version is not specified."
+        },
+        "upgrades": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OrchestratorProfile"
+          },
+          "description": "The list of available upgrade versions."
+        }
+      },
+      "required": [
+        "orchestratorVersion",
+        "orchestratorType",
+        "upgrades",
+        "default"
+      ],
+      "description": "The profile of an orchestrator and its available versions."
+    },
+    "OrchestratorVersionProfileProperties": {
+      "properties": {
+        "orchestrators": {
+          "type": "array",
+          "$ref": "#/definitions/OrchestratorVersionProfile",
+          "description": "List of orchstrator version profiles."
+        }
+      },
+      "required": [
+        "orchestrators"
+      ],
+      "description": "The properties of an orchestrator version profile."
+    },
+    "OrchestratorVersionProfileListResult": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Id of the orchestrator version profile list result."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Name of the orchestrator version profile list result."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Type of the orchestrator version profile list result."
+        },
+        "properties": {
+          "$ref": "#/definitions/OrchestratorVersionProfileProperties",
+          "description": "The properties of an orchestrator version profile.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "description": "The list of versions for supported orchestrators."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+      "x-ms-parameter-location": "client"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version.",
+      "x-ms-parameter-location": "client"
+    },
+    "LocationParameter": {
+      "name": "location",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of a supported Azure region.",
+      "x-ms-parameter-location": "method"
+    },
+    "ResourceTypeParameter": {
+      "name": "resource-type",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "resource type for which the list of orchestrators needs to be returned"
+    }
+  }
+}

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-09-30/location.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-09-30/location.json
@@ -63,6 +63,11 @@
               "$ref": "#/definitions/OrchestratorVersionProfileListResult"
             }
           }
+        },
+        "x-ms-examples": {
+          "List Container Service Orchestrators": {
+            "$ref": "./examples/ContainerServiceListOrchestrators.json"
+          }
         }
       }
     }

--- a/specification/containerservices/resource-manager/readme.md
+++ b/specification/containerservices/resource-manager/readme.md
@@ -1,0 +1,94 @@
+# ContainerServices
+
+> see https://aka.ms/autorest
+
+This is the AutoRest configuration file for ContainerServices (ACS/AKS).
+
+The ContainerServices RPv2 consists of two similar services: ContainerServices and ManagedClusters.
+Each service has its own swagger spec.
+
+The two specs are united by running `autorest` in this directory, which will use this readme.md
+file for configuration options. It will generate a single *azure-mgmt-containerservices* client
+library.
+
+---
+
+# Getting Started
+
+To build the SDK for ContainerServices, [install Autorest](https://aka.ms/autorest/install). Then
+in this folder, run this command:
+
+> `autorest`
+
+To see additional help and options, run:
+
+> `autorest --help`
+
+---
+
+## Configuration
+
+### Basic Information
+
+These are the global settings for the ContainerServices API.
+
+```yaml
+openapi-type: arm
+tag: package-2017-09
+```
+
+### Tag: package-2017-09
+
+These settings apply only when `--tag=package-2017-09` is specified on the command line.
+
+``` yaml $(tag) == 'package-2017-09'
+input-file:
+- Microsoft.ContainerService/2017-07-01/containerService.json
+- Microsoft.ContainerService/2017-08-31/managedClusters.json
+- Microsoft.ContainerService/2017-09-30/location.json
+```
+
+### Tag: package-2017-08
+
+These settings apply only when `--tag=package-2017-08` is specified on the command line.
+
+``` yaml $(tag) == 'package-2017-08'
+input-file:
+- Microsoft.ContainerService/2017-07-01/containerService.json
+- Microsoft.ContainerService/2017-08-31/managedClusters.json
+```
+
+### Tag: package-2017-07
+
+These settings apply only when `--tag=package-2017-07` is specified on the command line.
+
+``` yaml $(tag) == 'package-2017-07'
+input-file:
+- Microsoft.ContainerService/2017-07-01/containerService.json
+```
+
+---
+
+# Code Generation
+
+## Go
+
+These settings apply only when `--go` is specified on the command line.
+
+``` yaml $(go)
+go:
+  license-header: MICROSOFT_APACHE_NO_VERSION
+  clear-output-folder: true
+```
+
+## Python
+
+These settings apply only when `--python` is specified on the command line.
+
+``` yaml $(python)
+python:
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  namespace: azure.mgmt.containerservice
+  payload-flattening-threshold: 2
+```


### PR DESCRIPTION
Closes #1386.

This replaces #1912 with an updated API for ACS/AKS which lives in its own specification directory and uses `x-ms-client-flatten` consistently.

ping @rite2nikhil @shrutir25 @rjtsdl

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
