### PR TITLE
Remove skip encoding in GraphRbac when possible

### DIFF
--- a/specification/graphrbac/data-plane/1.6/graphrbac.json
+++ b/specification/graphrbac/data-plane/1.6/graphrbac.json
@@ -161,8 +161,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Application object ID.",
-            "x-ms-skip-url-encoding": true
+            "description": "Application object ID."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -195,8 +194,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Application object ID.",
-            "x-ms-skip-url-encoding": true
+            "description": "Application object ID."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -232,8 +230,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Application object ID.",
-            "x-ms-skip-url-encoding": true
+            "description": "Application object ID."
           },
           {
             "name": "parameters",
@@ -277,8 +274,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Application object ID.",
-            "x-ms-skip-url-encoding": true
+            "description": "Application object ID."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -317,8 +313,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Application object ID.",
-            "x-ms-skip-url-encoding": true
+            "description": "Application object ID."
           },
           {
             "name": "parameters",
@@ -362,8 +357,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Application object ID.",
-            "x-ms-skip-url-encoding": true
+            "description": "Application object ID."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -402,8 +396,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Application object ID.",
-            "x-ms-skip-url-encoding": true
+            "description": "Application object ID."
           },
           {
             "name": "parameters",
@@ -487,16 +480,14 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the group from which to remove the member.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the group from which to remove the member."
           },
           {
             "name": "memberObjectId",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Member object id",
-            "x-ms-skip-url-encoding": true
+            "description": "Member object id"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -531,8 +522,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the group to which to add the member.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the group to which to add the member."
           },
           {
             "name": "parameters",
@@ -576,8 +566,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the group to delete.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the group to delete."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -693,8 +682,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the group whose members should be retrieved.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the group whose members should be retrieved."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -736,8 +724,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the user for which to get group information.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the user for which to get group information."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -775,8 +762,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the group for which to get group membership.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the group for which to get group membership."
           },
           {
             "name": "parameters",
@@ -907,8 +893,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the service principal to delete.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the service principal to delete."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -941,8 +926,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the service principal to get.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the service principal to get."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -980,8 +964,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the service principal for which to get keyCredentials.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the service principal for which to get keyCredentials."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1020,8 +1003,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID for which to get service principal information.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID for which to get service principal information."
           },
           {
             "name": "parameters",
@@ -1065,8 +1047,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the service principal.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the service principal."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1105,8 +1086,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the service principal.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the service principal."
           },
           {
             "name": "parameters",
@@ -1231,8 +1211,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID or principal name of the user for which to get information.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID or principal name of the user for which to get information."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1268,8 +1247,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID or principal name of the user to update.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID or principal name of the user to update."
           },
           {
             "name": "parameters",
@@ -1311,8 +1289,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID or principal name of the user to delete.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID or principal name of the user to delete."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1347,8 +1324,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The object ID of the user for which to get group membership.",
-            "x-ms-skip-url-encoding": true
+            "description": "The object ID of the user for which to get group membership."
           },
           {
             "name": "parameters",

--- a/specification/graphrbac/data-plane/1.6/graphrbac.json
+++ b/specification/graphrbac/data-plane/1.6/graphrbac.json
@@ -553,41 +553,6 @@
         }
       }
     },
-    "/{tenantID}/groups/{groupObjectId}": {
-      "delete": {
-        "tags": [
-          "Group"
-        ],
-        "operationId": "Groups_Delete",
-        "description": "Delete a group from the directory.",
-        "parameters": [
-          {
-            "name": "groupObjectId",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The object ID of the group to delete."
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/tenantIDInPath"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/GraphError"
-            }
-          }
-        }
-      }
-    },
     "/{tenantID}/groups": {
       "post": {
         "tags": [
@@ -747,7 +712,40 @@
             }
           }
         }
-      }
+      },
+      "delete": {
+        "tags": [
+          "Group"
+        ],
+        "operationId": "Groups_Delete",
+        "description": "Delete a group from the directory.",
+        "parameters": [
+          {
+            "name": "objectId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The object ID of the group to delete."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/tenantIDInPath"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/GraphError"
+            }
+          }
+        }
+      }      
     },
     "/{tenantID}/groups/{objectId}/getMemberGroups": {
       "post": {


### PR DESCRIPTION
CLI issues:
https://github.com/Azure/azure-cli/issues/4775

We used x-ms-skip-url-encoding a little too much:
- For App, Group and SP, it's pointless since it's an UUID (i.e. no characters of an uuid change when encoded)
- For users, it can be UUID (so encoding is pointless) or a UserPrincipalName. In this case, encoding is important, since UPN can contains characters like # that MUST be encoded.

This is technically breaking if a customer found the bug, and workarounded it by encoding its UPN before using the SDK (in this case, after this PR this will be double-encoded). For everybody else, it's not breaking (most likely scenario). CLI is not broken by this PR, since CLI was not pre-encoding the UPN (hence the issue).

Fix strategy discussed with @amarzavery already.

Tested in Python already:
https://github.com/Azure/azure-sdk-for-python/pull/1594