### PR TITLE
Adding a News clause to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 This repository is the canonical source for REST API specifications for Microsoft Azure.
 
+## News
+
+Starting at **6:00 p.m. PST, Friday December 15th, 2017** a few important changes are taking place:
+  1. The default branch of this repository will be set back to `master` (today it is `current`.)
+  1. Stable and Preview swaggers will be differentiated by folders named `preview` and `stable` in the root of each Resource Provider's folder. e.g.  {repoRoot}/specification/keyvault/resource-manager/Microsoft.KeyVault/2015-06-01/keyvault.json -> {repoRoot}/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2015-06-01/keyvault.json
+  1. The `master` and `current` branches in the Private repository (https://github.com/Azure/azure-rest-api-specs-pr) will be locked to their counter part in the public repository. PRs in Private will still be enabled, but merging them will be disabled.
+
+What this means for Contributors:
+  - Most people should be unimpacted.
+  - If you are an Open Source contributor to this repository, only the branch you should target and the folder the API Specs live will change.
+  - If you are a member of a service team currently working on a Private swagger in the `current` branch, you will need to reachout to @salameer or @marstr for assistance transfering your work to the newly structured branches.
+
 ## Basics
 If you're a spec author looking for information about all of of the repositories and steps in the pipeline, go to the [adx-documentation-pr](https://github.com/Azure/adx-documentation-pr) repository. Make sure to [join the Github Azure organization](http://aka.ms/azuregithub) to get access to that repo.
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ This repository is the canonical source for REST API specifications for Microsof
 
 ## News
 
-Starting at **6:00 p.m. PST, Friday December 15th, 2017** a few important changes are taking place:
-  1. The default branch of this repository will be set back to `master` (today it is `current`.)
-  1. Stable and Preview swaggers will be differentiated by folders named `preview` and `stable` in the root of each Resource Provider's folder. e.g.  {repoRoot}/specification/keyvault/resource-manager/Microsoft.KeyVault/2015-06-01/keyvault.json -> {repoRoot}/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2015-06-01/keyvault.json
-  1. The `master` and `current` branches in the Private repository (https://github.com/Azure/azure-rest-api-specs-pr) will be locked to their counter part in the public repository. PRs in Private will still be enabled, but merging them will be disabled.
+While you're away for the holiday season, we're going to be making a few improvements to the Azure REST API Specs repository:
 
-What this means for Contributors:
-  - Most people should be unimpacted.
-  - If you are an Open Source contributor to this repository, only the branch you should target and the folder the API Specs live will change.
-  - If you are a member of a service team currently working on a Private swagger in the `current` branch, you will need to reachout to @salameer or @marstr for assistance transfering your work to the newly structured branches.
+  - We will stop merging PRs until the new year starting on **[Insert Date Here]**.
+  - Starting on **[Insert Date Here]**, we will be restoring `master` as the default branch for this repository.
+    - All open PRs will automatically be updated to target `master` instead of `current`.
+    - We will stop accepting contributions to the `current` branch.
+  - On **[Insert Date Here]**, we will merge a refactoring of this repository where we introduce `preview` and `stable` directories to differentiate Swaggers and services that are ready for General Availability and those that are not yet.
+  - Beginning **[Insert Date Here]**, the `master` branch in the private repository will become a read-only copy of the `master` branch in the public repository.
+
+For more information about this project, please see our wiki:
+[December 2017 Refactoring](https://github.com/Azure/azure-rest-api-specs/wiki/December-2017-Refactoring)
 
 ## Basics
 If you're a spec author looking for information about all of of the repositories and steps in the pipeline, go to the [adx-documentation-pr](https://github.com/Azure/adx-documentation-pr) repository. Make sure to [join the Github Azure organization](http://aka.ms/azuregithub) to get access to that repo.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This repository is the canonical source for REST API specifications for Microsof
 
 While you're away for the holiday season, we're going to be making a few improvements to the Azure REST API Specs repository:
 
-  - We will stop merging PRs until the new year starting on **[Insert Date Here]**.
-  - Starting on **[Insert Date Here]**, we will be restoring `master` as the default branch for this repository.
+  - We will stop merging PRs until the new year starting on **6:00 p.m. December 20th, 2017**.
+  - Starting on **December 21st, 2017**, we will be restoring `master` as the default branch for this repository.
     - All open PRs will automatically be updated to target `master` instead of `current`.
     - We will stop accepting contributions to the `current` branch.
-  - On **[Insert Date Here]**, we will merge a refactoring of this repository where we introduce `preview` and `stable` directories to differentiate Swaggers and services that are ready for General Availability and those that are not yet.
-  - Beginning **[Insert Date Here]**, the `master` branch in the private repository will become a read-only copy of the `master` branch in the public repository.
+  - On **December 21st, 2017**, we will merge a refactoring of this repository where we introduce `preview` and `stable` directories to differentiate Swaggers and services that are ready for General Availability and those that are not yet.
+  - Beginning **December 21st, 2017**, the `master` branch in the private repository will become a read-only copy of the `master` branch in the public repository.
 
 For more information about this project, please see our wiki:
 [December 2017 Refactoring](https://github.com/Azure/azure-rest-api-specs/wiki/December-2017-Refactoring)


### PR DESCRIPTION
Specifically, this is meant to inform of refactorings that are coming to
the public and private repositories on Friday, December 15th.

---

The usual Checklist has been omitted because these changes are meta-changes to the repository, and not to Swaggers directly.
