### PR TITLE
Check for no traffic

### DIFF
--- a/scripts/liveValidation.js
+++ b/scripts/liveValidation.js
@@ -99,7 +99,9 @@ async function runScript() {
     }
 
     console.log(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-    if (failingOperations.length > 0 || noTrafficOperations.length > 0) {
+    if (validationResult.totalOperationCount === 0) {
+        console.log(`There was no traffic detected for the provided RP and API version:${resourceProvider}-${apiVersion}. Please make sure there is traffic so the changes can be validated.`);
+    } else if (failingOperations.length > 0 || noTrafficOperations.length > 0) {
         console.log(`The changes in the specs introduced by this PR potentially do not reflect the Service API.`);
 
         console.log(`Active traffic and success rate > ${successThreshold}% FOR EACH OPERATION is required. Please review the following operations before moving forward.`);
@@ -116,7 +118,7 @@ async function runScript() {
         `);
         process.exitCode = 1;
     } else {
-        console.log(`SUCCESS RATE: ${validationResult.SuccessRate} > ${successThreshold}. You can move forward:`);
+        console.log(`SUCCESS RATE: ${validationResult.successRate} > ${successThreshold}. You can move forward.`);
     }
 }
 


### PR DESCRIPTION
- As right now  no traffic operations are not returned explicitly ( tracked by https://github.com/vladbarosan/openapi-platform/issues/6) we need to check the case where there
was no traffic otherwise it would go on the success path )
- Fix typo in object property for `successRate`