### PR TITLE
Removed 'use-internal-constructors: true' from OMS Data Plane

### DIFF
--- a/specification/operationalinsights/data-plane/readme.md
+++ b/specification/operationalinsights/data-plane/readme.md
@@ -54,7 +54,6 @@ csharp:
   namespace: Microsoft.Azure.OperationalInsights
   output-folder: $(csharp-sdks-folder)/OperationalInsights/DataPlane/OperationalInsights/Generated
   clear-output-folder: true
-  use-internal-constructors: true
   payload-flattening-threshold: 3
 directive:
   - reason: Don't expose the GET endpoint since it's behavior is more limited than POST


### PR DESCRIPTION
Removed 'use-internal-constructors: true' from Operational Insights data plane

I originally thought this was necessary for the C# client in order to always add a custom DelegatingHandler to the HttpClient but found a way around that using CustomInitialize() that isn't *too* scary.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
