### PR TITLE
Fix Consumption title after #2002

### DIFF
--- a/specification/consumption/resource-manager/Microsoft.Consumption/2017-11-30/consumption.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/2017-11-30/consumption.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "version": "2017-11-30",
-    "title": "Consumption Management",
+    "title": "ConsumptionManagementClient",
     "description": "Consumption management client provides access to consumption resources for Azure Enterprise Subscriptions."
   },
   "host": "management.azure.com",


### PR DESCRIPTION
Unnecessary breaking changes on the Python side.

I know that C# generator has some code to add "Client" automatically as a suffix, but this was never ported outside of the C# generator, but that's important :)