### PR TITLE
Disable Node for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   matrix:
   - MODE=syntax
   - MODE=python
-  - MODE=node
+  # - MODE=node
   - MODE=ruby
   - MODE=semantic PR_ONLY=true
   # - MODE=linter PR_ONLY=false Disabling to save travis-ci resource for now


### PR DESCRIPTION
Disable Node build for now, since there is some work to do on the node side to make it work again (does nothing since August)
Discussed with @amarzavery of course