### PR TITLE
Add resources for SourceControl and SourceControlSyncJob

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
@@ -14,6 +14,24 @@
   "produces": [
     "application/json"
   ],
+  "security": [
+    {
+      "azure_auth": [
+          "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+          "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
   "paths": {},
   "definitions": {
     "softwareUpdateConfigurationProperties": {
@@ -551,6 +569,369 @@
           "$ref": "#/definitions/updateConfigurationMachineRunProperties"
         }
       }
+    },
+    "SourceControlCreateOrUpdateProperties": {
+      "properties": {
+        "repoUrl": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Gets or sets the repo url of the source control."
+        },
+        "branch": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Gets or sets the repo branch of the source control. Include branch as empty string for VsoTfvc."
+        },
+        "folderPath": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Gets or sets the folder path of the source control. Path must be relative."
+        },
+        "autoAsync": {
+          "type": "boolean",
+          "description": "Gets or sets auto async of the source control. Default is false."
+        },
+        "publishRunbook": {
+          "type": "boolean",
+          "description": "Gets or sets the auto publish of the source control. Default is true."
+        },
+        "sourceType": {
+          "type": "string",
+          "description": "The source type. Must be one of VsoGit, VsoTfvc, GitHub, case sensitive.",
+          "enum": [
+            "VsoGit",
+            "VsoTfvc",
+            "GitHub"
+          ],
+          "x-ms-enum": {
+            "name": "sourceType",
+            "modelAsString": true
+          }
+        },
+        "securityToken": {
+          "type": "string",
+          "maxLength": 1024,
+          "description": "Gets or sets the authorization token for the repo of the source control."
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Gets or sets the user description of the source control."
+        }
+      },
+      "description": "The properties of the create source control operation."
+    },
+    "SourceControlCreateOrUpdateParameters": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the source control."
+        },
+        "properties": {
+          "$ref": "#/definitions/SourceControlCreateOrUpdateProperties",
+          "x-ms-client-flatten": true,
+          "description": "Gets or sets the properties of the source control."
+        }
+      },
+      "required": [
+        "name",
+        "properties"
+      ],
+      "description": "The parameters supplied to the create or update source control operation."
+    },
+    "SourceControlProperties": {
+      "properties": {
+        "repoUrl": {
+          "type": "string",
+          "description": "Gets or sets the repo url of the source control."
+        },
+        "branch": {
+          "type": "string",
+          "description": "Gets or sets the repo branch of the source control. Include branch as empty string for VsoTfvc."
+        },
+        "folderPath": {
+          "type": "string",
+          "description": "Gets or sets the folder path of the source control."
+        },
+        "autoAsync": {
+          "type": "boolean",
+          "description": "Gets or sets auto async of the source control. Default is false."
+        },
+        "publishRunbook": {
+          "type": "boolean",
+          "description": "Gets or sets the auto publish of the source control. Default is true."
+        },
+        "sourceType": {
+          "type": "string",
+          "description": "The source type. Must be one of VsoGit, VsoTfvc, GitHub.",
+          "enum": [
+            "VsoGit",
+            "VsoTfvc",
+            "GitHub"
+          ],
+          "x-ms-enum": {
+            "name": "sourceType",
+            "modelAsString": true
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "Gets or sets the description."
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the creation time."
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets or sets the last modified time."
+        }
+      },
+      "description": "Definition of the source control properties"
+    },
+    "SourceControl": {
+      "x-ms-azure-resource": true,
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type."
+        },
+        "properties": {
+          "$ref": "#/definitions/SourceControlProperties",
+          "x-ms-client-flatten": true,
+          "description": "Gets or sets the properties of the source control."
+        }
+      },
+      "description": "Definition of the source control."
+    },
+    "SourceControlListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SourceControl"
+          },
+          "description": "Gets or sets a list of souce controls."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the next link."
+        }
+      },
+      "description": "The response model for the list source controls operation."
+    },
+    "SourceControlUpdateProperties": {
+      "properties": {
+        "branch": {
+          "type": "string",
+          "description": "Gets or sets the repo branch of the source control."
+        },
+        "folderPath": {
+          "type": "string",
+          "description": "Gets or sets the folder path of the source control. Path must be relative."
+        },
+        "autoAsync": {
+          "type": "boolean",
+          "description": "Gets or sets auto async of the source control. Default is false."
+        },
+        "autoPublish": {
+          "type": "boolean",
+          "description": "Gets or sets the auto publish of the source control. Default is true."
+        },
+        "securityToken": {
+          "type": "string",
+          "description": "Gets or sets the authorization token for the repo of the source control."
+        },
+        "description": {
+          "type": "string",
+          "description": "Gets or sets the user description of the source control."
+        }
+      },
+      "description": "The properties of the update source control"
+    },
+    "SourceControlUpdateParameters": {
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SourceControlUpdateProperties",
+          "x-ms-client-flatten": true,
+          "description": "Gets or sets the value of the source control."
+        }
+      },
+      "description": "The parameters supplied to the update source control operation."
+    },
+    "SourceControlSyncJob": {
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource id."
+        },
+        "properties": {
+          "$ref": "#/definitions/SourceControlSyncJobProperties",
+          "x-ms-client-flatten": true,
+          "description": "Gets the properties of the source control sync job."
+        }
+      },
+      "description": "Definition of the source control sync job."
+    },
+    "SourceControlSyncJobProperties": {
+      "properties": {
+        "sourceControlSyncJobId": {
+          "type": "string",
+          "description": "Gets the source control sync job id."
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true,
+          "description": "Gets the creation time of the job."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the job.",
+          "enum": [
+            "Succeeded",
+            "Failed",
+            "Running"
+          ],
+          "x-ms-enum": {
+            "name": "provisioningState",
+            "modelAsString": true
+          }
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true,
+          "description": "Gets the start time of the job."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true,
+          "description": "Gets the end time of the job."
+        },
+        "startedBy": {
+          "type": "string",
+          "description": "Gets the user who started the sync job."
+        }
+      },
+      "description": "Definition of source control sync job properties."
+    },
+    "SourceControlSyncJobListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SourceControlSyncJob"
+          },
+          "description": "Gets a list of source control sync jobs."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Gets or sets the next link."
+        }
+      },
+      "description": "The response model for the list source control sync jobs operation."
+    },
+    "SourceControlSyncJobById": {
+      "properties": {
+          "id": {
+            "type": "string",
+            "description": "Gets the id of the job."
+          },
+          "properties": {
+            "$ref": "#/definitions/SourceControlSyncJobByIdProperties",
+            "x-ms-client-flatten": true,
+            "description": "Gets the properties of the source control sync job."
+          }
+      },
+      "description": "Definition of the source control sync job."
+    },
+    "SourceControlSyncJobByIdProperties": {
+      "properties": {
+        "sourceControlSyncJobId": {
+          "type": "string",
+          "description": "Gets the source control sync job id."
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true,
+          "description": "Gets the creation time of the job."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the job.",
+          "enum": [
+            "Succeeded",
+            "Failed",
+            "Running"
+          ],
+          "x-ms-enum": {
+            "name": "provisioningState",
+            "modelAsString": true
+          }
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true,
+          "description": "Gets the start time of the job."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true,
+          "description": "Gets the end time of the job."
+        },
+        "startedBy": {
+          "type": "string",
+          "description": "Gets the user who started the sync job."
+        },
+        "errors": {
+          "description": "Error details of the source control sync job.",
+          "$ref": "#/definitions/SourceControlSyncJobByIdErrors"
+        }
+      },
+      "description": "Definition of source control sync job properties."
+    },
+    "SourceControlSyncJobByIdErrors": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Gets the error code for the job."
+        },
+        "message": {
+          "type": "string",
+          "description": "Gets the error message for the job."
+        }
+      },
+      "description": "Error details of the source control sync job."
     }
   },
   "parameters": {

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
@@ -587,7 +587,7 @@
           "maxLength": 255,
           "description": "Gets or sets the folder path of the source control. Path must be relative."
         },
-        "autoAsync": {
+        "autoSync": {
           "type": "boolean",
           "description": "Gets or sets auto async of the source control. Default is false."
         },
@@ -623,10 +623,6 @@
     },
     "SourceControlCreateOrUpdateParameters": {
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Gets or sets the name of the source control."
-        },
         "properties": {
           "$ref": "#/definitions/SourceControlCreateOrUpdateProperties",
           "x-ms-client-flatten": true,
@@ -634,7 +630,6 @@
         }
       },
       "required": [
-        "name",
         "properties"
       ],
       "description": "The parameters supplied to the create or update source control operation."
@@ -653,7 +648,7 @@
           "type": "string",
           "description": "Gets or sets the folder path of the source control."
         },
-        "autoAsync": {
+        "autoSync": {
           "type": "boolean",
           "description": "Gets or sets auto async of the source control. Default is false."
         },
@@ -743,11 +738,11 @@
           "type": "string",
           "description": "Gets or sets the folder path of the source control. Path must be relative."
         },
-        "autoAsync": {
+        "autoSync": {
           "type": "boolean",
           "description": "Gets or sets auto async of the source control. Default is false."
         },
-        "autoPublish": {
+        "publishRunbook": {
           "type": "boolean",
           "description": "Gets or sets the auto publish of the source control. Default is true."
         },

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/createOrUpdateSourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/createOrUpdateSourceControl.json
@@ -6,13 +6,12 @@
     "sourceControlName": "sampleSourceControl",
     "api-version": "2015-10-31",
     "parameters": {
-      "name": "sampleSourceControl",
       "properties": {
         "repoUrl": "https://sampleUser.visualstudio.com/myProject/_git/myRepository",
         "branch": "master",
         "folderPath": "/folderOne/folderTwo",
         "autoSync": true,
-        "autoPublish": true,
+        "publishRunbook": true,
         "sourceType": "VsoGit",
         "securityToken": "3a326f7a0dcd343ea58fee21f2fd5fb4c1234567",
         "description": "my description"
@@ -32,7 +31,7 @@
           "branch": "master",
           "folderPath": "/folderOne/folderTwo",
           "autoSync": true,
-          "autoPublish": true,
+          "publishRunbook": true,
           "sourceType": "VsoGit",
           "description": "my description"
         }
@@ -50,7 +49,7 @@
           "branch": "master",
           "folderPath": "/folderOne/folderTwo",
           "autoSync": true,
-          "autoPublish": true,
+          "publishRunbook": true,
           "sourceType": "VsoGit",
           "description": "my description"
         }

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/createOrUpdateSourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/createOrUpdateSourceControl.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg",
+    "automationAccountName": "sampleAccount9",
+    "sourceControlName": "sampleSourceControl",
+    "api-version": "2015-10-31",
+    "parameters": {
+      "name": "sampleSourceControl",
+      "properties": {
+        "repoUrl": "https://sampleUser.visualstudio.com/myProject/_git/myRepository",
+        "branch": "master",
+        "folderPath": "/folderOne/folderTwo",
+        "autoSync": true,
+        "autoPublish": true,
+        "sourceType": "VsoGit",
+        "securityToken": "3a326f7a0dcd343ea58fee21f2fd5fb4c1234567",
+        "description": "my description"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/sampleAccount9/sourcecontrols/sampleSourceControl",
+        "name": "sampleSourceControl",
+        "properties": {
+          "creationTime": "2017-03-28T22:59:00.937+00:00",
+          "lastModifiedTime": "2017-03-28T22:59:00.937+00:00",
+          "repoUrl": "https://sampleUser.visualstudio.com/myProject/_git/myRepository",
+          "branch": "master",
+          "folderPath": "/folderOne/folderTwo",
+          "autoSync": true,
+          "autoPublish": true,
+          "sourceType": "VsoGit",
+          "description": "my description"
+        }
+      }
+    },
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/sampleAccount9/sourcecontrols/sampleSourceControl",
+        "name": "sampleSourceControl",
+        "properties": {
+          "creationTime": "2017-03-28T22:59:00.937+00:00",
+          "lastModifiedTime": "2017-03-28T22:59:00.937+00:00",
+          "repoUrl": "https://sampleUser.visualstudio.com/myProject/_git/myRepository",
+          "branch": "master",
+          "folderPath": "/folderOne/folderTwo",
+          "autoSync": true,
+          "autoPublish": true,
+          "sourceType": "VsoGit",
+          "description": "my description"
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/deleteSourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/deleteSourceControl.json
@@ -1,0 +1,12 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg",
+    "automationAccountName": "sampleAccount9",
+    "sourceControlName": "sampleSourceControl",
+    "api-version": "2015-10-31"
+  },
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getAllSourceControls.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getAllSourceControls.json
@@ -1,0 +1,91 @@
+{
+	"parameters": {
+		"subscriptionId": "subid",
+		"resourceGroupName": "rg",
+		"automationAccountName": "sampleAccount9",
+		"api-version": "2015-10-31"
+  },
+  "responses": {
+      "200": {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/sampleAccount9/sourcecontrols/sampleSourceControl1",
+            "name": "sampleSourceControl1",
+            "properties": {
+              "creationTime": "2017-03-28T22:59:00.937+00:00",
+              "lastModifiedTime": "2017-03-28T22:59:00.937+00:00",
+              "repoUrl": "https://github.com/SampleUserRepro/PowerShell-1",
+              "branch": "master",
+              "path": "/sampleFolder/sampleFolder2",
+              "autoSync": true,
+              "autoPublish": true,
+              "sourceType": "GitHub",
+              "description": "my description"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/sampleAccount9/sourcecontrols/sampleSourceControl2",
+            "name": "sampleSourceControl2",
+            "properties": {
+              "creationTime": "2017-03-28T22:59:00.937+00:00",
+              "lastModifiedTime": "2017-03-28T22:59:00.937+00:00",
+              "repoUrl": "https://github.com/SampleUserRepro/PowerShell-2",
+              "branch": "master",
+              "path": "/sampleFolder/sampleFolder2",
+              "autoSync": true,
+              "autoPublish": true,
+              "sourceType": "GitHub",
+              "description": "my description"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/sampleAccount9/sourcecontrols/sampleSourceControl3",
+            "name": "sampleSourceControl3",
+            "properties": {
+              "creationTime": "2017-03-28T22:59:00.937+00:00",
+              "lastModifiedTime": "2017-03-28T22:59:00.937+00:00",
+              "repoUrl": "https://github.com/SampleUserRepro/PowerShell-3",
+              "branch": "master",
+              "path": "/sampleFolder/sampleFolder2",
+              "autoSync": true,
+              "autoPublish": true,
+              "sourceType": "GitHub",
+              "description": "my description"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/sampleAccount9/sourcecontrols/sampleSourceControl4",
+            "name": "sampleSourceControl4",
+            "properties": {
+              "creationTime": "2017-03-28T22:59:00.937+00:00",
+              "lastModifiedTime": "2017-03-28T22:59:00.937+00:00",
+              "repoUrl": "https://github.com/SampleUserRepro/PowerShell-4",
+              "branch": "master",
+              "path": "/sampleFolder/sampleFolder2",
+              "autoSync": true,
+              "autoPublish": true,
+              "sourceType": "GitHub",
+              "description": "my description"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/sampleAccount9/sourcecontrols/sampleSourceControl5",
+            "name": "sampleSourceControl5",
+            "properties": {
+              "creationTime": "2017-03-28T22:59:00.937+00:00",
+              "lastModifiedTime": "2017-03-28T22:59:00.937+00:00",
+              "repoUrl": "https://github.com/SampleUserRepro/PowerShell-5",
+              "branch": "master",
+              "path": "/sampleFolder/sampleFolder2",
+              "autoSync": true,
+              "autoPublish": true,
+              "sourceType": "GitHub",
+              "description": "my description"
+            }
+          }
+        ]
+    }
+  }
+}
+
+

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getAllSourceControls.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getAllSourceControls.json
@@ -18,7 +18,7 @@
               "branch": "master",
               "path": "/sampleFolder/sampleFolder2",
               "autoSync": true,
-              "autoPublish": true,
+              "publishRunbook": true,
               "sourceType": "GitHub",
               "description": "my description"
             }
@@ -33,7 +33,7 @@
               "branch": "master",
               "path": "/sampleFolder/sampleFolder2",
               "autoSync": true,
-              "autoPublish": true,
+              "publishRunbook": true,
               "sourceType": "GitHub",
               "description": "my description"
             }
@@ -48,7 +48,7 @@
               "branch": "master",
               "path": "/sampleFolder/sampleFolder2",
               "autoSync": true,
-              "autoPublish": true,
+              "publishRunbook": true,
               "sourceType": "GitHub",
               "description": "my description"
             }
@@ -63,7 +63,7 @@
               "branch": "master",
               "path": "/sampleFolder/sampleFolder2",
               "autoSync": true,
-              "autoPublish": true,
+              "publishRunbook": true,
               "sourceType": "GitHub",
               "description": "my description"
             }
@@ -78,7 +78,7 @@
               "branch": "master",
               "path": "/sampleFolder/sampleFolder2",
               "autoSync": true,
-              "autoPublish": true,
+              "publishRunbook": true,
               "sourceType": "GitHub",
               "description": "my description"
             }

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getSourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getSourceControl.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg",
+    "automationAccountName": "sampleAccount9",
+    "sourceControlName": "sampleSourceControl",
+    "api-version": "2015-10-31"
+  },
+  "responses": {
+    "200": {
+      "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/sampleAccount9/sourcecontrols/sampleSourceControl",
+      "name": "sampleSourceControl",
+      "properties": {
+        "creationTime": "2017-03-28T22:59:00.937+00:00",
+        "lastModifiedTime": "2017-03-28T22:59:00.937+00:00",
+        "repoUrl": "https://github.com/SampleUserRepro/PowerShell",
+        "branch": "master",
+        "path": "/folderOne/folderTwo",
+        "autoSync": true,
+        "autoPublish": true,
+        "sourceType": "GitHub",
+        "description": "my description"
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getSourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getSourceControl.json
@@ -17,7 +17,7 @@
         "branch": "master",
         "path": "/folderOne/folderTwo",
         "autoSync": true,
-        "autoPublish": true,
+        "publishRunbook": true,
         "sourceType": "GitHub",
         "description": "my description"
       }

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/updateSourceControl_patch.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/updateSourceControl_patch.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg",
+    "automationAccountName": "sampleAccount9",
+    "sourceControlName": "sampleSourceControl",
+    "api-version": "2015-10-31",
+    "parameters": {
+      "name": "sampleSourceControl",
+      "properties": {
+        "branch": "master",
+        "folderPath": "/folderOne/folderTwo",
+        "autoSync": true,
+        "autoPublish": true,
+        "securityToken": "3a326f7a0dcd343ea58fee21f2fd5fb4c1234567",
+        "description": "my description"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/sampleAccount9/sourcecontrols/sampleSourceControl",
+        "name": "sampleSourceControl",
+        "properties": {
+          "creationTime": "2017-03-28T22:59:00.937+00:00",
+          "lastModifiedTime": "2017-03-28T22:59:00.937+00:00",
+          "repoUrl": "https://sampleUser.visualstudio.com/myProject/_git/myRepository",
+          "branch": "master",
+          "folderPath": "/folderOne/folderTwo",
+          "autoSync": true,
+          "autoPublish": true,
+          "sourceType": "VsoGit",
+          "description": "my description"
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/updateSourceControl_patch.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/updateSourceControl_patch.json
@@ -6,12 +6,11 @@
     "sourceControlName": "sampleSourceControl",
     "api-version": "2015-10-31",
     "parameters": {
-      "name": "sampleSourceControl",
       "properties": {
         "branch": "master",
         "folderPath": "/folderOne/folderTwo",
         "autoSync": true,
-        "autoPublish": true,
+        "publishRunbook": true,
         "securityToken": "3a326f7a0dcd343ea58fee21f2fd5fb4c1234567",
         "description": "my description"
       }
@@ -30,7 +29,7 @@
           "branch": "master",
           "folderPath": "/folderOne/folderTwo",
           "autoSync": true,
-          "autoPublish": true,
+          "publishRunbook": true,
           "sourceType": "VsoGit",
           "description": "my description"
         }

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/createSourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/createSourceControlSyncJob.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg",
+    "automationAccountName": "myAutomationAccount33",
+    "sourceControlName": "MySourceControl",
+    "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
+    "api-version": "2015-10-31"
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
+        "properties": {
+          "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
+          "creationTime": "2017-03-28T23:14:26.903+00:00",
+          "provisioningState": "Running",
+          "startTime": null,
+          "endTime": null,
+          "startedBy": "User1"
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
@@ -16,7 +16,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a1a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Processing",
+              "provisioningState": "Running",
               "startTime": null,
               "endTime": null,
               "startedBy": "User1"
@@ -27,7 +27,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a2a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Processing",
+              "provisioningState": "Running",
               "startTime": null,
               "endTime": null,
               "startedBy": "User1"
@@ -38,7 +38,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a3a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Processing",
+              "provisioningState": "Running",
               "startTime": null,
               "endTime": null,
               "startedBy": "User1"
@@ -49,7 +49,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a4a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Processing",
+              "provisioningState": "Running",
               "startTime": null,
               "endTime": null,
               "startedBy": "User1"
@@ -60,7 +60,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a5a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Processing",
+              "provisioningState": "Running",
               "startTime": null,
               "endTime": null,
               "startedBy": "User1"

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg",
+    "automationAccountName": "myAutomationAccount33",
+    "sourceControlName": "MySourceControl",
+    "api-version": "2015-10-31"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value" :[
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a1a",
+            "properties": {
+              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a1a",
+              "creationTime": "2017-03-28T23:14:26.903+00:00",
+              "provisioningState": "Processing",
+              "startTime": null,
+              "endTime": null,
+              "startedBy": "User1"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a2a",
+            "properties": {
+              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a2a",
+              "creationTime": "2017-03-28T23:14:26.903+00:00",
+              "provisioningState": "Processing",
+              "startTime": null,
+              "endTime": null,
+              "startedBy": "User1"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a3a",
+            "properties": {
+              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a3a",
+              "creationTime": "2017-03-28T23:14:26.903+00:00",
+              "provisioningState": "Processing",
+              "startTime": null,
+              "endTime": null,
+              "startedBy": "User1"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a4a",
+            "properties": {
+              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a4a",
+              "creationTime": "2017-03-28T23:14:26.903+00:00",
+              "provisioningState": "Processing",
+              "startTime": null,
+              "endTime": null,
+              "startedBy": "User1"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a5a",
+            "properties": {
+              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a5a",
+              "creationTime": "2017-03-28T23:14:26.903+00:00",
+              "provisioningState": "Processing",
+              "startTime": null,
+              "endTime": null,
+              "startedBy": "User1"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getSourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getSourceControlSyncJob.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg",
+    "automationAccountName": "myAutomationAccount33",
+    "sourceControlName": "MySourceControl",
+    "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
+    "api-version": "2015-10-31"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
+        "properties": {
+          "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
+          "creationTime": "2017-03-28T23:14:26.903+00:00",
+          "provisioningState": "Processing",
+          "startTime": null,
+          "endTime": null,
+          "startedBy": "User1",
+          "errors": {
+            "code": null,
+            "message": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getSourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getSourceControlSyncJob.json
@@ -15,7 +15,7 @@
         "properties": {
           "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
           "creationTime": "2017-03-28T23:14:26.903+00:00",
-          "provisioningState": "Processing",
+          "provisioningState": "Running",
           "startTime": null,
           "endTime": null,
           "startedBy": "User1",

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControl.json
@@ -1,0 +1,335 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "AutomationManagement",
+    "version": "2015-10-31"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/sourceControls/{sourceControlName}": {
+      "put": {
+        "tags": [
+          "SourceControl"
+        ],
+        "operationId": "SourceControl_CreateOrUpdate",
+        "description": "Create a source control.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/sourcecontroloperations"
+        },
+        "x-ms-examples": {
+          "Create or update a source control": {
+            "$ref": "./examples/sourceControl/createOrUpdateSourceControl.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "automationAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The automation account name."
+          },
+          {
+            "name": "sourceControlName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The source control name."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControlCreateOrUpdateParameters"
+            },
+            "description": "The parameters supplied to the create or update source control operation."
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControl"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControl"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../stable/2015-10-31/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "SourceControl"
+        ],
+        "operationId": "SourceControl_Update",
+        "description": "Update a source control.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/sourcecontroloperations"
+        },
+        "x-ms-examples": {
+          "Update a source control": {
+            "$ref": "./examples/sourceControl/updateSourceControl_patch.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "automationAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The automation account name."
+          },
+          {
+            "name": "sourceControlName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The source control name."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControlUpdateParameters"
+            },
+            "description": "The parameters supplied to the update source control operation."
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControl"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../stable/2015-10-31/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "SourceControl"
+        ],
+        "operationId": "SourceControl_Delete",
+        "description": "Delete the source control.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/sourcecontroloperations"
+        },
+        "x-ms-examples": {
+          "Delete a source control": {
+            "$ref": "./examples/sourceControl/deleteSourceControl.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "automationAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The automation account name."
+          },
+          {
+            "name": "sourceControlName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of source control."
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../stable/2015-10-31/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "SourceControl"
+        ],
+        "operationId": "SourceControl_Get",
+        "description": "Retrieve the source control identified by source control name.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/sourcecontroloperations"
+        },
+        "x-ms-examples": {
+          "Get a source control": {
+            "$ref": "./examples/sourceControl/getSourceControl.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "automationAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The automation account name."
+          },
+          {
+            "name": "sourceControlName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of source control."
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControl"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../stable/2015-10-31/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/sourceControls": {
+      "get": {
+        "tags": [
+          "SourceControl"
+        ],
+        "operationId": "SourceControl_ListByAutomationAccount",
+        "description": "Retrieve a list of source controls.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/sourcecontroloperations"
+        },
+        "x-ms-examples": {
+          "List sourceControls": {
+            "$ref": "./examples/sourceControl/getAllSourceControls.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "automationAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The automation account name."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation."
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControlListResult"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../stable/2015-10-31/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControlSyncJob.json
@@ -1,0 +1,229 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "AutomationManagement",
+    "version": "2015-10-31"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/sourceControls/{sourceControlName}/sourceControlSyncJobs/{sourceControlSyncJobId}": {
+      "put": {
+        "tags": [
+          "SourceControlSyncJob"
+        ],
+        "operationId": "SourceControlSyncJob_Create",
+        "description": "Creates the sync job for a source control.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/sourcecontrolsyncjoboperations"
+        },
+        "x-ms-examples": {
+          "Create or update a source control sync job": {
+            "$ref": "./examples/sourceControlSyncJob/createSourceControlSyncJob.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "automationAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The automation account name."
+          },
+          {
+            "name": "sourceControlName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The source control name."
+          },
+          {
+            "name": "sourceControlSyncJobId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "uuid",
+            "description": "The source control sync job id."
+          },
+          { 
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControlSyncJob"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../stable/2015-10-31/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "SourceControlSyncJob"
+        ],
+        "operationId": "SourceControlSyncJob_Get",
+        "description": "Retrieve the source control sync job identified by job id.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/sourcecontrolsyncjoboperations"
+        },
+        "x-ms-examples": {
+          "Get a source control sync job by job id": {
+            "$ref": "./examples/sourceControlSyncJob/getSourceControlSyncJob.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "automationAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The automation account name."
+          },
+          {
+            "name": "sourceControlName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The source control name."
+          },
+          {
+            "name": "sourceControlSyncJobId",
+            "in": "path",
+            "required": true,
+            "format": "uuid",
+            "type": "string",
+            "description": "The source control sync job id."
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControlSyncJobById"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../stable/2015-10-31/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/sourceControls/{sourceControlName}/sourceControlSyncJobs": {
+      "get": {
+        "tags": [
+          "SourceControlSyncJob"
+        ],
+        "operationId": "SourceControlSyncJob_ListByAutomationAccount",
+        "description": "Retrieve a list of source control sync jobs.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/sourcecontrolsyncjoboperations"
+        },
+        "x-ms-examples": {
+          "Get a list of source control sync jobs": {
+            "$ref": "./examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "automationAccountName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The automation account name."
+          },
+           {
+            "name": "sourceControlName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The source control name."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation."
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../stable/2015-10-31/definitions.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControlSyncJobListResult"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../stable/2015-10-31/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/readme.md
+++ b/specification/automation/resource-manager/readme.md
@@ -86,6 +86,8 @@ input-file:
 - Microsoft.Automation/preview/2017-05-15-preview/softwareUpdateConfiguration.json
 - Microsoft.Automation/preview/2017-05-15-preview/softwareUpdateConfigurationRun.json
 - Microsoft.Automation/preview/2017-05-15-preview/softwareUpdateConfigurationMachineRun.json
+- Microsoft.Automation/preview/2017-05-15-preview/sourceControl.json
+- Microsoft.Automation/preview/2017-05-15-preview/sourceControlSyncJob.json
 ```
 
 ---


### PR DESCRIPTION
Replacement for PR #2158 

SourceControl is a resource to link a user's source control with their Azure Automation (AA) account.

SourceControlSyncJob allows the user to sync their runbooks from their external source control with their AA account.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
