### PR TITLE
fixing odata declarations

### DIFF
--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/2016-08-10/service.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/2016-08-10/service.json
@@ -165,7 +165,7 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         },
-        "x-ms-odata": "ProtectedItemsQueryParameter",
+        "x-ms-odata": "#/definitions/ProtectedItemsQueryParameter",
         "x-ms-examples": {
           "Gets the list of replication protected items.": {
             "$ref": "./examples/ReplicationProtectedItems_List.json"
@@ -5263,7 +5263,7 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         },
-        "x-ms-odata": "JobQueryParameter",
+        "x-ms-odata": "#/definitions/JobQueryParameter",
         "x-ms-examples": {
           "Gets the list of jobs.": {
             "$ref": "./examples/ReplicationJobs_List.json"
@@ -5720,7 +5720,7 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         },
-        "x-ms-odata": "EventQueryParameter",
+        "x-ms-odata": "#/definitions/EventQueryParameter",
         "x-ms-examples": {
           "Gets the list of Azure Site Recovery events.": {
             "$ref": "./examples/ReplicationEvents_List.json"


### PR DESCRIPTION
see https://github.com/Azure/autorest/blob/master/docs/extensions/readme.md#x-ms-odata

Since external references are allowed in `x-ms-odata` as well, the formally correct way to interpret a plain word like `ProtectedItemsQueryParameter` is treating it as a file! AutoRest mistakenly didn't do so in the past (causing issues in other places), now it does, so this has to be fixed to adhere to the specification. 😉 