### PR TITLE
[ACS] clean up example for list orchestrators

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-09-30/examples/ContainerServiceListOrchestrators.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/2017-09-30/examples/ContainerServiceListOrchestrators.json
@@ -7,9 +7,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "\/subscriptions\/e240e532-1923-4fe0-86da-28abc43fc4c7\/providers\/Microsoft.ContainerService\/locations\/centralus\/orchestrators",
+        "id": "/subscriptions/subid1/providers/Microsoft.ContainerService/locations/location1/orchestrators",
         "name": "default",
-        "type": "Microsoft.ContainerService\/locations\/orchestrators",
+        "type": "Microsoft.ContainerService/locations/orchestrators",
         "properties": {
           "orchestrators": [
             {


### PR DESCRIPTION
I forgot to do a find-and-replace pass on this example apparently, and the URL paths don't need `\` escaping.