### PR TITLE
fixing path to spec in readme.md

### DIFF
--- a/specification/monitor/resource-manager/readme.md
+++ b/specification/monitor/resource-manager/readme.md
@@ -42,8 +42,8 @@ input-file:
 - microsoft.insights/stable/2016-03-01/alertRulesIncidents_API.json
 - microsoft.insights/stable/2016-03-01/alertRules_API.json
 - microsoft.insights/stable/2016-03-01/logProfiles_API.json
-- microsoft.insights/stable/2017-05-01-preview/diagnosticsSettings_API.json
-- microsoft.insights/stable/2017-05-01-preview/diagnosticsSettingsCategories_API.json
+- microsoft.insights/preview/2017-05-01-preview/diagnosticsSettings_API.json
+- microsoft.insights/preview/2017-05-01-preview/diagnosticsSettingsCategories_API.json
 - microsoft.insights/stable/2017-04-01/actionGroups_API.json
 - microsoft.insights/stable/2017-04-01/activityLogAlerts_API.json
 - microsoft.insights/stable/2015-04-01/activityLogs_API.json
@@ -66,8 +66,8 @@ input-file:
 - microsoft.insights/stable/2016-03-01/alertRulesIncidents_API.json
 - microsoft.insights/stable/2016-03-01/alertRules_API.json
 - microsoft.insights/stable/2016-03-01/logProfiles_API.json
-- microsoft.insights/stable/2017-05-01-preview/diagnosticsSettings_API.json
-- microsoft.insights/stable/2017-05-01-preview/diagnosticsSettingsCategories_API.json
+- microsoft.insights/preview/2017-05-01-preview/diagnosticsSettings_API.json
+- microsoft.insights/preview/2017-05-01-preview/diagnosticsSettingsCategories_API.json
 - microsoft.insights/stable/2017-04-01/actionGroups_API.json
 - microsoft.insights/stable/2017-04-01/activityLogAlerts_API.json
 ```


### PR DESCRIPTION
@marstr it appears that these paths are incorrect in the readme.md, so just fixing them to point to preview folders.