### PR TITLE
Fix ContentModerator credentials

### DIFF
--- a/specification/cognitiveservices/data-plane/ContentModerator/readme.md
+++ b/specification/cognitiveservices/data-plane/ContentModerator/readme.md
@@ -7,7 +7,7 @@ Configuration for generating Content Moderator SDK.
 The current release is `release_1_0`.
 
 ``` yaml
-
+add-credentials: true
 tag: release_1_0
 ```
 # Releases

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/ContentModerator.json
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/ContentModerator.json
@@ -17,6 +17,16 @@
   "schemes": [
     "https"
   ],
+  "securityDefinitions": {
+    "apiKeyHeader": {
+      "name": "Ocp-Apim-Subscription-Key",
+      "type": "apiKey",
+      "in": "header"
+    }
+  },
+  "security": [{
+    "apiKeyHeader": []
+  }],  
   "paths": {
     "/contentmoderator/moderate/v1.0/ProcessImage/FindFaces": {
       "post": {
@@ -28,9 +38,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/CacheImage"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
 
         ],
@@ -77,9 +84,6 @@
           },
           {
             "$ref": "#/parameters/enhanced"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -120,9 +124,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/CacheImage"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -165,9 +166,6 @@
           },
           {
             "$ref": "#/parameters/CacheImage"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
 
         ],
@@ -238,9 +236,6 @@
             ]
           },
           {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
-          {
             "$ref": "#/parameters/textContent"
           }
         ],
@@ -282,9 +277,6 @@
         "operationId": "TextModeration_DetectLanguage",
         "description": "This operation will detect the language of given input content. Returns the <a href=\"http://www-01.sil.org/iso639-3/codes.asp\">ISO 639-3 code</a> for the predominant language comprising the submitted text. Over 110 languages supported.",
         "parameters": [
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
           {
             "name": "Content-Type",
             "description": "The content type.",
@@ -342,9 +334,6 @@
         "description": "Returns the details of the image list with list Id equal to list Id passed.",
         "parameters": [
           {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
-          {
             "$ref": "#/parameters/listId"
           }
 
@@ -381,9 +370,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/listId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -428,9 +414,6 @@
           },
           {
             "$ref": "#/parameters/body"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -477,9 +460,6 @@
           },
           {
             "$ref": "#/parameters/body"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -514,11 +494,7 @@
         ],
         "operationId": "ListManagementImageLists_GetAllImageLists",
         "description": "Gets all the Image Lists.",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "OK",
@@ -553,9 +529,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/listId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -595,9 +568,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/listId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -632,9 +602,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/listId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -679,9 +646,6 @@
           },
           {
             "$ref": "#/parameters/body"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -728,9 +692,6 @@
           },
           {
             "$ref": "#/parameters/body"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -765,11 +726,7 @@
         ],
         "operationId": "ListManagementTermLists_GetAllTermLists",
         "description": "gets all the Term Lists",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "OK",
@@ -804,9 +761,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/listId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           },
           {
             "$ref": "#/parameters/language"
@@ -855,9 +809,6 @@
           },
           {
             "$ref": "#/parameters/label"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
 
         ],
@@ -901,9 +852,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/listId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -938,9 +886,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/listId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -980,9 +925,6 @@
           },
           {
             "$ref": "#/parameters/ImageId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -1025,9 +967,6 @@
           },
           {
             "$ref": "#/parameters/language"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
 
         ],
@@ -1072,9 +1011,6 @@
           },
           {
             "$ref": "#/parameters/language"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -1115,9 +1051,6 @@
           },
           {
             "$ref": "#/parameters/language"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           },
           {
             "name": "offset",
@@ -1169,9 +1102,6 @@
           },
           {
             "$ref": "#/parameters/language"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -1219,9 +1149,6 @@
             "description": "Id of the review.",
             "required": true,
             "type": "string"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -1269,9 +1196,6 @@
             "description": "Id of the job.",
             "required": true,
             "type": "string"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "responses": {
@@ -1380,9 +1304,6 @@
                 }
               }
             }
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -1435,9 +1356,6 @@
           },
           {
             "$ref": "#/parameters/CallBackEndpoint"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           },
           {
             "name": "Content-Type",
@@ -1527,9 +1445,6 @@
             "in": "query",
             "required": false,
             "type": "integer"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -1565,9 +1480,6 @@
           },
           {
             "$ref": "#/parameters/reviewId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           },
           {
             "name": "startSeed",
@@ -1629,9 +1541,6 @@
           },
           {
             "$ref": "#/parameters/reviewId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -1683,9 +1592,6 @@
           },
           {
             "$ref": "#/parameters/transcriptModerationBody"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -1726,9 +1632,6 @@
           },
           {
             "$ref": "#/parameters/reviewId"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           },
           {
             "name": "Content-Type",
@@ -1783,9 +1686,6 @@
           {
             "$ref": "#/parameters/CacheImage"
           },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
           
           {
             "$ref": "#/parameters/ImageStreamParameter"
@@ -1828,9 +1728,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/CacheImage"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           },
           {
             "name": "Content-Type",
@@ -1888,9 +1785,6 @@
             "$ref": "#/parameters/enhanced"
           },
           {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
-          {
             "name": "Content-Type",
             "description": "The content type.",
             "required": true,
@@ -1945,9 +1839,6 @@
           {
             "$ref": "#/parameters/enhanced"
           },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
          
           {
             "$ref": "#/parameters/ImageStreamParameter"
@@ -1992,9 +1883,6 @@
           {
             "$ref": "#/parameters/CacheImage"
           },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
           
           {
             "$ref": "#/parameters/ImageStreamParameter"
@@ -2037,9 +1925,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/CacheImage"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           },
           {
             "name": "Content-Type",
@@ -2094,9 +1979,6 @@
             "$ref": "#/parameters/CacheImage"
           },
           {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
-          {
             "name": "Content-Type",
             "description": "The content type.",
             "required": true,
@@ -2148,9 +2030,6 @@
           {
             "$ref": "#/parameters/CacheImage"
           },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
           
           {
             "$ref": "#/parameters/ImageStreamParameter"
@@ -2199,9 +2078,6 @@
           },
           {
             "$ref": "#/parameters/label"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           },
           {
             "name": "Content-Type",
@@ -2258,9 +2134,6 @@
           {
             "$ref": "#/parameters/label"
           },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
-          },
           
           {
             "$ref": "#/parameters/ImageStreamParameter"
@@ -2316,9 +2189,6 @@
           },
           {
             "$ref": "#/parameters/CreateVideoReviewsBody"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -2375,9 +2245,6 @@
           },
           {
             "$ref": "#/parameters/videoFrameBody"
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -2457,9 +2324,6 @@
             "required": true,
             "type": "string"
 
-          },
-          {
-            "$ref": "#/parameters/ocpApimSubscriptionKeyParameter"
           }
         ],
         "consumes": [
@@ -3754,7 +3618,6 @@
               "type": "string"
             }
 
-
           }
         }
       },
@@ -3915,14 +3778,6 @@
       },
       "description": "The image file.",
       "x-ms-parameter-location": "method"
-    },
-    "ocpApimSubscriptionKeyParameter": {
-      "name": "Ocp-Apim-Subscription-Key",
-      "description": "The subscription key in header",
-      "x-ms-parameter-location": "client",
-      "required": true,
-      "type": "string",
-      "in": "header"
     },
     "baseUrl": {
       "name": "baseUrl",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddFrameResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddFrameResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "teamName": "ModeratorTeam",
     "reviewId": "201711v18ea829372b14f9e9d382621e62429a9",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddFrameStreamResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddFrameStreamResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "teamName": "ModeratorTeam",
     "reviewId": "201711v18ea829372b14f9e9d382621e62429a9",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddImageResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddImageResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003",
     "tag": 105,

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddImageStreamResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddImageStreamResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003",
     "tag": 105,

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddTermResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddTermResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003",
     "term": "hell",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddVideoTranscriptResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/AddVideoTranscriptResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "teamName": "Content moderator",
     "reviewId": "201711v18ea829372b14f9e9d382621e62429a9",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateImageListResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateImageListResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "Content-Type": "application/json",
     "body": {

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateJobResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateJobResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "teamName": "sonaliProdTeam",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "ContentType": "Image",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateReviewResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateReviewResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "teamName": "ModeratorTeam",
     "subTeam": "SubteamA",
     "UrlContentType": "application/json",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateTermListResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateTermListResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "Content-Type": "application/json",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "body": {

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateVideoReviewResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/CreateVideoReviewResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "teamName": "ModeratorTeam",
     "subTeam": "SubteamA",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteAllImagesResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteAllImagesResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003"
   },

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteAllTermsResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteAllTermsResource.JSON
@@ -2,7 +2,6 @@
   "parameters": {
     "listId": "89003",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "language": "eng"
   },
   "responses": {

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteImageListResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteImageListResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003"
   },

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteImageResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteImageResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003",
     "ImageId": "34562"

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteTermListResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteTermListResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003"
   },

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteTermResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DeleteTermResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003",
     "term": "hell",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DetectLanguageResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/DetectLanguageResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "Content-Type": "text/plain",
     "Text Content": "Is this a crap email abcdef@abcd.com, phone: 6657789887, IP: 255.255.255.255, 1 Microsoft Way, Redmond, WA 98052"

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/EvaluateImageResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/EvaluateImageResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "CacheImage": true,
     "Content-Type": "application/json",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/EvaluateImageStreamResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/EvaluateImageStreamResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "CacheImage": true,
     "Content-Type": "image/jpeg",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/FindFacesResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/FindFacesResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "a79e5f9eeafa4f059ac507a93e1a9ff1",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "CacheImage": true,
     "Content-Type": "application/json",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/FindFacesStreamResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/FindFacesStreamResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "a79e5f9eeafa4f059ac507a93e1a9ff1",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "CacheImage": true,
     "imageFileContentType": "image/jpeg",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetAllImageIdsResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetAllImageIdsResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003"
   },

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetAllTermsResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetAllTermsResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003",
     "language": "eng"

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetFramesResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetFramesResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "teamName": "Content moderator",
     "reviewId": "201711v18ea829372b14f9e9d382621e62429a9",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetImageListIdDetailsResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetImageListIdDetailsResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "123",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "123"
   },

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetImageListsResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetImageListsResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com"
   },
   "responses": {

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetJobDetailsResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetJobDetailsResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "teamName": "ModeratorTeam",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "JobId": "201709i96f295aa5748101436064c42ddf"

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetReviewResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetReviewResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "teamName": "ModeratorTeam",
     "reviewId": "201709i96f295aa5748101436064c42ddf",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com"

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetTermListIdDetailsResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetTermListIdDetailsResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "listId": "89003",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com"
   },

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetTermListsResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/GetTermListsResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com"
   },
   "responses": {

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/MatchImageResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/MatchImageResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "cacheimage": true,
     "Content-Type": "application/json",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/MatchImageStreamResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/MatchImageStreamResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "cacheimage": true,
     "imageFileContentType": "image/jpeg",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/OCRResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/OCRResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "CacheImage": false,
     "Content-Type": "application/json",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/OCRStreamResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/OCRStreamResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "CacheImage": false,
     "imageFileContentType": "image/jpeg",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/PublishVideoReviewResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/PublishVideoReviewResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "teamName": "Content moderator",
     "reviewId": "201711v18ea829372b14f9e9d382621e62429a9"

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/RefreshImageIndexResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/RefreshImageIndexResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003"
   },

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/RefreshTermIndexResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/RefreshTermIndexResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003",
     "language": "eng"

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/ScreenTextResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/ScreenTextResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "Content-Type": "text/plain",
     "language": "eng",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/TranscriptModerationResult.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/TranscriptModerationResult.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "teamName": "ModeratorTeam",
     "reviewId": "201711v627c579149ec4220bc674214d93f5fe5",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/UpdateImageListResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/UpdateImageListResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "listId": "89003",
     "Content-Type": "application/json",

--- a/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/UpdateTermListResource.JSON
+++ b/specification/cognitiveservices/data-plane/ContentModerator/v1.0/examples/UpdateTermListResource.JSON
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "Ocp-Apim-Subscription-Key": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
     "baseUrl": "southeastasia.api.cognitive.microsoft.com",
     "Content-Type": "application/json",
     "listId": "89003",


### PR DESCRIPTION
Fix #2168 

@v-sodsou There is a SDK convention for CS, that credentials needs to be addressed using the `apiKey` Swagger feature and the Autorest `add-credentials` parameter.

FYI @alvadb @williexu @kirthik 