### PR TITLE
Re-add quickstart-template files in the location pre-reorg of folders in the rest api specs repo.

### DIFF
--- a/arm-compute/quickstart-templates/aliases.json
+++ b/arm-compute/quickstart-templates/aliases.json
@@ -1,0 +1,87 @@
+{
+  "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion":"1.0.0.0",
+  "parameters":{},
+  "variables":{},
+  "resources":[],
+
+  "outputs":{
+    "aliases":{
+      "type":"object",
+      "value":{
+
+        "Linux":{
+          "CentOS":{
+            "publisher":"OpenLogic",
+            "offer":"CentOS",
+            "sku":"7.3",
+            "version":"latest"
+          },
+          "CoreOS":{
+            "publisher":"CoreOS",
+            "offer":"CoreOS",
+            "sku":"Stable",
+            "version":"latest"
+          },
+          "Debian":{
+            "publisher":"credativ",
+            "offer":"Debian",
+            "sku":"8",
+            "version":"latest"
+          },
+          "openSUSE-Leap": {
+            "publisher":"SUSE",
+            "offer":"openSUSE-Leap",
+            "sku":"42.2",
+            "version": "latest"
+          },
+          "RHEL":{
+            "publisher":"RedHat",
+            "offer":"RHEL",
+            "sku":"7.3",
+            "version":"latest"
+          },
+          "SLES":{
+            "publisher":"SUSE",
+            "offer":"SLES",
+            "sku":"12-SP2",
+            "version":"latest"
+          },
+          "UbuntuLTS":{
+            "publisher":"Canonical",
+            "offer":"UbuntuServer",
+            "sku":"16.04-LTS",
+            "version":"latest"
+          }
+        },
+
+        "Windows":{
+          "Win2016Datacenter":{
+            "publisher":"MicrosoftWindowsServer",
+            "offer":"WindowsServer",
+            "sku":"2016-Datacenter",
+            "version":"latest"
+          },
+          "Win2012R2Datacenter":{
+            "publisher":"MicrosoftWindowsServer",
+            "offer":"WindowsServer",
+            "sku":"2012-R2-Datacenter",
+            "version":"latest"
+          },
+          "Win2012Datacenter":{
+            "publisher":"MicrosoftWindowsServer",
+            "offer":"WindowsServer",
+            "sku":"2012-Datacenter",
+            "version":"latest"
+          },
+          "Win2008R2SP1":{
+            "publisher":"MicrosoftWindowsServer",
+            "offer":"WindowsServer",
+            "sku":"2008-R2-SP1",
+            "version":"latest"
+          }
+        }
+      }
+    }
+  }
+}

--- a/arm-compute/quickstart-templates/swagger.json
+++ b/arm-compute/quickstart-templates/swagger.json
@@ -1,0 +1,420 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ComputeManagementConvenienceClient",
+    "version": "2015-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}": {
+      "put": {
+        "tags": [
+          "Deployments"
+        ],
+        "operationId": "VirtualMachines_QuickCreate",
+        "description": "Create a named template deployment using a template.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group. The name is case insensitive.",
+            "pattern": "^[-\\w\\._]+$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the deployment."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            },
+            "description": "Additional parameters supplied to the operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DeploymentExtended"
+            }
+          },
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DeploymentExtended"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "TemplateLink": {
+      "required": [
+        "uri"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "URI referencing the template.",
+          "enum": [
+            "https://raw.githubusercontent.com/stankovski/azure-rest-api-specs/master/arm-compute/quickstart-templates/vm-simple-linux.json"
+          ]
+        }
+      },
+      "description": "Entity representing the reference to the template."
+    },
+    "DeploymentProperties": {
+      "required": [
+        "templateLink",
+        "mode"
+      ],
+      "properties": {
+        "templateLink": {
+          "$ref": "#/definitions/TemplateLink",
+          "description": "Gets or sets the URI referencing the template. Use only one of Template or TemplateLink."
+        },
+        "parameters": {
+          "x-ms-client-flatten": true,
+          "description": "Deployment parameters. Use only one of Parameters or ParametersLink.",
+          "$ref": "#/definitions/DeploymentParameters"
+        },
+        "mode": {
+          "type": "string",
+          "description": "Gets or sets the deployment mode.",
+          "enum": [
+            "Incremental"
+          ]
+        }
+      },
+      "description": "Deployment properties."
+    },
+    "Deployment": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/DeploymentProperties",
+          "description": "Gets or sets the deployment properties."
+        }
+      },
+      "description": "Deployment operation parameters."
+    },
+    "DeploymentParameters": {
+      "properties": {
+        "adminUsername": {
+          "x-ms-client-flatten": true,
+          "type": "object",
+          "required": [
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "type": "string",
+              "description": "Username for the Virtual Machine."
+            }
+          }
+        },
+        "adminPassword": {
+          "x-ms-client-flatten": true,
+          "type": "object",
+          "required": [
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "type": "string",
+              "format": "password",
+              "description": "Password for the Virtual Machine."
+            }
+          }
+        },
+        "dnsLabelPrefix": {
+          "x-ms-client-flatten": true,
+          "type": "object",
+          "required": [
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "type": "string",
+              "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+            }
+          }
+        },
+        "osVersion": {
+          "x-ms-client-flatten": true,
+          "type": "object",
+          "required": [
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "type": "string",
+              "default": "14.04.2-LTS",
+              "description": "The OS version for the VM. This will pick a fully patched image of this given OS version.",
+              "enum": [
+                "12.04.5-LTS",
+                "14.04.2-LTS",
+                "15.10"
+              ]
+            }
+          },
+          "description": "Deployment operation parameters."
+        }
+      }
+    },
+    "DeploymentExtended": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the ID of the deployment."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the deployment."
+        },
+        "properties": {
+          "$ref": "#/definitions/DeploymentPropertiesExtended",
+          "description": "Gets or sets deployment properties."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "Deployment information."
+    },
+    "DeploymentPropertiesExtended": {
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets or sets the state of the provisioning."
+        },
+        "correlationId": {
+          "type": "string",
+          "description": "Gets or sets the correlation ID of the deployment."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the timestamp of the template deployment."
+        },
+        "outputs": {
+          "type": "object",
+          "description": "Gets or sets key/value pairs that represent deploymentoutput."
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Provider"
+          },
+          "description": "Gets the list of resource providers needed for the deployment."
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Dependency"
+          },
+          "description": "Gets the list of deployment dependencies."
+        },
+        "template": {
+          "type": "object",
+          "description": "Gets or sets the template content. Use only one of Template or TemplateLink."
+        },
+        "templateLink": {
+          "$ref": "#/definitions/TemplateLink",
+          "description": "Gets or sets the URI referencing the template. Use only one of Template or TemplateLink."
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Deployment parameters. Use only one of Parameters or ParametersLink."
+        },
+        "parametersLink": {
+          "$ref": "#/definitions/ParametersLink",
+          "description": "Gets or sets the URI referencing the parameters. Use only one of Parameters or ParametersLink."
+        },
+        "mode": {
+          "type": "string",
+          "description": "Gets or sets the deployment mode.",
+          "enum": [
+            "Incremental",
+            "Complete"
+          ],
+          "x-ms-enum": {
+            "name": "DeploymentMode",
+            "modelAsString": false
+          }
+        }
+      },
+      "description": "Deployment properties with additional details."
+    },
+    "Dependency": {
+      "properties": {
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BasicDependency"
+          },
+          "description": "Gets the list of dependencies."
+        },
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the ID of the dependency."
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "Gets or sets the dependency resource type."
+        },
+        "resourceName": {
+          "type": "string",
+          "description": "Gets or sets the dependency resource name."
+        }
+      },
+      "description": "Deployment dependency information."
+    },
+    "BasicDependency": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the ID of the dependency."
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "Gets or sets the dependency resource type."
+        },
+        "resourceName": {
+          "type": "string",
+          "description": "Gets or sets the dependency resource name."
+        }
+      },
+      "description": "Deployment dependency information."
+    },
+    "ParametersLink": {
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "URI referencing the template."
+        },
+        "contentVersion": {
+          "type": "string",
+          "description": "If included it must match the ContentVersion in the template."
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "description": "Entity representing the reference to the deployment paramaters."
+    },
+    "Provider": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the provider id."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Gets or sets the namespace of the provider."
+        },
+        "registrationState": {
+          "type": "string",
+          "description": "Gets or sets the registration state of the provider."
+        },
+        "resourceTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProviderResourceType"
+          },
+          "description": "Gets or sets the collection of provider resource types."
+        }
+      },
+      "description": "Resource provider information."
+    },
+    "ProviderResourceType": {
+      "properties": {
+        "resourceType": {
+          "type": "string",
+          "description": "Gets or sets the resource type."
+        },
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the collection of locations where this resource type can be created in."
+        },
+        "apiVersions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Gets or sets the api version."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Gets or sets the properties."
+        }
+      },
+      "description": "Resource type managed by the resource provider."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    }
+  }
+}

--- a/arm-compute/quickstart-templates/vm-simple-linux.json
+++ b/arm-compute/quickstart-templates/vm-simple-linux.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "User name for the Virtual Machine."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
+    },
+    "dnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+      }
+    },
+    "osVersion": {
+      "type": "string",
+      "defaultValue": "14.04.2-LTS",
+      "allowedValues": [
+        "12.04.5-LTS",
+        "14.04.2-LTS",
+        "15.10"
+      ],
+      "metadata": {
+        "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version. Allowed values: 12.04.5-LTS, 14.04.2-LTS, 15.10."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'salinuxvm')]",
+    "location": "[resourceGroup().location]",
+    "dataDisk1VhdName": "datadisk1",
+    "imagePublisher": "Canonical",
+    "imageOffer": "UbuntuServer",
+    "OSDiskName": "osdiskforlinuxsimple",
+    "nicName": "myVMNic",
+    "addressPrefix": "10.0.0.0/16",
+    "subnetName": "Subnet",
+    "subnetPrefix": "10.0.0.0/24",
+    "storageAccountType": "Standard_LRS",
+    "publicIPAddressName": "myPublicIP",
+    "publicIPAddressType": "Dynamic",
+    "vmStorageAccountContainerName": "vhds",
+    "vmName": "MyUbuntuVM",
+    "vmSize": "Standard_D1",
+    "virtualNetworkName": "MyVNET",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "apiVersion": "2015-06-15"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsLabelPrefix')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[variables('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('osVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          },
+          "dataDisks": [
+            {
+              "name": "datadisk1",
+              "diskSizeGB": "100",
+              "lun": 0,
+              "vhd": {
+                "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('dataDisk1VhdName'),'.vhd')]"
+              },
+              "createOption": "Empty"
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net')]"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/arm-compute/quickstart-templates/vm-simple-windows.json
+++ b/arm-compute/quickstart-templates/vm-simple-windows.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
+    },
+    "dnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+      }
+    },
+    "osVersion": {
+      "type": "string",
+      "defaultValue": "2012-R2-Datacenter",
+      "allowedValues": [
+        "2008-R2-SP1",
+        "2012-Datacenter",
+        "2012-R2-Datacenter"
+      ],
+      "metadata": {
+        "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'sawinvm')]",
+    "sizeOfDiskInGB": "100",
+    "dataDisk1VhdName": "datadisk1",
+    "location": "[resourceGroup().location]",
+    "imagePublisher": "MicrosoftWindowsServer",
+    "imageOffer": "WindowsServer",
+    "OSDiskName": "osdiskforwindowssimple",
+    "nicName": "myVMNic",
+    "addressPrefix": "10.0.0.0/16",
+    "subnetName": "Subnet",
+    "subnetPrefix": "10.0.0.0/24",
+    "storageAccountType": "Standard_LRS",
+    "publicIPAddressName": "myPublicIP",
+    "publicIPAddressType": "Dynamic",
+    "vmStorageAccountContainerName": "vhds",
+    "vmName": "MyWindowsVM",
+    "vmSize": "Standard_D1",
+    "virtualNetworkName": "MyVNET",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "apiVersion": "2015-06-15"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsLabelPrefix')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[variables('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('osVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          },
+          "dataDisks": [
+            {
+              "name": "datadisk1",
+              "diskSizeGB": "[variables('sizeOfDiskInGB')]",
+              "lun": 0,
+              "vhd": {
+                "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('dataDisk1VhdName'),'.vhd')]"
+              },
+              "createOption": "Empty"
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net')]"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/arm-compute/quickstart-templates/vm-simple.json
+++ b/arm-compute/quickstart-templates/vm-simple.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountName": {
+      "type": "string"
+    },
+    "newOrExisting": {
+      "type": "string",
+      "allowedValues": [
+        "new",
+        "existing"
+      ]
+    }
+  },
+  "variables": {
+    "templatelink": "[concat('https://raw.githubusercontent.com/rjmax/ArmExamples/master/',parameters('newOrExisting'),'StorageAccount.json')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-01-01",
+      "name": "nestedTemplate",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "incremental",
+        "templateLink": {
+          "uri": "[variables('templatelink')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "StorageAccountName": {
+            "value": "[parameters('storageAccountName')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "exampleOutput": {
+      "value": "[reference('nestedTemplate')]",
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Temporary fix for clients referencing the compute quickstart templates under arm-compute (not under specifications). The files are copied from 
  `specifications\compute\quickstart-templates` to `arm-compute\quickstart-templates`. 