### PR TITLE
convert usage properties in network to double (#1624)

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/applicationGateway.json
@@ -1,0 +1,2022 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}": {
+      "delete": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_Delete",
+        "description": "Deletes the specified application gateway.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "Request successful. Resource with the specified name does not exist"
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_Get",
+        "description": "Gets the specified application gateway.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns an ApplicationGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_CreateOrUpdate",
+        "description": "Creates or updates the specified application gateway.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application gateway."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            },
+            "description": "Parameters supplied to the create or update application gateway operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting ApplicationGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting ApplicationGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_UpdateTags",
+        "description": "Updates the specified application gateway tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application gateway."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update application gateway tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting ApplicationGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Application Gateway tags": { "$ref": "./examples/ApplicationGatewayUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways": {
+      "get": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_List",
+        "description": "Lists all application gateways in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a list of ApplicationGateway resources.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGateways": {
+      "get": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_ListAll",
+        "description": "Gets all the application gateways in a subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a list of ApplicationGateway resources.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/start": {
+      "post": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_Start",
+        "description": "Starts the specified application gateway.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation starts the ApplicationGateway resource."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/stop": {
+      "post": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_Stop",
+        "description": "Stops the specified application gateway in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation stops the ApplicationGateway resource."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/backendhealth": {
+      "post": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_BackendHealth",
+        "description": "Gets the backend health of the specified application gateway in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands BackendAddressPool and BackendHttpSettings referenced in backend health."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayBackendHealth"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+     "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableWafRuleSets": {
+      "get": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_ListAvailableWafRuleSets",
+        "description": "Lists all available web application firewall rule sets.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a list of all available web application firewall rule sets.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayAvailableWafRuleSetsResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default": {
+      "get": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_ListAvailableSslOptions",
+        "x-ms-examples": {
+          "ApplicationGatewayAvailableSslOptionsGet": { "$ref": "./examples/ApplicationGatewayAvailableSslOptionsGet.json" }
+        },
+        "description": "Lists available Ssl options for configuring Ssl policy.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns all available Ssl options for configuring Ssl policy.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayAvailableSslOptions"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies": {
+      "get": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_ListAvailableSslPredefinedPolicies",
+        "x-ms-examples": {
+          "ApplicationGatewayAvailableSslOptionsPredefinedPoliciesGet": { "$ref": "./examples/ApplicationGatewayAvailableSslOptionsPredefinedPoliciesGet.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "description": "Lists all SSL predefined policies for configuring Ssl policy.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a lists of all Ssl predefined policies for configuring Ssl policy.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayAvailableSslPredefinedPolicies"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies/{predefinedPolicyName}": {
+      "get": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_GetSslPredefinedPolicy",
+        "x-ms-examples": {
+          "ApplicationGatewayAvailableSslOptionsPredefinedPolicyGet": { "$ref": "./examples/ApplicationGatewayAvailableSslOptionsPredefinedPolicyGet.json" }
+        },
+        "description": "Gets Ssl predefined policy with the specified policy name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "predefinedPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Name of Ssl predefined policy."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a Ssl predefined policy with the specified policy name.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewaySslPredefinedPolicy"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ApplicationGatewayBackendHealth": {
+      "properties": {
+        "backendAddressPools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendHealthPool"
+          }
+        }
+      },
+      "description": "List of ApplicationGatewayBackendHealthPool resources."
+    },
+    "ApplicationGatewayBackendHealthPool": {
+      "properties": {
+        "backendAddressPool": {
+          "$ref": "#/definitions/ApplicationGatewayBackendAddressPool",
+          "description": "Reference of an ApplicationGatewayBackendAddressPool resource."
+        },
+        "backendHttpSettingsCollection": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendHealthHttpSettings"
+          },
+        "description": "List of ApplicationGatewayBackendHealthHttpSettings resources."
+        }
+      },
+      "description": "Application gateway BackendHealth pool."
+    },
+    "ApplicationGatewayBackendHealthHttpSettings": {
+      "properties": {
+        "backendHttpSettings": {
+          "$ref": "#/definitions/ApplicationGatewayBackendHttpSettings",
+          "description": "Reference of an ApplicationGatewayBackendHttpSettings resource."
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendHealthServer"
+        },
+        "description": "List of ApplicationGatewayBackendHealthServer resources."
+        }
+      },
+      "description": "Application gateway BackendHealthHttp settings."
+    },
+    "ApplicationGatewayBackendHealthServer": {
+      "properties": {
+        "address": {
+        "type": "string",
+        "description": "IP address or FQDN of backend server."
+        },
+        "ipConfiguration": {
+          "$ref": "./networkInterface.json#/definitions/NetworkInterfaceIPConfiguration",
+          "description": "Reference of IP configuration of backend server."
+        },
+        "health": {
+          "type": "string",
+          "description": "Health of backend server.",
+          "enum": [
+            "Unknown",
+            "Up",
+            "Down",
+            "Partial",
+            "Draining"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayBackendHealthServerHealth",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "Application gateway backendhealth http settings."
+    },
+    "ApplicationGatewaySku": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of an application gateway SKU.",
+          "enum": [
+            "Standard_Small",
+            "Standard_Medium",
+            "Standard_Large",
+            "WAF_Medium",
+            "WAF_Large"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewaySkuName",
+            "modelAsString": true
+          }
+        },
+        "tier": {
+          "type": "string",
+          "description": "Tier of an application gateway.",
+          "enum": [
+            "Standard",
+            "WAF"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayTier",
+            "modelAsString": true
+          }
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Capacity (instance count) of an application gateway."
+        }
+      },
+      "description": "SKU of an application gateway"
+    },
+    "ApplicationGatewaySslPolicy": {
+      "properties": {
+        "disabledSslProtocols": {
+          "type": "array",
+          "description": "Ssl protocols to be disabled on application gateway.",
+          "items":{
+            "type": "string",
+            "$ref": "#/definitions/ProtocolsEnum",
+            "x-ms-enum": {
+              "name": "ApplicationGatewaySslProtocol",
+              "modelAsString": true
+            }
+          }
+        },
+        "policyType": {
+          "type": "string",
+          "description": "Type of Ssl Policy",
+          "enum": [
+            "Predefined",
+            "Custom"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewaySslPolicyType",
+            "modelAsString": true
+          }
+        },
+        "policyName":{
+          "$ref": "#/definitions/PolicyNameEnum",
+          "description": "Name of Ssl predefined policy"
+        },
+        "cipherSuites":{
+          "type": "array",
+          "items":{
+            "$ref": "#/definitions/CipherSuitesEnum"
+          },
+          "description":"Ssl cipher suites to be enabled in the specified order to application gateway."
+        },
+        "minProtocolVersion":{
+          "$ref": "#/definitions/ProtocolsEnum",
+          "description": "Minimum version of Ssl protocol to be supported on application gateway."
+        }
+      },
+      "description": "Application Gateway Ssl policy."
+    },
+    "ApplicationGatewayIPConfigurationPropertiesFormat": {
+      "properties": {
+        "subnet": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Reference of the subnet resource. A subnet from where application gateway gets its private address."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the application gateway subnet resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of IP configuration of an application gateway."
+    },
+    "ApplicationGatewayIPConfiguration": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayIPConfigurationPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed."
+    },
+    "ApplicationGatewayAuthenticationCertificatePropertiesFormat": {
+      "properties": {
+        "data": {
+          "type": "string",
+          "description": "Certificate public data."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the authentication certificate resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Authentication certificates properties of an application gateway."
+    },
+    "ApplicationGatewayAuthenticationCertificate": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayAuthenticationCertificatePropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Authentication certificates of an application gateway."
+    },
+    "ApplicationGatewaySslCertificatePropertiesFormat": {
+      "properties": {
+        "data": {
+          "type": "string",
+          "description": "Base-64 encoded pfx certificate. Only applicable in PUT Request."
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for the pfx file specified in data. Only applicable in PUT request."
+        },
+        "publicCertData": {
+          "type": "string",
+          "description": "Base-64 encoded Public cert data corresponding to pfx specified in data. Only applicable in GET request."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the SSL certificate resource Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of SSL certificates of an application gateway."
+    },
+    "ApplicationGatewaySslCertificate": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewaySslCertificatePropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "SSL certificates of an application gateway."
+    },
+    "ApplicationGatewayFrontendIPConfigurationPropertiesFormat": {
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "PrivateIPAddress of the network interface IP Configuration."
+        },
+        "privateIPAllocationMethod": {
+          "type": "string",
+          "description": "PrivateIP allocation method.",
+          "enum": [
+            "Static",
+            "Dynamic"
+          ],
+          "x-ms-enum": {
+            "name": "IPAllocationMethod",
+            "modelAsString": true
+          }
+        },
+        "subnet": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Reference of the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Reference of the PublicIP resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of Frontend IP configuration of an application gateway."
+    },
+    "ApplicationGatewayFrontendIPConfiguration": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayFrontendIPConfigurationPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Frontend IP configuration of an application gateway."
+    },
+    "ApplicationGatewayFrontendPortPropertiesFormat": {
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Frontend port"
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the frontend port resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of Frontend port of an application gateway."
+    },
+    "ApplicationGatewayFrontendPort": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayFrontendPortPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Frontend port of an application gateway."
+    },
+    "ApplicationGatewayBackendAddress": {
+      "properties": {
+        "fqdn": {
+          "type": "string",
+          "description": "Fully qualified domain name (FQDN)."
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "IP address"
+        }
+      },
+      "description": "Backend address of an application gateway."
+    },
+    "ApplicationGatewayBackendAddressPoolPropertiesFormat": {
+      "properties": {
+        "backendIPConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "./networkInterface.json#/definitions/NetworkInterfaceIPConfiguration"
+          },
+          "description": "Collection of references to IPs defined in network interfaces."
+        },
+        "backendAddresses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendAddress"
+          },
+          "description": "Backend addresses"
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the backend address pool resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of Backend Address Pool of an application gateway."
+    },
+    "ApplicationGatewayBackendAddressPool": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayBackendAddressPoolPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Backend Address Pool of an application gateway."
+    },
+    "ApplicationGatewayBackendHttpSettingsPropertiesFormat": {
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port"
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Protocol.",
+          "enum": [
+            "Http",
+            "Https"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayProtocol",
+            "modelAsString": true
+          }
+        },
+        "cookieBasedAffinity": {
+          "type": "string",
+          "description": "Cookie based affinity.",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayCookieBasedAffinity",
+            "modelAsString": true
+          }
+        },
+        "requestTimeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Request timeout in seconds. Application Gateway will fail the request if response is not received within RequestTimeout. Acceptable values are from 1 second to 86400 seconds."
+        },
+        "probe": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Probe resource of an application gateway."
+        },
+        "authenticationCertificates": {
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Array of references to application gateway authentication certificates."
+        },
+        "connectionDraining": {
+            "$ref": "#/definitions/ApplicationGatewayConnectionDraining",
+            "description": "Connection draining of the backend http settings resource."
+        },
+        "hostName": {
+          "type": "string",
+          "description": "Host header to be sent to the backend servers."
+        },
+        "pickHostNameFromBackendAddress": {
+          "type": "boolean",
+          "description": "Whether to pick host header should be picked from the host name of the backend server. Default value is false."
+        },
+        "affinityCookieName": {
+          "type": "string",
+          "description": "Cookie name to use for the affinity cookie."
+        },
+        "probeEnabled": {
+          "type": "boolean",
+          "description": "Whether the probe is enabled. Default value is false."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path which should be used as a prefix for all HTTP requests. Null means no path will be prefixed. Default value is null."
+        },
+        "provisioningState": {
+            "type": "string",
+            "description": "Provisioning state of the backend http settings resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of Backend address pool settings of an application gateway."
+    },
+    "ApplicationGatewayBackendHttpSettings": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayBackendHttpSettingsPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Backend address pool settings of an application gateway."
+    },
+    "ApplicationGatewayHttpListenerPropertiesFormat": {
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Frontend IP configuration resource of an application gateway."
+        },
+        "frontendPort": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Frontend port resource of an application gateway."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Protocol.",
+          "enum": [
+            "Http",
+            "Https"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayProtocol",
+            "modelAsString": true
+          }
+        },
+        "hostName": {
+          "type": "string",
+          "description": "Host name of HTTP listener."
+        },
+        "sslCertificate": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "SSL certificate resource of an application gateway."
+        },
+        "requireServerNameIndication": {
+          "type": "boolean",
+          "description": "Applicable only if protocol is https. Enables SNI for multi-hosting."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the HTTP listener resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of HTTP listener of an application gateway."
+    },
+    "ApplicationGatewayHttpListener": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayHttpListenerPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Http listener of an application gateway."
+    },
+    "ApplicationGatewayPathRulePropertiesFormat": {
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Path rules of URL path map."
+        },
+        "backendAddressPool": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Backend address pool resource of URL path map path rule."
+        },
+        "backendHttpSettings": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Backend http settings resource of URL path map path rule."
+        },
+        "redirectConfiguration": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Redirect configuration resource of URL path map path rule."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Path rule of URL path map resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of path rule of an application gateway."
+    },
+    "ApplicationGatewayPathRule": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayPathRulePropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Path rule of URL path map of an application gateway."
+    },
+    "ApplicationGatewayProbePropertiesFormat": {
+      "properties": {
+        "protocol": {
+          "type": "string",
+          "description": "Protocol.",
+          "enum": [
+            "Http",
+            "Https"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayProtocol",
+            "modelAsString": true
+          }
+        },
+        "host": {
+          "type": "string",
+          "description": "Host name to send the probe to."
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path of probe. Valid path starts from '/'. Probe is sent to <Protocol>://<host>:<port><path>"
+        },
+        "interval": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The probing interval in seconds. This is the time interval between two consecutive probes. Acceptable values are from 1 second to 86400 seconds."
+        },
+        "timeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "the probe timeout in seconds. Probe marked as failed if valid response is not received with this timeout period. Acceptable values are from 1 second to 86400 seconds."
+        },
+        "unhealthyThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The probe retry count. Backend server is marked down after consecutive probe failure count reaches UnhealthyThreshold. Acceptable values are from 1 second to 20."
+        },
+        "pickHostNameFromBackendHttpSettings":{
+          "type":"boolean",
+          "description": "Whether the host header should be picked from the backend http settings. Default value is false."
+        },
+        "minServers":{
+          "type":"integer",
+          "format": "int32",
+          "description": "Minimum number of servers that are always marked healthy. Default value is 0."
+        },
+        "match":{
+          "$ref": "#/definitions/ApplicationGatewayProbeHealthResponseMatch",
+          "description": "Criterion for classifying a healthy probe response."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the backend http settings resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of probe of an application gateway."
+    },
+    "ApplicationGatewayProbeHealthResponseMatch": {
+      "properties": {
+        "body":{
+          "type": "string",
+          "description": "Body that must be contained in the health response. Default value is empty."
+        },
+        "statusCodes":{
+          "type": "array",
+          "items":{
+            "type": "string"
+          },
+          "description":"Allowed ranges of healthy status codes. Default range of healthy status codes is 200-399."
+        }
+      },
+      "description": "Application gateway probe health response match"
+    },
+    "ApplicationGatewayProbe": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayProbePropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Probe of the application gateway."
+    },
+    "ApplicationGatewayRequestRoutingRulePropertiesFormat": {
+      "properties": {
+        "ruleType": {
+          "type": "string",
+          "description": "Rule type.",
+          "enum": [
+            "Basic",
+            "PathBasedRouting"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayRequestRoutingRuleType",
+            "modelAsString": true
+          }
+        },
+        "backendAddressPool": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Backend address pool resource of the application gateway. "
+        },
+        "backendHttpSettings": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Frontend port resource of the application gateway."
+        },
+        "httpListener": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Http listener resource of the application gateway. "
+        },
+        "urlPathMap": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "URL path map resource of the application gateway."
+        },
+        "redirectConfiguration": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Redirect configuration resource of the application gateway."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the request routing rule resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of request routing rule of the application gateway."
+    },
+    "ApplicationGatewayRequestRoutingRule": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayRequestRoutingRulePropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Request routing rule of an application gateway."
+    },
+    "ApplicationGatewayRedirectConfigurationPropertiesFormat": {
+      "properties": {
+        "redirectType": {
+          "type": "string",
+          "$ref":"#/definitions/RedirectTypeEnum",
+          "description": "Supported http redirection types - Permanent, Temporary, Found, SeeOther.",
+          "x-ms-enum": {
+            "name": "ApplicationGatewayRedirectType",
+            "modelAsString": true
+          }
+        },
+        "targetListener": {
+          "$ref":"./network.json#/definitions/SubResource",
+          "description": "Reference to a listener to redirect the request to."
+        },
+        "targetUrl": {
+          "type": "string",
+          "description": "Url to redirect the request to."
+        },
+        "includePath": {
+          "type": "boolean",
+          "description": "Include path in the redirected url."
+        },
+        "includeQueryString": {
+          "type": "boolean",
+          "description": "Include query string in the redirected url."
+        },
+        "requestRoutingRules": {
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Request routing specifying redirect configuration."
+        },
+        "urlPathMaps": {
+          "type": "array",
+          "items": {
+            "$ref":"./network.json#/definitions/SubResource"
+          },
+          "description": "Url path maps specifying default redirect configuration."
+        },
+        "pathRules": {
+          "type": "array",
+          "items": {
+            "$ref":"./network.json#/definitions/SubResource"
+          },
+          "description": "Path rules specifying redirect configuration."
+        }
+      },
+      "description": "Properties of redirect configuration of the application gateway."
+    },
+    "ApplicationGatewayRedirectConfiguration": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayRedirectConfigurationPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Redirect configuration of an application gateway."
+    },
+    "ApplicationGatewayPropertiesFormat": {
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/ApplicationGatewaySku",
+          "description": "SKU of the application gateway resource."
+        },
+        "sslPolicy": {
+          "$ref": "#/definitions/ApplicationGatewaySslPolicy",
+          "description": "SSL policy of the application gateway resource."
+        },
+        "operationalState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Operational state of the application gateway resource.",
+          "enum": [
+            "Stopped",
+            "Starting",
+            "Running",
+            "Stopping"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayOperationalState",
+            "modelAsString": true
+          }
+        },
+        "gatewayIPConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayIPConfiguration"
+          },
+          "description": "Subnets of application the gateway resource."
+        },
+        "authenticationCertificates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayAuthenticationCertificate"
+          },
+          "description": "Authentication certificates of the application gateway resource."
+        },
+        "sslCertificates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewaySslCertificate"
+          },
+          "description": "SSL certificates of the application gateway resource."
+        },
+        "frontendIPConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFrontendIPConfiguration"
+          },
+          "description": "Frontend IP addresses of the application gateway resource."
+        },
+        "frontendPorts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFrontendPort"
+          },
+          "description": "Frontend ports of the application gateway resource."
+        },
+        "probes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayProbe"
+          },
+          "description": "Probes of the application gateway resource."
+        },
+        "backendAddressPools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendAddressPool"
+          },
+          "description": "Backend address pool of the application gateway resource."
+        },
+        "backendHttpSettingsCollection": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendHttpSettings"
+          },
+          "description": "Backend http settings of the application gateway resource."
+        },
+        "httpListeners": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayHttpListener"
+          },
+          "description": "Http listeners of the application gateway resource."
+        },
+        "urlPathMaps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayUrlPathMap"
+          },
+          "description": "URL path map of the application gateway resource."
+        },
+        "requestRoutingRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayRequestRoutingRule"
+          },
+          "description": "Request routing rules of the application gateway resource."
+        },
+        "redirectConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayRedirectConfiguration"
+          },
+          "description": "Redirect configurations of the application gateway resource."
+        },
+        "webApplicationFirewallConfiguration": {
+          "$ref": "#/definitions/ApplicationGatewayWebApplicationFirewallConfiguration",
+          "description": "Web application firewall configuration."
+        },
+        "enableHttp2": {
+          "type": "boolean",
+          "description": "Whether HTTP2 is enabled on the application gateway resource."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Resource GUID property of the application gateway resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the application gateway resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of the application gateway."
+    },
+    "ApplicationGateway": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayPropertiesFormat"
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "Application gateway resource"
+    },
+    "ApplicationGatewayListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGateway"
+          },
+          "description": "List of an application gateways in a resource group."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListApplicationGateways API service call."
+    },
+    "ApplicationGatewayUrlPathMapPropertiesFormat": {
+      "properties": {
+        "defaultBackendAddressPool": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Default backend address pool resource of URL path map."
+        },
+        "defaultBackendHttpSettings": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Default backend http settings resource of URL path map."
+        },
+        "defaultRedirectConfiguration": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Default redirect configuration resource of URL path map."
+        },
+        "pathRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayPathRule"
+          },
+          "description": "Path rule of URL path map resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the backend http settings resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of UrlPathMap of the application gateway."
+    },
+    "ApplicationGatewayUrlPathMap": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayUrlPathMapPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "UrlPathMaps give a url path to the backend mapping information for PathBasedRouting."
+    },
+    "ApplicationGatewayWebApplicationFirewallConfiguration": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the web application firewall is enabled or not."
+        },
+        "firewallMode": {
+          "type": "string",
+          "description": "Web application firewall mode.",
+          "enum": [
+            "Detection",
+            "Prevention"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayFirewallMode",
+            "modelAsString": true
+          }
+        },
+        "ruleSetType": {
+          "type": "string",
+          "description": "The type of the web application firewall rule set. Possible values are: 'OWASP'."
+        },
+        "ruleSetVersion": {
+          "type": "string",
+          "description": "The version of the rule set type."
+        },
+        "disabledRuleGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallDisabledRuleGroup"
+          },
+          "description": "The disabled rule groups."
+        }
+      },
+      "required": [
+        "enabled",
+        "firewallMode",
+        "ruleSetType",
+        "ruleSetVersion"
+      ],
+      "description": "Application gateway web application firewall configuration."
+    },
+    "ApplicationGatewayConnectionDraining": {
+        "properties": {
+            "enabled": {
+                "type": "boolean",
+                "description": "Whether connection draining is enabled or not."
+            },
+            "drainTimeoutInSec": {
+                "type": "integer",
+                "format": "int32",
+                "maximum": 3600,
+                "exclusiveMaximum": false,
+                "minimum": 1,
+                "exclusiveMinimum": false,
+                "description": "The number of seconds connection draining is active. Acceptable values are from 1 second to 3600 seconds."
+            }
+        },
+        "required": [
+            "enabled",
+            "drainTimeoutInSec"
+        ],
+        "description": "Connection draining allows open connections to a backend server to be active for a specified time after the backend server got removed from the configuration."
+    },
+    "ApplicationGatewayFirewallDisabledRuleGroup": {
+      "properties": {
+        "ruleGroupName": {
+          "type": "string",
+          "description": "The name of the rule group that will be disabled."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32",
+            "x-nullable": false
+          },
+          "description": "The list of rules that will be disabled. If null, all rules of the rule group will be disabled."
+        }
+      },
+      "required": [
+        "ruleGroupName"
+      ],
+      "description": "Allows to disable rules within a rule group or an entire rule group."
+    },
+    "ApplicationGatewayAvailableWafRuleSetsResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallRuleSet"
+          },
+          "description": "The list of application gateway rule sets."
+        }
+      },
+      "description": "Response for ApplicationGatewayAvailableWafRuleSets API service call."
+    },
+    "ApplicationGatewayFirewallRuleSet": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayFirewallRuleSetPropertiesFormat"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "A web application firewall rule set."
+    },
+    "ApplicationGatewayFirewallRuleSetPropertiesFormat": {
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the web application firewall rule set."
+        },
+        "ruleSetType": {
+          "type": "string",
+          "description": "The type of the web application firewall rule set."
+        },
+        "ruleSetVersion": {
+          "type": "string",
+          "description": "The version of the web application firewall rule set type."
+        },
+        "ruleGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallRuleGroup"
+          },
+          "description": "The rule groups of the web application firewall rule set."
+        }
+      },
+      "required": [
+        "ruleSetType",
+        "ruleSetVersion",
+        "ruleGroups"
+      ],
+      "description": "Properties of the web application firewall rule set."
+    },
+    "ApplicationGatewayFirewallRuleGroup": {
+      "properties": {
+        "ruleGroupName": {
+          "type": "string",
+          "description": "The name of the web application firewall rule group."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the web application firewall rule group."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallRule"
+          },
+          "description": "The rules of the web application firewall rule group."
+        }
+      },
+      "required": [
+        "ruleGroupName",
+        "rules"
+      ],
+      "description": "A web application firewall rule group."
+    },
+    "ApplicationGatewayFirewallRule": {
+      "properties": {
+        "ruleId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The identifier of the web application firewall rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the web application firewall rule."
+        }
+      },
+      "required": [
+        "ruleId"
+      ],
+      "description": "A web application firewall rule."
+    },
+    "ApplicationGatewayAvailableSslOptions": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewayAvailableSslOptionsPropertiesFormat"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "Response for ApplicationGatewayAvailableSslOptions API service call."
+    },
+    "ApplicationGatewayAvailableSslOptionsPropertiesFormat": {
+        "properties": {
+          "predefinedPolicies":{
+            "type": "array",
+            "items": {
+              "$ref": "./network.json#/definitions/SubResource"
+            },
+            "description": "List of available Ssl predefined policy."
+          },
+          "defaultPolicy":{
+            "$ref": "#/definitions/PolicyNameEnum",
+            "description": "Name of the Ssl predefined policy applied by default to application gateway"
+          },
+          "availableCipherSuites":{
+            "type":"array",
+            "items":{
+              "$ref": "#/definitions/CipherSuitesEnum"
+            },
+            "description": "List of available Ssl cipher suites."
+          },
+          "availableProtocols":{
+            "type":"array",
+            "items":{
+            "$ref": "#/definitions/ProtocolsEnum"
+          },
+          "description": "List of available Ssl protocols."
+        }
+      },
+      "description": "Properties of ApplicationGatewayAvailableSslOptions"
+    },
+    "ApplicationGatewayAvailableSslPredefinedPolicies": {
+      "properties": {
+        "value":{
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewaySslPredefinedPolicy"
+          },
+          "description": "List of available Ssl predefined policy."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      },
+      "description": "Response for ApplicationGatewayAvailableSslOptions API service call."
+    },
+    "ApplicationGatewaySslPredefinedPolicy": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of Ssl predefined policy."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationGatewaySslPredefinedPolicyPropertiesFormat"
+        }
+      },
+      "allOf":[
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "An Ssl predefined policy"
+    },
+    "ApplicationGatewaySslPredefinedPolicyPropertiesFormat":{
+      "properties":{
+        "cipherSuites":{
+          "type":"array",
+          "items":{
+            "$ref": "#/definitions/CipherSuitesEnum"
+          },
+          "description": "Ssl cipher suites to be enabled in the specified order for application gateway."
+        },
+        "minProtocolVersion":{
+          "$ref": "#/definitions/ProtocolsEnum",
+          "description": "Minimum version of Ssl protocol to be supported on application gateway."
+        }
+      },
+      "description": "Properties of ApplicationGatewaySslPredefinedPolicy"
+    },
+    "PolicyNameEnum":{
+      "type": "string",
+      "description": "Ssl predefined policy name enums.",
+      "enum":[
+        "AppGwSslPolicy20150501",
+        "AppGwSslPolicy20170401",
+        "AppGwSslPolicy20170401S"
+      ],
+      "x-ms-enum":{
+        "name": "ApplicationGatewaySslPolicyName",
+        "modelAsString": true
+      }
+    },
+    "ProtocolsEnum":{
+      "type": "string",
+      "description": "Ssl protocol enums.",
+      "enum":[
+        "TLSv1_0",
+        "TLSv1_1",
+        "TLSv1_2"
+      ],
+      "x-ms-enum":{
+        "name": "ApplicationGatewaySslProtocol",
+        "modelAsString": true
+      }
+    },
+    "CipherSuitesEnum":{
+      "type": "string",
+      "description": "Ssl cipher suites enums.",
+      "enum":[
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_CBC_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+        "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+        "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+        "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewaySslCipherSuite",
+        "modelAsString": true
+      }
+    },
+    "RedirectTypeEnum":{
+      "type": "string",
+      "enum":[
+        "Permanent",
+        "Found",
+        "SeeOther",
+        "Temporary"
+      ],
+      "x-ms-enum":{
+        "name": "ApplicationGatewayRedirectType",
+        "modelAsString": true
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/applicationSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/applicationSecurityGroup.json
@@ -1,0 +1,319 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}": {
+      "delete": {
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "operationId": "ApplicationSecurityGroups_Delete",
+        "description": "Deletes the specified application security group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application security group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Request successful. Resource does not exist."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Delete application security group": { "$ref": "./examples/ApplicationSecurityGroupDelete.json" }
+        }
+      },
+      "get": {
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "operationId": "ApplicationSecurityGroups_Get",
+        "description": "Gets information about the specified application security group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application security group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the specified application security group resource.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroup"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get application security group": { "$ref": "./examples/ApplicationSecurityGroupGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "operationId": "ApplicationSecurityGroups_CreateOrUpdate",
+        "description": "Creates or updates an application security group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application security group."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroup"
+            },
+            "description": "Parameters supplied to the create or update ApplicationSecurityGroup operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting application security group resource.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroup"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting application security group resource.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroup"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Create application security group": { "$ref": "./examples/ApplicationSecurityGroupCreate.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationSecurityGroups": {
+      "get": {
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "operationId": "ApplicationSecurityGroups_ListAll",
+        "description": "Gets all application security groups in a subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of application security group resources.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroupListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List all application security groups": { "$ref": "./examples/ApplicationSecurityGroupListAll.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups": {
+      "get": {
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "operationId": "ApplicationSecurityGroups_List",
+        "description": "Gets all the application security groups in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of application security group resources.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroupListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List load balancers in resource group": { "$ref": "./examples/ApplicationSecurityGroupList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ApplicationSecurityGroup": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationSecurityGroupPropertiesFormat",
+          "description": "Properties of the application security group."
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "An application security group in a resource group."
+    },
+    "ApplicationSecurityGroupPropertiesFormat": {
+      "properties": {
+        "resourceGuid": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource GUID property of the application security group resource. It uniquely identifies a resource, even if the user changes its name or migrate the resource across subscriptions or resource groups."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The provisioning state of the application security group resource. Possible values are: 'Succeeded', 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Application security group properties."
+    },
+    "ApplicationSecurityGroupListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationSecurityGroup"
+          },
+          "description": "A list of application security groups."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "A list of application security groups."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/checkDnsAvailability.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/checkDnsAvailability.json
@@ -1,0 +1,106 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/CheckDnsNameAvailability": {
+      "get": {
+        "operationId": "CheckDnsNameAvailability",
+        "description": "Checks whether a domain name in the cloudapp.azure.com zone is available for use.",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The location of the domain name."
+          },
+          {
+            "name": "domainNameLabel",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The domain name to be verified. It must conform to the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. Returns whether the DNS name is available.",
+            "schema": {
+              "$ref": "#/definitions/DnsNameAvailabilityResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Check Dns Name Availability": { "$ref": "./examples/CheckDnsNameAvailability.json" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "DnsNameAvailabilityResult": {
+      "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "Domain availability (True/False)."
+        }
+      },
+      "description": "Response for the CheckDnsNameAvailability API service call."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/endpointService.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/endpointService.json
@@ -1,0 +1,127 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/virtualNetworkAvailableEndpointServices": {
+      "get": {
+        "operationId": "AvailableEndpointServices_List",
+        "description": "List what values of endpoint services are available for use.",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The location to check available endpoint services."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. Returns list of available endpoint services.",
+            "schema": {
+              "$ref": "#/definitions/EndpointServicesListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "EndpointServicesList": { "$ref": "./examples/EndpointServicesList.json" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "EndpointServicesListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EndpointServiceResult"
+          },
+          "description": "List of available endpoint services in a region."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the ListAvailableEndpointServices API service call."
+    },
+    "EndpointServiceResult": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the endpoint service.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the endpoint service.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Endpoint service."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationGatewayAvailableSslOptionsGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationGatewayAvailableSslOptionsGet.json
@@ -1,0 +1,9 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationGatewayAvailableSslOptionsPredefinedPoliciesGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationGatewayAvailableSslOptionsPredefinedPoliciesGet.json
@@ -1,0 +1,9 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationGatewayAvailableSslOptionsPredefinedPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationGatewayAvailableSslOptionsPredefinedPolicyGet.json
@@ -1,0 +1,10 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "predefinedPolicyName": "AppGwSslPolicy20150501"
+  },
+  "responses": {
+    "200": { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationGatewayUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationGatewayUpdateTags.json
@@ -1,0 +1,148 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "applicationGatewayName" : "AppGw",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "AppGw",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw",
+        "type": "Microsoft.Network/applicationGateways",
+        "location": "westus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000",
+          "sku": {
+            "name": "Standard_Small",
+            "tier": "Standard",
+            "capacity": 2
+          },
+          "operationalState": "Running",
+          "gatewayIPConfigurations": [
+            {
+              "name": "GatewayIp01",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/gatewayIPConfigurations/GatewayIp01",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet1"
+                }
+              }
+            }
+          ],
+          "sslCertificates": [],
+          "authenticationCertificates": [],
+          "frontendIPConfigurations": [
+            {
+              "name": "FrontEndConfig01",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/frontendIPConfigurations/FrontEndConfig01",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAllocationMethod": "Dynamic",
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/publicIp1"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "FrontEndPort01",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/frontendPorts/FrontEndPort01",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "port": 80
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "Pool01",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/backendAddressPools/Pool01",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.10.10.1"
+                  },
+                  {
+                    "ipAddress": "10.10.10.2"
+                  },
+                  {
+                    "ipAddress": "10.10.10.3"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "PoolSetting01",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/backendHttpSettingsCollection/PoolSetting01",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "port": 80,
+                "protocol": "Http",
+                "cookieBasedAffinity": "Disabled",
+                "pickHostNameFromBackendAddress": false,
+                "requestTimeout": 30
+              }
+            }
+          ],
+          "httpListeners": [
+            {
+              "name": "listener1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/httpListeners/listener1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/frontendIPConfigurations/FrontEndConfig01"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/frontendPorts/FrontEndPort01"
+                },
+                "protocol": "Http",
+                "requireServerNameIndication": false
+              }
+            }
+          ],
+          "urlPathMaps": [],
+          "requestRoutingRules": [
+            {
+              "name": "Rule01",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/requestRoutingRules/Rule01",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "ruleType": "Basic",
+                "httpListener": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/httpListeners/listener1"
+                },
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/backendAddressPools/Pool01"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/backendHttpSettingsCollection/PoolSetting01"
+                }
+              }
+            }
+          ],
+          "probes": [],
+          "redirectConfigurations": []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupCreate.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg1",
+    "applicationSecurityGroupName": "test-asg",
+    "parameters": {
+      "location": "westus",
+      "properties": { }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-asg",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationSecurityGroups/test-asg",
+        "type": "Microsoft.Network/applicationSecurityGroups",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-asg",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationSecurityGroups/test-asg",
+        "type": "Microsoft.Network/applicationSecurityGroups",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg1",
+    "applicationSecurityGroupName": "test-asg"
+  },
+  "responses": {
+    "200": { },
+    "202": { },
+    "204": { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupGet.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg1",
+    "applicationSecurityGroupName": "test-asg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-asg",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationSecurityGroups/test-asg",
+        "type": "Microsoft.Network/applicationSecurityGroups",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupList.json
@@ -1,0 +1,35 @@
+{
+    "parameters" : {
+      "api-version" : "2017-11-01",
+      "subscriptionId" : "subid",
+      "resourceGroupName": "rg1"
+    },
+    "responses" : {
+      "200" : {
+        "body" : {
+          "value": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationSecurityGroups/asg1",
+              "name": "asg1",
+              "type": "Microsoft.Network/applicationSecurityGroups",
+              "location": "westus",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+              }
+            },
+            {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationSecurityGroups/asg2",
+              "name": "asg2",
+              "type": "Microsoft.Network/applicationSecurityGroups",
+              "location": "westus",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ApplicationSecurityGroupListAll.json
@@ -1,0 +1,34 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationSecurityGroups/asg1",
+            "name": "asg1",
+            "type": "Microsoft.Network/applicationSecurityGroups",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationSecurityGroups/asg2",
+            "name": "asg2",
+            "type": "Microsoft.Network/applicationSecurityGroups",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/CheckDnsNameAvailability.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/CheckDnsNameAvailability.json
@@ -1,0 +1,15 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "location" : "westus",
+    "domainNameLabel" : "testdns"
+  },
+  "responses" : {
+    "200" : {
+      "body": {
+        "available": false
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/DefaultSecurityRuleGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/DefaultSecurityRuleGet.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "resourceGroupName": "testrg",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "networkSecurityGroupName": "nsg1",
+    "defaultSecurityRuleName": "AllowVnetInBound"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "AllowVnetInBound",
+        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetInBound",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "description": "Allow inbound traffic from all VMs in VNET",
+          "protocol": "*",
+          "sourcePortRange": "*",
+          "destinationPortRange": "*",
+          "sourceAddressPrefix": "VirtualNetwork",
+          "destinationAddressPrefix": "VirtualNetwork",
+          "access": "Allow",
+          "priority": 65000,
+          "direction": "Inbound",
+          "sourcePortRanges": [],
+          "destinationPortRanges": [],
+          "sourceAddressPrefixes": [],
+          "destinationAddressPrefixes": []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/DefaultSecurityRuleList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/DefaultSecurityRuleList.json
@@ -1,0 +1,136 @@
+{
+  "parameters": {
+    "resourceGroupName": "testrg",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "networkSecurityGroupName": "nsg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "AllowVnetInBound",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetInBound",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "description": "Allow inbound traffic from all VMs in VNET",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "VirtualNetwork",
+              "access": "Allow",
+              "priority": 65000,
+              "direction": "Inbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "AllowAzureLoadBalancerInBound",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "description": "Allow inbound traffic from azure load balancer",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "AzureLoadBalancer",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 65001,
+              "direction": "Inbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "DenyAllInBound",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/DenyAllInBound",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "description": "Deny all inbound traffic",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Deny",
+              "priority": 65500,
+              "direction": "Inbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "AllowVnetOutBound",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetOutBound",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "VirtualNetwork",
+              "access": "Allow",
+              "priority": 65000,
+              "direction": "Outbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "AllowInternetOutBound",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowInternetOutBound",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "description": "Allow outbound traffic from all VMs to Internet",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "Internet",
+              "access": "Allow",
+              "priority": 65001,
+              "direction": "Outbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "DenyAllOutBound",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/DenyAllOutBound",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "description": "Deny all outbound traffic",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Deny",
+              "priority": 65500,
+              "direction": "Outbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/EndpointServicesList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/EndpointServicesList.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "location": "westus",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Storage",
+            "id": "/subscriptions/subid/providers/Microsoft.Network/virtualNetworkEndpointServices/Microsoft.Storage",
+            "type": "Microsoft.Network/virtualNetworkEndpointServices"
+          },
+          {
+            "name": "Microsoft.Sql",
+            "id": "/subscriptions/subid/providers/Microsoft.Network/virtualNetworkEndpointServices/Microsoft.Sql",
+            "type": "Microsoft.Network/virtualNetworkEndpointServices"
+          },
+          {
+            "name": "Microsoft.AzureActiveDirectory",
+            "id": "/subscriptions/subid/providers/Microsoft.Network/virtualNetworkEndpointServices/Microsoft.AzureActiveDirectory",
+            "type": "Microsoft.Network/virtualNetworkEndpointServices"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ExpressRouteCircuitUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ExpressRouteCircuitUpdateTags.json
@@ -1,0 +1,48 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "ertest",
+    "circuitName" : "er1",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "er1",
+        "id": "/subscriptions/subid/resourceGroups/ertest/providers/Microsoft.Network/expressRouteCircuits/er1",
+        "type": "Microsoft.Network/expressRouteCircuits",
+        "location": "brazilsouth",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Failed",
+          "peerings": [],
+          "authorizations": [],
+          "serviceProviderProperties": {
+            "serviceProviderName": "Equinix",
+            "peeringLocation": "Silicon Valley",
+            "bandwidthInMbps": 1000
+          },
+          "circuitProvisioningState": "Enabled",
+          "allowClassicOperations": false,
+          "gatewayManagerEtag": "",
+          "serviceKey": "0b392c2e-1e9d-46d7-b5e0-9ce90ca6b60c",
+          "serviceProviderProvisioningState": "NotProvisioned"
+        },
+        "sku": {
+          "name": "Standard_MeteredData",
+          "tier": "Standard",
+          "family": "MeteredData"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/InboundNatRuleCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/InboundNatRuleCreate.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "resourceGroupName": "testrg",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "loadBalancerName": "lb1",
+    "inboundNatRuleName": "natRule1.1",
+    "inboundNatRuleParameters": {
+      "properties": {
+        "protocol": "Tcp",
+        "frontendIPConfiguration": { "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/ip1"},
+        "frontendPort": 3390,
+        "backendPort": 3389,
+        "idleTimeoutInMinutes": 4,
+        "enableFloatingIP": false
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "natRule1.1",
+        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natRule1.1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfiguration": {
+          "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/ip1"
+          },
+          "frontendPort": 3390,
+          "backendPort": 3389,
+          "enableFloatingIP": false,
+          "idleTimeoutInMinutes": 4,
+          "protocol": "Tcp",
+          "backendIPConfiguration": {
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "natRule1.1",
+        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natRule1.1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfiguration": {
+          "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/ip1"
+          },
+          "frontendPort": 3390,
+          "backendPort": 3389,
+          "enableFloatingIP": false,
+          "idleTimeoutInMinutes": 4,
+          "protocol": "Tcp",
+          "backendIPConfiguration": {
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/InboundNatRuleDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/InboundNatRuleDelete.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "resourceGroupName": "testrg",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "loadBalancerName": "lb1",
+    "inboundNatRuleName": "natRule1.1"
+  },
+  "responses": {
+    "200": { },
+    "202": { },
+    "204": { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/InboundNatRuleGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/InboundNatRuleGet.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "resourceGroupName": "testrg",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "loadBalancerName": "lb1",
+    "inboundNatRuleName": "natRule1.1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "natRule1.1",
+        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natRule1.1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfiguration": {
+          "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/ip1"
+          },
+          "frontendPort": 3390,
+          "backendPort": 3389,
+          "enableFloatingIP": false,
+          "idleTimeoutInMinutes": 4,
+          "protocol": "Tcp",
+          "backendIPConfiguration": {
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/InboundNatRuleList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/InboundNatRuleList.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "resourceGroupName": "testrg",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "loadBalancerName": "lb1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "natRule1.1",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natRule1.1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/ip1"
+              },
+              "frontendPort": 3390,
+              "backendPort": 3389,
+              "enableFloatingIP": false,
+              "idleTimeoutInMinutes": 4,
+             "protocol": "Tcp",
+              "backendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1"
+              }
+            }
+          },
+          {
+            "name": "natRule1.3",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natRule1.3",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/ip1"
+              },
+              "frontendPort": 3392,
+              "backendPort": 3389,
+              "enableFloatingIP": false,
+              "idleTimeoutInMinutes": 4,
+              "protocol": "Tcp",
+              "backendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/nic1/ipConfigurations/ip1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerBackendAddressPoolGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerBackendAddressPoolGet.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "loadBalancerName": "lb",
+    "backendAddressPoolName": "backend",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "backend",
+        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backend",
+        "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "backendIPConfigurations": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/nic/ipConfigurations/default-ip-config"
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerBackendAddressPoolList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerBackendAddressPoolList.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "loadBalancerName": "lb",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "backend",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backend",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "backendIPConfigurations": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/nic/ipConfigurations/default-ip-config"
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreate.json
@@ -1,0 +1,332 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "loadBalancerName" : "lb",
+    "parameters": {
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "fe-lb",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              },
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ],
+              "inboundNatRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                }
+              ]
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "be-lb",
+            "properties": {
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ]
+            }
+          }
+        ],
+        "loadBalancingRules": [
+          {
+            "name": "rulelb",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+              },
+              "frontendPort": 80,
+              "backendPort": 80,
+              "enableFloatingIP": true,
+              "idleTimeoutInMinutes": 15,
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "probe": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+              }
+            }
+          }
+        ],
+        "probes": [
+          {
+            "name": "probe-lb",
+            "properties": {
+              "protocol": "Http",
+              "port": 80,
+              "requestPath": "healthcheck.aspx",
+              "intervalInSeconds": 15,
+              "numberOfProbes": 2,
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ]
+            }
+          }
+        ],
+        "inboundNatRules": [
+          {
+            "name": "in-nat-rule",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+              },
+              "frontendPort": 3389,
+              "backendPort": 3389,
+              "enableFloatingIP": true,
+              "idleTimeoutInMinutes": 15,
+              "protocol": "Tcp"
+            }
+          }
+        ],
+        "inboundNatPools": [],
+        "outboundNatRules": []
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "sku": {
+            "name": "Basic"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "fe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                },
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "be-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "rulelb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp",
+                "loadDistribution": "Default",
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "probe": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+                },
+                "disableOutboundSnat": false
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "probe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "healthcheck.aspx",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2,
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "inboundNatRules": [
+            {
+              "name": "in-nat-rule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 3389,
+                "backendPort": 3389,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp"
+              }
+            }
+          ],
+          "outboundNatRules": [],
+          "inboundNatPools": []
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "sku": {
+            "name": "Basic"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "fe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                },
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "be-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "rulelb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp",
+                "loadDistribution": "Default",
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "probe": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+                },
+                "disableOutboundSnat": false
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "probe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "healthcheck.aspx",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2,
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "inboundNatRules": [
+            {
+              "name": "in-nat-rule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 3389,
+                "backendPort": 3389,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp"
+              }
+            }
+          ],
+          "outboundNatRules": [],
+          "inboundNatPools": []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateStandardSku.json
@@ -1,0 +1,335 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "loadBalancerName" : "lb",
+    "parameters": {
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "fe-lb",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              },
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ],
+              "inboundNatRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                }
+              ]
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "be-lb",
+            "properties": {
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ]
+            }
+          }
+        ],
+        "loadBalancingRules": [
+          {
+            "name": "rulelb",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+              },
+              "frontendPort": 80,
+              "backendPort": 80,
+              "enableFloatingIP": true,
+              "idleTimeoutInMinutes": 15,
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "probe": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+              }
+            }
+          }
+        ],
+        "probes": [
+          {
+            "name": "probe-lb",
+            "properties": {
+              "protocol": "Http",
+              "port": 80,
+              "requestPath": "healthcheck.aspx",
+              "intervalInSeconds": 15,
+              "numberOfProbes": 2,
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ]
+            }
+          }
+        ],
+        "inboundNatRules": [
+          {
+            "name": "in-nat-rule",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+              },
+              "frontendPort": 3389,
+              "backendPort": 3389,
+              "enableFloatingIP": true,
+              "idleTimeoutInMinutes": 15,
+              "protocol": "Tcp"
+            }
+          }
+        ],
+        "inboundNatPools": [],
+        "outboundNatRules": []
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "sku": {
+            "name": "Standard"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "fe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                },
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "be-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "rulelb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp",
+                "loadDistribution": "Default",
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "probe": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+                },
+                "disableOutboundSnat": false
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "probe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "healthcheck.aspx",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2,
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "inboundNatRules": [
+            {
+              "name": "in-nat-rule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 3389,
+                "backendPort": 3389,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp"
+              }
+            }
+          ],
+          "outboundNatRules": [],
+          "inboundNatPools": []
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "sku": {
+            "name": "Standard"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "fe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                },
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "be-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "rulelb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp",
+                "loadDistribution": "Default",
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "probe": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+                },
+                "disableOutboundSnat": false
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "probe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "healthcheck.aspx",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2,
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "inboundNatRules": [
+            {
+              "name": "in-nat-rule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 3389,
+                "backendPort": 3389,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp"
+              }
+            }
+          ],
+          "outboundNatRules": [],
+          "inboundNatPools": []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -1,0 +1,165 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "loadBalancerName" : "lb",
+    "parameters": {
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "properties": {
+                  "serviceEndpoints": [],
+                  "resourceNavigationLinks": []
+                },
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/lbvnet/subnets/lbsubnet"
+              }
+            },
+            "name": "test",
+            "zones": [],
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/test"
+          }
+        ],
+        "backendAddressPools": [],
+        "loadBalancingRules": [],
+        "probes": [],
+        "inboundNatRules": [],
+        "inboundNatPools": [
+          {
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/test"
+              },
+              "protocol": "Tcp",
+              "frontendPortRangeStart": 8080,
+              "frontendPortRangeEnd": 8085,
+              "backendPort": 8888,
+              "idleTimeoutInMinutes": 10,
+              "enableFloatingIP": true
+            },
+            "name": "test",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatPools/test"
+          }
+        ],
+        "outboundNatRules": []
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "sku": {
+            "name": "Basic"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "test",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/test",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/lbvnet/subnets/lbsubnet"
+                },
+                "inboundNatPools": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatPools/test"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [],
+          "loadBalancingRules": [],
+          "probes": [],
+          "inboundNatRules": [],
+          "outboundNatRules": [],
+          "inboundNatPools": [
+            {
+              "name": "test",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatPools/test",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendPortRangeStart": 8080,
+                "frontendPortRangeEnd": 8085,
+                "backendPort": 8888,
+                "idleTimeoutInMinutes": 10,
+                "enableFloatingIP": true,
+                "protocol": "Tcp",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/test"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "sku": {
+            "name": "Basic"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "test",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/test",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/lbvnet/subnets/lbsubnet"
+                },
+                "inboundNatPools": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatPools/test"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [],
+          "loadBalancingRules": [],
+          "probes": [],
+          "inboundNatRules": [],
+          "outboundNatRules": [],
+          "inboundNatPools": [
+            {
+              "name": "test",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatPools/test",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendPortRangeStart": 8080,
+                "frontendPortRangeEnd": 8085,
+                "backendPort": 8888,
+                "idleTimeoutInMinutes": 10,
+                "enableFloatingIP": true,
+                "protocol": "Tcp",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/test"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateWithZones.json
@@ -1,0 +1,335 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "loadBalancerName" : "lb",
+    "parameters": {
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "fe-lb",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              },
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ],
+              "inboundNatRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                }
+              ]
+            },
+            "zones": [ "1" ]
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "be-lb",
+            "properties": {
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ]
+            }
+          }
+        ],
+        "loadBalancingRules": [
+          {
+            "name": "rulelb",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+              },
+              "frontendPort": 80,
+              "backendPort": 80,
+              "enableFloatingIP": true,
+              "idleTimeoutInMinutes": 15,
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "probe": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+              }
+            }
+          }
+        ],
+        "probes": [
+          {
+            "name": "probe-lb",
+            "properties": {
+              "protocol": "Http",
+              "port": 80,
+              "requestPath": "healthcheck.aspx",
+              "intervalInSeconds": 15,
+              "numberOfProbes": 2,
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ]
+            }
+          }
+        ],
+        "inboundNatRules": [
+          {
+            "name": "in-nat-rule",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+              },
+              "frontendPort": 3389,
+              "backendPort": 3389,
+              "enableFloatingIP": true,
+              "idleTimeoutInMinutes": 15,
+              "protocol": "Tcp"
+            }
+          }
+        ],
+        "inboundNatPools": [],
+        "outboundNatRules": []
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "sku": {
+            "name": "Basic"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "fe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
+              "zones": [ "1" ],
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                },
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "be-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "rulelb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp",
+                "loadDistribution": "Default",
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "probe": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+                },
+                "disableOutboundSnat": false
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "probe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "healthcheck.aspx",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2,
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "inboundNatRules": [
+            {
+              "name": "in-nat-rule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 3389,
+                "backendPort": 3389,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp"
+              }
+            }
+          ],
+          "outboundNatRules": [],
+          "inboundNatPools": []
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "sku": {
+            "name": "Basic"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "fe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
+              "zones": [ "1" ],
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                },
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "be-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "rulelb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp",
+                "loadDistribution": "Default",
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "probe": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+                },
+                "disableOutboundSnat": false
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "probe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "healthcheck.aspx",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2,
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "inboundNatRules": [
+            {
+              "name": "in-nat-rule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 3389,
+                "backendPort": 3389,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp"
+              }
+            }
+          ],
+          "outboundNatRules": [],
+          "inboundNatPools": []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "loadBalancerName" : "lb"
+  },
+  "responses" : {
+    "200" : { },
+    "202" : { },
+    "204" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerFrontendIPConfigurationGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerFrontendIPConfigurationGet.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "loadBalancerName": "lb",
+    "frontendIPConfigurationName": "frontend",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "frontend",
+        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/frontend",
+        "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateIPAddress": "10.0.1.4",
+          "privateIPAllocationMethod": "Dynamic",
+          "subnet": {
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+          },
+          "loadBalancingRules": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+            }
+          ],
+          "inboundNatRules": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/inrlb"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerFrontendIPConfigurationList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerFrontendIPConfigurationList.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "resourceGroupName": "testrg",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "loadBalancerName": "lb"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "frontend",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/frontend",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "privateIPAddress": "10.0.1.4",
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              },
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ],
+              "inboundNatRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/inrlb"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerGet.json
@@ -1,0 +1,125 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "loadBalancerName" : "lb"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "sku": {
+            "name": "Basic"
+        },        
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "fe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                },
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "be-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "rulelb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp",
+                "loadDistribution": "Default",
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "probe": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+                },
+                "disableOutboundSnat": false
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "probe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "healthcheck.aspx",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2,
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "inboundNatRules": [
+            {
+              "name": "in-nat-rule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 3389,
+                "backendPort": 3389,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp"
+              }
+            }
+          ],
+          "outboundNatRules": [],
+          "inboundNatPools": []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerList.json
@@ -1,0 +1,140 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "lb",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+            "type": "Microsoft.Network/loadBalancers",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "frontendIPConfigurations": [
+                {
+                  "name": "felb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/felb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAddress": "10.0.1.4",
+                    "privateIPAllocationMethod": "Dynamic",
+                    "subnet": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                    },
+                    "loadBalancingRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                      }
+                    ],
+                    "inboundNatRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/inrlb"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "backendAddressPools": [
+                {
+                  "name": "belb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/belb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "loadBalancingRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "name": "rulelb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "frontendIPConfiguration":{
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/felb"
+                    },
+                    "frontendPort": 80,
+                    "backendPort": 80,
+                    "enableFloatingIP": true,
+                    "idleTimeoutInMinutes": 15,
+                    "protocol": "Tcp",
+                    "loadDistribution": "Default",
+                    "backendAddressPool": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/belb"
+                    },
+                    "probe": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/prlb"
+                    }
+                  }
+                }
+              ],
+              "probes": [
+                {
+                  "name": "prlb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/prlb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "protocol": "Http",
+                    "port": 80,
+                    "requestPath": "healthcheck.aspx",
+                    "intervalInSeconds": 15,
+                    "numberOfProbes": 2,
+                    "loadBalancingRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "inboundNatRules": [
+                {
+                  "name": "inrlb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/inrlb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "frontendIPConfiguration": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/felb"
+                    },
+                    "frontendPort": 3389,
+                    "backendPort": 3389,
+                    "enableFloatingIP": true,
+                    "idleTimeoutInMinutes": 15,
+                    "protocol": "Tcp"
+                  }
+                }
+              ],
+              "outboundNatRules": [],
+              "inboundNatPools": []
+            }
+          },
+          {
+            "name": "lb2",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb2",
+            "type": "Microsoft.Network/loadBalancers",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "frontendIPConfigurations": [],
+              "backendAddressPools": [],
+              "loadBalancingRules": [],
+              "probes": [],
+              "inboundNatRules": [],
+              "outboundNatRules": [],
+              "inboundNatPools": []
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerListAll.json
@@ -1,0 +1,139 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "lb",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+            "type": "Microsoft.Network/loadBalancers",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "frontendIPConfigurations": [
+                {
+                  "name": "felb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/felb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAddress": "10.0.1.4",
+                    "privateIPAllocationMethod": "Dynamic",
+                    "subnet": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                    },
+                    "loadBalancingRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                      }
+                    ],
+                    "inboundNatRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/inrlb"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "backendAddressPools": [
+                {
+                  "name": "belb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/belb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "loadBalancingRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "name": "rulelb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "frontendIPConfiguration":{
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/felb"
+                    },
+                    "frontendPort": 80,
+                    "backendPort": 80,
+                    "enableFloatingIP": true,
+                    "idleTimeoutInMinutes": 15,
+                    "protocol": "Tcp",
+                    "loadDistribution": "Default",
+                    "backendAddressPool": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/belb"
+                    },
+                    "probe": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/prlb"
+                    }
+                  }
+                }
+              ],
+              "probes": [
+                {
+                  "name": "prlb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/prlb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "protocol": "Http",
+                    "port": 80,
+                    "requestPath": "healthcheck.aspx",
+                    "intervalInSeconds": 15,
+                    "numberOfProbes": 2,
+                    "loadBalancingRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "inboundNatRules": [
+                {
+                  "name": "inrlb",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/inrlb",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "frontendIPConfiguration": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/felb"
+                    },
+                    "frontendPort": 3389,
+                    "backendPort": 3389,
+                    "enableFloatingIP": true,
+                    "idleTimeoutInMinutes": 15,
+                    "protocol": "Tcp"
+                  }
+                }
+              ],
+              "outboundNatRules": [],
+              "inboundNatPools": []
+            }
+          },
+          {
+            "name": "lb3",
+            "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/loadBalancers/lb3",
+            "type": "Microsoft.Network/loadBalancers",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "frontendIPConfigurations": [],
+              "backendAddressPools": [],
+              "loadBalancingRules": [],
+              "probes": [],
+              "inboundNatRules": [],
+              "outboundNatRules": [],
+              "inboundNatPools": []
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerLoadBalancingRuleGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerLoadBalancingRuleGet.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "loadBalancerName": "lb1",
+    "loadBalancingRuleName": "rule1",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule1",
+        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/loadBalancingRules/rule1",
+        "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfiguration": {
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/lbfrontend"
+          },
+          "frontendPort": 80,
+          "backendPort": 80,
+          "enableFloatingIP": false,
+          "idleTimeoutInMinutes": 15,
+          "protocol": "Tcp",
+          "loadDistribution": "Default",
+          "backendAddressPool": {
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/bepool1"
+          },
+          "probe": {
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/probes/probe1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerLoadBalancingRuleList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerLoadBalancingRuleList.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "loadBalancerName": "lb1",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule1",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/loadBalancingRules/rule1",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/lbfrontend"
+              },
+              "frontendPort": 80,
+              "backendPort": 80,
+              "enableFloatingIP": false,
+              "idleTimeoutInMinutes": 15,
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/bepool1"
+              },
+              "probe": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb1/probes/probe1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerNetworkInterfaceListSimple.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerNetworkInterfaceListSimple.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "loadBalancerName": "lb",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "mynic",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/mynic",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000",
+              "ipConfigurations": [
+                {
+                  "name": "ipconfig1",
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/mynic/ipConfigurations/ipconfig1",
+                  "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAddress": "10.0.1.4",
+                    "privateIPAllocationMethod": "Dynamic",
+                    "subnet": {
+                      "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork/subnets/frontendSubnet"
+                    },
+                    "privateIPAddressVersion": "IPv4",
+                    "loadBalancerBackendAddressPools": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/bepool1"
+                      }
+                    ],
+                    "loadBalancerInboundNatRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/inbound1"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "dnsSettings": {
+                "dnsServers": [],
+                "appliedDnsServers": []
+              },
+              "enableAcceleratedNetworking": false,
+              "enableIPForwarding": false
+            },
+            "type": "Microsoft.Network/networkInterfaces"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerNetworkInterfaceListVmss.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerNetworkInterfaceListVmss.json
@@ -1,0 +1,112 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "loadBalancerName": "lb",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "vmss1Nic",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1Nic",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000",
+              "ipConfigurations": [
+                {
+                  "name": "vmss1IpConfig",
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1Nic/ipConfigurations/vmss1IpConfig",
+                  "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAddress": "10.0.0.4",
+                    "privateIPAllocationMethod": "Dynamic",
+                    "subnet": {
+                      "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/vmss1Vnet/subnets/default"
+                    },
+                    "primary": true,
+                    "privateIPAddressVersion": "IPv4",
+                    "loadBalancerBackendAddressPools": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/bepool"
+                      }
+                    ],
+                    "loadBalancerInboundNatRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/natpool.0"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "dnsSettings": {
+                "dnsServers": [],
+                "appliedDnsServers": [],
+                "internalDomainNameSuffix": "aaaaaaaaaaaaaaaaaaaaaaaaaa.dx.internal.cloudapp.net"
+              },
+              "macAddress": "00-00-00-00-00-00",
+              "enableAcceleratedNetworking": false,
+              "enableIPForwarding": false,
+              "primary": true,
+              "virtualMachine": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0"
+              }
+            }
+          },
+          {
+            "name": "vmss1Nic",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1Nic",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000",
+              "ipConfigurations": [
+                {
+                  "name": "vmss1IpConfig",
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/vmss1Nic/ipConfigurations/vmss1IpConfig",
+                  "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAddress": "10.0.0.5",
+                    "privateIPAllocationMethod": "Dynamic",
+                    "subnet": {
+                      "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/vmss1Vnet/subnets/default"
+                    },
+                    "primary": true,
+                    "privateIPAddressVersion": "IPv4",
+                    "loadBalancerBackendAddressPools": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/bepool"
+                      }
+                    ],
+                    "loadBalancerInboundNatRules":[
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/natpool.1"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "dnsSettings": {
+                "dnsServers": [],
+                "appliedDnsServers": [],
+                "internalDomainNameSuffix": "aaaaaaaaaaaaaaaaaaaaaaaaaa.dx.internal.cloudapp.net"
+              },
+              "macAddress": "00-00-00-00-00-00",
+              "enableAcceleratedNetworking": false,
+              "enableIPForwarding": false,
+              "primary": true,
+              "virtualMachine": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerProbeGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerProbeGet.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "loadBalancerName": "lb",
+    "probeName": "probe1",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "probe1",
+        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/probes/probe1",
+        "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "protocol": "Http",
+          "port": 80,
+          "requestPath": "healthcheck.aspx",
+          "intervalInSeconds": 15,
+          "numberOfProbes": 2,
+          "loadBalancingRules": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerProbeList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerProbeList.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "loadBalancerName": "lb",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "prlb",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/probes/prlb",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "protocol": "Http",
+              "port": 80,
+              "requestPath": "healthcheck.aspx",
+              "intervalInSeconds": 15,
+              "numberOfProbes": 2,
+              "loadBalancingRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerUpdateTags.json
@@ -1,0 +1,132 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "loadBalancerName" : "lb",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "lb",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
+        "type": "Microsoft.Network/loadBalancers",
+        "location": "westus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "frontendIPConfigurations": [
+            {
+              "name": "fe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.1.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                },
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ],
+                "inboundNatRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "be-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "rulelb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 80,
+                "backendPort": 80,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp",
+                "loadDistribution": "Default",
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "probe": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
+                },
+                "disableOutboundSnat": false
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "probe-lb",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "healthcheck.aspx",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2,
+                "loadBalancingRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
+                  }
+                ]
+              }
+            }
+          ],
+          "inboundNatRules": [
+            {
+              "name": "in-nat-rule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                },
+                "frontendPort": 3389,
+                "backendPort": 3389,
+                "enableFloatingIP": true,
+                "idleTimeoutInMinutes": 15,
+                "protocol": "Tcp"
+              }
+            }
+          ],
+          "outboundNatRules": [],
+          "inboundNatPools": []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LocalNetworkGatewayUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LocalNetworkGatewayUpdateTags.json
@@ -1,0 +1,38 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "localNetworkGatewayName": "lgw",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "lgw",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/localNetworkGateways/lgw",
+        "type": "Microsoft.Network/localNetworkGateways",
+        "location": "westus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000",
+          "localNetworkAddressSpace": {
+            "addressPrefixes": [
+              "12.0.0.0/8"
+            ]
+          },
+          "gatewayIpAddress": "12.0.0.1"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceCreate.json
@@ -1,0 +1,98 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "networkInterfaceName": "test-nic",
+    "parameters": {
+      "properties": {
+        "enableAcceleratedNetworking": true,
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "publicIPAddress": {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip"
+              },
+              "subnet": {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "test-nic",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic",
+        "location" : "eastus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "ipConfigurations" : [{
+              "name" : "ipconfig1",
+              "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig1",
+              "properties" : {
+                "provisioningState" : "Succeeded",
+                "privateIPAddress" : "172.20.2.4",
+                "privateIPAllocationMethod" : "Dynamic",
+                "publicIPAddress" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip"
+                },
+                "subnet" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                },
+                "primary" : true,
+                "privateIPAddressVersion" : "IPv4"
+              }
+            }
+          ],
+          "dnsSettings" : {
+            "dnsServers" : [],
+            "appliedDnsServers" : []
+          },
+          "enableAcceleratedNetworking" : true,
+          "enableIPForwarding" : false
+        },
+        "type" : "Microsoft.Network/networkInterfaces"
+      }
+    },
+    "201" : {
+      "body" : {
+        "name" : "test-nic",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic",
+        "location" : "eastus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "ipConfigurations" : [{
+              "name" : "ipconfig1",
+              "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig1",
+              "properties" : {
+                "provisioningState" : "Succeeded",
+                "privateIPAddress" : "172.20.2.4",
+                "privateIPAllocationMethod" : "Dynamic",
+                "publicIPAddress" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip"
+                },
+                "subnet" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                },
+                "primary" : true,
+                "privateIPAddressVersion" : "IPv4"
+              }
+            }
+          ],
+          "dnsSettings" : {
+            "dnsServers" : [],
+            "appliedDnsServers" : []
+          },
+          "enableAcceleratedNetworking" : true,
+          "enableIPForwarding" : false
+        },
+        "type" : "Microsoft.Network/networkInterfaces"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "networkInterfaceName": "test-nic"
+  },
+  "responses" : {
+    "200" : { },
+    "202" : { },
+    "204" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceEffectiveNSGList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceEffectiveNSGList.json
@@ -1,0 +1,71 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "networkInterfaceName": "nic1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value" : [
+          {
+            "networkSecurityGroup" : {
+              "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            },
+            "association" : {
+              "subnet" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+              },
+              "networkInterface" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic1"
+              }
+            },
+            "effectiveSecurityRules" : [
+              {
+                "name" : "securityRules/rule1",
+                "protocol" : "Tcp",
+                "sourcePortRange" : "456-456",
+                "destinationPortRange" : "6579-6579",
+                "sourceAddressPrefix" : "0.0.0.0/32",
+                "destinationAddressPrefix" : "0.0.0.0/32",
+                "access" : "Allow",
+                "priority" : 234,
+                "direction" : "Inbound"
+              },
+              {
+                "name" : "securityRules/default-allow-rdp",
+                "protocol" : "Tcp",
+                "sourcePortRange" : "0-65535",
+                "destinationPortRange" : "3389-3389",
+                "sourceAddressPrefix" : "1.1.1.1/32",
+                "destinationAddressPrefix" : "0.0.0.0/0",
+                "access" : "Allow",
+                "priority" : 1000,
+                "direction" : "Inbound"
+              },
+              {
+                "name" : "defaultSecurityRules/AllowInternetOutBound",
+                "protocol" : "All",
+                "sourcePortRange" : "0-65535",
+                "destinationPortRange" : "0-65535",
+                "sourceAddressPrefix" : "0.0.0.0/0",
+                "destinationAddressPrefix" : "Internet",
+                "expandedDestinationAddressPrefix" : [
+                  "32.0.0.0/3",
+                  "4.0.0.0/6",
+                  "2.0.0.0/7",
+                  "1.0.0.0/8"
+                ],
+                "access" : "Allow",
+                "priority" : 65001,
+                "direction" : "Outbound"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "202" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceEffectiveRouteTableList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceEffectiveRouteTableList.json
@@ -1,0 +1,71 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "networkInterfaceName": "nic1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "source": "Default",
+            "state": "Active",
+            "addressPrefix": [
+              "172.20.2.0/24"
+            ],
+            "nextHopType": "VnetLocal",
+            "nextHopIpAddress": []
+          },
+          {
+            "source": "Default",
+            "state": "Active",
+            "addressPrefix": [
+              "0.0.0.0/0"
+            ],
+            "nextHopType": "Internet",
+            "nextHopIpAddress": []
+          },
+          {
+            "source": "Default",
+            "state": "Active",
+            "addressPrefix": [
+              "10.0.0.0/8"
+            ],
+            "nextHopType": "None",
+            "nextHopIpAddress": []
+          },
+          {
+            "source": "Default",
+            "state": "Active",
+            "addressPrefix": [
+              "100.64.0.0/10"
+            ],
+            "nextHopType": "None",
+            "nextHopIpAddress": []
+          },
+          {
+            "source": "Default",
+            "state": "Active",
+            "addressPrefix": [
+              "172.16.0.0/12"
+            ],
+            "nextHopType": "None",
+            "nextHopIpAddress": []
+          },
+          {
+           "source": "Default",
+            "state": "Active",
+            "addressPrefix": [
+              "192.168.0.0/16"
+            ],
+            "nextHopType": "None",
+            "nextHopIpAddress": []
+          }
+        ]
+      }
+    },
+    "202" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceGet.json
@@ -1,0 +1,54 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "networkInterfaceName": "test-nic"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "test-nic",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic",
+        "location" : "eastus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "ipConfigurations" : [{
+              "name" : "ipconfig1",
+              "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig1",
+              "properties" : {
+                "provisioningState" : "Succeeded",
+                "privateIPAddress" : "172.20.2.4",
+                "privateIPAllocationMethod" : "Dynamic",
+                "publicIPAddress" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip"
+                },
+                "subnet" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                },
+                "primary" : true,
+                "privateIPAddressVersion" : "IPv4"
+              }
+            }
+          ],
+          "dnsSettings" : {
+            "dnsServers" : [],
+            "appliedDnsServers" : [],
+            "internalDomainNameSuffix" : "test.bx.internal.cloudapp.net"
+          },
+          "macAddress" : "00-0D-3A-1B-C7-21",
+          "enableAcceleratedNetworking" : true,
+          "enableIPForwarding" : false,
+          "networkSecurityGroup" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg"
+          },
+          "primary" : true,
+          "virtualMachine" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+          }
+        },
+        "type" : "Microsoft.Network/networkInterfaces"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceIPConfigurationGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceIPConfigurationGet.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "networkInterfaceName": "mynic",
+    "ipConfigurationName": "ipconfig1",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "ipconfig1",
+        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/mynic/ipConfigurations/ipconfig1",
+        "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateIPAddress": "10.0.1.4",
+          "privateIPAllocationMethod": "Dynamic",
+          "subnet": {
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork/subnets/frontendSubnet"
+          },
+          "privateIPAddressVersion": "IPv4",
+          "loadBalancerBackendAddressPools": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/backendAddressPools/bepool1"
+            }
+          ],
+          "loadBalancerInboundNatRules": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/inboundNatRules/inbound1"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceIPConfigurationList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceIPConfigurationList.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "networkInterfaceName": "nic1",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ipconfig1",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "privateIPAddress": "10.0.0.4",
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/vnet12/subnets/subnet12"
+              },
+              "primary": true,
+              "privateIPAddressVersion": "IPv4"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceList.json
@@ -1,0 +1,90 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name" : "test-nic",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic",
+            "location" : "eastus",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "ipConfigurations" : [{
+                  "name" : "ipconfig1",
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig1",
+                  "properties" : {
+                    "provisioningState" : "Succeeded",
+                    "privateIPAddress" : "172.20.2.4",
+                    "privateIPAllocationMethod" : "Dynamic",
+                    "publicIPAddress" : {
+                      "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip"
+                    },
+                    "subnet" : {
+                      "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                    },
+                    "primary" : true,
+                    "privateIPAddressVersion" : "IPv4"
+                  }
+                }
+              ],
+              "dnsSettings" : {
+                "dnsServers" : [],
+                "appliedDnsServers" : [],
+                "internalDomainNameSuffix" : "test.bx.internal.cloudapp.net"
+              },
+              "macAddress" : "00-0D-3A-1B-C7-21",
+              "enableAcceleratedNetworking" : true,
+              "enableIPForwarding" : false,
+              "networkSecurityGroup" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg"
+              },
+              "primary" : true,
+              "virtualMachine" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+              }
+            },
+            "type" : "Microsoft.Network/networkInterfaces"
+          },
+          {
+            "name" : "test-nic2",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic2",
+            "location" : "eastus",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "ipConfigurations" : [{
+                  "name" : "ipconfig1",
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic2/ipConfigurations/ipconfig1",
+                  "properties" : {
+                    "provisioningState" : "Succeeded",
+                    "privateIPAddress" : "172.20.2.4",
+                    "privateIPAllocationMethod" : "Dynamic",
+                    "publicIPAddress" : {
+                      "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip2"
+                    },
+                    "subnet" : {
+                      "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet2/subnets/default"
+                    },
+                    "primary" : true,
+                    "privateIPAddressVersion" : "IPv4"
+                  }
+                }
+              ],
+              "dnsSettings" : {
+                "dnsServers" : [],
+                "appliedDnsServers" : []
+              },
+              "enableAcceleratedNetworking" : true,
+              "enableIPForwarding" : false
+            },
+            "type" : "Microsoft.Network/networkInterfaces"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceListAll.json
@@ -1,0 +1,89 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name" : "test-nic",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic",
+            "location" : "eastus",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "ipConfigurations" : [{
+                  "name" : "ipconfig1",
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig1",
+                  "properties" : {
+                    "provisioningState" : "Succeeded",
+                    "privateIPAddress" : "172.20.2.4",
+                    "privateIPAllocationMethod" : "Dynamic",
+                    "publicIPAddress" : {
+                      "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip"
+                    },
+                    "subnet" : {
+                      "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                    },
+                    "primary" : true,
+                    "privateIPAddressVersion" : "IPv4"
+                  }
+                }
+              ],
+              "dnsSettings" : {
+                "dnsServers" : [],
+                "appliedDnsServers" : [],
+                "internalDomainNameSuffix" : "test.bx.internal.cloudapp.net"
+              },
+              "macAddress" : "00-0D-3A-1B-C7-21",
+              "enableAcceleratedNetworking" : true,
+              "enableIPForwarding" : false,
+              "networkSecurityGroup" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg"
+              },
+              "primary" : true,
+              "virtualMachine" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+              }
+            },
+            "type" : "Microsoft.Network/networkInterfaces"
+          },
+          {
+            "name" : "test-nic2",
+            "id" : "/subscriptions/subid/resourceGroups/rgnew/providers/Microsoft.Network/networkInterfaces/test-nic2",
+            "location" : "eastus",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "ipConfigurations" : [{
+                  "name" : "ipconfig1",
+                  "id" : "/subscriptions/subid/resourceGroups/rgnew/providers/Microsoft.Network/networkInterfaces/test-nic2/ipConfigurations/ipconfig1",
+                  "properties" : {
+                    "provisioningState" : "Succeeded",
+                    "privateIPAddress" : "172.20.2.4",
+                    "privateIPAllocationMethod" : "Dynamic",
+                    "publicIPAddress" : {
+                      "id" : "/subscriptions/subid/resourceGroups/rgnew/providers/Microsoft.Network/publicIPAddresses/test-ip2"
+                    },
+                    "subnet" : {
+                      "id" : "/subscriptions/subid/resourceGroups/rgnew/providers/Microsoft.Network/virtualNetworks/rgnew-vnet2/subnets/default"
+                    },
+                    "primary" : true,
+                    "privateIPAddressVersion" : "IPv4"
+                  }
+                }
+              ],
+              "dnsSettings" : {
+                "dnsServers" : [],
+                "appliedDnsServers" : []
+              },
+              "enableAcceleratedNetworking" : true,
+              "enableIPForwarding" : false
+            },
+            "type" : "Microsoft.Network/networkInterfaces"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceLoadBalancerList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceLoadBalancerList.json
@@ -1,0 +1,139 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "networkInterfaceName": "nic1",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "lbname1",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "type": "Microsoft.Network/loadBalancers",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000",
+              "frontendIPConfigurations": [
+                {
+                  "name": "lbfrontend",
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/frontendIPConfigurations/lbfrontend",
+                  "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAllocationMethod": "Dynamic",
+                    "publicIPAddress": {
+                      "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/publicIPAddresses/myDynamicPublicIP"
+                    },
+                    "loadBalancingRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/loadBalancingRules/rule1"
+                      }
+                    ],
+                    "inboundNatRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/inboundNatRules/inbound1"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "backendAddressPools": [
+                {
+                  "name": "bepool1",
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/backendAddressPools/bepool1",
+                  "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "backendIPConfigurations": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"
+                      }
+                    ],
+                    "loadBalancingRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/loadBalancingRules/rule1"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "name": "rule1",
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/loadBalancingRules/rule1",
+                  "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "frontendIPConfiguration": {
+                      "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/frontendIPConfigurations/lbfrontend"
+                    },
+                    "frontendPort": 80,
+                    "backendPort": 80,
+                    "enableFloatingIP": false,
+                    "idleTimeoutInMinutes": 15,
+                    "protocol": "Tcp",
+                    "loadDistribution": "Default",
+                    "backendAddressPool": {
+                      "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/backendAddressPools/bepool1"
+                    },
+                    "probe": {
+                      "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/probes/probe1"
+                    }
+                  }
+                }
+              ],
+              "probes": [
+                {
+                  "name": "probe1",
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/probes/probe1",
+                  "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "protocol": "Http",
+                    "port": 80,
+                    "requestPath": "healthcheck.aspx",
+                    "intervalInSeconds": 15,
+                    "numberOfProbes": 2,
+                    "loadBalancingRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/loadBalancingRules/rule1"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "inboundNatRules": [
+                {
+                  "name": "inbound1",
+                  "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/inboundNatRules/inbound1",
+                  "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "frontendIPConfiguration": {
+                      "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/loadBalancers/lbname1/frontendIPConfigurations/lbfrontend"
+                    },
+                    "frontendPort": 3389,
+                    "backendPort": 3389,
+                    "enableFloatingIP": false,
+                    "idleTimeoutInMinutes": 15,
+                    "protocol": "Tcp",
+                    "backendIPConfiguration": {
+                      "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1"
+                    }
+                  }
+                }
+              ],
+              "outboundNatRules": [],
+              "inboundNatPools": []
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceUpdateTags.json
@@ -1,0 +1,55 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "networkInterfaceName": "test-nic",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "test-nic",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic",
+        "location" : "eastus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "ipConfigurations" : [{
+              "name" : "ipconfig1",
+              "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig1",
+              "properties" : {
+                "provisioningState" : "Succeeded",
+                "privateIPAddress" : "172.20.2.4",
+                "privateIPAllocationMethod" : "Dynamic",
+                "publicIPAddress" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip"
+                },
+                "subnet" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                },
+                "primary" : true,
+                "privateIPAddressVersion" : "IPv4"
+              }
+            }
+          ],
+          "dnsSettings" : {
+            "dnsServers" : [],
+            "appliedDnsServers" : []
+          },
+          "enableAcceleratedNetworking" : true,
+          "enableIPForwarding" : false
+        },
+        "type" : "Microsoft.Network/networkInterfaces"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupCreate.json
@@ -1,0 +1,231 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkSecurityGroupName" : "testnsg",
+    "parameters": {}
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "testnsg",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
+        "type": "Microsoft.Network/networkSecurityGroups",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "securityRules": [ ],
+          "defaultSecurityRules": [
+            {
+              "name": "AllowVnetInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Inbound"
+              }
+            },
+            {
+            "name": "AllowAzureLoadBalancerInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from azure load balancer",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "AzureLoadBalancer",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "DenyAllInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all inbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "AllowVnetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Outbound"
+              }
+            },
+           {
+              "name": "AllowInternetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowInternetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to Internet",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "Internet",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Outbound"
+              }
+            },
+            {
+              "name": "DenyAllOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllOutBound",
+             "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all outbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Outbound"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "testnsg",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
+        "type": "Microsoft.Network/networkSecurityGroups",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "securityRules": [ ],
+          "defaultSecurityRules": [
+            {
+              "name": "AllowVnetInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Inbound"
+              }
+            },
+            {
+            "name": "AllowAzureLoadBalancerInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from azure load balancer",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "AzureLoadBalancer",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "DenyAllInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all inbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "AllowVnetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Outbound"
+              }
+            },
+           {
+              "name": "AllowInternetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowInternetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to Internet",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "Internet",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Outbound"
+              }
+            },
+            {
+              "name": "DenyAllOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllOutBound",
+             "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all outbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -1,0 +1,281 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkSecurityGroupName" : "testnsg",
+    "parameters": {
+      "properties": {
+        "securityRules": [
+          {
+            "name": "rule1",
+            "properties": {
+              "protocol": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "destinationPortRange": "80",
+              "sourcePortRange": "*",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "testnsg",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
+        "type": "Microsoft.Network/networkSecurityGroups",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "securityRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/securityRules/rule1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "80",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 130,
+                "direction": "Inbound"
+              }
+            }
+          ],
+          "defaultSecurityRules": [
+            {
+              "name": "AllowVnetInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Inbound"
+              }
+            },
+            {
+            "name": "AllowAzureLoadBalancerInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from azure load balancer",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "AzureLoadBalancer",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "DenyAllInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all inbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "AllowVnetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Outbound"
+              }
+            },
+           {
+              "name": "AllowInternetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowInternetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to Internet",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "Internet",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Outbound"
+              }
+            },
+            {
+              "name": "DenyAllOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllOutBound",
+             "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all outbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Outbound"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "testnsg",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
+        "type": "Microsoft.Network/networkSecurityGroups",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "securityRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/securityRules/rule1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "80",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 130,
+                "direction": "Inbound"
+              }
+            }
+          ],
+          "defaultSecurityRules": [
+            {
+              "name": "AllowVnetInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Inbound"
+              }
+            },
+            {
+            "name": "AllowAzureLoadBalancerInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from azure load balancer",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "AzureLoadBalancer",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "DenyAllInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all inbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "AllowVnetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Outbound"
+              }
+            },
+           {
+              "name": "AllowInternetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowInternetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to Internet",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "Internet",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Outbound"
+              }
+            },
+            {
+              "name": "DenyAllOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllOutBound",
+             "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all outbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkSecurityGroupName" : "testnsg"
+  },
+  "responses" : {
+    "200" : { },
+    "202" : { },
+    "204" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupGet.json
@@ -1,0 +1,136 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkSecurityGroupName" : "testnsg"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "testnsg",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
+        "type": "Microsoft.Network/networkSecurityGroups",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "securityRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/securityRules/rule1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "80",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 130,
+                "direction": "Inbound"
+              }
+            }
+          ],
+          "defaultSecurityRules": [
+            {
+              "name": "AllowVnetInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Inbound"
+              }
+            },
+            {
+            "name": "AllowAzureLoadBalancerInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from azure load balancer",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "AzureLoadBalancer",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "DenyAllInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all inbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "AllowVnetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Outbound"
+              }
+            },
+           {
+              "name": "AllowInternetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowInternetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to Internet",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "Internet",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Outbound"
+              }
+            },
+            {
+              "name": "DenyAllOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllOutBound",
+             "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all outbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupList.json
@@ -1,0 +1,231 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "nsg1",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "securityRules": [],
+              "defaultSecurityRules": [
+                {
+                  "name": "AllowVnetInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow inbound traffic from all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "AllowAzureLoadBalancerInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow inbound traffic from azure load balancer",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "AzureLoadBalancer",
+                    "destinationAddressPrefix": "*",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "DenyAllInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/DenyAllInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Deny all inbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "AllowVnetOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Outbound"
+                  }
+                },
+                {
+                  "name": "AllowInternetOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowInternetOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow outbound traffic from all VMs to Internet",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "Internet",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Outbound"
+                  }
+                },
+                {
+                  "name": "DenyAllOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/DenyAllOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Deny all outbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Outbound"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "nsg3",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg3",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "securityRules": [],
+              "defaultSecurityRules": [
+                {
+                  "name": "AllowVnetInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/AllowVnetInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow inbound traffic from all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "AllowAzureLoadBalancerInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow inbound traffic from azure load balancer",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "AzureLoadBalancer",
+                    "destinationAddressPrefix": "*",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "DenyAllInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/DenyAllInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Deny all inbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "AllowVnetOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/AllowVnetOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Outbound"
+                  }
+                },
+                {
+                  "name": "AllowInternetOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/AllowInternetOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow outbound traffic from all VMs to Internet",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "Internet",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Outbound"
+                  }
+                },
+                {
+                  "name": "DenyAllOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/DenyAllOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Deny all outbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Outbound"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupListAll.json
@@ -1,0 +1,230 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "nsg1",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "securityRules": [],
+              "defaultSecurityRules": [
+                {
+                  "name": "AllowVnetInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow inbound traffic from all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "AllowAzureLoadBalancerInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow inbound traffic from azure load balancer",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "AzureLoadBalancer",
+                    "destinationAddressPrefix": "*",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "DenyAllInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/DenyAllInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Deny all inbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "AllowVnetOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Outbound"
+                  }
+                },
+                {
+                  "name": "AllowInternetOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowInternetOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow outbound traffic from all VMs to Internet",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "Internet",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Outbound"
+                  }
+                },
+                {
+                  "name": "DenyAllOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/DenyAllOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Deny all outbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Outbound"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "nsg3",
+            "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/nsg3",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "securityRules": [],
+              "defaultSecurityRules": [
+                {
+                  "name": "AllowVnetInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/AllowVnetInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow inbound traffic from all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "AllowAzureLoadBalancerInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow inbound traffic from azure load balancer",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "AzureLoadBalancer",
+                    "destinationAddressPrefix": "*",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "DenyAllInBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/DenyAllInBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Deny all inbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Inbound"
+                  }
+                },
+                {
+                  "name": "AllowVnetOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/AllowVnetOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Outbound"
+                  }
+                },
+                {
+                  "name": "AllowInternetOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/AllowInternetOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Allow outbound traffic from all VMs to Internet",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "Internet",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Outbound"
+                  }
+                },
+                {
+                  "name": "DenyAllOutBound",
+                  "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/nsg3/defaultSecurityRules/DenyAllOutBound",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "description": "Deny all outbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Outbound"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupRuleCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupRuleCreate.json
@@ -1,0 +1,57 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkSecurityGroupName" : "testnsg",
+    "securityRuleName": "rule1",
+    "securityRuleParameters": {
+      "properties": {
+        "protocol": "*",
+        "sourceAddressPrefix": "10.0.0.0/8",
+        "destinationAddressPrefix": "11.0.0.0/8",
+        "access": "Deny",
+        "destinationPortRange": "8080",
+        "sourcePortRange": "*",
+        "priority": 100,
+        "direction": "Outbound"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "rule1",
+        "id":"/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/securityRules/rule1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "protocol": "*",
+          "sourcePortRange": "*",
+          "destinationPortRange": "8080",
+          "sourceAddressPrefix": "10.0.0.0/8",
+          "destinationAddressPrefix": "11.0.0.0/8",
+          "access": "Deny",
+          "priority": 100,
+          "direction": "Outbound"
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "rule1",
+        "id":"/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/securityRules/rule1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "protocol": "*",
+          "sourcePortRange": "*",
+          "destinationPortRange": "8080",
+          "sourceAddressPrefix": "10.0.0.0/8",
+          "destinationAddressPrefix": "11.0.0.0/8",
+          "access": "Deny",
+          "priority": 100,
+          "direction": "Outbound"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupRuleDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupRuleDelete.json
@@ -1,0 +1,14 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkSecurityGroupName" : "testnsg",
+    "securityRuleName": "rule1"
+  },
+  "responses" : {
+    "200" : { },
+    "202" : { },
+    "204" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupRuleGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupRuleGet.json
@@ -1,0 +1,28 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkSecurityGroupName" : "testnsg",
+    "securityRuleName": "rule1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "rule1",
+        "id":"/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/securityRules/rule1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "protocol": "*",
+          "sourcePortRange": "*",
+          "destinationPortRange": "80",
+          "sourceAddressPrefix": "*",
+          "destinationAddressPrefix": "*",
+          "access": "Allow",
+          "priority": 130,
+          "direction": "Inbound"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupRuleList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupRuleList.json
@@ -1,0 +1,31 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkSecurityGroupName" : "testnsg"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "rule1",
+            "id":"/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/securityRules/rule1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupUpdateTags.json
@@ -1,0 +1,130 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkSecurityGroupName" : "testnsg",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "testnsg",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
+        "type": "Microsoft.Network/networkSecurityGroups",
+        "location": "westus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "securityRules": [ ],
+          "defaultSecurityRules": [
+            {
+              "name": "AllowVnetInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Inbound"
+              }
+            },
+            {
+            "name": "AllowAzureLoadBalancerInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow inbound traffic from azure load balancer",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "AzureLoadBalancer",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "DenyAllInBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllInBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all inbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "AllowVnetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowVnetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 65000,
+                "direction": "Outbound"
+              }
+            },
+           {
+              "name": "AllowInternetOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/AllowInternetOutBound",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Allow outbound traffic from all VMs to Internet",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "Internet",
+                "access": "Allow",
+                "priority": 65001,
+                "direction": "Outbound"
+              }
+            },
+            {
+              "name": "DenyAllOutBound",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg/defaultSecurityRules/DenyAllOutBound",
+             "properties": {
+                "provisioningState": "Succeeded",
+                "description": "Deny all outbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 65500,
+                "direction": "Outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherAvailableProvidersListGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherAvailableProvidersListGet.json
@@ -1,0 +1,66 @@
+{
+  "parameters" : {
+    "api-version" : "2017-08-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "azureLocations" : [ "West US" ],
+      "country" : "United States",
+      "state" : "washington",
+      "city" : "seattle"
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "countries" : [
+          {
+            "countryName" : "United States",
+            "states" : [
+              {
+                "stateName" : "washington",
+                "cities" : [
+                  {
+                    "cityName" : "seattle",
+                    "providers" : [
+                      "Comcast Cable Communications, Inc. - ASN 7922",
+                      "Comcast Cable Communications, LLC - ASN 7922",
+                      "Level 3 Communications, Inc. (GBLX) - ASN 3549",
+                      "Qwest Communications Company, LLC - ASN 209"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "202" : {
+      "body" : {
+        "countries" : [
+          {
+            "countryName" : "United States",
+            "states" : [
+              {
+                "stateName" : "washington",
+                "cities" : [
+                  {
+                    "cityName" : "seattle",
+                    "providers" : [
+                      "Comcast Cable Communications, Inc. - ASN 7922",
+                      "Comcast Cable Communications, LLC - ASN 7922",
+                      "Level 3 Communications, Inc. (GBLX) - ASN 3549",
+                      "Qwest Communications Company, LLC - ASN 209"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherAzureReachabilityReportGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherAzureReachabilityReportGet.json
@@ -1,0 +1,82 @@
+{
+  "parameters" : {
+    "api-version" : "2017-08-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "providerLocation" : {
+        "country" : "United States",
+        "state" : "washington"
+      },
+      "providers" : [
+        "Frontier Communications of America, Inc. - ASN 5650"
+      ],
+      "azureLocations" : [
+        "West US"
+      ],
+      "startTime": "2017-09-07T00:00:00Z",
+      "endTime": "2017-09-10T00:00:00Z"
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "aggregationLevel" : "State",
+        "providerLocation" : {
+          "country" : "United States",
+          "state" : "washington"
+        },
+        "reachabilityReport" : [
+          {
+            "provider" : "Frontier Communications of America, Inc. - ASN 5650",
+            "azureLocation": "West US",
+            "latencies": [
+              {
+                "timeStamp": "2017-09-07T00:00:00Z",
+                "score": 94
+              },
+              {
+                "timeStamp": "2017-09-08T00:00:00Z",
+                "score": 94
+              },
+              {
+                "timeStamp": "2017-09-09T00:00:00Z",
+                "score": 94    
+              }
+            ]  
+          }
+        ]
+      }
+    },
+    "202" : {
+      "body" : {
+        "aggregationLevel" : "State",
+        "providerLocation" : {
+          "country" : "United States",
+          "state" : "washington"
+        },
+        "reachabilityReport" : [
+          {
+            "provider" : "Frontier Communications of America, Inc. - ASN 5650",
+            "azureLocation": "West US",
+            "latencies": [
+              {
+                "timeStamp": "2017-09-07T00:00:00Z",
+                "score": 94
+              },
+              {
+                "timeStamp": "2017-09-08T00:00:00Z",
+                "score": 94
+              },
+              {
+                "timeStamp": "2017-09-09T00:00:00Z",
+                "score": 94    
+              }
+            ]  
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorCreate.json
@@ -1,0 +1,47 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "connectionMonitorName" : "cm1",
+    "location": "centraluseuap",
+    "parameters" : {
+      "properties": {
+        "source": {
+          "resourceId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+        },
+        "destination": {
+          "address": "bing.com",
+          "port": 80
+        },
+        "MonitoringIntervalInSeconds": 60
+      }
+    }
+  },
+  "responses" : {
+    "201" : {
+      "body" : {
+        "name" : "cm1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/connectionMonitors/cm1",
+        "etag" : "W/\"e7497f26-5f09-4559-900b-fe98f3dedb6f\"",
+        "properties" : {
+          "provisioningState": "Updating",
+          "source": {
+            "resourceId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+            "port": 0
+          },
+          "destination": {
+            "address": "bing.com",
+            "port": 80
+          },
+          "monitoringIntervalInSeconds": 60,
+          "autoStart": true,
+          "monitoringStatus": "NotStarted"
+        },
+        "location": "centraluseuap",
+        "type": "Microsoft.Network/networkWatchers/connectionMonitors"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorGet.json
@@ -1,0 +1,35 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "connectionMonitorName" : "cm1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "cm1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/connectionMonitors/cm1",
+        "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "source": {
+            "resourceId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+            "port": 0
+          },
+          "destination": {
+            "address": "bing.com",
+            "port": 80
+          },
+          "monitoringIntervalInSeconds": 60,
+          "autoStart": true,
+          "startTime": "2018-01-08T03:42:33.3387305Z",
+          "monitoringStatus": "Running"
+        },
+        "location": "centraluseuap",
+        "type": "Microsoft.Network/networkWatchers/connectionMonitors"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorList.json
@@ -1,0 +1,60 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value" : [
+          {
+            "name" : "cm1",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/connectionMonitors/cm1",
+            "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "source": {
+                "resourceId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+                "port": 0
+              },
+              "destination": {
+                "address": "bing.com",
+                "port": 80
+              },
+              "monitoringIntervalInSeconds": 60,
+              "autoStart": true,
+              "startTime": "2018-01-08T03:42:33.3387305Z",
+              "monitoringStatus": "Running"
+            },
+            "location": "centraluseuap",
+            "type": "Microsoft.Network/networkWatchers/connectionMonitors"
+          },
+          {
+            "name" : "cm2",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/connectionMonitors/cm2",
+            "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "source": {
+                "resourceId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2",
+                "port": 0
+              },
+              "destination": {
+                "address": "google.com",
+                "port": 80
+              },
+              "monitoringIntervalInSeconds": 30,
+              "autoStart": true,
+              "startTime": "2018-01-08T05:42:33.3387305Z",
+              "monitoringStatus": "Running"
+            },
+            "location": "centraluseuap",
+            "type": "Microsoft.Network/networkWatchers/connectionMonitors"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorQuery.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorQuery.json
@@ -1,0 +1,75 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "connectionMonitorName" : "cm1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "states" : [
+          {
+            "connectionState" : "Reachable",
+            "startTime" : "2018-01-08T03:42:33.3387305Z",
+            "endTime" : "2018-01-08T05:12:41.5265438Z",
+            "evaluationState" : "Completed",
+            "hops" : [
+              {
+                "type" : "Source",
+                "id" : "7dbbe7aa-60ba-4650-831e-63d775d38e9e",
+                "address" : "10.1.1.4",
+                "resourceId" : "subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic0/ipConfigurations/ipconfig1",
+                "nextHopIds" : [
+                "75c8d819-b208-4584-a311-1aa45ce753f9"
+                ],
+                "issues" : []
+              },
+              {
+                "type" : "VirtualNetwork",
+                "id" : "75c8d819-b208-4584-a311-1aa45ce753f9",
+                "address" : "192.168.100.4",
+                "resourceId" : "subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1",
+                "nextHopIds" : [],
+                "issues" : []
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "202" : {
+      "body" : {
+        "states" : [
+          {
+            "connectionState" : "Reachable",
+            "startTime" : "2018-01-08T03:42:33.3387305Z",
+            "endTime" : "2018-01-08T05:12:41.5265438Z",
+            "evaluationState" : "Completed",
+            "hops" : [
+              {
+                "type" : "Source",
+                "id" : "7dbbe7aa-60ba-4650-831e-63d775d38e9e",
+                "address" : "10.1.1.4",
+                "resourceId" : "subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic0/ipConfigurations/ipconfig1",
+                "nextHopIds" : [
+                "75c8d819-b208-4584-a311-1aa45ce753f9"
+                ],
+                "issues" : []
+              },
+              {
+                "type" : "VirtualNetwork",
+                "id" : "75c8d819-b208-4584-a311-1aa45ce753f9",
+                "address" : "192.168.100.4",
+                "resourceId" : "subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1",
+                "nextHopIds" : [],
+                "issues" : []
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorStart.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorStart.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "connectionMonitorName" : "cm1"
+  },
+  "responses" : {
+    "200" : {},
+    "202" : {}
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorStop.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectionMonitorStop.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "connectionMonitorName" : "cm1"
+  },
+  "responses" : {
+    "200" : {},
+    "202" : {}
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectivityCheck.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherConnectivityCheck.json
@@ -1,0 +1,81 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "properties" : {
+        "source" : {
+          "resourceId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
+        },
+        "destination" : {
+          "address" : "192.168.100.4",
+          "port" : "3389"
+        }
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "hops" : [
+          {
+            "type" : "Source",
+            "id" : "7dbbe7aa-60ba-4650-831e-63d775d38e9e",
+            "address" : "10.1.1.4",
+            "resourceId" : "subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkInterfaces/nic0/ipConfigurations/ipconfig1",
+            "nextHopIds" : [
+              "75c8d819-b208-4584-a311-1aa45ce753f9"
+            ],
+            "issues" : []
+          },
+          {
+            "type" : "VirtualNetwork",
+            "id" : "75c8d819-b208-4584-a311-1aa45ce753f9",
+            "address" : "192.168.100.4",
+            "resourceId" : "subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1",
+            "nextHopIds" : [],
+            "issues" : []
+          }
+        ],
+        "connectionStatus" : "Connected",
+        "avgLatencyInMs" : 1,
+        "minLatencyInMs" : 1,
+        "maxLatencyInMs" : 4,
+        "probesSent" : 100,
+        "probesFailed" : 0
+      }
+    },
+    "202" : {
+      "body" : {
+        "hops" : [
+          {
+            "type" : "Source",
+            "id" : "7dbbe7aa-60ba-4650-831e-63d775d38e9e",
+            "address" : "10.1.1.4",
+            "resourceId" : "subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkInterfaces/nic0/ipConfigurations/ipconfig1",
+            "nextHopIds" : [
+              "75c8d819-b208-4584-a311-1aa45ce753f9"
+            ],
+            "issues" : []
+          },
+          {
+            "type" : "VirtualNetwor",
+            "id" : "75c8d819-b208-4584-a311-1aa45ce753f9",
+            "address" : "192.168.100.4",
+            "resourceId" : "subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/ipconfig1",
+            "nextHopIds" : [],
+            "issues" : []
+          }
+        ],
+        "connectionStatus" : "Connected",
+        "avgLatencyInMs" : 1,
+        "minLatencyInMs" : 1,
+        "maxLatencyInMs" : 4,
+        "probesSent" : 100,
+        "probesFailed" : 0
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherCreate.json
@@ -1,0 +1,41 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "properties" : {
+        "location" : "eastus"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "nw1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1",
+        "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+        "type" : "Microsoft.Network/networkWatchers",
+        "location" : "eastus",
+        "tags" : [],
+        "properties" : {
+          "provisioningState" : "Succeeded"
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name" : "nw1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1",
+        "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+        "type" : "Microsoft.Network/networkWatchers",
+        "location" : "eastus",
+        "tags" : [],
+        "properties" : {
+          "provisioningState" : "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherDelete.json
@@ -1,0 +1,12 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1"
+  },
+  "responses" : {
+    "202" : {},
+    "204" : {}
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherFlowLogConfigure.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherFlowLogConfigure.json
@@ -1,0 +1,37 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "properties" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1",
+        "properties" : {
+          "storageId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/st1",
+          "enabled" : true
+        }
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1",
+        "properties" : {
+          "storageId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/st1",
+          "enabled" : true
+        }
+      }
+    },
+    "202" : {
+      "body" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1",
+        "properties" : {
+          "storageId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/st1",
+          "enabled" : true
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherFlowLogStatusQuery.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherFlowLogStatusQuery.json
@@ -1,0 +1,33 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "properties" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1",
+        "properties" : {
+          "storageId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/st1",
+          "enabled" : true
+        }
+      }
+    },
+    "202" : {
+      "body" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1",
+        "properties" : {
+          "storageId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/st1",
+          "enabled" : true
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherGet.json
@@ -1,0 +1,23 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "nw1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1",
+        "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+        "type" : "Microsoft.Network/networkWatchers",
+        "location" : "eastus",
+        "tags" : [],
+        "properties" : {
+          "provisioningState" : "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherIpFlowVerify.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherIpFlowVerify.json
@@ -1,0 +1,33 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "properties" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
+        "direction" : "Outbound",
+        "protocol" : "TCP",
+        "localPort" : "80",
+        "remotePort" : "80",
+        "localIPAddress" : "10.2.0.4",
+        "remoteIPAddress" : "121.10.1.1"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "access" : "Allow",
+        "ruleName" : "Rule1"
+      }
+    },
+    "202" : {
+      "body" : {
+        "access" : "Allow",
+        "ruleName" : "Rule1"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherList.json
@@ -1,0 +1,37 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value" : [
+          {
+            "name" : "nw1",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1",
+            "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+            "type" : "Microsoft.Network/networkWatchers",
+            "location" : "eastus",
+            "tags" : [],
+            "properties" : {
+              "provisioningState" : "Succeeded"
+            }
+          },
+          {
+            "name" : "nw2",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw2",
+            "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+            "type" : "Microsoft.Network/networkWatchers",
+            "location" : "eastus",
+            "tags" : [],
+            "properties" : {
+              "provisioningState" : "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherListAll.json
@@ -1,0 +1,36 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value" : [
+          {
+            "name" : "nw1",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1",
+            "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+            "type" : "Microsoft.Network/networkWatchers",
+            "location" : "eastus",
+            "tags" : [],
+            "properties" : {
+              "provisioningState" : "Succeeded"
+            }
+          },
+          {
+            "name" : "nw2",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw2",
+            "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+            "type" : "Microsoft.Network/networkWatchers",
+            "location" : "westus",
+            "tags" : [],
+            "properties" : {
+              "provisioningState" : "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherNextHopGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherNextHopGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "properties" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
+        "sourcIPAddress" : "10.0.0.5",
+        "destinationIPAddress" : "10.0.0.10",
+        "targetNicResourceId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic1"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "nextHopType" : "VnetLocal",
+        "nextHopIpAddress" : "10.0.0.1",
+        "routeTableId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/routeTables/rt1"
+      }
+    },
+    "202" : {
+      "body" : {
+        "nextHopType" : "VnetLocal",
+        "nextHopIpAddress" : "10.0.0.1",
+        "routeTableId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/routeTables/rt1"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureCreate.json
@@ -1,0 +1,56 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "packetCaptureName" : "pc1",
+    "parameters" : {
+      "properties" : {
+        "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
+        "bytesToCapturePerPacket" : "10000",
+        "totalBytesPerSession" : "100000",
+        "timeLimitInSeconds" : "100",
+        "storageLocation" : {
+          "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
+          "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
+          "filePath" : "D:\\capture\\pc1.cap"
+        },
+        "filters" : [
+          {
+            "protocol" : "TCP",
+            "localIPAddress" : "10.0.0.4",
+            "localPort" : "80"
+          }
+        ]
+      }
+    }
+  },
+  "responses" : {
+    "201" : {
+      "body" : {
+        "name" : "pc1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/packetCaptures/pc1",
+        "properties" : {
+          "provisioningState" : "Updating",
+          "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
+          "bytesToCapturePerPacket" : "10000",
+          "totalBytesPerSession" : "100000",
+          "timeLimitInSeconds" : "100",
+          "storageLocation" : {
+            "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
+            "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
+            "filePath" : "D:\\capture\\pc1.cap"
+          },
+          "filters" : [
+            {
+              "protocol" : "TCP",
+              "localIPAddress" : "10.0.0.4",
+              "localPort" : "80"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "packetCaptureName" : "pc1"
+  },
+  "responses" : {
+    "204" : {},
+    "202" : {}
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureGet.json
@@ -1,0 +1,37 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "packetCaptureName" : "pc1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "pc1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/packetCaptures/pc1",
+        "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+        "properties" : {
+          "provisioningState" : "Updating",
+          "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
+          "bytesToCapturePerPacket" : "10000",
+          "totalBytesPerSession" : "100000",
+          "timeLimitInSeconds" : "100",
+          "storageLocation" : {
+            "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
+            "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
+            "filePath" : "D:\\capture\\pc1.cap"
+          },
+          "filters" : [
+            {
+              "protocol" : "TCP",
+              "localIPAddress" : "10.0.0.4",
+              "localPort" : "80"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureQueryStatus.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureQueryStatus.json
@@ -1,0 +1,31 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "packetCaptureName" : "pc1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "pc1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/packetCaptures/pc1",
+        "captureStartTime" : "9/7/2016 12:35:24PM",
+        "packetCaptureStatus" : "Stopped",
+        "stopReason" : "TimeExceeded",
+        "packetCaptureError" : []
+      }
+    },
+    "202" : {
+      "body" : {
+        "name" : "pc1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/packetCaptures/pc1",
+        "captureStartTime" : "9/7/2016 12:35:24PM",
+        "packetCaptureStatus" : "Stopped",
+        "stopReason" : "TimeExceeded",
+        "packetCaptureError" : []
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureStop.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCaptureStop.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "packetCaptureName" : "pc1"
+  },
+  "responses" : {
+    "200" : {},
+    "202" : {}
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCapturesList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherPacketCapturesList.json
@@ -1,0 +1,58 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value" : [
+          {
+            "name" : "pc1",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/packetCaptures/pc1",
+            "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+            "properties" : {
+              "provisioningState" : "Updating",
+              "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
+              "bytesToCapturePerPacket" : "10000",
+              "totalBytesPerSession" : "100000",
+              "timeLimitInSeconds" : "100",
+              "storageLocation" : {
+                "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
+                "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
+                "filePath" : "D:\\capture\\pc1.cap"
+              },
+              "filters" : [
+                {
+                  "protocol" : "TCP",
+                  "localIPAddress" : "10.0.0.4",
+                  "localPort" : "80"
+                }
+              ]
+            }
+          },
+          {
+            "name" : "pc2",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1/packetCaptures/pc2",
+            "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
+              "bytesToCapturePerPacket" : "10000",
+              "totalBytesPerSession" : "100000",
+              "timeLimitInSeconds" : "100",
+              "storageLocation" : {
+                "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
+                "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc2.cap",
+                "filePath" : "D:\\capture\\pc2.cap"
+              },
+              "filters" : []
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherSecurityGroupViewGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherSecurityGroupViewGet.json
@@ -1,0 +1,143 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "properties" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "networkInterfaces" : [
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkInterfaces/nic1",
+            "securityRuleAssociations" : {
+              "subnetAssociation" : {
+                "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1",
+                "securityRules" : [
+                  {
+                    "name" : "fe_rule",
+                    "id" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/AppNSG/securityRules/fe_rule",
+                    "etag" : "W/\"00000000-0000-0000-0000-000000000000\"",
+                    "properties" : {
+                      "provisioningState" : "Succeeded",
+                      "description" : "Allow Frontend",
+                      "protocol" : "Tcp",
+                      "sourcePortRange" : "*",
+                      "destinationPortRange" : "*",
+                      "sourceAddressPrefix" : "10.1.0.0/24",
+                      "destinationAddressPrefix" : "*",
+                      "access" : "Allow",
+                      "priority" : 100,
+                      "direction" : "Inbound"
+                    }
+                  }
+                ],         
+                "defaultSecurityRules" : [
+                  {
+                    "name" : "AllowVnetInBound",
+                    "id" : "/subscriptions//resourceGroups//providers/Microsoft.Network/networkSecurityGroups//defaultSecurityRules/",
+                    "properties" : {
+                      "provisioningState" : "Succeeded",
+                      "description" : "Allow inbound traffic from all VMs in VNET",
+                      "protocol" : "*",
+                      "sourcePortRange" : "*",
+                      "destinationPortRange" : "*",
+                      "sourceAddressPrefix" : "VirtualNetwork",
+                      "destinationAddressPrefix" : "VirtualNetwork",
+                      "access" : "Allow",
+                      "priority" : 65000,
+                      "direction" : "Inbound"
+                    }
+                  }
+                ],        
+                "effectiveSecurityRules" : [
+                  {
+                    "name" : "DefaultOutboundDenyAll",
+                    "protocol" : "All",
+                    "sourcePortRange" : "0-65535",
+                    "destinationPortRange" : "0-65535",
+                    "sourceAddressPrefix" : "*",
+                    "destinationAddressPrefix" : "*",
+                    "access" : "Deny",
+                    "priority" : 65500,
+                    "direction" : "Outbound"
+                  }
+                ]  
+              }
+            }
+          }
+        ]
+      }
+    },
+    "202" : {
+      "body" : {
+        "networkInterfaces": [
+          {
+            "id" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkInterfaces/nic1",
+            "securityRuleAssociations" : {
+              "subnetAssociation" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1",
+                "securityRules" : [
+                  {
+                    "name" : "fe_rule",
+                    "id" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkSecurityGroups/AppNSG/securityRules/fe_rule",
+                    "etag" : "W/\"00000000-0000-0000-0000-000000000000\"",
+                    "properties" : {
+                      "provisioningState" : "Succeeded",
+                      "description" : "Allow Frontend",
+                      "protocol" : "Tcp",
+                      "sourcePortRange" : "*",
+                      "destinationPortRange" : "*",
+                      "sourceAddressPrefix" : "10.1.0.0/24",
+                      "destinationAddressPrefix" : "*",
+                      "access" : "Allow",
+                      "priority" : 100,
+                      "direction" : "Inbound"
+                    }
+                  }
+                ],         
+                "defaultSecurityRules" : [
+                  {
+                    "name" : "AllowVnetInBound",
+                    "id" : "/subscriptions//resourceGroups//providers/Microsoft.Network/networkSecurityGroups//defaultSecurityRules/",
+                    "properties" : {
+                      "provisioningState" : "Succeeded",
+                      "description" : "Allow inbound traffic from all VMs in VNET",
+                      "protocol" : "*",
+                      "sourcePortRange" : "*",
+                      "destinationPortRange" : "*",
+                      "sourceAddressPrefix" : "VirtualNetwork",
+                      "destinationAddressPrefix" : "VirtualNetwork",
+                      "access" : "Allow",
+                      "priority" : 65000,
+                      "direction" : "Inbound"
+                    }
+                  }
+                ],        
+                "effectiveSecurityRules" : [
+                  {
+                    "name" : "DefaultOutboundDenyAll",
+                    "protocol" : "All",
+                    "sourcePortRange" : "0-65535",
+                    "destinationPortRange" : "0-65535",
+                    "sourceAddressPrefix" : "*",
+                    "destinationAddressPrefix" : "*",
+                    "access" : "Deny",
+                    "priority" : 65500,
+                    "direction" : "Outbound"
+                  }
+                ]  
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherTopologyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherTopologyGet.json
@@ -1,0 +1,39 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "targetResourceGroupName": "rg2"
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "id" : "ce592f46-8164-4bf2-ad36-b8e4acf6fb68",
+        "createdDateTime" : "2017-08-02T19:31:55.9461781Z",
+        "lastModified" : "2017-05-27T00:00:13.2005337Z",
+        "resources" : [
+          {
+            "name" : "MultiTierApp0",
+            "id" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/MultiTierApp0",
+            "location" : "westus",
+            "associations" : [
+              {
+                "name" : "appNic0",
+                "resourceId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkInterfaces/appNic0",
+                "associationType" : "Contains"
+              },
+              {
+                "name" : "appNic10",
+                "resourceId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/networkInterfaces/appNic10",
+                "associationType" : "Contains"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherTroubleshootGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherTroubleshootGet.json
@@ -1,0 +1,73 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "properties" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
+        "properties" : {
+          "storageId" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/st1",
+          "storagePath" : "https://st1.blob.core.windows.net/cn1"
+        }
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "startTime" : "2017-01-12T00:19:47.0442834Z",
+        "endTime" : "2017-01-12T00:20:09.914Z",
+        "code" : "UnHealthy",
+        "results" : [
+          { 
+            "id": "000000", 
+            "reasonType" : "VipUnResponsive",
+            "summary": "We are sorry, your VPN gateway is unreachable from the Internet", 
+            "detail": "During this time S2S VPN tunnels to on premises sites or other Azure virtual networks will be disconnected", 
+            "recommendedActions": [ 
+              { 
+                "actionText": "Verify if there is a network security group (NSG) applied to the GatewaySubnet", 
+                "actionUri": "https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal",
+                "actionUriText": "Verify" 
+              }, 
+              { 
+                "actionText": "If your VPN gateway isn't up and running by the expected resolution time, contact support", 
+                "actionUri": "http://azure.microsoft.com/support", 
+                "actionUriText": "contact support"
+              } 
+            ] 
+          } 
+        ]
+      }
+    },
+    "202" : {
+      "body" : {
+        "startTime" : "2017-01-12T00:19:47.0442834Z",
+        "endTime" : "2017-01-12T00:20:09.914Z",
+        "code" : "UnHealthy",
+        "results" : [
+          { 
+            "id": "000000", 
+            "reasonType" : "VipUnResponsive",
+            "summary": "We are sorry, your VPN gateway is unreachable from the Internet", 
+            "detail": "During this time S2S VPN tunnels to on premises sites or other Azure virtual networks will be disconnected", 
+            "recommendedActions": [ 
+              { 
+                "actionText": "Verify if there is a network security group (NSG) applied to the GatewaySubnet", 
+                "actionUri": "https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal",
+                "actionUriText": "Verify" 
+              }, 
+              { 
+                "actionText": "If your VPN gateway isn't up and running by the expected resolution time, contact support", 
+                "actionUri": "http://azure.microsoft.com/support", 
+                "actionUriText": "contact support"
+              } 
+            ] 
+          } 
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherTroubleshootResultQuery.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherTroubleshootResultQuery.json
@@ -1,0 +1,69 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "properties" : {
+        "targetResourceId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "startTime" : "2017-01-12T00:19:47.0442834Z",
+        "endTime" : "2017-01-12T00:20:09.914Z",
+        "code" : "UnHealthy",
+        "results" : [
+          { 
+            "id": "000000", 
+            "reasonType" : "VipUnResponsive",
+            "summary" : "We are sorry, your VPN gateway is unreachable from the Internet", 
+            "detail" : "During this time S2S VPN tunnels to on premises sites or other Azure virtual networks will be disconnected", 
+            "recommendedActions" : [ 
+              { 
+                "actionText" : "Verify if there is a network security group (NSG) applied to the GatewaySubnet", 
+                "actionUri" : "https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal",
+                "actionUriText" : "Verify" 
+              }, 
+              { 
+                "actionText" : "If your VPN gateway isn't up and running by the expected resolution time, contact support", 
+                "actionUri" : "http://azure.microsoft.com/support", 
+                "actionUriText" : "contact support"
+              } 
+            ] 
+          } 
+        ]
+      }
+    },
+    "202" : {
+      "body" : {
+        "startTime" : "2017-01-12T00:19:47.0442834Z",
+        "endTime" : "2017-01-12T00:20:09.914Z",
+        "code" : "UnHealthy",
+        "results" : [
+          { 
+            "id" : "000000", 
+            "reasonType" : "VipUnResponsive",
+            "summary" : "We are sorry, your VPN gateway is unreachable from the Internet", 
+            "detail" : "During this time S2S VPN tunnels to on premises sites or other Azure virtual networks will be disconnected", 
+            "recommendedActions" : [ 
+              { 
+                "actionText" : "Verify if there is a network security group (NSG) applied to the GatewaySubnet", 
+                "actionUri" : "https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal",
+                "actionUriText" : "Verify" 
+              }, 
+              { 
+                "actionText" : "If your VPN gateway isn't up and running by the expected resolution time, contact support", 
+                "actionUri" : "http://azure.microsoft.com/support", 
+                "actionUriText" : "contact support"
+              } 
+            ] 
+          } 
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkWatcherUpdateTags.json
@@ -1,0 +1,32 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkWatcherName" : "nw1",
+    "parameters" : {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "nw1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkWatchers/nw1",
+        "etag" :  "W/\"00000000-0000-0000-0000-000000000000\"",
+        "type" : "Microsoft.Network/networkWatchers",
+        "location" : "eastus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties" : {
+          "provisioningState" : "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/OperationList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/OperationList.json
@@ -1,0 +1,137 @@
+{
+  "parameters": {
+    "location": "westus",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Network/localnetworkgateways/read",
+            "display": {
+              "provider": "Microsoft Network",
+              "resource": "LocalNetworkGateway",
+              "operation": "Get LocalNetworkGateway",
+              "description": "Gets LocalNetworkGateway"
+            }
+          },
+          {
+            "name": "Microsoft.Network/localnetworkgateways/write",
+            "display": {
+              "provider": "Microsoft Network",
+              "resource": "LocalNetworkGateway",
+              "operation": "Create or update LocalNetworkGateway",
+              "description": "Creates or updates an existing LocalNetworkGateway"
+            }
+          },
+          {
+            "name": "Microsoft.Network/localnetworkgateways/delete",
+            "display": {
+              "provider": "Microsoft Network",
+              "resource": "LocalNetworkGateway",
+              "operation": "Delete LocalNetworkGateway",
+              "description": "Deletes LocalNetworkGateway"
+            }
+          },
+          {
+            "name": "Microsoft.Network/networkInterfaces/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "provider": "Microsoft Network",
+              "resource": "Network Interface metric definition",
+              "operation": "Read Network Interface metric definitions",
+              "description": "Gets available metrics for the Network Interface"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "BytesSentRate",
+                    "displayName": "Bytes Sent",
+                    "displayDescription": "Number of bytes the Network Interface sent",
+                    "unit": "Count",
+                    "aggregationType": "Total",
+                    "availabilities": [
+                      {
+                        "timeGrain": "00:01:00",
+                        "retention": "00:00:00",
+                        "blobDuration": "01:00:00"
+                      },
+                      {
+                        "timeGrain": "01:00:00",
+                        "retention": "00:00:00",
+                        "blobDuration": "1.00:00:00"
+                      }
+                    ],
+                    "enableRegionalMdmAccount": false,
+                    "metricFilterPattern": "^__Ready__$",
+                    "fillGapWithZero": false,
+                    "dimensions": [],
+                    "isInternal": false
+                  },
+                  {
+                    "name": "BytesReceivedRate",
+                    "displayName": "Bytes Received",
+                    "displayDescription": "Number of bytes the Network Interface received",
+                    "unit": "Count",
+                    "aggregationType": "Total",
+                    "availabilities": [
+                      {
+                        "timeGrain": "00:01:00",
+                        "retention": "00:00:00",
+                        "blobDuration": "01:00:00"
+                      },
+                      {
+                        "timeGrain": "01:00:00",
+                        "retention": "00:00:00",
+                        "blobDuration": "1.00:00:00"
+                      }
+                    ],
+                    "enableRegionalMdmAccount": false,
+                    "metricFilterPattern": "^__Ready__$",
+                    "fillGapWithZero": false,
+                    "dimensions": [],
+                    "isInternal": false
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Network/networksecuritygroups/providers/Microsoft.Insights/logDefinitions/read",
+            "display": {
+              "provider": "Microsoft Network",
+              "resource": "Network Security Groups Log Definitions",
+              "operation": "Get Network Security Group Event Log Definitions",
+              "description": "Gets the events for network security group"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "logSpecifications": [
+                  {
+                    "name": "NetworkSecurityGroupEvent",
+                    "displayName": "Network Security Group Event",
+                    "blobDuration": "PT1H"
+                  },
+                  {
+                    "name": "NetworkSecurityGroupRuleCounter",
+                    "displayName": "Network Security Group Rule Counter",
+                    "blobDuration": "PT1H"
+                  },
+                  {
+                    "name": "NetworkSecurityGroupFlowEvent",
+                    "displayName": "Network Security Group Rule Flow Event",
+                    "blobDuration": "PT1H"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -1,0 +1,63 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "publicIpAddressName": "test-ip",
+    "zones": [ "1" ],
+    "parameters": {
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "idleTimeoutInMinutes": 10,
+        "publicIPAddressVersion": "IPv4"
+      },
+      "sku": {
+        "name": "Standard"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "testDNS-ip",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location" : "westus",
+        "zones": [ "1" ],
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "publicIPAddressVersion" : "IPv4",
+          "publicIPAllocationMethod" : "Static",
+          "idleTimeoutInMinutes" : 10,
+          "ipConfiguration" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+          }
+        },
+        "sku": {
+            "name": "Standard"
+        },
+        "type" : "Microsoft.Network/publicIPAddresses"
+      }
+    },
+    "201" : {
+      "body" : {
+        "name" : "testDNS-ip",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location" : "westus",
+        "zones": [ "1" ],
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "publicIPAddressVersion" : "IPv4",
+          "publicIPAllocationMethod" : "Static",
+          "idleTimeoutInMinutes" : 10,
+          "ipConfiguration" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+          }
+        },
+        "sku": {
+            "name": "Standard"
+        },
+        "type" : "Microsoft.Network/publicIPAddresses"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateDefaults.json
@@ -1,0 +1,51 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "publicIpAddressName": "test-ip",
+    "parameters": {}
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "testDNS-ip",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "publicIPAddressVersion" : "IPv4",
+          "publicIPAllocationMethod" : "Dynamic",
+          "idleTimeoutInMinutes" : 4,
+          "ipConfiguration" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+          }
+        },
+        "sku": {
+            "name": "Basic"
+        },
+        "type" : "Microsoft.Network/publicIPAddresses"
+      }
+    },
+    "201" : {
+      "body" : {
+        "name" : "testDNS-ip",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "publicIPAddressVersion" : "IPv4",
+          "publicIPAllocationMethod" : "Dynamic",
+          "idleTimeoutInMinutes" : 4,
+          "ipConfiguration" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+          }
+        },
+        "sku": {
+            "name": "Basic"
+        },
+        "type" : "Microsoft.Network/publicIPAddresses"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateDns.json
@@ -1,0 +1,59 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "publicIpAddressName": "test-ip",
+    "parameters": {
+      "properties": {
+        "dnsSettings": {
+          "domainNameLabel": "dnslbl"
+        }
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "testDNS-ip",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "publicIPAddressVersion" : "IPv4",
+          "publicIPAllocationMethod" : "Dynamic",
+          "idleTimeoutInMinutes" : 4,
+          "dnsSettings" : {
+            "domainNameLabel" : "dnslbl",
+            "fqdn" : "dnslbl.westus.cloudapp.azure.com"
+          },
+          "ipConfiguration" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+          }
+        },
+        "type" : "Microsoft.Network/publicIPAddresses"
+      }
+    },
+    "201" : {
+      "body" : {
+        "name" : "testDNS-ip",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "publicIPAddressVersion" : "IPv4",
+          "publicIPAllocationMethod" : "Dynamic",
+          "idleTimeoutInMinutes" : 4,
+          "dnsSettings" : {
+            "domainNameLabel" : "dnslbl",
+            "fqdn" : "dnslbl.westus.cloudapp.azure.com"
+          },
+          "ipConfiguration" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+          }
+        },
+        "type" : "Microsoft.Network/publicIPAddresses"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "publicIpAddressName": "test-ip"
+  },
+  "responses" : {
+    "200" : { },
+    "202" : { },
+    "204" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressGet.json
@@ -1,0 +1,37 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "publicIpAddressName": "testDNS-ip"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "testDNS-ip",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/testDNS-ip",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "publicIPAddressVersion" : "IPv4",
+          "publicIPAllocationMethod" : "Dynamic",
+          "idleTimeoutInMinutes" : 4,
+          "ipConfiguration" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+          },
+          "ipTags" : [
+            {
+              "ipTagType" : "FirstPartyUsage",
+              "tag" : "SQL"
+            },
+            {
+              "ipTagType" : "FirstPartyUsage",
+              "tag" : "Storage"
+            }
+           ]
+          },
+        "type" : "Microsoft.Network/publicIPAddresses"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressList.json
@@ -1,0 +1,60 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value" : [
+          {
+            "name" : "testDNS-ip",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/testDNS-ip",
+            "location" : "westus",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "publicIPAddressVersion" : "IPv4",
+              "publicIPAllocationMethod" : "Dynamic",
+              "idleTimeoutInMinutes" : 4,
+              "ipConfiguration" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+              },
+              "ipTags" : [
+                {
+                  "ipTagType" : "FirstPartyUsage",
+                  "tag" : "SQL"
+                },
+                {
+                  "ipTagType" : "FirstPartyUsage",
+                  "tag" : "Storage"
+                }
+               ]
+              },
+            "type" : "Microsoft.Network/publicIPAddresses"
+          },
+          {
+            "name" : "ip03",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/ip03",
+            "location" : "westus",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "ipAddress" : "40.85.154.247",
+              "publicIPAddressVersion" : "IPv4",
+              "publicIPAllocationMethod" : "Dynamic",
+              "idleTimeoutInMinutes" : 4,
+              "dnsSettings" : {
+                "domainNameLabel" : "testlbl",
+                "fqdn" : "testlbl.westus.cloudapp.azure.com"
+              },
+              "ipConfiguration" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/testLb/frontendIPConfigurations/LoadBalancerFrontEnd"
+              }
+            },
+            "type" : "Microsoft.Network/publicIPAddresses"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressListAll.json
@@ -1,0 +1,49 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value" : [
+          {
+            "name" : "testDNS-ip",
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/testDNS-ip",
+            "location" : "westus",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "publicIPAddressVersion" : "IPv4",
+              "publicIPAllocationMethod" : "Dynamic",
+              "idleTimeoutInMinutes" : 4,
+              "ipConfiguration" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+              }
+            },
+            "type" : "Microsoft.Network/publicIPAddresses"
+          },
+          {
+            "name" : "ip01",
+            "id" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/publicIPAddresses/ip01",
+            "location" : "westus",
+            "properties" : {
+              "provisioningState" : "Succeeded",
+              "ipAddress" : "40.85.154.247",
+              "publicIPAddressVersion" : "IPv4",
+              "publicIPAllocationMethod" : "Dynamic",
+              "idleTimeoutInMinutes" : 4,
+              "dnsSettings" : {
+                "domainNameLabel" : "testlbl",
+                "fqdn" : "testlbl.westus.cloudapp.azure.com"
+              },
+              "ipConfiguration" : {
+                "id" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/loadBalancers/testLb/frontendIPConfigurations/LoadBalancerFrontEnd"
+              }
+            },
+            "type" : "Microsoft.Network/publicIPAddresses"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressUpdateTags.json
@@ -1,0 +1,37 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "publicIpAddressName": "test-ip",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "testDNS-ip",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "publicIPAddressVersion" : "IPv4",
+          "publicIPAllocationMethod" : "Static",
+          "idleTimeoutInMinutes" : 10,
+          "ipConfiguration" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testDNS649/ipConfigurations/ipconfig1"
+          }
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "type" : "Microsoft.Network/publicIPAddresses"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterCreate.json
@@ -1,0 +1,96 @@
+{
+    "parameters": {
+        "routeFilterName": "filterName",
+        "resourceGroupName": "rg1",
+        "api-version": "2017-11-01",
+        "subscriptionId": "subid",
+        "routeFilterParameters": {
+            "location": "West US",
+            "tags": {
+                "key1": "value1"
+            },
+            "properties": {
+                "rules": [
+                    {
+                        "name": "ruleName",
+                        "properties": {
+                            "access": "Allow",
+                            "routeFilterRuleType": "Community",
+                            "communities": [
+                                "12076:5030",
+                                "12076:5040"
+                            ]
+                        }
+                    }
+                ],
+                "peerings": [ ]
+            }
+        }
+    },
+    "responses": {
+        "201": {
+            "body": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName",
+                "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                "location": "West US",
+                "name": "filterName",
+                "type": "Microsofot.Network/routeFilters",
+                "tags": {
+                    "key1": "value1"
+                },
+                "properties": {
+                    "provisioningState": "Succeeded",
+                    "rules": [
+                        {
+                            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+                            "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                            "name": "ruleName",
+                            "properties": {
+                                "provisioningState": "Succeeded",
+                                "access": "Allow",
+                                "routeFilterRuleType": "Community",
+                                "communities": [
+                                    "12076:5030",
+                                    "12076:5040"
+                                ]
+                            }
+                        }
+                    ],
+                    "peerings": [ ]
+                }
+            }
+        },
+        "200": {
+            "body": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName",
+                "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                "location": "West US",
+                "name": "filterName",
+                "type": "Microsofot.Network/routeFilters",
+                "tags": {
+                    "key1": "value1"
+                },
+                "properties": {
+                    "provisioningState": "Succeeded",
+                    "rules": [
+                        {
+                            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+                            "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                            "name": "ruleName",
+                            "properties": {
+                                "provisioningState": "Succeeded",
+                                "access": "Allow",
+                                "routeFilterRuleType": "Community",
+                                "communities": [
+                                    "12076:5030",
+                                    "12076:5040"
+                                ]
+                            }
+                        }
+                    ],
+                    "peerings": [ ]
+                }
+            }
+        }
+    }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "routeFilterName": "filterName",
+    "resourceGroupName": "rg1",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": { },
+    "202": { },
+    "204": { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterGet.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "routeFilterName": "filterName",
+    "resourceGroupName": "rg1",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName",
+        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+        "location": "West US",
+        "name": "filterName",
+        "type": "Microsofot.Network/routeFilters",
+        "tags": {
+          "key1": "value1"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+              "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+              "name": "ruleName",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "access": "Allow",
+                "routeFilterRuleType": "Community",
+                "communities": [
+                  "12076:5030",
+                  "12076:5040"
+                ]
+              }
+            }
+          ],
+          "peerings": []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterList.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName",
+              "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+              "location": "West US",
+              "name": "filterName",
+              "type": "Microsofot.Network/routeFilters",
+              "tags": {
+                "key1": "value1"
+              },
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+                    "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                    "name": "ruleName",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "access": "Allow",
+                      "routeFilterRuleType": "Community",
+                      "communities": [
+                        "12076:5030",
+                        "12076:5040"
+                      ]
+                    }
+                  }
+                ],
+                "peerings": []
+              }            
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterListByResourceGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterListByResourceGroup.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName",
+              "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+              "location": "West US",
+              "name": "filterName",
+              "type": "Microsofot.Network/routeFilters",
+              "tags": {
+                "key1": "value1"
+              },
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+                    "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+                    "name": "ruleName",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "access": "Allow",
+                      "routeFilterRuleType": "Community",
+                      "communities": [
+                        "12076:5030",
+                        "12076:5040"
+                      ]
+                    }
+                  }
+                ],
+                "peerings": []
+              }            
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleCreate.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "routeFilterName": "filterName",
+    "ruleName": "ruleName",
+    "resourceGroupName": "rg1",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "routeFilterRuleParameters": {
+      "tags": {
+        "key1": "value1"
+      },
+      "properties": {
+        "access": "Allow",
+        "routeFilterRuleType": "Community",
+        "communities": [
+          "12076:5030",
+          "12076:5040"
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+        "tags": {
+          "key1": "value1"
+        },
+        "name": "ruleName",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "access": "Allow",
+          "routeFilterRuleType": "Community",
+          "communities": [
+            "12076:5030",
+            "12076:5040"
+          ]
+        }
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+        "tags": {
+          "key1": "value1"
+        },
+        "name": "ruleName",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "access": "Allow",
+          "routeFilterRuleType": "Community",
+          "communities": [
+            "12076:5030",
+            "12076:5040"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleDelete.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "routeFilterName": "filterName",
+    "ruleName": "ruleName",
+    "resourceGroupName": "rg1",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": { },
+    "202": { },
+    "204": { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "ruleName": "filterName",
+    "routeFilterName": "filterName",
+    "resourceGroupName": "rg1",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+        "tags": {
+          "key1": "value1"
+        },
+        "name": "ruleName",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "access": "Allow",
+          "routeFilterRuleType": "Community",
+          "communities": [
+            "12076:5030",
+            "12076:5040"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleListByRouteFilter.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleListByRouteFilter.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "subid",
+    "routeFilterName": "filterName"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+            "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+            "tags": {
+              "key1": "value1"
+            },
+            "name": "ruleName",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "access": "Allow",
+              "routeFilterRuleType": "Community",
+              "communities": [
+                "12076:5030",
+                "12076:5040"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterRuleUpdate.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "routeFilterName": "filterName",
+    "ruleName": "ruleName",
+    "resourceGroupName": "rg1",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "routeFilterRuleParameters": {
+      "tags": {
+        "key1": "value1"
+      },
+      "properties": {
+        "access": "Allow",
+        "routeFilterRuleType": "Community",
+        "communities": [
+          "12076:5030",
+          "12076:5040"
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+        "tags": {
+          "key1": "value1"
+        },
+        "name": "ruleName",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "access": "Allow",
+          "routeFilterRuleType": "Community",
+          "communities": [
+            "12076:5030",
+            "12076:5040"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteFilterUpdate.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "routeFilterName": "filterName",
+    "resourceGroupName": "rg1",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "routeFilterParameters": {
+      "tags": {
+        "key1": "value1"
+      },
+      "properties": {
+        "rules": [
+          {
+            "name": "ruleName",
+            "properties": {
+              "access": "Allow",
+              "routeFilterRuleType": "Community",
+              "communities": [
+                "12076:5030"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName",
+        "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+        "location": "West US",
+        "name": "filterName",
+        "type": "Microsofot.Network/routeFilters",
+        "tags": {
+          "key1": "value1"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsofot.Network/routeFilters/filterName/routeFilterRules/ruleName",
+              "etag": "w/\\00000000-0000-0000-0000-000000000000\\",
+              "name": "ruleName",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "access": "Allow",
+                "routeFilterRuleType": "Community",
+                "communities": [
+                  "12076:5030"
+                ]
+              }
+            }
+          ],
+          "peerings": []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableCreate.json
@@ -1,0 +1,37 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "routeTableName" : "testrt",
+    "parameters": {}
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "testrt",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt",
+        "type": "Microsoft.Network/routeTables",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "routes": [ ],
+          "disableBgpRoutePropagation": true
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "testrt",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt",
+        "type": "Microsoft.Network/routeTables",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "disableBgpRoutePropagation": true,
+          "routes": [ ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableCreateWithRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableCreateWithRoute.json
@@ -1,0 +1,69 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "routeTableName" : "testrt",
+    "parameters": {
+      "properties": {
+        "disableBgpRoutePropagation": true,
+        "routes": [
+          {
+            "name": "route1",
+            "properties": {
+              "addressPrefix": "10.0.3.0/24",
+              "nextHopType": "VirtualNetworkGateway"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "testrt",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt",
+        "type": "Microsoft.Network/routeTables",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "disableBgpRoutePropagation": true,
+          "routes": [
+            {
+              "name": "route1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "addressPrefix": "10.0.3.0/24",
+                "nextHopType": "VirtualNetworkGateway"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "testrt",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt",
+        "type": "Microsoft.Network/routeTables",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "routes": [
+            {
+              "name": "route1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "addressPrefix": "10.0.3.0/24",
+                "nextHopType": "VirtualNetworkGateway"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "routeTableName" : "testrt"
+  },
+  "responses" : {
+    "200" : { },
+    "202" : { },
+    "204" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableGet.json
@@ -1,0 +1,33 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "routeTableName" : "testrt"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "testrt",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt",
+        "type": "Microsoft.Network/routeTables",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "disableBgpRoutePropagation": false,
+          "routes": [
+            {
+              "name": "route1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "addressPrefix": "10.0.3.0/24",
+                "nextHopType": "VirtualNetworkGateway"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableList.json
@@ -1,0 +1,47 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "testrt",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt",
+            "type": "Microsoft.Network/routeTables",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "disableBgpRoutePropagation": true,
+              "routes": [
+                {
+                  "name": "route1",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route1",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "addressPrefix": "10.0.3.0/24",
+                    "nextHopType": "VirtualNetworkGateway"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "testrt2",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt2",
+            "type": "Microsoft.Network/routeTables",
+            "location": "westus",
+            "properties": {
+              "disableBgpRoutePropagation": true,
+              "provisioningState": "Succeeded",
+              "routes": [ ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableListAll.json
@@ -1,0 +1,44 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "testrt",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt",
+            "type": "Microsoft.Network/routeTables",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "routes": [
+                {
+                  "name": "route1",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route1",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "addressPrefix": "10.0.3.0/24",
+                    "nextHopType": "VirtualNetworkGateway"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "testrt3",
+            "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/routeTables/testrt3",
+            "type": "Microsoft.Network/routeTables",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "routes": [ ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableRouteCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableRouteCreate.json
@@ -1,0 +1,39 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "routeTableName" : "testrt",
+    "routeName": "route1",
+    "routeParameters": {
+      "properties": {
+        "addressPrefix": "10.0.3.0/24",
+        "nextHopType": "VirtualNetworkGateway"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "route1",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "addressPrefix": "10.0.3.0/24",
+          "nextHopType": "VirtualNetworkGateway"
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name": "route1",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "addressPrefix": "10.0.3.0/24",
+          "nextHopType": "VirtualNetworkGateway"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableRouteDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableRouteDelete.json
@@ -1,0 +1,14 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "routeTableName" : "testrt",
+    "routeName": "route1"
+  },
+  "responses" : {
+    "200" : { },
+    "202" : { },
+    "204" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableRouteGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableRouteGet.json
@@ -1,0 +1,22 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "routeTableName" : "testrt",
+    "routeName": "route1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "route1",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "addressPrefix": "10.0.3.0/24",
+          "nextHopType": "Internet"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableRouteList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableRouteList.json
@@ -1,0 +1,34 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "routeTableName" : "testrt"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "route1",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "addressPrefix": "10.0.3.0/24",
+              "nextHopType": "Internet"
+            }
+          },
+          {
+            "name": "route2",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt/routes/route2",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "addressPrefix": "10.0.2.0/24",
+              "nextHopType": "VirtualNetworkGateway"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/RouteTableUpdateTags.json
@@ -1,0 +1,32 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "routeTableName" : "testrt",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "testrt",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeTables/testrt",
+        "type": "Microsoft.Network/routeTables",
+        "location": "westus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "routes": [ ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ServiceCommunityList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/ServiceCommunityList.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid/providers/Microsofot.Network/bgpServiceCommunities/skype",
+            "name": "skype",
+            "type": "Microsofot.Network/bgpServiceCommunities",
+            "properties": {
+              "serviceName" : "skype",
+              "bgpCommunities": [
+                {
+                  "serviceSupportedRegion": "Global",
+                  "communityName": "Skype For Business Online",
+                  "communityValue": "12076:5030",
+                  "communityPrefixes": [
+                    "13.67.56.225/32",
+                    "13.67.186.105/32"
+                  ],
+                  "isAuthorizedToUse": true,
+                  "serviceGroup" : "O365"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/subid/providers/Microsofot.Network/bgpServiceCommunities/exchange",
+            "name": "exchange",
+            "type": "Microsofot.Network/bgpServiceCommunities",
+            "properties": {
+              "serviceName" : "exchange",
+              "bgpCommunities": [
+                {
+                  "serviceSupportedRegion": "Global",
+                  "communityName": "Exchange Online",
+                  "communityValue": "12076:5040",
+                  "communityPrefixes": [
+                    "13.67.56.225/32",
+                    "13.67.186.105/32"
+                  ],
+                  "isAuthorizedToUse": true,
+                  "serviceGroup" : "O365"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetCreate.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "subnetName": "subnet1",
+    "virtualNetworkName": "vnetname",
+    "resourceGroupName": "subnet-test",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "subnetParameters": {
+      "properties": {
+        "addressPrefix": "10.0.0.0/16"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/subnet-test/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/subnet1",
+        "name": "subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/16",
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/subnet-test/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/subnet1",
+        "name": "subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/16",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetCreateServiceEndpoint.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetCreateServiceEndpoint.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "subnetName": "subnet1",
+    "virtualNetworkName": "vnetname",
+    "resourceGroupName": "subnet-test",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "subnetParameters": {
+      "properties": {
+        "addressPrefix": "10.0.0.0/16",
+        "serviceEndpoints": [
+          { "service": "Microsoft.Storage" }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/subnet-test/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/subnet1",
+        "name": "subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/16",
+          "serviceEndpoints": [{
+            "service": "Microsoft.Storage",
+            "locations": [
+              "eastus2(stage)",
+              "usnorth(stage)"
+            ],
+            "provisioningState": "Succeeded"
+          }],
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/subnet-test/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/subnet1",
+        "name": "subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/16",
+          "serviceEndpoints": [{
+            "service": "Microsoft.Storage",
+            "locations": [
+              "eastus2(stage)",
+              "usnorth(stage)"
+            ],
+            "provisioningState": "Succeeded"
+          }],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetDelete.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "subnetName": "subnet1",
+    "virtualNetworkName": "vnetname",
+    "resourceGroupName": "subnet-test",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": { },
+    "202": { },
+    "204": { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetGet.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "subnetName": "subnet1",
+    "virtualNetworkName": "vnetname",
+    "resourceGroupName": "subnet-test",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/subnet-test/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/subnet1",
+        "name": "subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/16",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/SubnetList.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "virtualNetworkName": "vnetname",
+    "resourceGroupName": "subnet-test",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/subnet-test/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/subnet1",
+            "name": "subnet1",
+            "properties": {
+              "addressPrefix": "10.0.0.0/16",
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/subnet-test/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/subnet2",
+            "name": "subnet2",
+            "properties": {
+              "addressPrefix": "10.0.0.0/16",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/UsageList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/UsageList.json
@@ -1,0 +1,265 @@
+{
+  "parameters": {
+    "location": "westus",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "currentValue": 8.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/VirtualNetworks",
+            "limit": 50.0,
+            "name": {
+              "localizedValue": "Virtual Networks",
+              "value": "VirtualNetworks"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 3.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/StaticPublicIPAddresses",
+            "limit": 20.0,
+            "name": {
+              "localizedValue": "Static Public IP Addresses",
+              "value": "StaticPublicIPAddresses"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 1.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/NetworkSecurityGroups",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Network Security Groups",
+              "value": "NetworkSecurityGroups"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 8.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/PublicIPAddresses",
+            "limit": 60.0,
+            "name": {
+              "localizedValue": "Public IP Addresses",
+              "value": "PublicIPAddresses"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 2.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/NetworkInterfaces",
+            "limit": 350.0,
+            "name": {
+              "localizedValue": "Network Interfaces",
+              "value": "NetworkInterfaces"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 2.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/LoadBalancers",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Load Balancers",
+              "value": "LoadBalancers"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 1.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/ApplicationGateways",
+            "limit": 50.0,
+            "name": {
+              "localizedValue": "Application Gateways",
+              "value": "ApplicationGateways"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/RouteTables",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Route Tables",
+              "value": "RouteTables"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/RouteFilters",
+            "limit": 1000.0,
+            "name": {
+              "localizedValue": "Route Filters",
+              "value": "RouteFilters"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/NetworkWatchers",
+            "limit": 1.0,
+            "name": {
+              "localizedValue": "Network Watchers",
+              "value": "NetworkWatchers"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/PacketCaptures",
+            "limit": 10.0,
+            "name": {
+              "localizedValue": "Packet Captures",
+              "value": "PacketCaptures"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/DnsServersPerVirtualNetwork",
+            "limit": 9.0,
+            "name": {
+              "localizedValue": "DNS servers per Virtual Network",
+              "value": "DnsServersPerVirtualNetwork"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/SubnetsPerVirtualNetwork",
+            "limit": 1000.0,
+            "name": {
+              "localizedValue": "Subnets per Virtual Network",
+              "value": "SubnetsPerVirtualNetwork"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/IPConfigurationsPerVirtualNetwork",
+            "limit": 4096.0,
+            "name": {
+              "localizedValue": "IP Configurations per Virtual Network",
+              "value": "IPConfigurationsPerVirtualNetwork"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/PeeringsPerVirtualNetwork",
+            "limit": 10.0,
+            "name": {
+              "localizedValue": "Peerings per Virtual Network",
+              "value": "PeeringsPerVirtualNetwork"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/SecurityRulesPerNetworkSecurityGroup",
+            "limit": 200.0,
+            "name": {
+              "localizedValue": "Security rules per Network Security Group",
+              "value": "SecurityRulesPerNetworkSecurityGroup"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/SecurityRuleAddressesOrPortsPerNetworkSecurityGroup",
+            "limit": 2000.0,
+            "name": {
+              "localizedValue": "Security rules addresses or ports per Network Security Group",
+              "value": "SecurityRuleAddressesOrPortsPerNetworkSecurityGroup"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/InboundRulesPerLoadBalancer",
+            "limit": 150.0,
+            "name": {
+              "localizedValue": "Inbound Rules per Load Balancer",
+              "value": "InboundRulesPerLoadBalancer"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/FrontendIPConfigurationPerLoadBalancer",
+            "limit": 10.0,
+            "name": {
+              "localizedValue": "Frontend IP Configurations per Load Balancer",
+              "value": "FrontendIPConfigurationPerLoadBalancer"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/OutboundNatRulesPerLoadBalancer",
+            "limit": 5.0,
+            "name": {
+              "localizedValue": "Outbound NAT Rules per Load Balancer",
+              "value": "OutboundNatRulesPerLoadBalancer"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/RoutesPerRouteTable",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Routes per Route Table",
+              "value": "RoutesPerRouteTable"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/SecondaryIPConfigurationsPerNetworkInterface",
+            "limit": 256.0,
+            "name": {
+              "localizedValue": "Secondary IP Configurations per Network Interface",
+              "value": "SecondaryIPConfigurationsPerNetworkInterface"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/InboundRulesPerNetworkInterface",
+            "limit": 500.0,
+            "name": {
+              "localizedValue": "Inbound rules per Network Interface",
+              "value": "InboundRulesPerNetworkInterface"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/RouteFilterRulesPerRouteFilter",
+            "limit": 1.0,
+            "name": {
+              "localizedValue": "Route filter rules per Route Filter",
+              "value": "RouteFilterRulesPerRouteFilter"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/westus/usages/RouteFiltersPerExpressRouteBgpPeering",
+            "limit": 1.0,
+            "name": {
+              "localizedValue": "Route filters per Express route BGP Peering",
+              "value": "RouteFiltersPerExpressRouteBgpPeering"
+            },
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCheckIPAddressAvailability.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCheckIPAddressAvailability.json
@@ -1,0 +1,23 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualNetworkName" : "test-vnet",
+    "IPAddress": "10.0.1.4"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "available": false,
+        "availableIPAddresses": [
+          "10.0.1.5",
+          "10.0.1.6",
+          "10.0.1.7",
+          "10.0.1.8",
+          "10.0.1.9"
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreate.json
@@ -1,0 +1,56 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualNetworkName" : "test-vnet",
+    "location": "westus",
+    "parameters": {
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        }
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "test-vnet",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
+        "type" : "Microsoft.Network/virtualNetworks",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "addressSpace" : {
+            "addressPrefixes" : [
+              "10.0.0.0/16"
+            ]
+          },
+          "subnets" : [],
+          "virtualNetworkPeerings" : []
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name" : "test-vnet",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
+        "type" : "Microsoft.Network/virtualNetworks",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "addressSpace" : {
+            "addressPrefixes" : [
+              "10.0.0.0/16"
+            ]
+          },
+          "subnets" : [],
+          "virtualNetworkPeerings" : []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -1,0 +1,110 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "vnetTest",
+    "virtualNetworkName" : "vnet1",
+    "parameters": {
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "test-1",
+            "properties": {
+              "addressPrefix": "10.0.0.0/16",
+              "serviceEndpoints": [
+                {
+                  "service": "Microsoft.Storage"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "vnet1",
+        "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
+        "type" : "Microsoft.Network/virtualNetworks",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "addressSpace" : {
+            "addressPrefixes" : [
+              "10.0.0.0/16"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "test-1",
+              "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
+              "properties": {
+                "addressPrefix": "10.0.0.0/16",
+                "ipConfigurations": [],
+                "resourceNavigationLinks": [],
+                "serviceEndpoints": [
+                  {
+                    "provisioningState": "Succeeded",
+                    "service": "Microsoft.Storage",
+                    "locations": [
+                      "eastus2(stage)",
+                      "usnorth(stage)"
+                    ]
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "virtualNetworkPeerings" : []
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name" : "vnet1",
+        "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
+        "type" : "Microsoft.Network/virtualNetworks",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "addressSpace" : {
+            "addressPrefixes" : [
+              "10.0.0.0/16"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "test-1",
+              "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
+              "properties": {
+                "addressPrefix": "10.0.0.0/16",
+                "ipConfigurations": [],
+                "resourceNavigationLinks": [],
+                "serviceEndpoints": [
+                  {
+                    "provisioningState": "Succeeded",
+                    "service": "Microsoft.Storage",
+                    "locations": [
+                      "eastus2(stage)",
+                      "usnorth(stage)"
+                    ]
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "virtualNetworkPeerings" : []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreateSubnet.json
@@ -1,0 +1,81 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualNetworkName" : "test-vnet",
+    "parameters": {
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "test-1",
+            "properties": {
+              "addressPrefix": "10.0.0.0/24"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "test-vnet",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
+        "type" : "Microsoft.Network/virtualNetworks",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "addressSpace" : {
+            "addressPrefixes" : [
+              "10.0.0.0/16"
+            ]
+          },
+          "subnets": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-1",
+              "name": "test-1",
+              "properties": {
+                "addressPrefix": "10.0.0.0/24",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "virtualNetworkPeerings" : []
+        }
+      }
+    },
+    "201" : {
+      "body" : {
+        "name" : "test-vnet",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
+        "type" : "Microsoft.Network/virtualNetworks",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "addressSpace" : {
+            "addressPrefixes" : [
+              "10.0.0.0/16"
+            ]
+          },
+          "subnets": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-1",
+              "name": "test-1",
+              "properties": {
+                "addressPrefix": "10.0.0.0/24",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "virtualNetworkPeerings" : []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName": "rg1",
+    "virtualNetworkName": "test-vnet"
+  },
+  "responses" : {
+    "200" : { },
+    "202" : { },
+    "204" : { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkGatewayConnectionUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkGatewayConnectionUpdateTags.json
@@ -1,0 +1,47 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualNetworkGatewayConnectionName": "test",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "test",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/connections/test",
+        "type": "Microsoft.Network/connections",
+        "location": "westus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000",
+          "virtualNetworkGateway1": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw"
+          },
+          "localNetworkGateway2": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/localNetworkGateways/lgw"
+          },
+          "connectionType": "IPsec",
+          "routingWeight": 0,
+          "sharedKey": "temp1234",
+          "enableBgp": false,
+          "usePolicyBasedTrafficSelectors": false,
+          "ipsecPolicies": [],
+          "connectionStatus": "Unknown",
+          "ingressBytesTransferred": 0,
+          "egressBytesTransferred": 0
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkGatewayUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkGatewayUpdateTags.json
@@ -1,0 +1,62 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualNetworkGatewayName" : "vpngw",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "vpngw",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw",
+        "type": "Microsoft.Network/virtualNetworkGateways",
+        "location": "westus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000",
+          "ipConfigurations": [
+            {
+              "name": "default",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw/ipConfigurations/default",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAllocationMethod": "Dynamic",
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/testpub1"
+                },
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/GatewaySubnet"
+                }
+              }
+            }
+          ],
+          "sku": {
+            "name": "VpnGw1",
+            "tier": "VpnGw1",
+            "capacity": 2
+          },
+          "gatewayType": "Vpn",
+          "vpnType": "RouteBased",
+          "enableBgp": false,
+          "activeActive": false,
+          "bgpSettings": {
+            "asn": 65515,
+            "bgpPeeringAddress": "10.0.0.254",
+            "peerWeight": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkGatewaysListConnections.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkGatewaysListConnections.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "subid",
+    "resourceGroupName": "testrg",
+    "virtualNetworkGatewayName": "test-vpn-gateway-1",
+    "api-version": "2017-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          { 
+            "name": "test-vpn-connection",
+            "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/connections/test-vpn-connection",
+            "etag": "W/\\\"00000000-0000-0000-0000-000000000000\\\"",
+            "type": "Microsoft.Network/connections",
+            "location": "eastus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-000000000000",
+              "virtualNetworkGateway1": {
+                "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworkGateways/test-vpn-gateway-1"
+              },
+              "virtualNetworkGateway2": {
+                "id": "/subscriptions/subid/resourceGroups/testrg-2/providers/Microsoft.Network/virtualNetworkGateways/test-vpn-gateway-2"
+              },
+              "connectionType": "Vnet2Vnet",
+              "routingWeight": 22,
+              "enableBgp": true,
+              "usePolicyBasedTrafficSelectors": false,
+              "ipsecPolicies": [],
+              "ingressBytesTransferred": 0,
+              "egressBytesTransferred": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkGet.json
@@ -1,0 +1,41 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualNetworkName" : "test-vnet"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "test-vnet",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
+        "type" : "Microsoft.Network/virtualNetworks",
+        "location" : "westus",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "addressSpace" : {
+            "addressPrefixes" : [
+              "10.0.0.0/16"
+            ]
+          },
+          "subnets" : [{
+              "name" : "subnet1",
+              "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1",
+              "properties" : {
+                "provisioningState" : "Succeeded",
+
+                "addressPrefix" : "10.0.1.0/24",
+                "ipConfigurations" : [{
+                    "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe"
+                  }
+                ]
+              }
+            }
+          ],
+          "virtualNetworkPeerings" : []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkList.json
@@ -1,0 +1,64 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1",
+            "name": "vnet1",
+            "type": "Microsoft.Network/virtualNetworks",
+            "location": "westus",
+            "properties": {
+              "addressSpace": {
+                "addressPrefixes": [
+                  "10.0.0.0/8"
+                ]
+              },
+              "dhcpOptions": {
+                "dnsServers": []
+              },
+              "subnets": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
+                  "name": "test-1",
+                  "properties": {
+                    "addressPrefix": "10.0.0.0/24",
+                    "provisioningState": "Succeeded"
+                  }
+                }
+              ],
+              "virtualNetworkPeerings": [],
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet2",
+            "name": "vnet2",
+            "type": "Microsoft.Network/virtualNetworks",
+            "location": "westus",
+            "properties": {
+              "addressSpace": {
+                "addressPrefixes": [
+                  "10.0.0.0/16"
+                ]
+              },
+              "dhcpOptions": {
+                "dnsServers": [
+                  "8.8.8.8"
+                ]
+              },
+              "subnets": [],
+              "virtualNetworkPeerings": [],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkListAll.json
@@ -1,0 +1,63 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1",
+            "name": "vnet1",
+            "type": "Microsoft.Network/virtualNetworks",
+            "location": "westus",
+            "properties": {
+              "addressSpace": {
+                "addressPrefixes": [
+                  "10.0.0.0/8"
+                ]
+              },
+              "dhcpOptions": {
+                "dnsServers": []
+              },
+              "subnets": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
+                  "name": "test-1",
+                  "properties": {
+                    "addressPrefix": "10.0.0.0/24",
+                    "provisioningState": "Succeeded"
+                  }
+                }
+              ],
+              "virtualNetworkPeerings": [],
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/vnet2",
+            "name": "vnet2",
+            "type": "Microsoft.Network/virtualNetworks",
+            "location": "westus",
+            "properties": {
+              "addressSpace": {
+                "addressPrefixes": [
+                  "10.0.0.0/16"
+                ]
+              },
+              "dhcpOptions": {
+                "dnsServers": [
+                  "8.8.8.8"
+                ]
+              },
+              "subnets": [],
+              "virtualNetworkPeerings": [],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkListUsage.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkListUsage.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "virtualNetworkName": "vnetName",
+    "resourceGroupName": "rg1",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "currentValue": -1.0,
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetName/subnets/GatewaySubnet",
+            "limit": -1.0,
+            "name": {
+              "localizedValue": "Subnet size and usage",
+              "value": "SubnetSpace"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 2.0,
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetName/subnets/newSubnet",
+            "limit": 3.0,
+            "name": {
+              "localizedValue": "Subnet size and usage",
+              "value": "SubnetSpace"
+            },
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkPeeringCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkPeeringCreate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "virtualNetworkPeeringName": "peer",
+    "virtualNetworkName": "vnet1",
+    "resourceGroupName": "peerTest",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid",
+    "VirtualNetworkPeeringParameters": {
+      "properties": {
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": true,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false,
+        "remoteVirtualNetwork": {
+          "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet2"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peer",
+        "name": "peer",
+        "properties": {
+          "allowVirtualNetworkAccess": true,
+          "allowForwardedTraffic": true,
+          "allowGatewayTransit": false,
+          "useRemoteGateways": false,
+          "remoteVirtualNetwork": {
+            "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet2"
+          },
+          "remoteAddressSpace": {
+            "addressPrefixes": [
+              "12.0.0.0/8"
+            ]
+          },
+          "peeringState": "Initiated",
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peer",
+        "name": "peer",
+        "properties": {
+          "allowVirtualNetworkAccess": true,
+          "allowForwardedTraffic": true,
+          "allowGatewayTransit": false,
+          "useRemoteGateways": false,
+          "remoteVirtualNetwork": {
+            "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet2"
+          },
+          "remoteAddressSpace": {
+            "addressPrefixes": [
+              "12.0.0.0/8"
+            ]
+          },
+          "peeringState": "Initiated",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkPeeringDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkPeeringDelete.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "virtualNetworkPeeringName": "peer",
+    "virtualNetworkName": "vnet1",
+    "resourceGroupName": "peerTest",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": { },
+    "202": { },
+    "204": { }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkPeeringGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkPeeringGet.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "virtualNetworkPeeringName": "peer",
+    "virtualNetworkName": "vnet1",
+    "resourceGroupName": "peerTest",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peer",
+        "name": "peer",
+        "properties": {
+          "allowVirtualNetworkAccess": true,
+          "allowForwardedTraffic": true,
+          "allowGatewayTransit": false,
+          "useRemoteGateways": false,
+          "remoteVirtualNetwork": {
+            "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet2"
+          },
+          "remoteAddressSpace": {
+            "addressPrefixes": [
+              "12.0.0.0/8"
+            ]
+          },
+          "peeringState": "Initiated",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkPeeringList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkPeeringList.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "virtualNetworkName": "vnet1",
+    "resourceGroupName": "peerTest",
+    "api-version": "2017-11-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peer",
+            "name": "peer",
+            "properties": {
+              "allowVirtualNetworkAccess": true,
+              "allowForwardedTraffic": true,
+              "allowGatewayTransit": false,
+              "useRemoteGateways": false,
+              "remoteVirtualNetwork": {
+                "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet2"
+              },
+              "remoteAddressSpace": {
+                "addressPrefixes": [
+                  "12.0.0.0/8"
+                ]
+              },
+              "peeringState": "Initiated",
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet1/virtualNetworkPeerings/peer2",
+            "name": "peer",
+            "properties": {
+              "allowVirtualNetworkAccess": true,
+              "allowForwardedTraffic": false,
+              "allowGatewayTransit": false,
+              "useRemoteGateways": false,
+              "remoteVirtualNetwork": {
+                "id": "/subscriptions/subid/resourceGroups/peerTest/providers/Microsoft.Network/virtualNetworks/vnet3"
+              },
+              "remoteAddressSpace": {
+                "addressPrefixes": [
+                  "13.0.0.0/8"
+                ]
+              },
+              "peeringState": "Initiated",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkUpdateTags.json
@@ -1,0 +1,39 @@
+{
+  "parameters" : {
+    "api-version" : "2017-11-01",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualNetworkName" : "test-vnet",
+    "location": "westus",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "test-vnet",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
+        "type" : "Microsoft.Network/virtualNetworks",
+        "location" : "westus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "addressSpace" : {
+            "addressPrefixes" : [
+              "10.0.0.0/16"
+            ]
+          },
+          "subnets" : [],
+          "virtualNetworkPeerings" : []
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssNetworkInterfaceGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssNetworkInterfaceGet.json
@@ -1,0 +1,65 @@
+{
+  "parameters" : {
+    "api-version" : "2017-03-30",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "networkInterfaceName" : "nic1",
+    "virtualMachineScaleSetName": "vmss1",
+    "virtualmachineIndex": "1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name" : "nic1",
+        "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1",
+        "properties" : {
+          "provisioningState" : "Succeeded",
+          "ipConfigurations" : [
+            {
+              "name" : "ip1",
+              "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1",
+              "properties" : {
+                "provisioningState" : "Succeeded",
+                "privateIPAddress" : "10.0.0.5",
+                "privateIPAllocationMethod" : "Dynamic",
+                "publicIPAddress" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1/publicIPAddresses/pub1"
+                },
+                "subnet" : {
+                  "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
+                },
+                "primary" : true,
+                "privateIPAddressVersion" : "IPv4",
+                "loadBalancerBackendAddressPools" : [
+                  {
+                    "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/addressPool1"
+                  }
+                ],
+                "loadBalancerInboundNatRules" : [
+                  {
+                    "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natPool1.1"
+                  }
+                ]
+              }
+            }
+          ],
+          "dnsSettings" : {
+            "dnsServers" : [],
+            "appliedDnsServers" : [],
+            "internalDomainNameSuffix" : "dns.cdmx.internal.cloudapp.net"
+          },
+          "macAddress" : "00-00-00-00-00-00",
+          "enableAcceleratedNetworking" : false,
+          "enableIPForwarding" : false,
+          "networkSecurityGroup" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1"
+          },
+          "primary" : true,
+          "virtualMachine" : {
+            "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssNetworkInterfaceIpConfigGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssNetworkInterfaceIpConfigGet.json
@@ -1,0 +1,39 @@
+{
+  "parameters" : {
+    "api-version" : "2017-03-30",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualMachineScaleSetName": "vmss1",
+    "virtualmachineIndex": "2",
+    "networkInterfaceName": "nic1",
+    "ipConfigurationName": "ip1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "name": "ip1",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/nic1/ipConfigurations/ip1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateIPAddress": "10.0.0.6",
+          "privateIPAllocationMethod": "Dynamic",
+          "subnet": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
+          },
+          "primary": true,
+          "privateIPAddressVersion": "IPv4",
+          "loadBalancerBackendAddressPools": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/addressPool1"
+            }
+          ],
+          "loadBalancerInboundNatRules": [
+            {
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natPool1.2"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssNetworkInterfaceIpConfigList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssNetworkInterfaceIpConfigList.json
@@ -1,0 +1,42 @@
+{
+  "parameters" : {
+    "api-version" : "2017-03-30",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualMachineScaleSetName": "vmss1",
+    "virtualmachineIndex": "2",
+    "networkInterfaceName": "nic1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "ip1",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/2/networkInterfaces/nic1/ipConfigurations/ip1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "privateIPAddress": "10.0.0.6",
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
+              },
+              "primary": true,
+              "privateIPAddressVersion": "IPv4",
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/addressPool1"
+                }
+              ],
+              "loadBalancerInboundNatRules": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natPool1.2"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssNetworkInterfaceList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssNetworkInterfaceList.json
@@ -1,0 +1,118 @@
+{
+  "parameters" : {
+    "api-version" : "2017-03-30",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualMachineScaleSetName": "vmss1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "nic1",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/nic1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "ipConfigurations": [
+                {
+                  "name": "ip1",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/nic1/ipConfigurations/ip1",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAddress": "10.0.0.4",
+                    "privateIPAllocationMethod": "Dynamic",
+                    "publicIPAddress": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/nic1/ipConfigurations/ip1/publicIPAddresses/pub1"
+                    },
+                    "subnet": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
+                    },
+                    "primary": true,
+                    "privateIPAddressVersion": "IPv4",
+                    "loadBalancerBackendAddressPools": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/addressPool1"
+                      }
+                    ],
+                    "loadBalancerInboundNatRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natPool1.0"
+                      }
+                    ]
+                  }
+                }
+             ],
+              "dnsSettings": {
+                "dnsServers": [],
+                "appliedDnsServers": [],
+                "internalDomainNameSuffix": "ruw4wz3grewudjsyzrxj44pxod.cdmx.internal.cloudapp.net"
+              },
+              "macAddress": "00-00-00-00-00-00",
+              "enableAcceleratedNetworking": false,
+              "enableIPForwarding": false,
+              "networkSecurityGroup": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1"
+              },
+              "primary": true,
+              "virtualMachine": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0"
+              }
+            }
+          },
+          {
+            "name": "nic1",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "ipConfigurations": [
+                {
+                  "name": "ip1",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAddress": "10.0.0.5",
+                    "privateIPAllocationMethod": "Dynamic",
+                    "publicIPAddress": {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1/publicIPAddresses/pub1"
+                    },
+                    "subnet": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
+                    },
+                    "primary": true,
+                    "privateIPAddressVersion": "IPv4",
+                    "loadBalancerBackendAddressPools": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/addressPool1"
+                      }
+                    ],
+                    "loadBalancerInboundNatRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natPool1.1"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "dnsSettings": {
+                "dnsServers": [],
+                "appliedDnsServers": [],
+                "internalDomainNameSuffix": "ruw4wz3grewudjsyzrxj44pxod.cdmx.internal.cloudapp.net"
+              },
+              "macAddress": "00-00-00-00-00-00",
+              "enableAcceleratedNetworking": false,
+              "enableIPForwarding": false,
+              "networkSecurityGroup": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1"
+              },
+              "primary": true,
+              "virtualMachine": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssPublicIpGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssPublicIpGet.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "virtualMachineScaleSetName": "vmss1",
+    "resourceGroupName": "vmss-tester",
+    "api-version": "2017-03-30",
+    "subscriptionId": "subid",
+    "virtualmachineIndex": 1,
+    "networkInterfaceName": "nic1",
+    "ipConfigurationName": "ip1",
+    "publicIpAddressName": "pub1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/vmss-tester/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1/publicIPAddresses/pub1",
+        "name": "pub1",
+        "properties": {
+          "publicIPAllocationMethod": "Dynamic",
+          "publicIPAddressVersion": "IPv4",
+          "ipConfiguration": {
+            "id": "/subscriptions/subid/resourceGroups/vmss-tester/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1"
+          },
+          "dnsSettings": {
+            "domainNameLabel": "vm1.testvmssacc",
+            "fqdn": "vm1.testvmssacc.southeastasia.cloudapp.azure.com"
+          },
+          "ipAddress": "13.67.119.72",
+          "idleTimeoutInMinutes": 10,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssPublicIpListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssPublicIpListAll.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "virtualMachineScaleSetName": "vmss1",
+    "resourceGroupName": "vmss-tester",
+    "api-version": "2017-03-30",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/vmss-tester/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1/publicIPAddresses/pub1",
+            "name": "pub1",
+            "properties": {
+              "publicIPAllocationMethod": "Dynamic",
+              "publicIPAddressVersion": "IPv4",
+              "ipConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/vmss-tester/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1"
+              },
+              "dnsSettings": {
+                "domainNameLabel": "vm1.testvmssacc",
+                "fqdn": "vm1.testvmssacc.southeastasia.cloudapp.azure.com"
+              },
+              "ipAddress": "13.67.119.72",
+              "idleTimeoutInMinutes": 10,
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/subid/resourceGroups/vmss-tester/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/nic1/ipConfigurations/ip1/publicIPAddresses/pub1",
+            "name": "pub1",
+            "properties": {
+              "publicIPAllocationMethod": "Dynamic",
+              "publicIPAddressVersion": "IPv4",
+              "ipConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/vmss-tester/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/3/networkInterfaces/nic1/ipConfigurations/ip1"
+              },
+              "dnsSettings": {
+                "domainNameLabel": "vm3.testvmssacc",
+                "fqdn": "vm3.testvmssacc.southeastasia.cloudapp.azure.com"
+              },
+              "ipAddress": "13.67.118.216",
+              "idleTimeoutInMinutes": 10,
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssVmNetworkInterfaceList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssVmNetworkInterfaceList.json
@@ -1,0 +1,68 @@
+{
+  "parameters" : {
+    "api-version" : "2017-03-30",
+    "subscriptionId" : "subid",
+    "resourceGroupName" : "rg1",
+    "virtualMachineScaleSetName": "vmss1",
+    "virtualmachineIndex": "1"
+  },
+  "responses" : {
+    "200" : {
+      "body" : {
+        "value": [
+          {
+            "name": "nic1",
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "ipConfigurations": [
+                {
+                  "name": "ip1",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAddress": "10.0.0.5",
+                    "privateIPAllocationMethod": "Dynamic",
+                    "publicIPAddress": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1/publicIPAddresses/pub1"
+                    },
+                    "subnet": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
+                    },
+                    "primary": true,
+                    "privateIPAddressVersion": "IPv4",
+                    "loadBalancerBackendAddressPools": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/addressPool1"
+                      }
+                    ],
+                    "loadBalancerInboundNatRules": [
+                      {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/natPool1.1"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "dnsSettings": {
+                "dnsServers": [],
+                "appliedDnsServers": [],
+                "internalDomainNameSuffix": "ruw4wz3grewudjsyzrxj44pxod.cdmx.internal.cloudapp.net"
+              },
+              "macAddress": "00-00-00-00-00-00",
+              "enableAcceleratedNetworking": false,
+              "enableIPForwarding": false,
+              "networkSecurityGroup": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1"
+              },
+              "primary": true,
+              "virtualMachine": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssVmPublicIpList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VmssVmPublicIpList.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "virtualMachineScaleSetName": "vmss1",
+    "resourceGroupName": "vmss-tester",
+    "api-version": "2017-03-30",
+    "subscriptionId": "subid",
+    "virtualmachineIndex": 1,
+    "networkInterfaceName": "nic1",
+    "ipConfigurationName": "ip1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid/resourceGroups/vmss-tester/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1/publicIPAddresses/pub1",
+            "name": "pub1",
+            "properties": {
+              "publicIPAllocationMethod": "Dynamic",
+              "publicIPAddressVersion": "IPv4",
+              "ipConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/vmss-tester/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/1/networkInterfaces/nic1/ipConfigurations/ip1"
+              },
+              "dnsSettings": {
+                "domainNameLabel": "vm1.testvmssacc",
+                "fqdn": "vm1.testvmssacc.southeastasia.cloudapp.azure.com"
+              },
+              "ipAddress": "13.67.119.72",
+              "idleTimeoutInMinutes": 10,
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/expressRouteCircuit.json
@@ -1,0 +1,1622 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}": {
+      "delete": {
+        "tags": [
+          "ExpressRouteCircuitAuthorizations"
+        ],
+        "operationId": "ExpressRouteCircuitAuthorizations_Delete",
+        "description": "Deletes the specified authorization from the specified express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "authorizationName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the authorization."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Delete successful."
+          },
+          "204": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "ExpressRouteCircuitAuthorizations"
+        ],
+        "operationId": "ExpressRouteCircuitAuthorizations_Get",
+        "description": "Gets the specified authorization from the specified express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "authorizationName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the authorization."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the ExpressRouteCircuitAuthorization resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ExpressRouteCircuitAuthorizations"
+        ],
+        "operationId": "ExpressRouteCircuitAuthorizations_CreateOrUpdate",
+        "description": "Creates or updates an authorization in the specified express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "authorizationName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the authorization."
+          },
+          {
+            "name": "authorizationParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+            },
+            "description": "Parameters supplied to the create or update express route circuit authorization operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting ExpressRouteCircuitAuthorization resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting ExpressRouteCircuitAuthorization resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations": {
+      "get": {
+        "tags": [
+          "ExpressRouteCircuitAuthorizations"
+        ],
+        "operationId": "ExpressRouteCircuitAuthorizations_List",
+        "description": "Gets all authorizations in an express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the circuit."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of ExpressRouteCircuitAuthorization resources.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}": {
+      "delete": {
+        "tags": [
+          "ExpressRouteCircuitPeerings"
+        ],
+        "operationId": "ExpressRouteCircuitPeerings_Delete",
+        "description": "Deletes the specified peering from the specified express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delete successful."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "ExpressRouteCircuitPeerings"
+        ],
+        "operationId": "ExpressRouteCircuitPeerings_Get",
+        "description": "Gets the specified authorization from the specified express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting ExpressRouteCircuitPeering resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeering"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ExpressRouteCircuitPeerings"
+        ],
+        "operationId": "ExpressRouteCircuitPeerings_CreateOrUpdate",
+        "description": "Creates or updates a peering in the specified express route circuits.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "name": "peeringParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeering"
+            },
+            "description": "Parameters supplied to the create or update express route circuit peering operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting ExpressRouteCircuitPeering resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeering"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting ExpressRouteCircuitPeering resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeering"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings": {
+      "get": {
+        "tags": [
+          "ExpressRouteCircuitPeerings"
+        ],
+        "operationId": "ExpressRouteCircuitPeerings_List",
+        "description": "Gets all peerings in a specified express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of ExpressRouteCircuitPeering resources.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeeringListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}": {
+      "delete": {
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "operationId": "ExpressRouteCircuits_Delete",
+        "description": "Deletes the specified express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Delete successful."
+          },
+          "202": {
+            "description": "Accepted. Sets 'Disabling' provisioningState until the operation completes. Returns an operation URI that can be queried to find the current state of the operation."
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "operationId": "ExpressRouteCircuits_Get",
+        "description": "Gets information about the specified express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of express route circuit."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting ExpressRouteCircuit resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "operationId": "ExpressRouteCircuits_CreateOrUpdate",
+        "description": "Creates or updates an express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the circuit."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            },
+            "description": "Parameters supplied to the create or update express route circuit operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting ExpressRouteCircuit resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting ExpressRouteCircuit resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "operationId": "ExpressRouteCircuits_UpdateTags",
+        "description": "Updates an express route circuit tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the circuit."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update express route circuit tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting ExpressRouteCircuit resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Express Route Circuit Tags": { "$ref": "./examples/ExpressRouteCircuitUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/arpTables/{devicePath}": {
+      "post": {
+        "tags": [
+          "ExpressRouteCircuitArpTable"
+        ],
+        "operationId": "ExpressRouteCircuits_ListArpTable",
+        "description": "Gets the currently advertised ARP table associated with the express route circuit in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "name": "devicePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path of the device."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting ExpressRouteCircuitsArpTable resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitsArpTableListResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTables/{devicePath}": {
+      "post": {
+        "tags": [
+          "ExpressRouteCircuitRoutesTable"
+        ],
+        "operationId": "ExpressRouteCircuits_ListRoutesTable",
+        "description": "Gets the currently advertised routes table associated with the express route circuit in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "name": "devicePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path of the device."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting ExpressRouteCircuitsRouteTable resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitsRoutesTableListResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTablesSummary/{devicePath}": {
+      "post": {
+        "tags": [
+          "ExpressRouteCircuitRoutesTableSummary"
+        ],
+        "operationId": "ExpressRouteCircuits_ListRoutesTableSummary",
+        "description": "Gets the currently advertised routes table summary associated with the express route circuit in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "name": "devicePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The path of the device."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting ExpressRouteCircuitsRoutesTableSummary resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitsRoutesTableSummaryListResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/stats": {
+      "get": {
+        "tags": [
+          "ExpressRouteCircuitStats"
+        ],
+        "operationId": "ExpressRouteCircuits_GetStats",
+        "description": "Gets all the stats from an express route circuit in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting ExpressRouteCircuitStats resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitStats"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/stats": {
+      "get": {
+        "tags": [
+          "ExpressRouteCircuitStats"
+        ],
+        "operationId": "ExpressRouteCircuits_GetPeeringStats",
+        "description": "Gets all stats from an express route circuit in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting ExpressRouteCircuitStats resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitStats"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits": {
+      "get": {
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "operationId": "ExpressRouteCircuits_List",
+        "description": "Gets all the express route circuits in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting ExpressRouteCircuitAuthorization resource.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCircuits": {
+      "get": {
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "operationId": "ExpressRouteCircuits_ListAll",
+        "description": "Gets all the express route circuits in a subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of ExpressRouteCircuit resources.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteServiceProviders": {
+      "get": {
+        "tags": [
+          "ExpressRouteServiceProviders"
+        ],
+        "operationId": "ExpressRouteServiceProviders_List",
+        "description": "Gets all the available express route service providers.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of ExpressRouteServiceProdiver resources.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteServiceProviderListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AuthorizationPropertiesFormat": {
+      "properties": {
+        "authorizationKey": {
+          "type": "string",
+          "description": "The authorization key."
+        },
+        "authorizationUseStatus": {
+          "type": "string",
+          "description": "AuthorizationUseStatus. Possible values are: 'Available' and 'InUse'.",
+          "enum": [
+            "Available",
+            "InUse"
+          ],
+          "x-ms-enum": {
+            "name": "AuthorizationUseStatus",
+            "modelAsString": true
+          }
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      }
+    },
+    "ExpressRouteCircuitAuthorization": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AuthorizationPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Authorization in an ExpressRouteCircuit resource."
+    },
+    "AuthorizationListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+          },
+          "description": "The authorizations in an ExpressRoute Circuit."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListAuthorizations API service call retrieves all authorizations that belongs to an ExpressRouteCircuit."
+    },
+    "ExpressRouteCircuitPeeringConfig": {
+      "properties": {
+        "advertisedPublicPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The reference of AdvertisedPublicPrefixes."
+        },
+        "advertisedCommunities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The communities of bgp peering. Spepcified for microsoft peering"
+        },
+        "advertisedPublicPrefixesState": {
+          "type": "string",
+          "description": "AdvertisedPublicPrefixState of the Peering resource. Possible values are 'NotConfigured', 'Configuring', 'Configured', and 'ValidationNeeded'.",
+          "enum": [
+            "NotConfigured",
+            "Configuring",
+            "Configured",
+            "ValidationNeeded"
+          ],
+          "x-ms-enum": {
+            "name": "ExpressRouteCircuitPeeringAdvertisedPublicPrefixState",
+            "modelAsString": true
+          }
+        },
+        "legacyMode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The legacy mode of the peering."
+        },
+        "customerASN": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The CustomerASN of the peering."
+        },
+        "routingRegistryName": {
+          "type": "string",
+          "description": "The RoutingRegistryName of the configuration."
+        }
+      },
+      "description": "Specifies the peering configuration."
+    },
+    "Ipv6ExpressRouteCircuitPeeringConfig": {
+      "properties": {
+        "primaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The primary address prefix."
+        },
+        "secondaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The secondary address prefix."
+        },
+        "microsoftPeeringConfig": {
+          "$ref": "#/definitions/ExpressRouteCircuitPeeringConfig",
+          "description": "The Microsoft peering configuration."
+        },
+        "routeFilter": {
+          "$ref": "./routeFilter.json#/definitions/RouteFilter",
+          "description": "The reference of the RouteFilter resource."
+        },
+        "state": {
+          "type": "string",
+          "description": "The state of peering. Possible values are: 'Disabled' and 'Enabled'",
+          "enum": [
+            "Disabled",
+            "Enabled"
+          ],
+          "x-ms-enum": {
+            "name": "ExpressRouteCircuitPeeringState",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "Contains IPv6 peering config."
+    },
+    "ExpressRouteCircuitStats": {
+      "properties": {
+        "primarybytesIn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets BytesIn of the peering."
+        },
+        "primarybytesOut": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets BytesOut of the peering."
+        },
+        "secondarybytesIn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets BytesIn of the peering."
+        },
+        "secondarybytesOut": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Gets BytesOut of the peering."
+        }
+      },
+      "description": "Contains stats associated with the peering."
+    },
+    "ExpressRouteCircuitPeeringPropertiesFormat": {
+      "properties": {
+        "peeringType": {
+          "type": "string",
+          "description": "The PeeringType. Possible values are: 'AzurePublicPeering', 'AzurePrivatePeering', and 'MicrosoftPeering'.",
+          "enum": [
+            "AzurePublicPeering",
+            "AzurePrivatePeering",
+            "MicrosoftPeering"
+          ],
+          "x-ms-enum": {
+            "name": "ExpressRouteCircuitPeeringType",
+            "modelAsString": true
+          }
+        },
+        "state": {
+          "type": "string",
+          "description": "The state of peering. Possible values are: 'Disabled' and 'Enabled'",
+          "enum": [
+            "Disabled",
+            "Enabled"
+          ],
+          "x-ms-enum": {
+            "name": "ExpressRouteCircuitPeeringState",
+            "modelAsString": true
+          }
+        },
+        "azureASN": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The Azure ASN."
+        },
+        "peerASN": {
+          "type": "integer",
+          "format": "int64",
+          "minimum": 1,
+          "maximum": 4294967295,
+          "description": "The peer ASN."
+        },
+        "primaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The primary address prefix."
+        },
+        "secondaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The secondary address prefix."
+        },
+        "primaryAzurePort": {
+          "type": "string",
+          "description": "The primary port."
+        },
+        "secondaryAzurePort": {
+          "type": "string",
+          "description": "The secondary port."
+        },
+        "sharedKey": {
+          "type": "string",
+          "description": "The shared key."
+        },
+        "vlanId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The VLAN ID."
+        },
+        "microsoftPeeringConfig": {
+          "$ref": "#/definitions/ExpressRouteCircuitPeeringConfig",
+          "description": "The Microsoft peering configuration."
+        },
+        "stats": {
+          "$ref": "#/definitions/ExpressRouteCircuitStats",
+          "description": "Gets peering stats."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        },
+        "gatewayManagerEtag": {
+          "type": "string",
+          "description": "The GatewayManager Etag."
+        },
+        "lastModifiedBy": {
+            "type": "string",
+            "description": "Gets whether the provider or the customer last modified the peering."
+        },
+        "routeFilter": {
+          "$ref": "./routeFilter.json#/definitions/RouteFilter",
+          "description": "The reference of the RouteFilter resource."
+        },
+        "ipv6PeeringConfig": {
+          "$ref": "#/definitions/Ipv6ExpressRouteCircuitPeeringConfig",
+          "description": "The IPv6 peering configuration."
+        }
+      }
+    },
+    "ExpressRouteCircuitPeering": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ExpressRouteCircuitPeeringPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Peering in an ExpressRouteCircuit resource."
+    },
+    "ExpressRouteCircuitPeeringListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitPeering"
+          },
+          "description": "The peerings in an express route circuit."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListPeering API service call retrieves all peerings that belong to an ExpressRouteCircuit."
+    },
+    "ExpressRouteCircuitSku": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU."
+        },
+        "tier": {
+          "type": "string",
+          "description": "The tier of the SKU. Possible values are 'Standard' and 'Premium'.",
+          "enum": [
+            "Standard",
+            "Premium"
+          ],
+          "x-ms-enum": {
+            "name": "ExpressRouteCircuitSkuTier",
+            "modelAsString": true
+          }
+        },
+        "family": {
+          "type": "string",
+          "description": "The family of the SKU. Possible values are: 'UnlimitedData' and 'MeteredData'.",
+          "enum": [
+            "UnlimitedData",
+            "MeteredData"
+          ],
+          "x-ms-enum": {
+            "name": "ExpressRouteCircuitSkuFamily",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "Contains SKU in an ExpressRouteCircuit."
+    },
+    "ExpressRouteCircuitServiceProviderProperties": {
+      "properties": {
+        "serviceProviderName": {
+          "type": "string",
+          "description": "The serviceProviderName."
+        },
+        "peeringLocation": {
+          "type": "string",
+          "description": "The peering location."
+        },
+        "bandwidthInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The BandwidthInMbps."
+        }
+      },
+      "description": "Contains ServiceProviderProperties in an ExpressRouteCircuit."
+    },
+    "ExpressRouteCircuitPropertiesFormat": {
+      "properties": {
+        "allowClassicOperations": {
+          "type": "boolean",
+          "description": "Allow classic operations"
+        },
+        "circuitProvisioningState": {
+          "type": "string",
+          "description": "The CircuitProvisioningState state of the resource."
+        },
+        "serviceProviderProvisioningState": {
+          "type": "string",
+          "description": "The ServiceProviderProvisioningState state of the resource. Possible values are 'NotProvisioned', 'Provisioning', 'Provisioned', and 'Deprovisioning'.",
+          "enum": [
+            "NotProvisioned",
+            "Provisioning",
+            "Provisioned",
+            "Deprovisioning"
+          ],
+          "x-ms-enum": {
+            "name": "ServiceProviderProvisioningState",
+            "modelAsString": true
+          }
+        },
+        "authorizations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+          },
+          "description": "The list of authorizations."
+        },
+        "peerings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitPeering"
+          },
+          "description": "The list of peerings."
+        },
+        "serviceKey": {
+          "type": "string",
+          "description": "The ServiceKey."
+        },
+        "serviceProviderNotes": {
+          "type": "string",
+          "description": "The ServiceProviderNotes."
+        },
+        "serviceProviderProperties": {
+          "$ref": "#/definitions/ExpressRouteCircuitServiceProviderProperties",
+          "description": "The ServiceProviderProperties."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        },
+        "gatewayManagerEtag": {
+          "type": "string",
+          "description": "The GatewayManager Etag."
+        }
+      },
+      "description": "Properties of ExpressRouteCircuit."
+    },
+    "ExpressRouteCircuit": {
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/ExpressRouteCircuitSku",
+          "description": "The SKU."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ExpressRouteCircuitPropertiesFormat"
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Gets a unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "ExpressRouteCircuit resource"
+    },
+    "ExpressRouteCircuitArpTable": {
+      "properties": {
+        "age": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Age"
+        },
+        "interface": {
+          "type": "string",
+          "description": "Interface"
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "The IP address."
+        },
+        "macAddress": {
+          "type": "string",
+          "description": "The MAC address."
+        }
+      },
+      "description": "The ARP table associated with the ExpressRouteCircuit."
+    },
+    "ExpressRouteCircuitsArpTableListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitArpTable"
+          },
+          "description": "Gets list of the ARP table."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListArpTable associated with the Express Route Circuits API."
+    },
+    "ExpressRouteCircuitRoutesTable": {
+      "properties": {
+        "network": {
+          "type": "string",
+          "description": "network"
+        },
+        "nextHop": {
+          "type": "string",
+          "description": "nextHop"
+        },
+        "locPrf": {
+          "type": "string",
+          "description": "locPrf"
+        },
+        "weight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "weight."
+        },
+        "path": {
+          "type": "string",
+          "description": "path"
+        }
+      },
+      "description": "The routes table associated with the ExpressRouteCircuit"
+    },
+    "ExpressRouteCircuitsRoutesTableListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitRoutesTable"
+          },
+          "description": "The list of routes table."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListRoutesTable associated with the Express Route Circuits API."
+    },
+    "ExpressRouteCircuitRoutesTableSummary": {
+      "properties": {
+        "neighbor": {
+          "type": "string",
+          "description": "Neighbor"
+        },
+        "v": {
+          "type": "integer",
+          "format": "int32",
+          "description": "BGP version number spoken to the neighbor."
+        },
+        "as": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Autonomous system number."
+        },
+        "upDown": {
+          "type": "string",
+          "description": "The length of time that the BGP session has been in the Established state, or the current status if not in the Established state."
+        },
+        "statePfxRcd": {
+          "type": "string",
+          "description": "Current state of the BGP session, and the number of prefixes that have been received from a neighbor or peer group."
+        }
+      },
+      "description": "The routes table associated with the ExpressRouteCircuit."
+    },
+    "ExpressRouteCircuitsRoutesTableSummaryListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitRoutesTableSummary"
+          },
+          "description": "A list of the routes table."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListRoutesTable associated with the Express Route Circuits API."
+    },
+    "ExpressRouteCircuitListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuit"
+          },
+          "description": "A list of ExpressRouteCircuits in a resource group."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListExpressRouteCircuit API service call."
+    },
+    "ExpressRouteServiceProviderBandwidthsOffered": {
+      "properties": {
+        "offerName": {
+          "type": "string",
+          "description": "The OfferName."
+        },
+        "valueInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The ValueInMbps."
+        }
+      },
+      "description": "Contains bandwidths offered in ExpressRouteServiceProvider resources."
+    },
+    "ExpressRouteServiceProviderPropertiesFormat": {
+      "properties": {
+        "peeringLocations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Get a list of peering locations."
+        },
+        "bandwidthsOffered": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteServiceProviderBandwidthsOffered"
+          },
+          "description": "Gets bandwidths offered."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the resource."
+        }
+      },
+      "description": "Properties of ExpressRouteServiceProvider."
+    },
+    "ExpressRouteServiceProvider": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ExpressRouteServiceProviderPropertiesFormat"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "A ExpressRouteResourceProvider object."
+    },
+    "ExpressRouteServiceProviderListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteServiceProvider"
+          },
+          "description": "A list of ExpressRouteResourceProvider resources."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the ListExpressRouteServiceProvider API service call."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/loadBalancer.json
@@ -1,0 +1,1674 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}": {
+      "delete": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancers_Delete",
+        "description": "Deletes the specified load balancer.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Request successful. Resource does not exist."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-examples": {
+          "Delete load balancer": { "$ref": "./examples/LoadBalancerDelete.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancers_Get",
+        "description": "Gets the specified load balancer.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting LoadBalancer resource.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get load balancer": { "$ref": "./examples/LoadBalancerGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancers_CreateOrUpdate",
+        "description": "Creates or updates a load balancer.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            },
+            "description": "Parameters supplied to the create or update load balancer operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting LoadBalancer resource.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting LoadBalancer resource.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create load balancer": { "$ref": "./examples/LoadBalancerCreate.json" },
+          "Create load balancer with inbound nat pool": { "$ref": "./examples/LoadBalancerCreateWithInboundNatPool.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancers_UpdateTags",
+        "description": "Updates a load balancer tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update load balancer tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting LoadBalancer resource.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update load balancer tags": { "$ref": "./examples/LoadBalancerUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/loadBalancers": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancers_ListAll",
+        "description": "Gets all the load balancers in a subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of LoadBalancer resources.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all load balancers": { "$ref": "./examples/LoadBalancerListAll.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancers_List",
+        "description": "Gets all the load balancers in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of LoadBalancer resources.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List load balancers in resource group": { "$ref": "./examples/LoadBalancerList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancerBackendAddressPools_List",
+        "description": "Gets all the load balancer backed address pools.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of LoadBalancer BackendAddressPool resources.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerBackendAddressPoolListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LoadBalancerBackendAddressPoolList": { "$ref": "./examples/LoadBalancerBackendAddressPoolList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancerBackendAddressPools_Get",
+        "description": "Gets load balancer backend address pool.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "name": "backendAddressPoolName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the backend address pool."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns LoadBalancer BackendAddressPool resource.",
+            "schema": {
+              "$ref": "#/definitions/BackendAddressPool"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LoadBalancerBackendAddressPoolGet": { "$ref": "./examples/LoadBalancerBackendAddressPoolGet.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/frontendIPConfigurations": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancerFrontendIPConfigurations_List",
+        "description": "Gets all the load balancer frontend IP configurations.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of LoadBalancer FrontendIPConfiguration resources.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerFrontendIPConfigurationListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LoadBalancerFrontendIPConfigurationList": { "$ref": "./examples/LoadBalancerFrontendIPConfigurationList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/frontendIPConfigurations/{frontendIPConfigurationName}": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancerFrontendIPConfigurations_Get",
+        "description": "Gets load balancer frontend IP configuration.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "name": "frontendIPConfigurationName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the frontend IP configuration."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns LoadBalancer FrontendIPConfiguration resource.",
+            "schema": {
+              "$ref": "#/definitions/FrontendIPConfiguration"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LoadBalancerFrontendIPConfigurationGet": { "$ref": "./examples/LoadBalancerFrontendIPConfigurationGet.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "InboundNatRules_List",
+        "description": "Gets all the inbound nat rules in a load balancer.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of LoadBalancer InboundNatRule resources.",
+            "schema": {
+              "$ref": "#/definitions/InboundNatRuleListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "InboundNatRuleList": { "$ref": "./examples/InboundNatRuleList.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}": {
+      "delete": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "InboundNatRules_Delete",
+        "description": "Deletes the specified load balancer inbound nat rule.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "name": "inboundNatRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the inbound nat rule."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Request successful. Resource does not exist."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-examples": {
+          "InboundNatRuleDelete": { "$ref": "./examples/InboundNatRuleDelete.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "InboundNatRules_Get",
+        "description": "Gets the specified load balancer inbound nat rule.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "name": "inboundNatRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the inbound nat rule."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting InboundNatRule resource.",
+            "schema": {
+              "$ref": "#/definitions/InboundNatRule"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "InboundNatRuleGet": { "$ref": "./examples/InboundNatRuleGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "InboundNatRules_CreateOrUpdate",
+        "description": "Creates or updates a load balancer inbound nat rule.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "name": "inboundNatRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the inbound nat rule."
+          },
+          {
+            "name": "inboundNatRuleParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InboundNatRule"
+            },
+            "description": "Parameters supplied to the create or update inbound nat rule operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting InboundNatRule resource.",
+            "schema": {
+              "$ref": "#/definitions/InboundNatRule"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting InboundNatRule resource.",
+            "schema": {
+              "$ref": "#/definitions/InboundNatRule"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "InboundNatRuleCreate": { "$ref": "./examples/InboundNatRuleCreate.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancerLoadBalancingRules_List",
+        "description": "Gets all the load balancing rules in a load balancer.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of LoadBalancer LoadBalancingRule resources.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerLoadBalancingRuleListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "LoadBalancerLoadBalancingRuleList": { "$ref": "./examples/LoadBalancerLoadBalancingRuleList.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules/{loadBalancingRuleName}": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancerLoadBalancingRules_Get",
+        "description": "Gets the specified load balancer load balancing rule.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "name": "loadBalancingRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancing rule."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting LoadBalancingRule resource.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancingRule"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LoadBalancerLoadBalancingRuleGet": { "$ref": "./examples/LoadBalancerLoadBalancingRuleGet.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/networkInterfaces": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancerNetworkInterfaces_List",
+        "description": "Gets associated load balancer network interfaces.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkInterface resources.",
+            "schema": {
+              "$ref": "./networkInterface.json#/definitions/NetworkInterfaceListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LoadBalancerNetworkInterfaceListVmss": { "$ref": "./examples/LoadBalancerNetworkInterfaceListVmss.json" },
+          "LoadBalancerNetworkInterfaceListSimple": { "$ref": "./examples/LoadBalancerNetworkInterfaceListSimple.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancerProbes_List",
+        "description": "Gets all the load balancer probes.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of LoadBalancer Probe resources.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerProbeListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LoadBalancerProbeList": { "$ref": "./examples/LoadBalancerProbeList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}": {
+      "get": {
+        "tags": [
+          "LoadBalancers"
+        ],
+        "operationId": "LoadBalancerProbes_Get",
+        "description": "Gets load balancer probe.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the load balancer."
+          },
+          {
+            "name": "probeName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the probe."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns LoadBalancer Probe resource.",
+            "schema": {
+              "$ref": "#/definitions/Probe"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LoadBalancerProbeGet": { "$ref": "./examples/LoadBalancerProbeGet.json" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "LoadBalancerSku": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of a load balancer SKU.",
+          "enum": [
+            "Basic",
+            "Standard"
+          ],
+          "x-ms-enum": {
+            "name": "LoadBalancerSkuName",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "SKU of a load balancer"
+    },
+    "FrontendIPConfigurationPropertiesFormat": {
+      "properties": {
+        "inboundNatRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Read only. Inbound rules URIs that use this frontend IP."
+        },
+        "inboundNatPools": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Read only. Inbound pools URIs that use this frontend IP."
+        },
+        "outboundNatRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Read only. Outbound rules URIs that use this frontend IP."
+        },
+        "loadBalancingRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Gets load balancing rules URIs that use this frontend IP."
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The private IP address of the IP configuration."
+        },
+        "privateIPAllocationMethod": {
+          "type": "string",
+          "description": "The Private IP allocation method. Possible values are: 'Static' and 'Dynamic'.",
+          "enum": [
+            "Static",
+            "Dynamic"
+          ],
+          "x-ms-enum": {
+            "name": "IPAllocationMethod",
+            "modelAsString": true
+          }
+        },
+        "subnet": {
+          "$ref": "./virtualNetwork.json#/definitions/Subnet",
+          "description": "The reference of the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "./publicIpAddress.json#/definitions/PublicIPAddress",
+          "description": "The reference of the Public IP resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of Frontend IP Configuration of the load balancer."
+    },
+    "FrontendIPConfiguration": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/FrontendIPConfigurationPropertiesFormat",
+          "description": "Properties of the load balancer probe."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "zones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of availability zones denoting the IP allocated for the resource needs to come from."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Frontend IP address of the load balancer."
+    },
+    "BackendAddressPoolPropertiesFormat": {
+      "properties": {
+        "backendIPConfigurations": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./networkInterface.json#/definitions/NetworkInterfaceIPConfiguration"
+          },
+          "description": "Gets collection of references to IP addresses defined in network interfaces."
+        },
+        "loadBalancingRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Gets load balancing rules that use this backend address pool."
+        },
+        "outboundNatRule": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Gets outbound rules that use this backend address pool."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Get provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of the backend address pool."
+    },
+    "BackendAddressPool": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/BackendAddressPoolPropertiesFormat",
+          "description": "Properties of load balancer backend address pool."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Pool of backend IP addresses."
+    },
+    "LoadBalancingRulePropertiesFormat": {
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "A reference to frontend IP addresses."
+        },
+        "backendAddressPool": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "A reference to a pool of DIPs. Inbound traffic is randomly load balanced across IPs in the backend IPs."
+        },
+        "probe": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference of the load balancer probe used by the load balancing rule."
+        },
+        "protocol": {
+          "$ref": "#/definitions/TransportProtocol"
+        },
+        "loadDistribution": {
+          "type": "string",
+          "description": "The load distribution policy for this rule. Possible values are 'Default', 'SourceIP', and 'SourceIPProtocol'.",
+          "enum": [
+            "Default",
+            "SourceIP",
+            "SourceIPProtocol"
+          ],
+          "x-ms-enum": {
+            "name": "LoadDistribution",
+            "modelAsString": true
+          }
+        },
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port for the external endpoint. Port numbers for each rule must be unique within the Load Balancer. Acceptable values are between 0 and 65534. Note that value 0 enables \"Any Port\""
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port used for internal connections on the endpoint. Acceptable values are between 0 and 65535. Note that value 0 enables \"Any Port\""
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to TCP."
+        },
+        "enableFloatingIP": {
+          "type": "boolean",
+          "description": "Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group. This setting is required when using the SQL AlwaysOn Availability Groups in SQL server. This setting can't be changed after you create the endpoint."
+        },
+        "disableOutboundSnat": {
+          "type": "boolean",
+          "description": "Configures SNAT for the VMs in the backend pool to use the publicIP address specified in the frontend of the load balancing rule."
+         },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the PublicIP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "required": [
+        "protocol",
+        "frontendPort"
+      ],
+      "description": "Properties of the load balancer."
+    },
+    "LoadBalancingRule": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/LoadBalancingRulePropertiesFormat",
+          "description": "Properties of load balancer load balancing rule."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "A load balancing rule for a load balancer."
+    },
+    "ProbePropertiesFormat": {
+      "properties": {
+        "loadBalancingRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "The load balancer rules that use this probe."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "The protocol of the end point. Possible values are: 'Http' or 'Tcp'. If 'Tcp' is specified, a received ACK is required for the probe to be successful. If 'Http' is specified, a 200 OK response from the specifies URI is required for the probe to be successful.",
+          "enum": [
+            "Http",
+            "Tcp"
+          ],
+          "x-ms-enum": {
+            "name": "ProbeProtocol",
+            "modelAsString": true
+          }
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port for communicating the probe. Possible values range from 1 to 65535, inclusive."
+        },
+        "intervalInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The interval, in seconds, for how frequently to probe the endpoint for health status. Typically, the interval is slightly less than half the allocated timeout period (in seconds) which allows two full probes before taking the instance out of rotation. The default value is 15, the minimum value is 5."
+        },
+        "numberOfProbes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of probes where if no response, will result in stopping further traffic from being delivered to the endpoint. This values allows endpoints to be taken out of rotation faster or slower than the typical times used in Azure."
+        },
+        "requestPath": {
+          "type": "string",
+          "description": "The URI used for requesting health status from the VM. Path is required if a protocol is set to http. Otherwise, it is not allowed. There is no default value."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "required": [
+        "protocol",
+        "port"
+      ],
+      "description": "Load balancer probe resource."
+    },
+    "Probe": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ProbePropertiesFormat",
+          "description": "Properties of load balancer probe."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "A load balancer probe."
+    },
+    "InboundNatRulePropertiesFormat": {
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "A reference to frontend IP addresses."
+        },
+        "backendIPConfiguration": {
+          "readOnly": true,
+          "$ref": "./networkInterface.json#/definitions/NetworkInterfaceIPConfiguration",
+          "description": "A reference to a private IP address defined on a network interface of a VM. Traffic sent to the frontend port of each of the frontend IP configurations is forwarded to the backend IP."
+        },
+        "protocol": {
+          "$ref": "#/definitions/TransportProtocol"
+        },
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port for the external endpoint. Port numbers for each rule must be unique within the Load Balancer. Acceptable values range from 1 to 65534."
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port used for the internal endpoint. Acceptable values range from 1 to 65535."
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to TCP."
+        },
+        "enableFloatingIP": {
+          "type": "boolean",
+          "description": "Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group. This setting is required when using the SQL AlwaysOn Availability Groups in SQL server. This setting can't be changed after you create the endpoint."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of the inbound NAT rule."
+    },
+    "InboundNatRule": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/InboundNatRulePropertiesFormat",
+          "description": "Properties of load balancer inbound nat rule."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Inbound NAT rule of the load balancer."
+    },
+    "InboundNatPoolPropertiesFormat": {
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "A reference to frontend IP addresses."
+        },
+        "protocol": {
+          "$ref": "#/definitions/TransportProtocol"
+        },
+        "frontendPortRangeStart": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The first port number in the range of external ports that will be used to provide Inbound Nat to NICs associated with a load balancer. Acceptable values range between 1 and 65534."
+        },
+        "frontendPortRangeEnd": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The last port number in the range of external ports that will be used to provide Inbound Nat to NICs associated with a load balancer. Acceptable values range between 1 and 65535."
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port used for internal connections on the endpoint. Acceptable values are between 1 and 65535."
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to TCP."
+        },
+        "enableFloatingIP": {
+          "type": "boolean",
+          "description": "Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group. This setting is required when using the SQL AlwaysOn Availability Groups in SQL server. This setting can't be changed after you create the endpoint."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the PublicIP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "required": [
+        "protocol",
+        "frontendPortRangeStart",
+        "frontendPortRangeEnd",
+        "backendPort"
+      ],
+      "description": "Properties of Inbound NAT pool."
+    },
+    "InboundNatPool": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/InboundNatPoolPropertiesFormat",
+          "description": "Properties of load balancer inbound nat pool."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Inbound NAT pool of the load balancer."
+    },
+    "OutboundNatRulePropertiesFormat": {
+      "properties": {
+        "allocatedOutboundPorts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of outbound ports to be used for NAT."
+        },
+        "frontendIPConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "The Frontend IP addresses of the load balancer."
+        },
+        "backendAddressPool": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "A reference to a pool of DIPs. Outbound traffic is randomly load balanced across IPs in the backend IPs."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the PublicIP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "required": [
+        "backendAddressPool"
+      ],
+      "description": "Outbound NAT pool of the load balancer."
+    },
+    "OutboundNatRule": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/OutboundNatRulePropertiesFormat",
+          "description": "Properties of load balancer outbound nat rule."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Outbound NAT pool of the load balancer."
+    },
+    "LoadBalancerPropertiesFormat": {
+      "properties": {
+        "frontendIPConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FrontendIPConfiguration"
+          },
+          "description": "Object representing the frontend IPs to be used for the load balancer"
+        },
+        "backendAddressPools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BackendAddressPool"
+          },
+          "description": "Collection of backend address pools used by a load balancer"
+        },
+        "loadBalancingRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancingRule"
+          },
+          "description": "Object collection representing the load balancing rules Gets the provisioning "
+        },
+        "probes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Probe"
+          },
+          "description": "Collection of probe objects used in the load balancer"
+        },
+        "inboundNatRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InboundNatRule"
+          },
+          "description": "Collection of inbound NAT Rules used by a load balancer. Defining inbound NAT rules on your load balancer is mutually exclusive with defining an inbound NAT pool. Inbound NAT pools are referenced from virtual machine scale sets. NICs that are associated with individual virtual machines cannot reference an Inbound NAT pool. They have to reference individual inbound NAT rules."
+        },
+        "inboundNatPools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InboundNatPool"
+          },
+          "description": "Defines an external port range for inbound NAT to a single backend port on NICs associated with a load balancer. Inbound NAT rules are created automatically for each NIC associated with the Load Balancer using an external port from this range. Defining an Inbound NAT pool on your Load Balancer is mutually exclusive with defining inbound Nat rules. Inbound NAT pools are referenced from virtual machine scale sets. NICs that are associated with individual virtual machines cannot reference an inbound NAT pool. They have to reference individual inbound NAT rules."
+        },
+        "outboundNatRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OutboundNatRule"
+          },
+          "description": "The outbound NAT rules."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the load balancer resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the PublicIP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of the load balancer."
+    },
+    "LoadBalancer": {
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/LoadBalancerSku",
+          "description": "The load balancer SKU."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/LoadBalancerPropertiesFormat",
+          "description": "Properties of load balancer."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "LoadBalancer resource"
+    },
+    "LoadBalancerListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancer"
+          },
+          "description": "A list of load balancers in a resource group."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListLoadBalancers API service call."
+    },
+    "InboundNatRuleListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InboundNatRule"
+          },
+          "description": "A list of inbound nat rules in a load balancer."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListInboundNatRule API service call."
+    },
+    "LoadBalancerBackendAddressPoolListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BackendAddressPool"
+          },
+          "description": "A list of backend address pools in a load balancer."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListBackendAddressPool API service call."
+    },
+    "LoadBalancerFrontendIPConfigurationListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FrontendIPConfiguration"
+          },
+          "description": "A list of frontend IP configurations in a load balancer."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListFrontendIPConfiguration API service call."
+    },
+    "LoadBalancerLoadBalancingRuleListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancingRule"
+          },
+          "description": "A list of load balancing rules in a load balancer."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListLoadBalancingRule API service call."
+    },
+    "LoadBalancerProbeListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Probe"
+          },
+          "description": "A list of probes in a load balancer."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListProbe API service call."
+    },
+    "TransportProtocol": {
+      "type": "string",
+      "description": "The transport protocol for the endpoint. Possible values are 'Udp' or 'Tcp' or 'All.'",
+      "enum": [
+        "Udp",
+        "Tcp",
+        "All"
+      ],
+      "x-ms-enum": {
+        "name": "TransportProtocol",
+        "modelAsString": true
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/network.json
@@ -1,0 +1,167 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+  },
+  "definitions": {
+    "ErrorDetails": {
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorDetails"
+          }
+        },
+        "innerError": {
+          "type": "string"
+        }
+      }
+    },
+    "AzureAsyncOperationResult": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status of the Azure async operation. Possible values are: 'InProgress', 'Succeeded', and 'Failed'.",
+          "enum": [
+            "InProgress",
+            "Succeeded",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "NetworkOperationStatus",
+            "modelAsString": true
+          }
+        },
+        "error": {
+          "$ref": "#/definitions/Error"
+        }
+      },
+      "description": "The response body contains the status of the specified asynchronous operation, indicating whether it has succeeded, is in progress, or has failed. Note that this status is distinct from the HTTP status code returned for the Get Operation Status operation itself. If the asynchronous operation succeeded, the response body includes the HTTP status code for the successful request. If the asynchronous operation failed, the response body includes the HTTP status code for the failed request and error information regarding the failure."
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type."
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags."
+        }
+      },
+      "description": "Common resource representation.",
+      "x-ms-azure-resource": true
+    },
+    "SubResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        }
+      },
+      "description": "Reference to another subresource.",
+      "x-ms-azure-resource": true
+    },
+    "TagsObject": {
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags."
+        }
+      },
+      "description": "Tags object for patch operations."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkInterface.json
@@ -1,0 +1,1113 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}": {
+      "delete": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_Delete",
+        "description": "Deletes the specified network interface.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Request successful. Resource does not exist."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-examples": {
+          "Delete network interface": { "$ref": "./examples/NetworkInterfaceDelete.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_Get",
+        "description": "Gets information about the specified network interface.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting NetworkInterface resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get network interface": { "$ref": "./examples/NetworkInterfaceGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_CreateOrUpdate",
+        "description": "Creates or updates a network interface.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            },
+            "description": "Parameters supplied to the create or update network interface operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting NetworkInterface resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting NetworkInterface resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create network interface": { "$ref": "./examples/NetworkInterfaceCreate.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_UpdateTags",
+        "description": "Updates a network interface tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update network interface tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting NetworkInterface resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update network interface tags": { "$ref": "./examples/NetworkInterfaceUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkInterfaces": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_ListAll",
+        "description": "Gets all network interfaces in a subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkInterface resources.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all network interfaces": { "$ref": "./examples/NetworkInterfaceListAll.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_List",
+        "description": "Gets all network interfaces in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkInterface resources.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List network interfaces in resource group": { "$ref": "./examples/NetworkInterfaceList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveRouteTable": {
+      "post": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_GetEffectiveRouteTable",
+        "description": "Gets all route tables applied to a network interface.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of EffectRoute resources.",
+            "schema": {
+              "$ref": "#/definitions/EffectiveRouteListResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-examples": {
+          "Show network interface effective route tables": { "$ref": "./examples/NetworkInterfaceEffectiveRouteTableList.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveNetworkSecurityGroups": {
+      "post": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_ListEffectiveNetworkSecurityGroups",
+        "description": "Gets all network security groups applied to a network interface.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkSecurityGroup resources.",
+            "schema": {
+              "$ref": "#/definitions/EffectiveNetworkSecurityGroupListResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-examples": {
+          "List network interface effective network security groups": { "$ref": "./examples/NetworkInterfaceEffectiveNSGList.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaceIPConfigurations_List",
+        "description": "Get all ip configurations in a network interface",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkInterface IPConfiguration resources.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceIPConfigurationListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "NetworkInterfaceIPConfigurationList": { "$ref": "./examples/NetworkInterfaceIPConfigurationList.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations/{ipConfigurationName}": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaceIPConfigurations_Get",
+        "description": "Gets the specified network interface ip configuration.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "name": "ipConfigurationName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the ip configuration name."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting NetworkInterface IPConfiguration resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceIPConfiguration"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkInterfaceIPConfigurationGet": { "$ref": "./examples/NetworkInterfaceIPConfigurationGet.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/loadBalancers": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaceLoadBalancers_List",
+        "description": "List all load balancers in a network interface.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkInterface LoadBalancer resources.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceLoadBalancerListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "NetworkInterfaceLoadBalancerList": { "$ref": "./examples/NetworkInterfaceLoadBalancerList.json" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "NetworkInterfaceIPConfigurationPropertiesFormat": {
+      "properties": {
+        "applicationGatewayBackendAddressPools": {
+          "type": "array",
+          "items": {
+            "$ref": "./applicationGateway.json#/definitions/ApplicationGatewayBackendAddressPool"
+          },
+          "description": "The reference of ApplicationGatewayBackendAddressPool resource."
+        },
+        "loadBalancerBackendAddressPools": {
+          "type": "array",
+          "items": {
+            "$ref": "./loadBalancer.json#/definitions/BackendAddressPool"
+          },
+          "description": "The reference of LoadBalancerBackendAddressPool resource."
+        },
+        "loadBalancerInboundNatRules": {
+          "type": "array",
+          "items": {
+            "$ref": "./loadBalancer.json#/definitions/InboundNatRule"
+          },
+          "description": "A list of references of LoadBalancerInboundNatRules."
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "Private IP address of the IP configuration."
+        },
+        "privateIPAllocationMethod": {
+          "type": "string",
+          "description": "Defines how a private IP address is assigned. Possible values are: 'Static' and 'Dynamic'.",
+          "enum": [
+            "Static",
+            "Dynamic"
+          ],
+          "x-ms-enum": {
+            "name": "IPAllocationMethod",
+            "modelAsString": true
+          }
+        },
+        "privateIPAddressVersion": {
+          "type": "string",
+          "description": "Available from Api-Version 2016-03-30 onwards, it represents whether the specific ipconfiguration is IPv4 or IPv6. Default is taken as IPv4.  Possible values are: 'IPv4' and 'IPv6'.",
+          "enum": [
+            "IPv4",
+            "IPv6"
+          ],
+          "x-ms-enum": {
+            "name": "IPVersion",
+            "modelAsString": true
+          }
+        },
+        "subnet": {
+          "$ref": "./virtualNetwork.json#/definitions/Subnet",
+          "description": "Subnet bound to the IP configuration."
+        },
+        "primary": {
+          "type": "boolean",
+          "description": "Gets whether this is a primary customer address on the network interface."
+        },
+        "publicIPAddress": {
+          "$ref": "./publicIpAddress.json#/definitions/PublicIPAddress",
+          "description": "Public IP address bound to the IP configuration."
+        },
+        "applicationSecurityGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "./applicationSecurityGroup.json#/definitions/ApplicationSecurityGroup"
+          },
+          "description": "Application security groups in which the IP configuration is included."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the network interface IP configuration. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of IP configuration."
+    },
+    "NetworkInterfaceIPConfiguration": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/NetworkInterfaceIPConfigurationPropertiesFormat",
+          "description": "Network interface IP configuration properties."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "IPConfiguration in a network interface."
+    },
+    "NetworkInterfaceDnsSettings": {
+      "properties": {
+        "dnsServers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of DNS servers IP addresses. Use 'AzureProvidedDNS' to switch to azure provided DNS resolution. 'AzureProvidedDNS' value cannot be combined with other IPs, it must be the only value in dnsServers collection."
+        },
+        "appliedDnsServers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers from all NICs that are part of the Availability Set. This property is what is configured on each of those VMs."
+        },
+        "internalDnsNameLabel": {
+          "type": "string",
+          "description": "Relative DNS name for this NIC used for internal communications between VMs in the same virtual network."
+        },
+        "internalFqdn": {
+          "type": "string",
+          "description": "Fully qualified DNS name supporting internal communications between VMs in the same virtual network."
+        },
+        "internalDomainNameSuffix": {
+          "type": "string",
+          "description": "Even if internalDnsNameLabel is not specified, a DNS entry is created for the primary NIC of the VM. This DNS name can be constructed by concatenating the VM name with the value of internalDomainNameSuffix."
+        }
+      },
+      "description": "DNS settings of a network interface."
+    },
+    "NetworkInterfacePropertiesFormat": {
+      "properties": {
+        "virtualMachine": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference of a virtual machine."
+        },
+        "networkSecurityGroup": {
+          "$ref": "./networkSecurityGroup.json#/definitions/NetworkSecurityGroup",
+          "description": "The reference of the NetworkSecurityGroup resource."
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceIPConfiguration"
+          },
+          "description": "A list of IPConfigurations of the network interface."
+        },
+        "dnsSettings": {
+          "$ref": "#/definitions/NetworkInterfaceDnsSettings",
+          "description": "The DNS settings in network interface."
+        },
+        "macAddress": {
+          "type": "string",
+          "description": "The MAC address of the network interface."
+        },
+        "primary": {
+          "type": "boolean",
+          "description": "Gets whether this is a primary network interface on a virtual machine."
+        },
+        "enableAcceleratedNetworking": {
+          "type": "boolean",
+          "description": "If the network interface is accelerated networking enabled."
+        },
+        "enableIPForwarding": {
+          "type": "boolean",
+          "description": "Indicates whether IP forwarding is enabled on this network interface."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the network interface resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "NetworkInterface properties. "
+    },
+    "NetworkInterface": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/NetworkInterfacePropertiesFormat",
+          "description": "Properties of the network interface."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "A network interface in a resource group."
+    },
+    "NetworkInterfaceListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkInterface"
+          },
+          "description": "A list of network interfaces in a resource group."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the ListNetworkInterface API service call."
+    },
+    "NetworkInterfaceIPConfigurationListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceIPConfiguration"
+          },
+          "description": "A list of ip configurations."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for list ip configurations API service call."
+    },
+    "NetworkInterfaceLoadBalancerListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "./loadBalancer.json#/definitions/LoadBalancer"
+          },
+          "description": "A list of load balancers."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for list ip configurations API service call."
+    },
+    "EffectiveNetworkSecurityGroup": {
+      "properties": {
+        "networkSecurityGroup": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The ID of network security group that is applied."
+        },
+        "association": {
+          "$ref": "#/definitions/EffectiveNetworkSecurityGroupAssociation",
+          "description": "Associated resources."
+        },
+        "effectiveSecurityRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EffectiveNetworkSecurityRule"
+          },
+          "description": "A collection of effective security rules."
+        },
+        "tagMap": {
+          "type": "string",
+          "additionalProperties": {
+            "type":"array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of IP Addresses within the tag (key)"
+          },
+          "description": "Mapping of tags to list of IP Addresses included within the tag."
+        }
+      },
+      "description": "Effective network security group."
+    },
+    "EffectiveNetworkSecurityGroupAssociation": {
+      "properties": {
+        "subnet": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The ID of the subnet if assigned."
+        },
+        "networkInterface": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The ID of the network interface if assigned."
+        }
+      },
+      "description": "The effective network security group association."
+    },
+    "EffectiveNetworkSecurityRule": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the security rule specified by the user (if created by the user)."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "The network protocol this rule applies to. Possible values are: 'Tcp', 'Udp', and 'All'.",
+          "enum": [
+            "Tcp",
+            "Udp",
+            "All"
+          ],
+          "x-ms-enum": {
+            "name": "EffectiveSecurityRuleProtocol",
+            "modelAsString": true
+          }
+        },
+        "sourcePortRange": {
+          "type": "string",
+          "description": "The source port or range."
+        },
+        "destinationPortRange": {
+          "type": "string",
+          "description": "The destination port or range."
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+        },
+        "sourceAddressPrefix": {
+          "type": "string",
+          "description": "The source address prefix."
+        },
+        "destinationAddressPrefix": {
+          "type": "string",
+          "description": "The destination address prefix."
+        },
+        "sourceAddressPrefixes" : {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+        },
+        "destinationAddressPrefixes" : {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+        },
+        "expandedSourceAddressPrefix": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The expanded source address prefix."
+        },
+        "expandedDestinationAddressPrefix": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Expanded destination address prefix."
+        },
+        "access": {
+          "type": "string",
+          "description": "Whether network traffic is allowed or denied. Possible values are: 'Allow' and 'Deny'.",
+          "enum": [
+            "Allow",
+            "Deny"
+          ],
+          "x-ms-enum": {
+            "name": "SecurityRuleAccess",
+            "modelAsString": true
+          }
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of the rule."
+        },
+        "direction": {
+          "type": "string",
+          "description": "The direction of the rule. Possible values are: 'Inbound and Outbound'.",
+          "enum": [
+            "Inbound",
+            "Outbound"
+          ],
+          "x-ms-enum": {
+            "name": "SecurityRuleDirection",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "Effective network security rules."
+    },
+    "EffectiveNetworkSecurityGroupListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EffectiveNetworkSecurityGroup"
+          },
+          "description": "A list of effective network security groups."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for list effective network security groups API service call."
+    },
+    "EffectiveRoute": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user defined route. This is optional."
+        },
+        "source": {
+          "type": "string",
+          "description": "Who created the route. Possible values are: 'Unknown', 'User', 'VirtualNetworkGateway', and 'Default'.",
+          "enum": [
+            "Unknown",
+            "User",
+            "VirtualNetworkGateway",
+            "Default"
+          ],
+          "x-ms-enum": {
+            "name": "EffectiveRouteSource",
+            "modelAsString": true
+          }
+        },
+        "state": {
+          "type": "string",
+          "description": "The value of effective route. Possible values are: 'Active' and 'Invalid'.",
+          "enum": [
+            "Active",
+            "Invalid"
+          ],
+          "x-ms-enum": {
+            "name": "EffectiveRouteState",
+            "modelAsString": true
+          }
+        },
+        "addressPrefix": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The address prefixes of the effective routes in CIDR notation."
+        },
+        "nextHopIpAddress": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The IP address of the next hop of the effective route."
+        },
+        "nextHopType": {
+          "type": "string",
+          "description": "The type of Azure hop the packet should be sent to. Possible values are: 'VirtualNetworkGateway', 'VnetLocal', 'Internet', 'VirtualAppliance', and 'None'.",
+          "enum": [
+            "VirtualNetworkGateway",
+            "VnetLocal",
+            "Internet",
+            "VirtualAppliance",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "RouteNextHopType",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "Effective Route"
+    },
+    "EffectiveRouteListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EffectiveRoute"
+          },
+          "description": "A list of effective routes."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for list effective route API service call."
+    },
+    "IPConfigurationPropertiesFormat": {
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The private IP address of the IP configuration."
+        },
+        "privateIPAllocationMethod": {
+          "type": "string",
+          "description": "The private IP allocation method. Possible values are 'Static' and 'Dynamic'.",
+          "enum": [
+            "Static",
+            "Dynamic"
+          ],
+          "x-ms-enum": {
+            "name": "IPAllocationMethod",
+            "modelAsString": true
+          }
+        },
+        "subnet": {
+          "$ref": "./virtualNetwork.json#/definitions/Subnet",
+          "description": "The reference of the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "./publicIpAddress.json#/definitions/PublicIPAddress",
+          "description": "The reference of the public IP resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Gets the provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of IP configuration."
+    },
+    "IPConfiguration": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/IPConfigurationPropertiesFormat",
+          "description": "Properties of the IP configuration"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "IP configuration"
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkSecurityGroup.json
@@ -1,0 +1,866 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}": {
+      "delete": {
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "operationId": "NetworkSecurityGroups_Delete",
+        "description": "Deletes the specified network security group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Delete successful."
+          },
+          "204": {
+            "description": "Request successful. Resource does not exist."
+          }
+        },
+        "x-ms-examples": {
+          "Delete network security group": { "$ref": "./examples/NetworkSecurityGroupDelete.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "operationId": "NetworkSecurityGroups_Get",
+        "description": "Gets the specified network security group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting NetworkSecurityGroup resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get network security group": { "$ref": "./examples/NetworkSecurityGroupGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "operationId": "NetworkSecurityGroups_CreateOrUpdate",
+        "description": "Creates or updates a network security group in the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            },
+            "description": "Parameters supplied to the create or update network security group operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting NetworkSecurityGroup resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting NetworkSecurityGroup resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create network security group": { "$ref": "./examples/NetworkSecurityGroupCreate.json" },
+          "Create network security group with rule": { "$ref": "./examples/NetworkSecurityGroupCreateWithRule.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "operationId": "NetworkSecurityGroups_UpdateTags",
+        "description": "Updates a network security group tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update network security group tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting NetworkSecurityGroup resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update network security group tags": { "$ref": "./examples/NetworkSecurityGroupUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkSecurityGroups": {
+      "get": {
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "operationId": "NetworkSecurityGroups_ListAll",
+        "description": "Gets all network security groups in a subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkSecurityGroup resources.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroupListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all network security groups": { "$ref": "./examples/NetworkSecurityGroupListAll.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups": {
+      "get": {
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "operationId": "NetworkSecurityGroups_List",
+        "description": "Gets all network security groups in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkSecurityGroup resources.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroupListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List network security groups in resource group": { "$ref": "./examples/NetworkSecurityGroupList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}": {
+      "delete": {
+        "tags": [
+          "SecurityRules"
+        ],
+        "operationId": "SecurityRules_Delete",
+        "description": "Deletes the specified network security rule.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "name": "securityRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the security rule."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Request successful. Resource does not exist."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-examples": {
+          "Delete network security rule from network security group": { "$ref": "./examples/NetworkSecurityGroupRuleDelete.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "SecurityRules"
+        ],
+        "operationId": "SecurityRules_Get",
+        "description": "Get the specified network security rule.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "name": "securityRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the security rule."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting SecurityRule resource.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get network security rule in network security group": { "$ref": "./examples/NetworkSecurityGroupRuleGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "SecurityRules"
+        ],
+        "operationId": "SecurityRules_CreateOrUpdate",
+        "description": "Creates or updates a security rule in the specified network security group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "name": "securityRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the security rule."
+          },
+          {
+            "name": "securityRuleParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            },
+            "description": "Parameters supplied to the create or update network security rule operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting SecurityRule resource.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting SecurityRule resource.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create security rule": { "$ref": "./examples/NetworkSecurityGroupRuleCreate.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules": {
+      "get": {
+        "tags": [
+          "SecurityRules"
+        ],
+        "operationId": "SecurityRules_List",
+        "description": "Gets all security rules in a network security group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of SecurityRule resources.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRuleListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List network security rules in network security group": { "$ref": "./examples/NetworkSecurityGroupRuleList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/defaultSecurityRules": {
+      "get": {
+        "tags": [
+          "SecurityRules"
+        ],
+        "operationId": "DefaultSecurityRules_List",
+        "description": "Gets all default security rules in a network security group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of SecurityRule resources.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRuleListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DefaultSecurityRuleList": { "$ref": "./examples/DefaultSecurityRuleList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/defaultSecurityRules/{defaultSecurityRuleName}" : {
+      "get": {
+        "tags": [
+          "SecurityRules"
+        ],
+        "operationId": "DefaultSecurityRules_Get",
+        "description": "Get the specified default network security rule.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network security group."
+          },
+          {
+            "name": "defaultSecurityRuleName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the default security rule."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting SecurityRule resource.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DefaultSecurityRuleGet": { "$ref": "./examples/DefaultSecurityRuleGet.json" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "SecurityRulePropertiesFormat": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description for this rule. Restricted to 140 chars."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Network protocol this rule applies to. Possible values are 'Tcp', 'Udp', and '*'.",
+          "enum": [
+            "Tcp",
+            "Udp",
+            "*"
+          ],
+          "x-ms-enum": {
+            "name": "SecurityRuleProtocol",
+            "modelAsString": true
+          }
+        },
+        "sourcePortRange": {
+          "type": "string",
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+        },
+        "destinationPortRange": {
+          "type": "string",
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+        },
+        "sourceAddressPrefix": {
+          "type": "string",
+          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+        },
+        "sourceAddressPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The CIDR or source IP ranges."
+        },
+        "sourceApplicationSecurityGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "./applicationSecurityGroup.json#/definitions/ApplicationSecurityGroup"
+          },
+          "description": "The application security group specified as source."
+        },
+        "destinationAddressPrefix": {
+          "type": "string",
+          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+        },
+        "destinationAddressPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The destination address prefixes. CIDR or destination IP ranges."
+        },
+        "destinationApplicationSecurityGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "./applicationSecurityGroup.json#/definitions/ApplicationSecurityGroup"
+          },
+          "description": "The application security group specified as destination."
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "The source port."
+          },
+          "description": "The source port ranges."
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "The destination port."
+          },
+          "description": "The destination port ranges."
+        },
+        "access": {
+          "type": "string",
+          "description": "The network traffic is allowed or denied. Possible values are: 'Allow' and 'Deny'.",
+          "enum": [
+            "Allow",
+            "Deny"
+          ],
+          "x-ms-enum": {
+            "name": "SecurityRuleAccess",
+            "modelAsString": true
+          }
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of the rule. The value can be between 100 and 4096. The priority number must be unique for each rule in the collection. The lower the priority number, the higher the priority of the rule."
+        },
+        "direction": {
+          "type": "string",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "enum": [
+            "Inbound",
+            "Outbound"
+          ],
+          "x-ms-enum": {
+            "name": "SecurityRuleDirection",
+            "modelAsString": true
+          }
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "required": [
+        "protocol",
+        "access",
+        "direction"
+      ],
+      "description": "Security rule resource."
+    },
+    "SecurityRule": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/SecurityRulePropertiesFormat",
+          "description": "Properties of the security rule"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Network security rule."
+    },
+    "SecurityRuleListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRule"
+          },
+          "description": "The security rules in a network security group."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListSecurityRule API service call. Retrieves all security rules that belongs to a network security group."
+    },
+    "NetworkSecurityGroupPropertiesFormat": {
+      "properties": {
+        "securityRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRule"
+          },
+          "description": "A collection of security rules of the network security group."
+        },
+        "defaultSecurityRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRule"
+          },
+          "description": "The default security rules of network security group."
+        },
+        "networkInterfaces": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./networkInterface.json#/definitions/NetworkInterface"
+          },
+          "description": "A collection of references to network interfaces."
+        },
+        "subnets": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/Subnet"
+          },
+          "description": "A collection of references to subnets."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the network security group resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Network Security Group resource."
+    },
+    "NetworkSecurityGroup": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/NetworkSecurityGroupPropertiesFormat",
+          "description": "Properties of the network security group"
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "NetworkSecurityGroup resource."
+    },
+    "NetworkSecurityGroupListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityGroup"
+          },
+          "description": "A list of NetworkSecurityGroup resources."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListNetworkSecurityGroups API service call."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkWatcher.json
@@ -1,0 +1,2969 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}": {
+      "put": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_CreateOrUpdate",
+        "description": "Creates or updates a network watcher in the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            },
+            "description": "Parameters that define the network watcher resource."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting network watcher resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting network watcher resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_Get",
+        "description": "Gets the specified network watcher by resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a network watcher resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_Delete",
+        "x-ms-long-running-operation": true,
+        "description": "Deletes the specified network watcher resource.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "Delete successful."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_UpdateTags",
+        "description": "Updates a network watcher tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update network watcher tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting network watcher resource.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update network watcher tags": { "$ref": "./examples/NetworkWatcherUpdateTags.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers": {
+      "get": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_List",
+        "description": "Gets all network watchers by resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of network watcher resources.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcherListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkWatchers": {
+      "get": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_ListAll",
+        "description": "Gets all network watchers by subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of network watcher resources.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcherListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/topology": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_GetTopology",
+        "description": "Gets the current network topology by resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TopologyParameters"
+            },
+            "description": "Parameters that define the representation of topology."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the topology of resource group.",
+            "schema": {
+              "$ref": "#/definitions/Topology"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Topology": {
+            "$ref": "./examples/NetworkWatcherTopologyGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/ipFlowVerify": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_VerifyIPFlow",
+        "x-ms-long-running-operation": true,
+        "description": "Verify IP flow from the specified VM to a location given the currently configured NSG rules.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VerificationIPFlowParameters"
+            },
+            "description": "Parameters that define the IP flow to be verified."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the result of IP flow verification.",
+            "schema": {
+              "$ref": "#/definitions/VerificationIPFlowResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/VerificationIPFlowResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/nextHop": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_GetNextHop",
+        "x-ms-long-running-operation": true,
+        "description": "Gets the next hop from the specified VM.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NextHopParameters"
+            },
+            "description": "Parameters that define the source and destination endpoint."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the next hop from the VM.",
+            "schema": {
+              "$ref": "#/definitions/NextHopResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/NextHopResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/securityGroupView": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_GetVMSecurityRules",
+        "x-ms-long-running-operation": true,
+        "description": "Gets the configured and effective security group rules on the specified VM.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityGroupViewParameters"
+            },
+            "description": "Parameters that define the VM to check security groups for."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns security group rules on the VM.",
+            "schema": {
+              "$ref": "#/definitions/SecurityGroupViewResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/SecurityGroupViewResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}": {
+      "put": {
+        "tags": [
+          "PacketCaptures"
+        ],
+        "operationId": "PacketCaptures_Create",
+        "x-ms-long-running-operation": true,
+        "description": "Create and start a packet capture on the specified VM.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the packet capture session."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PacketCapture"
+            },
+            "description": "Parameters that define the create packet capture operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Request successful. The operation returns the resulting packet capture session.",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureResult"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PacketCaptures"
+        ],
+        "operationId": "PacketCaptures_Get",
+        "description": "Gets a packet capture session by name.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the packet capture session."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a packet capture session.",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureResult"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PacketCaptures"
+        ],
+        "operationId": "PacketCaptures_Delete",
+        "x-ms-long-running-operation": true,
+        "description": "Deletes the specified packet capture session.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the packet capture session."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Delete successful."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/stop": {
+      "post": {
+        "tags": [
+          "PacketCaptures"
+        ],
+        "operationId": "PacketCaptures_Stop",
+        "x-ms-long-running-operation": true,
+        "description": "Stops a specified packet capture session.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher."
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the packet capture session."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation stops the packet capture session."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/queryStatus": {
+      "post": {
+        "tags": [
+          "PacketCaptures"
+        ],
+        "operationId": "PacketCaptures_GetStatus",
+        "x-ms-long-running-operation": true,
+        "description": "Query the status of a running packet capture session.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Network Watcher resource."
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name given to the packet capture session."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful query of packet capture status.",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureQueryStatusResult"
+            }
+          },
+          "202": {
+            "description": "Accepted query status of packet capture.",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureQueryStatusResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures": {
+      "get": {
+        "tags": [
+          "PacketCaptures"
+        ],
+        "operationId": "PacketCaptures_List",
+        "description": "Lists all packet capture sessions within the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Network Watcher resource."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful packet capture enumeration request.",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/troubleshoot": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_GetTroubleshooting",
+        "x-ms-long-running-operation": true,
+        "description": "Initiate troubleshooting on a specified resource",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingParameters"
+            },
+            "description": "Parameters that define the resource to troubleshoot."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful troubleshooting request",
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingResult"
+            }
+          },
+          "202": {
+            "description": "Accepted get troubleshooting request.",
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryTroubleshootResult": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_GetTroubleshootingResult",
+        "x-ms-long-running-operation": true,
+        "description": "Get the last completed troubleshooting result on a specified resource",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueryTroubleshootingParameters"
+            },
+            "description": "Parameters that define the resource to query the troubleshooting result."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful get troubleshooting result request",
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingResult"
+            }
+          },
+          "202": {
+            "description": "Accepted get troubleshooting result request.",
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/configureFlowLog": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_SetFlowLogConfiguration",
+        "x-ms-long-running-operation": true,
+        "description": "Configures flow log on a specified resource.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            },
+            "description": "Parameters that define the configuration of flow log."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request for setting flow log configuration.",
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryFlowLogStatus": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_GetFlowLogStatus",
+        "x-ms-long-running-operation": true,
+        "description": "Queries status of flow log on a specified resource.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FlowLogStatusParameters"
+            },
+            "description": "Parameters that define a resource to query flow log status."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request for query flow log status.",
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectivityCheck": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_CheckConnectivity",
+        "x-ms-long-running-operation": true,
+        "description": "Verifies the possibility of establishing a direct TCP connection from a virtual machine to a given endpoint including another VM or an arbitrary remote server.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectivityParameters"
+            },
+            "description": "Parameters that determine how the connectivity check will be performed."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request for checking connectivity.",
+            "schema": {
+              "$ref": "#/definitions/ConnectivityInformation"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/ConnectivityInformation"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/azureReachabilityReport": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_GetAzureReachabilityReport",
+        "x-ms-long-running-operation": true,
+        "description": "Gets the relative latency score for internet service providers from a specified location to Azure regions.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AzureReachabilityReportParameters"
+            },
+            "description": "Parameters that determine Azure reachability report configuration."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request for Azure reachability report.",
+            "schema": {
+              "$ref": "#/definitions/AzureReachabilityReport"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/AzureReachabilityReport"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Azure Reachability Report": {
+            "$ref": "./examples/NetworkWatcherAzureReachabilityReportGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/availableProvidersList": {
+      "post": {
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "operationId": "NetworkWatchers_ListAvailableProviders",
+        "x-ms-long-running-operation": true,
+        "description": "Lists all available internet service providers for a specified Azure region.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource group."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network watcher resource."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AvailableProvidersListParameters"
+            },
+            "description": "Parameters that scope the list of available providers."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request for list of available providers.",
+            "schema": {
+              "$ref": "#/definitions/AvailableProvidersList"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/AvailableProvidersList"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Azure Reachability Report": {
+            "$ref": "./examples/NetworkWatcherAvailableProvidersListGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}": {
+      "put": {
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "operationId": "ConnectionMonitors_CreateOrUpdate",
+        "x-ms-long-running-operation": true,
+        "description": "Create or update a connection monitor.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group containing Network Watcher."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Network Watcher resource."
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the connection monitor."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitor"
+            },
+            "description": "Parameters that define the operation to create a connection monitor."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting network watcher resource.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorResult"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting network watcher resource.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorResult"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "operationId": "ConnectionMonitors_Get",
+        "description": "Gets a connection monitor by name.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group containing Network Watcher."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Network Watcher resource."
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the connection monitor."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a connection monitor.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorResult"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "operationId": "ConnectionMonitors_Delete",
+        "x-ms-long-running-operation": true,
+        "description": "Deletes the specified connection monitor.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group containing Network Watcher."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Network Watcher resource."
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the connection monitor."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Delete successful."
+          },
+          "202": {
+            "description": "Accepted. The operation will complete asynchronously."
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/stop": {
+      "post": {
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "operationId": "ConnectionMonitors_Stop",
+        "x-ms-long-running-operation": true,
+        "description": "Stops the specified connection monitor.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group containing Network Watcher."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Network Watcher resource."
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the connection monitor."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation stops the connection monitor."
+          },
+          "202": {
+            "description": "Accepted. The operation will complete asynchronously."
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/start": {
+      "post": {
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "operationId": "ConnectionMonitors_Start",
+        "x-ms-long-running-operation": true,
+        "description": "Starts the specified connection monitor.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group containing Network Watcher."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Network Watcher resource."
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the connection monitor."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation starts the connection monitor."
+          },
+          "202": {
+            "description": "Accepted. The operation will complete asynchronously."
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/query": {
+      "post": {
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "operationId": "ConnectionMonitors_Query",
+        "x-ms-long-running-operation": true,
+        "description": "Query a snapshot of the most recent connection states.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group containing Network Watcher."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Network Watcher resource."
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name given to the connection monitor."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful query of connection states.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorQueryResult"
+            }
+          },
+          "202": {
+            "description": "Accepted query of connection states.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorQueryResult"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors": {
+      "get": {
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "operationId": "ConnectionMonitors_List",
+        "description": "Lists all connection monitors for the specified Network Watcher.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group containing Network Watcher."
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Network Watcher resource."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful connection monitor enumeration request.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
+        }
+      }
+    }
+  },
+  "definitions": {
+    "NetworkWatcher": {
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/NetworkWatcherPropertiesFormat"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "Network watcher in a resource group."
+    },
+    "NetworkWatcherPropertiesFormat": {
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "enum": [
+            "Succeeded",
+            "Updating",
+            "Deleting",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "ProvisioningState",
+            "modelAsString": true
+          },
+          "description": "The provisioning state of the resource."
+        }
+      },
+      "description": "The network watcher properties."
+    },
+    "NetworkWatcherListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkWatcher"
+          }
+        }
+      },
+      "description": "List of network watcher resources."
+    },
+    "TopologyParameters": {
+      "properties": {
+        "targetResourceGroupName": {
+          "type": "string",
+          "description": "The name of the target resource group to perform topology on."
+        },
+        "targetVirtualNetwork": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference of the Virtual Network resource."
+        },
+        "targetSubnet": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference of the Subnet resource."
+        }
+      },
+      "description": "Parameters that define the representation of topology."
+    },
+    "Topology": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "GUID representing the operation id."
+        },
+        "createdDateTime": {
+          "readOnly": true,
+          "type": "string",
+          "format": "date-time",
+          "description": "The datetime when the topology was initially created for the resource group."
+        },
+        "lastModified": {
+          "readOnly": true,
+          "type": "string",
+          "format": "date-time",
+          "description": "The datetime when the topology was last modified."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TopologyResource"
+          }
+        }
+      },
+      "description": "Topology of the specified resource group."
+    },
+    "TopologyResource": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "ID of the resource."
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "associations": {
+          "type": "array",
+          "description": "Holds the associations the resource has with other resources in the resource group.",
+          "items": {
+            "$ref": "#/definitions/TopologyAssociation"
+          }
+        }
+      },
+      "description": "The network resource topology information for the given resource group."
+    },
+    "TopologyAssociation": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is associated with the parent resource."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "The ID of the resource that is associated with the parent resource."
+        },
+        "associationType": {
+          "type": "string",
+          "enum": [
+            "Associated",
+            "Contains"
+          ],
+          "x-ms-enum": {
+            "name": "AssociationType",
+            "modelAsString": true
+          },
+          "description": "The association type of the child resource to the parent resource."
+        }
+      },
+      "description": "Resources that have an association with the parent resource."
+    },
+    "VerificationIPFlowParameters": {
+      "description": "Parameters that define the IP flow to be verified.",
+      "required": [
+        "targetResourceId",
+        "direction",
+        "protocol",
+        "localPort",
+        "remotePort",
+        "localIPAddress",
+        "remoteIPAddress"
+      ],
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "The ID of the target resource to perform next-hop on."
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "Inbound",
+            "Outbound"
+          ],
+          "x-ms-enum": {
+            "name": "Direction",
+            "modelAsString": true
+          },
+          "description": "The direction of the packet represented as a 5-tuple."
+        },
+        "protocol": {
+          "type": "string",
+          "enum": [
+            "TCP",
+            "UDP"
+          ],
+          "x-ms-enum": {
+            "name": "Protocol",
+            "modelAsString": true
+          },
+          "description": "Protocol to be verified on."
+        },
+        "localPort": {
+          "type": "string",
+          "description": "The local port. Acceptable values are a single integer in the range (0-65535). Support for * for the source port, which depends on the direction."
+        },
+        "remotePort": {
+          "type": "string",
+          "description": "The remote port. Acceptable values are a single integer in the range (0-65535). Support for * for the source port, which depends on the direction."
+        },
+        "localIPAddress": {
+          "type": "string",
+          "description": "The local IP address. Acceptable values are valid IPv4 addresses."
+        },
+        "remoteIPAddress": {
+          "type": "string",
+          "description": "The remote IP address. Acceptable values are valid IPv4 addresses."
+        },
+        "targetNicResourceId": {
+          "type": "string",
+          "description": "The NIC ID. (If VM has multiple NICs and IP forwarding is enabled on any of them, then this parameter must be specified. Otherwise optional)."
+        }
+      }
+    },
+    "VerificationIPFlowResult": {
+      "description": "Results of IP flow verification on the target resource.",
+      "properties": {
+        "access": {
+          "type": "string",
+          "enum": [
+            "Allow",
+            "Deny"
+          ],
+          "x-ms-enum": {
+            "name": "Access",
+            "modelAsString": true
+          },
+          "description": "Indicates whether the traffic is allowed or denied."
+        },
+        "ruleName": {
+          "type": "string",
+          "description": "Name of the rule. If input is not matched against any security rule, it is not displayed."
+        }
+      }
+    },
+    "NextHopParameters": {
+      "description": "Parameters that define the source and destination endpoint.",
+      "required": [
+        "targetResourceId",
+        "sourceIPAddress",
+        "destinationIPAddress"
+      ],
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "The resource identifier of the target resource against which the action is to be performed."
+        },
+        "sourceIPAddress": {
+          "type": "string",
+          "description": "The source IP address."
+        },
+        "destinationIPAddress": {
+          "type": "string",
+          "description": "The destination IP address."
+        },
+        "targetNicResourceId": {
+          "type": "string",
+          "description": "The NIC ID. (If VM has multiple NICs and IP forwarding is enabled on any of the nics, then this parameter must be specified. Otherwise optional)."
+        }
+      }
+    },
+    "NextHopResult": {
+      "description": "The information about next hop from the specified VM.",
+      "properties": {
+        "nextHopType": {
+          "type": "string",
+          "enum": [
+            "Internet",
+            "VirtualAppliance",
+            "VirtualNetworkGateway",
+            "VnetLocal",
+            "HyperNetGateway",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "NextHopType",
+            "modelAsString": true
+          },
+          "description": "Next hop type."
+        },
+        "nextHopIpAddress": {
+          "type": "string",
+          "description": "Next hop IP Address"
+        },
+        "routeTableId": {
+          "type": "string",
+          "description": "The resource identifier for the route table associated with the route being returned. If the route being returned does not correspond to any user created routes then this field will be the string 'System Route'."
+        }
+      }
+    },
+    "SecurityGroupViewParameters": {
+      "description": "Parameters that define the VM to check security groups for.",
+      "required": [
+        "targetResourceId"
+      ],
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "ID of the target VM."
+        }
+      }
+    },
+    "SecurityGroupViewResult": {
+      "description": "The information about security rules applied to the specified VM.",
+      "properties": {
+        "networkInterfaces": {
+          "type": "array",
+          "description": "List of network interfaces on the specified VM.",
+          "items": {
+            "$ref": "#/definitions/SecurityGroupNetworkInterface"
+          }
+        }
+      }
+    },
+    "SecurityGroupNetworkInterface": {
+      "description": "Network interface and all its associated security rules.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID of the network interface."
+        },
+        "securityRuleAssociations": {
+          "$ref": "#/definitions/SecurityRuleAssociations"
+        }
+      }
+    },
+    "SecurityRuleAssociations": {
+      "description": "All security rules associated with the network interface.",
+      "properties": {
+        "networkInterfaceAssociation": {
+          "$ref": "#/definitions/NetworkInterfaceAssociation"
+        },
+        "subnetAssociation": {
+          "$ref": "#/definitions/SubnetAssociation"
+        },
+        "defaultSecurityRules": {
+          "type": "array",
+          "items": {
+            "$ref": "./networkSecurityGroup.json#/definitions/SecurityRule"
+          },
+          "description": "Collection of default security rules of the network security group."
+        },
+        "effectiveSecurityRules": {
+          "type": "array",
+          "items": {
+            "$ref": "./networkInterface.json#/definitions/EffectiveNetworkSecurityRule"
+          },
+          "description": "Collection of effective security rules."
+        }
+      }
+    },
+    "NetworkInterfaceAssociation": {
+      "description": "Network interface and its custom security rules.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Network interface ID."
+        },
+        "securityRules": {
+          "type": "array",
+          "description": "Collection of custom security rules.",
+          "items": {
+            "$ref": "./networkSecurityGroup.json#/definitions/SecurityRule"
+          }
+        }
+      }
+    },
+    "SubnetAssociation": {
+      "description": "Network interface and its custom security rules.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Subnet ID."
+        },
+        "securityRules": {
+          "type": "array",
+          "description": "Collection of custom security rules.",
+          "items": {
+            "$ref": "./networkSecurityGroup.json#/definitions/SecurityRule"
+          }
+        }
+      }
+    },
+    "PacketCapture": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PacketCaptureParameters"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "description": "Parameters that define the create packet capture operation."
+    },
+    "PacketCaptureParameters": {
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "The ID of the targeted resource, only VM is currently supported."
+        },
+        "bytesToCapturePerPacket": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of bytes captured per packet, the remaining bytes are truncated."
+        },
+        "totalBytesPerSession": {
+          "type": "integer",
+          "default": 1073741824,
+          "description": "Maximum size of the capture output."
+        },
+        "timeLimitInSeconds": {
+          "type": "integer",
+          "default": 18000,
+          "description": "Maximum duration of the capture session in seconds."
+        },
+        "storageLocation": {
+          "$ref": "#/definitions/PacketCaptureStorageLocation"
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PacketCaptureFilter"
+          }
+        }
+      },
+      "required": [
+        "target",
+        "storageLocation"
+      ],
+      "description": "Parameters that define the create packet capture operation."
+    },
+    "PacketCaptureStorageLocation": {
+      "properties": {
+        "storageId": {
+          "type": "string",
+          "description": "The ID of the storage account to save the packet capture session. Required if no local file path is provided."
+        },
+        "storagePath": {
+          "type": "string",
+          "description": "The URI of the storage path to save the packet capture. Must be a well-formed URI describing the location to save the packet capture."
+        },
+        "filePath": {
+          "type": "string",
+          "description": "A valid local path on the targeting VM. Must include the name of the capture file (*.cap). For linux virtual machine it must start with /var/captures. Required if no storage ID is provided, otherwise optional."
+        }
+      },
+      "description": "Describes the storage location for a packet capture session."
+    },
+    "PacketCaptureFilter": {
+      "properties": {
+        "protocol": {
+          "type": "string",
+          "enum": [
+            "TCP",
+            "UDP",
+            "Any"
+          ],
+          "x-ms-enum": {
+            "name": "PcProtocol",
+            "modelAsString": true
+          },
+          "default": "Any",
+          "description": "Protocol to be filtered on."
+        },
+        "localIPAddress": {
+          "type": "string",
+          "description": "Local IP Address to be filtered on. Notation: \"127.0.0.1\" for single address entry. \"127.0.0.1-127.0.0.255\" for range. \"127.0.0.1;127.0.0.5\"? for multiple entries. Multiple ranges not currently supported. Mixing ranges with multiple entries not currently supported. Default = null."
+        },
+        "remoteIPAddress": {
+          "type": "string",
+          "description": "Local IP Address to be filtered on. Notation: \"127.0.0.1\" for single address entry. \"127.0.0.1-127.0.0.255\" for range. \"127.0.0.1;127.0.0.5;\" for multiple entries. Multiple ranges not currently supported. Mixing ranges with multiple entries not currently supported. Default = null."
+        },
+        "localPort": {
+          "type": "string",
+          "description": "Local port to be filtered on. Notation: \"80\" for single port entry.\"80-85\" for range. \"80;443;\" for multiple entries. Multiple ranges not currently supported. Mixing ranges with multiple entries not currently supported. Default = null."
+        },
+        "remotePort": {
+          "type": "string",
+          "description": "Remote port to be filtered on. Notation: \"80\" for single port entry.\"80-85\" for range. \"80;443;\" for multiple entries. Multiple ranges not currently supported. Mixing ranges with multiple entries not currently supported. Default = null."
+        }
+      },
+      "description": "Filter that is applied to packet capture request. Multiple filters can be applied."
+    },
+    "PacketCaptureListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PacketCaptureResult"
+          },
+          "description": "Information about packet capture sessions."
+        }
+      },
+      "description": "List of packet capture sessions."
+    },
+    "PacketCaptureResult": {
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Name of the packet capture session."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "ID of the packet capture operation."
+        },
+        "etag": {
+          "type": "string",
+          "default": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PacketCaptureResultProperties"
+        }
+      },
+      "description": "Information about packet capture session."
+    },
+    "PacketCaptureResultProperties": {
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "enum": [
+            "Succeeded",
+            "Updating",
+            "Deleting",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "ProvisioningState",
+            "modelAsString": true
+          },
+          "description": "The provisioning state of the packet capture session."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PacketCaptureParameters"
+        }
+      ],
+      "description": "Describes the properties of a packet capture session."
+    },
+    "PacketCaptureQueryStatusResult": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the packet capture resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the packet capture resource."
+        },
+        "captureStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time of the packet capture session."
+        },
+        "packetCaptureStatus": {
+          "type": "string",
+          "enum": [
+            "NotStarted",
+            "Running",
+            "Stopped",
+            "Error",
+            "Unknown"
+          ],
+          "x-ms-enum": {
+            "name": "PcStatus",
+            "modelAsString": true
+          },
+          "description": "The status of the packet capture session."
+        },
+        "stopReason": {
+          "type": "string",
+          "description": "The reason the current packet capture session was stopped."
+        },
+        "packetCaptureError": {
+          "type": "array",
+          "description": "List of errors of packet capture session.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "InternalError",
+              "AgentStopped",
+              "CaptureFailed",
+              "LocalFileFailed",
+              "StorageFailed"
+            ],
+            "x-ms-enum": {
+              "name": "PcError",
+              "modelAsString": true
+            }
+          }
+        }
+      },
+      "description": "Status of packet capture session."
+    },
+    "TroubleshootingParameters": {
+      "description": "Parameters that define the resource to troubleshoot.",
+      "required": [
+        "targetResourceId",
+        "properties"
+      ],
+      "properties": {
+        "targetResourceId": {
+          "description": "The target resource to troubleshoot.",
+          "type": "string"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/TroubleshootingProperties"
+        }
+      }
+    },
+    "QueryTroubleshootingParameters": {
+      "description": "Parameters that define the resource to query the troubleshooting result.",
+      "required": [
+        "targetResourceId"
+      ],
+      "properties": {
+        "targetResourceId": {
+          "description": "The target resource ID to query the troubleshooting result.",
+          "type": "string"
+        }
+      }
+    },
+    "TroubleshootingProperties": {
+      "description": "Storage location provided for troubleshoot.",
+      "required": [
+        "storageId",
+        "storagePath"
+      ],
+      "properties": {
+        "storageId": {
+          "description": "The ID for the storage account to save the troubleshoot result.",
+          "type": "string"
+        },
+        "storagePath": {
+          "description": "The path to the blob to save the troubleshoot result in.",
+          "type": "string"
+        }
+      }
+    },
+    "TroubleshootingResult": {
+      "description": "Troubleshooting information gained from specified resource.",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time of the troubleshooting."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time of the troubleshooting."
+        },
+        "code": {
+          "type": "string",
+          "description": "The result code of the troubleshooting."
+        },
+        "results": {
+          "type": "array",
+          "description": "Information from troubleshooting.",
+          "items": {
+            "$ref": "#/definitions/TroubleshootingDetails"
+          }
+        }
+      }
+    },
+    "TroubleshootingDetails": {
+      "description": "Information gained from troubleshooting of specified resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The id of the get troubleshoot operation."
+        },
+        "reasonType": {
+          "type": "string",
+          "description": "Reason type of failure."
+        },
+        "summary": {
+          "type": "string",
+          "description": "A summary of troubleshooting."
+        },
+        "detail": {
+          "type": "string",
+          "description": "Details on troubleshooting results."
+        },
+        "recommendedActions": {
+          "type": "array",
+          "description": "List of recommended actions.",
+          "items": {
+            "$ref": "#/definitions/TroubleshootingRecommendedActions"
+          }
+        }
+      }
+    },
+    "TroubleshootingRecommendedActions": {
+      "description": "Recommended actions based on discovered issues.",
+      "properties": {
+        "actionId": {
+          "description": "ID of the recommended action.",
+          "type": "string"
+        },
+        "actionText": {
+          "description": "Description of recommended actions.",
+          "type": "string"
+        },
+        "actionUri": {
+          "description": "The uri linking to a documentation for the recommended troubleshooting actions.",
+          "type": "string"
+        },
+        "actionUriText": {
+          "description": "The information from the URI for the recommended troubleshooting actions.",
+          "type": "string"
+        }
+      }
+    },
+    "FlowLogProperties": {
+      "description": "Parameters that define the configuration of flow log.",
+      "required": [
+        "storageId",
+        "enabled"
+      ],
+      "properties": {
+        "storageId": {
+          "description": "ID of the storage account which is used to store the flow log.",
+          "type": "string"
+        },
+        "enabled": {
+          "description": "Flag to enable/disable flow logging.",
+          "type": "boolean"
+        },
+        "retentionPolicy": {
+          "$ref": "#/definitions/RetentionPolicyParameters"
+        }
+      }
+    },
+    "FlowLogStatusParameters": {
+      "description": "Parameters that define a resource to query flow log status.",
+      "required": [
+        "targetResourceId"
+      ],
+      "properties": {
+        "targetResourceId": {
+          "description": "The target resource where getting the flow logging status.",
+          "type": "string"
+        }
+      }
+    },
+    "RetentionPolicyParameters": {
+      "description": "Parameters that define the retention policy for flow log.",
+      "properties": {
+        "days": {
+          "description": "Number of days to retain flow log records.",
+          "type": "integer",
+          "default": 0
+        },
+        "enabled": {
+          "description": "Flag to enable/disable retention.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "FlowLogInformation": {
+      "description": "Information on the configuration of flow log.",
+      "required": [
+        "targetResourceId",
+        "properties"
+      ],
+      "properties": {
+        "targetResourceId": {
+          "description": "The ID of the resource to configure for flow logging.",
+          "type": "string"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/FlowLogProperties"
+        }
+      }
+    },
+    "ConnectivityParameters": {
+      "description": "Parameters that determine how the connectivity check will be performed.",
+      "required": [
+        "source",
+        "destination"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/ConnectivitySource"
+        },
+        "destination": {
+          "$ref": "#/definitions/ConnectivityDestination"
+        }
+      }
+    },
+    "ConnectivitySource": {
+      "description": "Parameters that define the source of the connection.",
+      "required": [
+        "resourceId"
+      ],
+      "properties": {
+        "resourceId": {
+          "description": "The ID of the resource from which a connectivity check will be initiated.",
+          "type": "string"
+        },
+        "port": {
+          "description": "The source port from which a connectivity check will be performed.",
+          "type": "integer"
+        }
+      }
+    },
+    "ConnectivityDestination": {
+      "description": "Parameters that define destination of connection.",
+      "properties": {
+        "resourceId": {
+          "description": "The ID of the resource to which a connection attempt will be made.",
+          "type": "string"
+        },
+        "address": {
+          "description": "The IP address or URI the resource to which a connection attempt will be made.",
+          "type": "string"
+        },
+        "port": {
+          "description": "Port on which check connectivity will be performed.",
+          "type": "integer"
+        }
+      }
+    },
+    "ConnectivityInformation": {
+      "description": "Information on the connectivity status.",
+      "properties": {
+        "hops": {
+          "readOnly": true,
+          "type": "array",
+          "description": "List of hops between the source and the destination.",
+          "items": {
+            "$ref": "#/definitions/ConnectivityHop"
+          }
+        },
+        "connectionStatus": {
+          "readOnly": true,
+          "type": "string",
+          "enum": [
+            "Unknown",
+            "Connected",
+            "Disconnected",
+            "Degraded"
+          ],
+          "x-ms-enum": {
+            "name": "ConnectionStatus",
+            "modelAsString": true
+          },
+          "description": "The connection status."
+        },
+        "avgLatencyInMs": {
+          "description": "Average latency in milliseconds.",
+          "readOnly": true,
+          "type": "integer"
+        },
+        "minLatencyInMs": {
+          "description": "Minimum latency in milliseconds.",
+          "readOnly": true,
+          "type": "integer"
+        },
+        "maxLatencyInMs": {
+          "description": "Maximum latency in milliseconds.",
+          "readOnly": true,
+          "type": "integer"
+        },
+        "probesSent": {
+          "description": "Total number of probes sent.",
+          "readOnly": true,
+          "type": "integer"
+        },
+        "probesFailed": {
+          "description": "Number of failed probes.",
+          "readOnly": true,
+          "type": "integer"
+        }
+      }
+    },
+    "ConnectivityHop": {
+      "description": "Information about a hop between the source and the destination.",
+      "properties": {
+        "type": {
+          "description": "The type of the hop.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "id": {
+          "description": "The ID of the hop.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "address": {
+          "description": "The IP address of the hop.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "resourceId": {
+          "description": "The ID of the resource corresponding to this hop.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "nextHopIds": {
+          "readOnly": true,
+          "type": "array",
+          "description": "List of next hop identifiers.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "issues": {
+          "readOnly": true,
+          "type": "array",
+          "description": "List of issues.",
+          "items": {
+            "$ref": "#/definitions/ConnectivityIssue"
+          }
+        }
+      }
+    },
+    "ConnectivityIssue": {
+      "description": "Information about an issue encountered in the process of checking for connectivity.",
+      "properties": {
+        "origin": {
+          "readOnly": true,
+          "type": "string",
+          "enum": [
+            "Local",
+            "Inbound",
+            "Outbound"
+          ],
+          "x-ms-enum": {
+            "name": "Origin",
+            "modelAsString": true
+          },
+          "description": "The origin of the issue."
+        },
+        "severity": {
+          "readOnly": true,
+          "type": "string",
+          "enum": [
+            "Error",
+            "Warning"
+          ],
+          "x-ms-enum": {
+            "name": "Severity",
+            "modelAsString": true
+          },
+          "description": "The severity of the issue."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "enum": [
+            "Unknown",
+            "AgentStopped",
+            "GuestFirewall",
+            "DnsResolution",
+            "SocketBind",
+            "NetworkSecurityRule",
+            "UserDefinedRoute",
+            "PortThrottled",
+            "Platform"
+          ],
+          "x-ms-enum": {
+            "name": "IssueType",
+            "modelAsString": true
+          },
+          "description": "The type of issue."
+        },
+        "context": {
+          "readOnly": true,
+          "type": "array",
+          "description": "Provides additional context on the issue.",
+          "items": {
+            "$ref": "#/definitions/IssueContext"
+          }
+        }
+      }
+    },
+    "IssueContext": {
+      "description": "A key-value pair that provides additional context on the issue.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "AzureReachabilityReportParameters": {
+      "properties": {
+        "providerLocation": {
+          "$ref": "#/definitions/AzureReachabilityReportLocation"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of Internet service providers."
+        },
+        "azureLocations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional Azure regions to scope the query to."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time for the Azure reachability report."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time for the Azure reachability report."
+        }
+      },
+      "required": [
+        "providerLocation",
+        "startTime",
+        "endTime"
+      ],
+      "description": "Geographic and time constraints for Azure reachability report."
+    },
+    "AzureReachabilityReportLocation": {
+      "properties": {
+        "country": {
+          "type": "string",
+          "description": "The name of the country."
+        },
+        "state": {
+          "type": "string",
+          "description": "The name of the state."
+        },
+        "city": {
+          "type": "string",
+          "description": "The name of the city or town."
+        }
+      },
+      "required": [
+        "country"
+      ],
+      "description": "Parameters that define a geographic location."
+    },
+    "AzureReachabilityReport": {
+      "properties": {
+        "aggregationLevel": {
+          "type": "string",
+          "description": "The aggregation level of Azure reachability report. Can be Country, State or City."
+        },
+        "providerLocation": {
+          "$ref": "#/definitions/AzureReachabilityReportLocation"
+        },
+        "reachabilityReport": {
+          "type": "array",
+          "description": "List of Azure reachability report items.",
+          "items": {
+            "$ref": "#/definitions/AzureReachabilityReportItem"
+          }
+        }
+      },
+      "required": [
+        "aggregationLevel",
+        "providerLocation",
+        "reachabilityReport"
+      ],
+      "description": "Azure reachability report details."
+    },
+    "AzureReachabilityReportItem": {
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "The Internet service provider."
+        },
+        "azureLocation": {
+          "type": "string",
+          "description": "The Azure region."
+        },
+        "latencies": {
+          "type": "array",
+          "description": "List of latency details for each of the time series.",
+          "items": {
+            "$ref": "#/definitions/AzureReachabilityReportLatencyInfo"
+          }
+        }
+      },
+      "description": "Azure reachability report details for a given provider location."
+    },
+    "AzureReachabilityReportLatencyInfo": {
+      "properties": {
+        "timeStamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time stamp."
+        },
+        "score": {
+          "type": "integer",
+          "description": "The relative latency score between 1 and 100, higher values indicating a faster connection.",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "description": "Details on latency for a time series."
+    },
+    "AvailableProvidersListParameters": {
+      "properties": {
+        "azureLocations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of Azure regions."
+        },
+        "country": {
+          "type": "string",
+          "description": "The country for available providers list."
+        },
+        "state": {
+          "type": "string",
+          "description": "The state for available providers list."
+        },
+        "city": {
+          "type": "string",
+          "description": "The city or town for available providers list."
+        }
+      },
+      "description": "Constraints that determine the list of available Internet service providers."
+    },
+    "AvailableProvidersList": {
+      "properties": {
+        "countries": {
+          "type": "array",
+          "description": "List of available countries.",
+          "items": {
+            "$ref": "#/definitions/AvailableProvidersListCountry"
+          }
+        }
+      },
+      "required": [
+        "countries"
+      ],
+      "description": "List of available countries with details."
+    },
+    "AvailableProvidersListCountry": {
+      "properties": {
+        "countryName": {
+          "type": "string",
+          "description": "The country name."
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of Internet service providers."
+        },
+        "states": {
+          "type": "array",
+          "description": "List of available states in the country.",
+          "items": {
+            "$ref": "#/definitions/AvailableProvidersListState"
+          }
+        }
+      },
+      "description": "Country details."
+    },
+    "AvailableProvidersListState": {
+      "properties": {
+        "stateName": {
+          "type": "string",
+          "description": "The state name."
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of Internet service providers."
+        },
+        "cities": {
+          "type": "array",
+          "description": "List of available cities or towns in the state.",
+          "items": {
+            "$ref": "#/definitions/AvailableProvidersListCity"
+          }
+        }
+      },
+      "description": "State details."
+    },
+    "AvailableProvidersListCity": {
+      "properties": {
+        "cityName": {
+          "type": "string",
+          "description": "The city or town name."
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of Internet service providers."
+        }
+      },
+      "description": "City or town details."
+    },
+    "ConnectionMonitor": {
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Connection monitor location."         
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Connection monitor tags."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ConnectionMonitorParameters"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "description": "Parameters that define the operation to create a connection monitor."
+    },
+    "ConnectionMonitorParameters": {
+      "properties": {
+        "source": {
+      "$ref": "#/definitions/ConnectionMonitorSource"
+        },
+        "destination": {
+      "$ref": "#/definitions/ConnectionMonitorDestination"
+        },
+        "autoStart": {
+          "type": "boolean",
+          "default": true,
+          "description": "Determines if the connection monitor will start automatically once created."
+        },
+        "monitoringIntervalInSeconds": {
+          "type": "integer",
+          "default": 60,
+          "description": "Monitoring interval in seconds."
+        }
+      },
+      "required": [
+        "source",
+        "destination"
+      ],
+      "description": "Parameters that define the operation to create a connection monitor."
+    },
+    "ConnectionMonitorSource": {
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "The ID of the resource used as the source by connection monitor."
+        },
+        "port": {
+          "type": "integer",
+          "description": "The source port used by connection monitor."
+        }
+      },
+      "required": [
+        "resourceId"
+      ],
+      "description": "Describes the source of connection monitor."
+    },
+    "ConnectionMonitorDestination": {
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "The ID of the resource used as the destination by connection monitor."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address of the connection monitor destination (IP or domain name)."
+        },
+        "port": {
+          "type": "integer",
+          "description": "The destination port used by connection monitor."
+        }
+      },
+      "description": "Describes the destination of connection monitor."
+    },
+    "ConnectionMonitorListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConnectionMonitorResult"
+          },
+          "description": "Information about connection monitors."
+        }
+      },
+      "description": "List of connection monitors."
+    },
+    "ConnectionMonitorResult": {
+      "x-ms-azure-resource": true,
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Name of the connection monitor."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "ID of the connection monitor."
+        },
+        "etag": {
+          "type": "string",
+          "default": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Connection monitor type."
+        },
+        "location": {
+          "type": "string",
+          "description": "Connection monitor location."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Connection monitor tags."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ConnectionMonitorResultProperties"
+        }
+      },
+      "description": "Information about the connection monitor."
+    },
+    "ConnectionMonitorResultProperties": {
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "enum": [
+            "Succeeded",
+            "Updating",
+            "Deleting",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "ProvisioningState",
+            "modelAsString": true
+          },
+          "description": "The provisioning state of the connection monitor."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time when the connection monitor was started."
+        },
+        "monitoringStatus": {
+          "type": "string",
+          "description": "The monitoring status of the connection monitor."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionMonitorParameters"
+        }
+      ],
+      "description": "Describes the properties of a connection monitor."
+    },
+    "ConnectionMonitorQueryResult": {
+      "properties": {
+        "states": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConnectionStateSnapshot"
+          },
+          "description": "Information about connection states."
+        }
+      },
+      "description": "List of connection states snaphots."
+    },
+    "ConnectionStateSnapshot": {
+      "properties": {
+        "connectionState": {
+          "type": "string",
+          "enum": [
+            "Reachable",
+            "Unreachable",
+            "Unknown"
+          ],
+          "x-ms-enum": {
+            "name": "ConnectionState",
+            "modelAsString": true
+          },
+          "description": "The connection state."
+        },
+        "startTime": {
+          "type": "string",
+         "format": "date-time",
+          "description": "The start time of the connection snapshot."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time of the connection snapshot."
+        },
+        "evaluationState": {
+          "type": "string",
+          "enum": [
+            "NotStarted",
+            "InProgress",
+            "Completed"
+          ],
+          "x-ms-enum": {
+            "name": "EvaluationState",
+            "modelAsString": true
+          },
+          "description": "Connectivity analysis evaluation state."
+        },
+        "hops": {
+          "readOnly": true,
+          "type": "array",
+          "description": "List of hops between the source and the destination.",
+          "items": {
+            "$ref": "#/definitions/ConnectivityHop"
+          }
+        }
+      },
+      "description": "Connection state snapshot."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/operation.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/operation.json
@@ -1,0 +1,279 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/providers/Microsoft.Network/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "description": "Lists all of the available Network Rest API operations.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get a list of operations for a resource provider": { "$ref": "./examples/OperationList.json" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "OperationListResult": {
+     "description": "Result of the request to list Network operations. It contains a list of operations and a URL link to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          },
+          "description": "List of Network operations supported by the Network resource provider."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of operation list results if there are any."
+        }
+      }
+    },
+    "Operation": {
+      "description": "Network REST API operation definition.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Operation name: {provider}/{resource}/{operation}",
+          "type": "string"
+        },
+        "display": {
+          "description": "Display metadata associated with the operation.",
+          "properties": {
+            "provider": {
+              "description": "Service provider: Microsoft Network.",
+              "type": "string"
+            },
+            "resource": {
+              "description": "Resource on which the operation is performed.",
+              "type": "string"
+            },
+            "operation": {
+              "description": "Type of the operation: get, read, delete, etc.",
+              "type": "string"
+            },
+            "description": {
+              "description": "Description of the operation.",
+              "type": "string"
+            }
+          }
+        },
+        "origin": {
+          "description": "Origin of the operation.",
+          "type": "string"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/OperationPropertiesFormat",
+          "description": "Operation properties format."
+        }
+      }
+    },
+    "OperationPropertiesFormat": {
+      "description": "Description of operation properties format.",
+      "properties": {
+        "serviceSpecification": {
+          "description": "Specification of the service.",
+          "properties": {
+            "metricSpecifications": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MetricSpecification"
+              },
+              "description": "Operation service specification."
+            },
+            "logSpecifications": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LogSpecification"
+              },
+              "description": "Operation log specification."
+            }
+          }
+        }
+      }
+    },
+    "LogSpecification": {
+      "description": "Description of logging specification.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the specification."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the specification."
+        },
+        "blobDuration": {
+          "type": "string",
+          "description": "Duration of the blob."
+        }
+      }
+    },
+    "MetricSpecification": {
+      "description": "Description of metrics specification.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the metric."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the metric."
+        },
+        "displayDescription": {
+          "type": "string",
+          "description": "The description of the metric."
+        },
+        "unit": {
+          "type": "string",
+          "description": "Units the metric to be displayed in."
+        },
+        "aggregationType": {
+          "type": "string",
+          "description": "The aggregation type."
+        },
+        "availabilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Availability"
+          },
+          "description": "List of availability."
+        },
+        "enableRegionalMdmAccount": {
+          "type": "boolean",
+          "description": "Whether regional MDM account enabled."
+        },
+        "fillGapWithZero": {
+          "type": "boolean",
+          "description": "Whether gaps would be filled with zeros."
+        },
+        "metricFilterPattern": {
+          "type": "string",
+          "description": "Pattern for the filter of the metric."
+        },
+        "dimensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Dimension"
+          },
+          "description": "List of dimensions."
+        },
+        "isInternal": {
+          "type": "boolean",
+          "description": "Whether the metric is internal."
+        },
+        "sourceMdmAccount": {
+          "type": "string",
+          "description": "The source MDM account."
+        },
+        "sourceMdmNamespace": {
+          "type": "string",
+          "description": "The source MDM namespace."
+        },
+        "resourceIdDimensionNameOverride": {
+          "type": "string",
+          "description": "The resource Id dimension name override."
+        }
+      }
+    },
+    "Dimension": {
+      "description": "Dimension of the metric.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the dimension."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the dimension."
+        },
+        "internalName": {
+          "type": "string",
+          "description": "The internal name of the dimension."
+        }
+      }
+    },
+    "Availability": {
+      "description": "Availability of the metric.",
+      "properties": {
+        "timeGrain": {
+          "type": "string",
+          "description": "The time grain of the availability."
+        },
+        "retention": {
+          "type": "string",
+          "description": "The retention of the availability."
+        },
+        "blobDuration": {
+          "type": "string",
+          "description": "Duration of the availability blob."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/publicIpAddress.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/publicIpAddress.json
@@ -1,0 +1,483 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}": {
+      "delete": {
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "operationId": "PublicIPAddresses_Delete",
+        "description": "Deletes the specified public IP address.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the subnet."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Request successful. Resource does not exist."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-examples": {
+          "Delete public IP address": { "$ref": "./examples/PublicIpAddressDelete.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "operationId": "PublicIPAddresses_Get",
+        "description": "Gets the specified public IP address in a specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the subnet."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting PublicIPAddress resource.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get public IP address": { "$ref": "./examples/PublicIpAddressGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "operationId": "PublicIPAddresses_CreateOrUpdate",
+        "description": "Creates or updates a static or dynamic public IP address.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the public IP address."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            },
+            "description": "Parameters supplied to the create or update public IP address operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting PublicIPAddress resource.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting PublicIPAddress resource.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create public IP address defaults": { "$ref": "./examples/PublicIpAddressCreateDefaults.json" },
+          "Create public IP address allocation method": { "$ref": "./examples/PublicIpAddressCreateCustomizedValues.json" },
+          "Create public IP address DNS": { "$ref": "./examples/PublicIpAddressCreateDns.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "operationId": "PublicIPAddresses_UpdateTags",
+        "description": "Updates public IP address tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the public IP address."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update public IP address tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting PublicIPAddress resource.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update public IP address tags": { "$ref": "./examples/PublicIpAddressUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPAddresses": {
+      "get": {
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "operationId": "PublicIPAddresses_ListAll",
+        "description": "Gets all the public IP addresses in a subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of PublicIPAddress resources.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddressListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all public IP addresses": { "$ref": "./examples/PublicIpAddressListAll.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses": {
+      "get": {
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "operationId": "PublicIPAddresses_List",
+        "description": "Gets all public IP addresses in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of PublicIPAddress resources.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddressListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List resource group public IP addresses": { "$ref": "./examples/PublicIpAddressList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "PublicIPAddressSku": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of a public IP address SKU.",
+          "enum": [
+            "Basic",
+            "Standard"
+          ],
+          "x-ms-enum": {
+            "name": "PublicIPAddressSkuName",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "SKU of a public IP address"
+    },
+    "PublicIPAddressPropertiesFormat": {
+      "properties": {
+        "publicIPAllocationMethod": {
+          "type": "string",
+          "description": "The public IP allocation method. Possible values are: 'Static' and 'Dynamic'.",
+          "enum": [
+            "Static",
+            "Dynamic"
+          ],
+          "x-ms-enum": {
+            "name": "IPAllocationMethod",
+            "modelAsString": true
+          }
+        },
+        "publicIPAddressVersion": {
+          "type": "string",
+          "description": "The public IP address version. Possible values are: 'IPv4' and 'IPv6'.",
+          "enum": [
+            "IPv4",
+            "IPv6"
+          ],
+          "x-ms-enum": {
+            "name": "IPVersion",
+            "modelAsString": true
+          }
+        },
+        "ipConfiguration": {
+          "readOnly": true,
+          "$ref": "./networkInterface.json#/definitions/IPConfiguration",
+          "description": "The IP configuration associated with the public IP address."
+        },
+        "dnsSettings": {
+          "$ref": "#/definitions/PublicIPAddressDnsSettings",
+          "description": "The FQDN of the DNS record associated with the public IP address."
+        },
+        "ipTags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IpTag"
+          },
+          "description": "The list of tags associated with the public IP address."
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "The IP address associated with the public IP address resource."
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The idle timeout of the public IP address."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the public IP resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the PublicIP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Public IP address properties."
+    },
+    "PublicIPAddress": {
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/PublicIPAddressSku",
+          "description": "The public IP address SKU."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PublicIPAddressPropertiesFormat",
+          "description": "Public IP address properties."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "zones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of availability zones denoting the IP allocated for the resource needs to come from."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "Public IP address resource."
+    },
+    "PublicIPAddressListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PublicIPAddress"
+          },
+          "description": "A list of public IP addresses that exists in a resource group."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListPublicIpAddresses API service call."
+    },
+    "PublicIPAddressDnsSettings": {
+      "properties": {
+        "domainNameLabel": {
+          "type": "string",
+          "description": "Gets or sets the Domain name label.The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system."
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "Gets the FQDN, Fully qualified domain name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone."
+        },
+        "reverseFqdn": {
+          "type": "string",
+          "description": "Gets or Sets the Reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN. "
+        }
+      },
+      "description": "Contains FQDN of the DNS record associated with the public IP address"
+    },
+    "IpTag": {
+      "properties": {
+        "ipTagType": {
+          "type": "string",
+          "description": "Gets or sets the ipTag type: Example FirstPartyUsage."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Gets or sets value of the IpTag associated with the public IP. Example SQL, Storage etc"
+        }
+      },
+      "description": "Contains the IpTag associated with the public IP address"
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/routeFilter.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/routeFilter.json
@@ -1,0 +1,813 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "NetworkManagementClient",
+        "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+        "version": "2017-11-01"
+    },
+    "host": "management.azure.com",
+    "schemes": [
+        "https"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "security": [
+        {
+            "azure_auth": [
+                "user_impersonation"
+            ]
+        }
+    ],
+    "securityDefinitions": {
+        "azure_auth": {
+            "type": "oauth2",
+            "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+            "flow": "implicit",
+            "description": "Azure Active Directory OAuth2 Flow",
+            "scopes": {
+                "user_impersonation": "impersonate your user account"
+            }
+        }
+    },
+    "paths": {
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}": {
+            "delete": {
+                "tags": [
+                    "RouteFilters"
+                ],
+                "operationId": "RouteFilters_Delete",
+                "x-ms-examples": {
+                    "RouteFilterDelete": { "$ref": "./examples/RouteFilterDelete.json" }
+                },
+                "description": "Deletes the specified route filter.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "name": "routeFilterName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted and the operation will complete asynchronously."
+                    },
+                    "200": {
+                        "description": "Delete successful."
+                    },
+                    "204": {
+                        "description": "Delete successful."
+                    }
+                },
+                "x-ms-long-running-operation": true
+            },
+            "get": {
+                "tags": [
+                    "RouteFilters"
+                ],
+                "operationId": "RouteFilters_Get",
+                "x-ms-examples": {
+                    "RouteFilterGet": { "$ref": "./examples/RouteFilterGet.json" }
+                },
+                "description": "Gets the specified route filter.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "name": "routeFilterName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "name": "$expand",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "description": "Expands referenced express route bgp peering resources."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successful. The operation returns the resulting Route Filter resource.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilter"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "RouteFilters"
+                ],
+                "operationId": "RouteFilters_CreateOrUpdate",
+                "x-ms-examples": {
+                    "RouteFilterCreate": { "$ref": "./examples/RouteFilterCreate.json" }
+                },
+                "description": "Creates or updates a route filter in a specified resource group.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "name": "routeFilterName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter."
+                    },
+                    {
+                        "name": "routeFilterParameters",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilter"
+                        },
+                        "description": "Parameters supplied to the create or update route filter operation."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successful. The operation returns the resulting Route Filter resource.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilter"
+                        }
+                    },
+                    "201": {
+                        "description": "Create successful. The operation returns the resulting Route Filter resource.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilter"
+                        }
+                    }
+                },
+                "x-ms-long-running-operation": true
+            },
+            "patch": {
+                "tags": [
+                    "RouteFilters"
+                ],
+                "operationId": "RouteFilters_Update",
+                "x-ms-examples": {
+                    "RouteFilterUpdate": { "$ref": "./examples/RouteFilterUpdate.json" }
+                },
+                "description": "Updates a route filter in a specified resource group.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "name": "routeFilterName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter."
+                    },
+                    {
+                        "name": "routeFilterParameters",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/PatchRouteFilter"
+                        },
+                        "description": "Parameters supplied to the update route filter operation."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successful. The operation returns the resulting Route Filter resource.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilter"
+                        }
+                    }
+                },
+                "x-ms-long-running-operation": true
+            }
+        },
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters": {
+            "get": {
+                "tags": [
+                    "RouteFilters"
+                ],
+                "operationId": "RouteFilters_ListByResourceGroup",
+                "x-ms-examples": {
+                    "RouteFilterListByResourceGroup": { "$ref": "./examples/RouteFilterListByResourceGroup.json" }
+                },
+                "description": "Gets all route filters in a resource group.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successful. The operation returns a list of Route Filter resources.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilterListResult"
+                        }
+                    }
+                },
+                "x-ms-pageable": {
+                    "nextLinkName": "nextLink"
+                }
+            }
+        },
+        "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeFilters": {
+            "get": {
+                "tags": [
+                    "RouteFilters"
+                ],
+                "operationId": "RouteFilters_List",
+                "x-ms-examples": {
+                    "RouteFilterList": { "$ref": "./examples/RouteFilterList.json" }
+                },
+                "description": "Gets all route filters in a subscription.",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successful. The operation returns a list of Route Filter resources.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilterListResult"
+                        }
+                    }
+                },
+                "x-ms-pageable": {
+                    "nextLinkName": "nextLink"
+                }
+            }
+        },
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}": {
+            "delete": {
+                "tags": [
+                    "RouteFilterRules"
+                ],
+                "operationId": "RouteFilterRules_Delete",
+                "x-ms-examples": {
+                    "RouteFilterRuleDelete": { "$ref": "./examples/RouteFilterRuleDelete.json" }
+                },
+                "description": "Deletes the specified rule from a route filter.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "name": "routeFilterName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter."
+                    },
+                    {
+                        "name": "ruleName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the rule."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted and the operation will complete asynchronously."
+                    },
+                    "200": {
+                        "description": "Accepted."
+                    },
+                    "204": {
+                        "description": "Rule was deleted or not found."
+                    }
+                },
+                "x-ms-long-running-operation": true
+            },
+            "get": {
+                "tags": [
+                    "RouteFilterRules"
+                ],
+                "operationId": "RouteFilterRules_Get",
+                "x-ms-examples": {
+                    "RouteFilterRuleGet": { "$ref": "./examples/RouteFilterRuleGet.json" }
+                },
+                "description": "Gets the specified rule from a route filter.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "name": "routeFilterName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter."
+                    },
+                    {
+                        "name": "ruleName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the rule."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successful. The operation returns the resulting Route Filter Rule resource.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilterRule"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "RouteFilterRules"
+                ],
+                "operationId": "RouteFilterRules_CreateOrUpdate",
+                "x-ms-examples": {
+                    "RouteFilterRuleCreate": { "$ref": "./examples/RouteFilterRuleCreate.json" }
+                },
+                "description": "Creates or updates a route in the specified route filter.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "name": "routeFilterName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter."
+                    },
+                    {
+                        "name": "ruleName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter rule."
+                    },
+                    {
+                        "name": "routeFilterRuleParameters",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilterRule"
+                        },
+                        "description": "Parameters supplied to the create or update route filter rule operation."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Update successful. The operation returns the resulting Route Filter Rule resource.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilterRule"
+                        }
+                    },
+                    "201": {
+                        "description": "Create successful. The operation returns the resulting Route Filter Rule resource.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilterRule"
+                        }
+                    }
+                },
+                "x-ms-long-running-operation": true
+            },
+            "patch": {
+                "tags": [
+                    "RouteFilterRules"
+                ],
+                "operationId": "RouteFilterRules_Update",
+                "x-ms-examples": {
+                    "RouteFilterRuleUpdate": { "$ref": "./examples/RouteFilterRuleUpdate.json" }
+                },
+                "description": "Updates a route in the specified route filter.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "name": "routeFilterName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter."
+                    },
+                    {
+                        "name": "ruleName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter rule."
+                    },
+                    {
+                        "name": "routeFilterRuleParameters",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/PatchRouteFilterRule"
+                        },
+                        "description": "Parameters supplied to the update route filter rule operation."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Update successful. The operation returns the resulting Route Filter Rule resource.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilterRule"
+                        }
+                    }
+                },
+                "x-ms-long-running-operation": true
+            }
+        },
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules": {
+            "get": {
+                "tags": [
+                    "RouteFilterRules"
+                ],
+                "operationId": "RouteFilterRules_ListByRouteFilter",
+                "x-ms-examples": {
+                    "RouteFilterRuleListByRouteFilter": { "$ref": "./examples/RouteFilterRuleListByRouteFilter.json" }
+                },
+                "description": "Gets all RouteFilterRules in a route filter.",
+                "parameters": [
+                    {
+                        "name": "resourceGroupName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the resource group."
+                    },
+                    {
+                        "name": "routeFilterName",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "The name of the route filter."
+                    },
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successful. The operation returns a list of Route Filter Rule resources.",
+                        "schema": {
+                            "$ref": "#/definitions/RouteFilterRuleListResult"
+                        }
+                    }
+                },
+                "x-ms-pageable": {
+                    "nextLinkName": "nextLink"
+                }
+            }
+        }
+    },
+    "definitions": {
+        "RouteFilterRulePropertiesFormat": {
+            "required": [
+                "access",
+                "routeFilterRuleType",
+                "communities"
+            ],
+            "properties": {
+                "access": {
+                    "type": "string",
+                    "description": "The access type of the rule. Valid values are: 'Allow', 'Deny'",
+                    "enum": [
+                        "Allow",
+                        "Deny"
+                    ],
+                    "x-ms-enum": {
+                        "name": "Access",
+                        "modelAsString": true
+                    }
+                },
+                "routeFilterRuleType": {
+                    "type": "string",
+                    "description": "The rule type of the rule. Valid value is: 'Community'",
+                    "enum": [
+                        "Community"
+                    ],
+                    "x-ms-enum": {
+                        "name": "RouteFilterRuleType",
+                        "modelAsString": true
+                    }
+                },
+                "communities": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "The collection for bgp community values to filter on. e.g. ['12076:5010','12076:5020']"
+                },
+                "provisioningState": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "The provisioning state of the resource. Possible values are: 'Updating', 'Deleting', 'Succeeded' and 'Failed'."
+                }
+            },
+            "description": "Route Filter Rule Resource"
+        },
+        "RouteFilterRule": {
+            "properties": {
+                "properties": {
+                    "x-ms-client-flatten": true,
+                    "$ref": "#/definitions/RouteFilterRulePropertiesFormat"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+                },
+                "location": {
+                    "type": "string",
+                    "description": "Resource location."
+                },
+                "etag": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "A unique read-only string that changes whenever the resource is updated."
+                },
+                "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Resource tags."
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "./network.json#/definitions/SubResource"
+                }
+            ],
+            "description": "Route Filter Rule Resource"
+        },
+        "PatchRouteFilterRule": {
+            "properties": {
+                "properties": {
+                    "x-ms-client-flatten": true,
+                    "$ref": "#/definitions/RouteFilterRulePropertiesFormat"
+                },
+                "name": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+                },
+                "etag": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "A unique read-only string that changes whenever the resource is updated."
+                },
+                "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Resource tags."
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "./network.json#/definitions/SubResource"
+                }
+            ],
+            "description": "Route Filter Rule Resource"
+        },
+        "RouteFilterPropertiesFormat": {
+            "properties": {
+                "rules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/RouteFilterRule"
+                    },
+                    "description": "Collection of RouteFilterRules contained within a route filter."
+                },
+                "peerings": {              
+                    "type": "array",
+                    "items": {
+                        "$ref": "./expressRouteCircuit.json#/definitions/ExpressRouteCircuitPeering"
+                    },
+                    "description": "A collection of references to express route circuit peerings."
+                },
+                "provisioningState": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "The provisioning state of the resource. Possible values are: 'Updating', 'Deleting', 'Succeeded' and 'Failed'."
+                }
+            },
+            "description": "Route Filter Resource"
+        },
+        "RouteFilter": {
+            "required": [
+                "location"
+            ],
+            "properties": {
+                "properties": {
+                    "x-ms-client-flatten": true,
+                    "$ref": "#/definitions/RouteFilterPropertiesFormat"
+                },
+                "etag": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "Gets a unique read-only string that changes whenever the resource is updated."
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "./network.json#/definitions/Resource"
+                }
+            ],
+            "description": "Route Filter Resource."
+        },
+        "PatchRouteFilter": {
+            "properties": {
+                "properties": {
+                    "x-ms-client-flatten": true,
+                    "$ref": "#/definitions/RouteFilterPropertiesFormat"
+                },
+                "name": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+                },
+                "etag": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "A unique read-only string that changes whenever the resource is updated."
+                },
+                "type": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "Resource type."
+                },
+                "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Resource tags."
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "./network.json#/definitions/SubResource"
+                }
+            ],
+            "description": "Route Filter Resource."
+        },
+        "RouteFilterListResult": {
+            "properties": {
+                "value": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/RouteFilter"
+                    },
+                    "description": "Gets a list of route filters in a resource group."
+                },
+                "nextLink": {
+                    "type": "string",
+                    "description": "The URL to get the next set of results."
+                }
+            },
+            "description": "Response for the ListRouteFilters API service call."
+        },
+        "RouteFilterRuleListResult": {
+            "properties": {
+                "value": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/RouteFilterRule"
+                    },
+                    "description": "Gets a list of RouteFilterRules in a resource group."
+                },
+                "nextLink": {
+                    "type": "string",
+                    "description": "The URL to get the next set of results."
+                }
+            },
+            "description": "Response for the ListRouteFilterRules API service call"
+        }
+    },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/routeTable.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/routeTable.json
@@ -1,0 +1,672 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}": {
+      "delete": {
+        "tags": [
+          "RouteTables"
+        ],
+        "operationId": "RouteTables_Delete",
+        "description": "Deletes the specified route table.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route table."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Request successful. Resource does not exist."
+          },
+          "200": {
+            "description": "Request successful. Operation to delete was accepted."
+          },
+          "202": {
+            "description": "Accepted. If route table not found returned synchronously, otherwise if found returned asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Delete route table": { "$ref": "./examples/RouteTableDelete.json" }
+        }
+      },
+      "get": {
+        "tags": [
+          "RouteTables"
+        ],
+        "operationId": "RouteTables_Get",
+        "description": "Gets the specified route table.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route table."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting RouteTable resource.",
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get route table": { "$ref": "./examples/RouteTableGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "RouteTables"
+        ],
+        "operationId": "RouteTables_CreateOrUpdate",
+        "description": "Create or updates a route table in a specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route table."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            },
+            "description": "Parameters supplied to the create or update route table operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting RouteTable resource.",
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting RouteTable resource.",
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create route table": { "$ref": "./examples/RouteTableCreate.json" },
+          "Create route table with route": { "$ref": "./examples/RouteTableCreateWithRoute.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "RouteTables"
+        ],
+        "operationId": "RouteTables_UpdateTags",
+        "description": "Updates a route table tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route table."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update route table tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting RouteTable resource.",
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update route table tags": { "$ref": "./examples/RouteTableUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables": {
+      "get": {
+        "tags": [
+          "RouteTables"
+        ],
+        "operationId": "RouteTables_List",
+        "description": "Gets all route tables in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of RouteTable resources.",
+            "schema": {
+              "$ref": "#/definitions/RouteTableListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List route tables in resource group": { "$ref": "./examples/RouteTableList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeTables": {
+      "get": {
+        "tags": [
+          "RouteTables"
+        ],
+        "operationId": "RouteTables_ListAll",
+        "description": "Gets all route tables in a subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of RouteTable resources.",
+            "schema": {
+              "$ref": "#/definitions/RouteTableListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all route tables": { "$ref": "./examples/RouteTableListAll.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}": {
+      "delete": {
+        "tags": [
+          "Routes"
+        ],
+        "operationId": "Routes_Delete",
+        "description": "Deletes the specified route from a route table.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route table."
+          },
+          {
+            "name": "routeName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Accepted."
+          },
+          "204": {
+            "description": "Route was deleted or not found."
+          }
+        },
+        "x-ms-examples": {
+          "Delete route": { "$ref": "./examples/RouteTableRouteDelete.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "Routes"
+        ],
+        "operationId": "Routes_Get",
+        "description": "Gets the specified route from a route table.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route table."
+          },
+          {
+            "name": "routeName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting Route resource.",
+            "schema": {
+              "$ref": "#/definitions/Route"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get route": { "$ref": "./examples/RouteTableRouteGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "Routes"
+        ],
+        "operationId": "Routes_CreateOrUpdate",
+        "description": "Creates or updates a route in the specified route table.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route table."
+          },
+          {
+            "name": "routeName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route."
+          },
+          {
+            "name": "routeParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Route"
+            },
+            "description": "Parameters supplied to the create or update route operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting Route resource.",
+            "schema": {
+              "$ref": "#/definitions/Route"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting Route resource.",
+            "schema": {
+              "$ref": "#/definitions/Route"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create route": { "$ref": "./examples/RouteTableRouteCreate.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes": {
+      "get": {
+        "tags": [
+          "Routes"
+        ],
+        "operationId": "Routes_List",
+        "description": "Gets all routes in a route table.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the route table."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of Route resources.",
+            "schema": {
+              "$ref": "#/definitions/RouteListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List routes": { "$ref": "./examples/RouteTableRouteList.json" }
+        }
+      }
+    }    
+  },
+  "definitions": {
+    "RoutePropertiesFormat": {
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "The destination CIDR to which the route applies."
+        },
+        "nextHopType": {
+          "type": "string",
+          "description": "The type of Azure hop the packet should be sent to. Possible values are: 'VirtualNetworkGateway', 'VnetLocal', 'Internet', 'VirtualAppliance', and 'None'",
+          "enum": [
+            "VirtualNetworkGateway",
+            "VnetLocal",
+            "Internet",
+            "VirtualAppliance",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "RouteNextHopType",
+            "modelAsString": true
+          }
+        },
+        "nextHopIpAddress": {
+          "type": "string",
+          "description": "The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "required": [
+        "nextHopType"
+      ],
+      "description": "Route resource"
+    },
+    "Route": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/RoutePropertiesFormat",
+          "description": "Properties of the route."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Route resource"
+    },
+    "RouteTablePropertiesFormat": {
+      "properties": {
+        "routes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Route"
+          },
+          "description": "Collection of routes contained within a route table."
+        },
+        "subnets": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/Subnet"
+          },
+          "description": "A collection of references to subnets."
+        },
+        "disableBgpRoutePropagation": {
+          "type": "boolean",
+          "description": "Gets or sets whether to disable the routes learned by BGP on that route table. True means disable."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Route Table resource"
+    },
+    "RouteTable": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/RouteTablePropertiesFormat",
+          "description": "Properties of the route table."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Gets a unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "Route table resource."
+    },
+    "RouteTableListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RouteTable"
+          },
+          "description": "Gets a list of route tables in a resource group."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the ListRouteTable API service call."
+    },
+    "RouteListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Route"
+          },
+          "description": "Gets a list of routes in a resource group."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the ListRoute API service call"
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/serviceCommunity.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/serviceCommunity.json
@@ -1,0 +1,165 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bgpServiceCommunities": {
+      "get": {
+        "tags": [
+          "BgpServiceCommunities"
+        ],
+        "operationId": "BgpServiceCommunities_List",
+        "x-ms-examples": {
+          "ServiceCommunityList": { "$ref": "./examples/ServiceCommunityList.json" }
+        },
+        "description": "Gets all the available bgp service communities.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of BgpServiceCommunity resources.",
+            "schema": {
+              "$ref": "#/definitions/BgpServiceCommunityListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "BGPCommunity": {
+      "properties": {
+        "serviceSupportedRegion": {
+          "type": "string",
+            "description": "The region which the service support. e.g. For O365, region is Global."
+        },
+        "communityName": {
+          "type": "string",
+          "description": "The name of the bgp community. e.g. Skype."
+        },
+        "communityValue": {
+          "type": "string",
+          "description": "The value of the bgp community. For more information: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-routing."
+        },
+        "communityPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The prefixes that the bgp community contains."
+        },
+        "isAuthorizedToUse": {
+          "type": "boolean",
+          "description": "Customer is authorized to use bgp community or not."
+        },
+        "serviceGroup": {
+          "type": "string",
+          "description": "The service group of the bgp community contains."
+        }
+      },
+      "description": "Contains bgp community information offered in Service Community resources."
+    },
+    "BgpServiceCommunityPropertiesFormat": {
+      "properties": {
+        "serviceName": {
+          "type": "string",
+          "description": "The name of the bgp community. e.g. Skype."
+        },
+        "bgpCommunities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BGPCommunity"
+          },
+          "description": "Get a list of bgp communities."
+        }
+      },
+      "description": "Properties of Service Community."
+    },
+    "BgpServiceCommunity": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/BgpServiceCommunityPropertiesFormat"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "Service Community Properties."
+    },
+    "BgpServiceCommunityListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BgpServiceCommunity"
+          },
+          "description": "A list of service community resources."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the ListServiceCommunity API service call."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/usage.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/usage.json
@@ -1,0 +1,167 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/usages": {
+      "get": {
+        "tags": [
+          "Usages"
+        ],
+        "operationId": "Usages_List",
+        "description": "List network usages for a subscription.",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The location where resource usage is queried.",
+            "pattern": "^[-\\w\\._]+$"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of Usage resources.",
+            "schema": {
+              "$ref": "#/definitions/UsagesListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List usages": { "$ref": "./examples/UsageList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "UsageName": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "A string describing the resource name."
+        },
+        "localizedValue": {
+          "type": "string",
+          "description": "A localized string describing the resource name."
+        }
+      },
+      "description": "The usage names."
+    },
+    "Usage": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Resource identifier."
+        },
+        "unit": {
+          "type": "string",
+          "description": "An enum describing the unit of measurement.",
+          "enum": [
+            "Count"
+          ],
+          "x-ms-enum": {
+            "name": "UsageUnit",
+            "modelAsString": true
+          }
+        },
+        "currentValue": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The current value of the usage."
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The limit of usage."
+        },
+        "name": {
+          "$ref": "#/definitions/UsageName",
+          "description": "The name of the type of usage."
+        }
+      },
+      "required": [
+        "unit",
+        "currentValue",
+        "limit",
+        "name"
+      ],
+      "description": "Describes network resource usage."
+    },
+    "UsagesListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Usage"
+          },
+          "description": "The list network resource usages."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      },
+      "description": "The list usages operation response."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/usage.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/usage.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NetworkManagementClient",
     "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
-    "version": "2017-11-01"
+    "version": "2018-01-01"
   },
   "host": "management.azure.com",
   "schemes": [
@@ -109,13 +109,13 @@
           }
         },
         "currentValue": {
-          "type": "integer",
-          "format": "int64",
+          "type": "number",
+          "format": "double",
           "description": "The current value of the usage."
         },
         "limit": {
-          "type": "integer",
-          "format": "int64",
+          "type": "number",
+          "format": "double",
           "description": "The limit of usage."
         },
         "name": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/virtualNetwork.json
@@ -1,0 +1,1251 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}": {
+      "delete": {
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "operationId": "VirtualNetworks_Delete",
+        "description": "Deletes the specified virtual network.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "Delete successful."
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Delete virtual network": { "$ref": "./examples/VirtualNetworkDelete.json" }
+        }
+      },
+      "get": {
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "operationId": "VirtualNetworks_Get",
+        "description": "Gets the specified virtual network by resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting VirtualNetwork resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get virtual network": { "$ref": "./examples/VirtualNetworkGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "operationId": "VirtualNetworks_CreateOrUpdate",
+        "description": "Creates or updates a virtual network in the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            },
+            "description": "Parameters supplied to the create or update virtual network operation"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting VirtualNetwork resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting VirtualNetwork resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Create virtual network": { "$ref": "./examples/VirtualNetworkCreate.json" },
+          "Create virtual network with subnet": { "$ref": "./examples/VirtualNetworkCreateSubnet.json" },
+          "Create virtual network with service endpoints": { "$ref": "./examples/VirtualNetworkCreateServiceEndpoints.json" }
+        }
+      },
+      "patch": {
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "operationId": "VirtualNetworks_UpdateTags",
+        "description": "Updates a virtual network tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update virtual network tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting VirtualNetwork resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Update virtual network tags": { "$ref": "./examples/VirtualNetworkUpdateTags.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworks": {
+      "get": {
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "operationId": "VirtualNetworks_ListAll",
+        "description": "Gets all virtual networks in a subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of VirtualNetwork resources.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all virtual networks": { "$ref": "./examples/VirtualNetworkListAll.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks": {
+      "get": {
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "operationId": "VirtualNetworks_List",
+        "description": "Gets all virtual networks in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of VirtualNetwork resources.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List virtual networks in resource group": { "$ref": "./examples/VirtualNetworkList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}": {
+      "delete": {
+        "tags": [
+          "Subnets"
+        ],
+        "operationId": "Subnets_Delete",
+        "description": "Deletes the specified subnet.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the subnet."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delete successful."
+          },
+          "204": {
+            "description": "Request successful. Resource does not exist."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-examples": {
+          "Delete subnet": { "$ref": "./examples/SubnetDelete.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "Subnets"
+        ],
+        "operationId": "Subnets_Get",
+        "description": "Gets the specified subnet by virtual network and resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the subnet."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting Subnet resource.",
+            "schema": {
+              "$ref": "#/definitions/Subnet"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get subnet": { "$ref": "./examples/SubnetGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "Subnets"
+        ],
+        "operationId": "Subnets_CreateOrUpdate",
+        "description": "Creates or updates a subnet in the specified virtual network.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the subnet."
+          },
+          {
+            "name": "subnetParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Subnet"
+            },
+            "description": "Parameters supplied to the create or update subnet operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting Subnet resource.",
+            "schema": {
+              "$ref": "#/definitions/Subnet"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting Subnet resource.",
+            "schema": {
+              "$ref": "#/definitions/Subnet"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Create subnet": { "$ref": "./examples/SubnetCreate.json" },
+          "Create subnet with service endpoints": { "$ref": "./examples/SubnetCreateServiceEndpoint.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets": {
+      "get": {
+        "tags": [
+          "Subnets"
+        ],
+        "operationId": "Subnets_List",
+        "description": "Gets all subnets in a virtual network.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of Subnet resources.",
+            "schema": {
+              "$ref": "#/definitions/SubnetListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List subnets": { "$ref": "./examples/SubnetList.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}": {
+      "delete": {
+        "tags": [
+          "VirtualNetworkPeerings"
+        ],
+        "operationId": "VirtualNetworkPeerings_Delete",
+        "description": "Deletes the specified virtual network peering.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "name": "virtualNetworkPeeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network peering."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delete successful."
+          },
+          "204": {
+            "description": "Delete successful."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-examples": {
+          "Delete peering": { "$ref": "./examples/VirtualNetworkPeeringDelete.json" }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "VirtualNetworkPeerings"
+        ],
+        "operationId": "VirtualNetworkPeerings_Get",
+        "description": "Gets the specified virtual network peering.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "name": "virtualNetworkPeeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network peering."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting VirtualNetworkPeering resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeering"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get peering": { "$ref": "./examples/VirtualNetworkPeeringGet.json" }
+        }
+      },
+      "put": {
+        "tags": [
+          "VirtualNetworkPeerings"
+        ],
+        "operationId": "VirtualNetworkPeerings_CreateOrUpdate",
+        "description": "Creates or updates a peering in the specified virtual network.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "name": "virtualNetworkPeeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "name": "VirtualNetworkPeeringParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeering"
+            },
+            "description": "Parameters supplied to the create or update virtual network peering operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting VirtualNetworkPeering resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeering"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting VirtualNetworkPeering resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeering"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create peering": { "$ref": "./examples/VirtualNetworkPeeringCreate.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings": {
+      "get": {
+        "tags": [
+          "VirtualNetworkPeerings"
+        ],
+        "operationId": "VirtualNetworkPeerings_List",
+        "description": "Gets all virtual network peerings in a virtual network.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of VirtualNetworkPeering resources.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeeringListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List peerings": { "$ref": "./examples/VirtualNetworkPeeringList.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/CheckIPAddressAvailability": {
+      "get": {
+        "operationId": "VirtualNetworks_CheckIPAddressAvailability",
+        "description": "Checks whether a private IP address is available for use.",
+        "parameters": [
+          {
+            "name": "ipAddress",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The private IP address to be verified."
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Private IP address availability and list of other free addresses if the requested one is not available.",
+            "schema": {
+              "$ref": "#/definitions/IPAddressAvailabilityResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Check IP address availability": { "$ref": "./examples/VirtualNetworkCheckIPAddressAvailability.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/usages": {
+      "get": {
+        "operationId": "VirtualNetworks_ListUsage",
+        "description": "Lists usage stats.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage stats for vnet.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkListUsageResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "VnetGetUsage": { "$ref": "./examples/VirtualNetworkListUsage.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ResourceNavigationLinkFormat": {
+      "properties": {
+        "linkedResourceType": {
+          "type": "string",
+          "description": "Resource type of the linked resource."
+        },
+        "link": {
+          "type": "string",
+          "description": "Link to the external resource"
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Provisioning state of the ResourceNavigationLink resource."
+        }
+      },
+      "description": "Properties of ResourceNavigationLink."
+    },
+    "ResourceNavigationLink": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ResourceNavigationLinkFormat",
+          "description": "Resource navigation link properties format."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "ResourceNavigationLink resource."
+    },
+    "SubnetPropertiesFormat": {
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "The address prefix for the subnet."
+        },
+        "networkSecurityGroup": {
+          "$ref": "./networkSecurityGroup.json#/definitions/NetworkSecurityGroup",
+          "description": "The reference of the NetworkSecurityGroup resource."
+        },
+        "routeTable": {
+          "$ref": "./routeTable.json#/definitions/RouteTable",
+          "description": "The reference of the RouteTable resource."
+        },
+        "serviceEndpoints": {
+        "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceEndpointPropertiesFormat"
+          },
+          "description": "An array of service endpoints."
+        },
+        "ipConfigurations": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./networkInterface.json#/definitions/IPConfiguration"
+          },
+          "description": "Gets an array of references to the network interface IP configurations using subnet."
+        },
+        "resourceNavigationLinks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceNavigationLink"
+          },
+          "description": "Gets an array of references to the external resources using subnet."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the resource."
+        }
+      },
+      "description": "Properties of the subnet."
+    },
+    "ServiceEndpointPropertiesFormat": {
+      "properties": {
+        "service": {
+          "type": "string",
+          "description": "The type of the endpoint service."
+        },
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of locations."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the resource."
+        }
+      },
+      "description": "The service endpoint properties."
+    },
+    "VirtualNetworkPeeringPropertiesFormat": {
+      "properties": {
+        "allowVirtualNetworkAccess": {
+          "type": "boolean",
+          "description": "Whether the VMs in the linked virtual network space would be able to access all the VMs in local Virtual network space."
+        },
+        "allowForwardedTraffic": {
+          "type": "boolean",
+          "description": "Whether the forwarded traffic from the VMs in the remote virtual network will be allowed/disallowed."
+        },
+        "allowGatewayTransit": {
+          "type": "boolean",
+          "description": "If gateway links can be used in remote virtual networking to link to this virtual network."
+        },
+        "useRemoteGateways": {
+          "type": "boolean",
+          "description": "If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway."
+        },
+        "remoteVirtualNetwork": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference of the remote virtual network. The remote virtual network can be in the same or different region (preview). See here to register for the preview and learn more (https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-create-peering)."
+        },
+        "remoteAddressSpace": {
+          "$ref": "#/definitions/AddressSpace",
+          "description": "The reference of the remote virtual network address space."
+        },
+        "peeringState": {
+          "type": "string",
+          "description": "The status of the virtual network peering. Possible values are 'Initiated', 'Connected', and 'Disconnected'.",
+          "enum": [
+            "Initiated",
+            "Connected",
+            "Disconnected"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkPeeringState",
+            "modelAsString": true
+          }
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the resource."
+        }
+      },
+      "description": "Properties of the virtual network peering."
+    },
+    "Subnet": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/SubnetPropertiesFormat",
+          "description": "Properties of the subnet."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Subnet in a virtual network resource."
+    },
+    "VirtualNetworkPeering": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VirtualNetworkPeeringPropertiesFormat",
+          "description": "Properties of the virtual network peering."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Peerings in a virtual network resource."
+    },
+    "SubnetListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          },
+          "description": "The subnets in a virtual network."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListSubnets API service callRetrieves all subnet that belongs to a virtual network"
+    },
+    "VirtualNetworkPeeringListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkPeering"
+          },
+          "description": "The peerings in a virtual network."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListSubnets API service call. Retrieves all subnets that belong to a virtual network."
+    },
+    "VirtualNetworkPropertiesFormat": {
+      "properties": {
+        "addressSpace": {
+          "$ref": "#/definitions/AddressSpace",
+          "description": "The AddressSpace that contains an array of IP address ranges that can be used by subnets."
+        },
+        "dhcpOptions": {
+          "$ref": "#/definitions/DhcpOptions",
+          "description": "The dhcpOptions that contains an array of DNS servers available to VMs deployed in the virtual network."
+        },
+        "subnets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          },
+          "description": "A list of subnets in a Virtual Network."
+        },
+        "virtualNetworkPeerings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkPeering"
+          },
+          "description": "A list of peerings in a Virtual Network."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resourceGuid property of the Virtual Network resource."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the PublicIP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        },
+        "enableDdosProtection": { 
+          "type": "boolean", 
+          "description": "Indicates if DDoS protection is enabled for all the protected resources in a Virtual Network." 
+        }, 
+        "enableVmProtection": { 
+          "type": "boolean", 
+          "description": "Indicates if Vm protection is enabled for all the subnets in a Virtual Network." 
+        }
+      },
+      "description": "Properties of the virtual network."
+    },
+    "VirtualNetwork": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VirtualNetworkPropertiesFormat",
+          "description": "Properties of the virtual network."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Gets a unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "Virtual Network resource."
+    },
+    "VirtualNetworkListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VirtualNetwork"
+          },
+          "description": "Gets a list of VirtualNetwork resources in a resource group."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the ListVirtualNetworks API service call."
+    },
+    "AddressSpace": {
+      "properties": {
+        "addressPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of address blocks reserved for this virtual network in CIDR notation."
+        }
+      },
+      "description": "AddressSpace contains an array of IP address ranges that can be used by subnets of the virtual network."
+    },
+    "DhcpOptions": {
+      "properties": {
+        "dnsServers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of DNS servers IP addresses."
+        }
+      },
+      "description": "DhcpOptions contains an array of DNS servers available to VMs deployed in the virtual network. Standard DHCP option for a subnet overrides VNET DHCP options."
+    },
+    "IPAddressAvailabilityResult": {
+      "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "Private IP address availability."
+        },
+        "availableIPAddresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Contains other available private IP addresses if the asked for address is taken."
+        }
+      },
+      "description": "Response for CheckIPAddressAvailability API service call"
+    },
+    "VirtualNetworkListUsageResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkUsage"
+          },
+          "description": "VirtualNetwork usage stats."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the virtual networks GetUsage API service call."
+    },
+    "VirtualNetworkUsage": {
+      "properties": {
+        "currentValue": {
+          "type": "number",
+          "format": "double",
+          "readOnly": true,
+          "description": "Indicates number of IPs used from the Subnet."
+        },
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Subnet identifier."
+        },
+        "limit": {
+          "type": "number",
+          "format": "double",
+          "readOnly": true,
+          "description": "Indicates the size of the subnet."
+        },
+        "name": {
+          "$ref": "#/definitions/VirtualNetworkUsageName",
+          "readOnly": true,
+          "description": "The name containing common and localized value for usage."
+        },
+        "unit": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Usage units. Returns 'Count'"
+        }
+      },
+      "description": "Usage details for subnet."
+    },
+    "VirtualNetworkUsageName": {
+      "properties": {
+        "localizedValue": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Localized subnet size and usage string."
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Subnet size and usage string."
+        }
+      },
+      "description": "Usage strings container."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/virtualNetworkGateway.json
@@ -1,0 +1,2432 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-11-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}": {
+      "put": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_CreateOrUpdate",
+        "description": "Creates or updates a virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            },
+            "description": "Parameters supplied to create or update virtual network gateway operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting VirtualNetworkGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting VirtualNetworkGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_Get",
+        "description": "Gets the specified virtual network gateway by resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a VirtualNetworkGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_Delete",
+        "description": "Deletes the specified virtual network gateway.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Delete successful."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_UpdateTags",
+        "description": "Updates a virtual network gateway tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update virtual network gateway tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting VirtualNetworkGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Virtual Network Gateway Tags": { "$ref": "./examples/VirtualNetworkGatewayUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways": {
+      "get": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_List",
+        "description": "Gets all virtual network gateways by resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of VirtualNetworkGateway resources.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/connections": {
+      "get": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_ListConnections",
+        "description": "Gets all the connections in a virtual network gateway.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of VirtualNetworkGatewayConnection resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayListConnectionsResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "VirtualNetworkGatewaysListConnections": { "$ref": "./examples/VirtualNetworkGatewaysListConnections.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/reset": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_Reset",
+        "description": "Resets the primary of the virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "name": "gatewayVip",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Virtual network gateway vip address supplied to the begin reset of the active-active feature enabled gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Request successful. The operation reset the primary of the virtual network gateway.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnclientpackage": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_Generatevpnclientpackage",
+        "description": "Generates VPN client package for P2S client of the virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnClientParameters"
+            },
+            "description": "Parameters supplied to the generate virtual network gateway VPN client package operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "VPN client package URL.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnprofile": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_GenerateVpnProfile",
+        "description": "Generates VPN profile for P2S client of the virtual network gateway in the specified resource group. Used for IKEV2 and radius based authentication.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnClientParameters"
+            },
+            "description": "Parameters supplied to the generate virtual network gateway VPN client package operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "VPN profile package URL.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getvpnprofilepackageurl": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_GetVpnProfilePackageUrl",
+        "description": "Gets pre-generated VPN profile for P2S client of the virtual network gateway in the specified resource group. The profile needs to be generated first using generateVpnProfile.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "VPN profile package URL.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getBgpPeerStatus": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_GetBgpPeerStatus",
+        "description": "The GetBgpPeerStatus operation retrieves the status of all BGP peers.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "name": "peer",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The IP address of the peer to retrieve the status of."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of BGP peer statuses",
+            "schema": {
+              "$ref": "#/definitions/BgpPeerStatusListResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/supportedvpndevices": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_SupportedVpnDevices",
+        "description": "Gets a xml format representation for supported vpn devices.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Xml format representation for supported vpn devices.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getLearnedRoutes": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_GetLearnedRoutes",
+        "description": "This operation retrieves a list of routes the virtual network gateway has learned, including routes learned from BGP peers.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of advertised BGP routes",
+            "schema": {
+              "$ref": "#/definitions/GatewayRouteListResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getAdvertisedRoutes": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_GetAdvertisedRoutes",
+        "description": "This operation retrieves a list of routes the virtual network gateway is advertising to the specified peer.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "name": "peer",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The IP address of the peer"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of learned BGP routes",
+            "schema": {
+              "$ref": "#/definitions/GatewayRouteListResult"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/vpndeviceconfigurationscript": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_VpnDeviceConfigurationScript",
+        "description": "Gets a xml format representation for vpn device configuration script.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway connection for which the configuration script is generated."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnDeviceScriptParameters"
+            },
+            "description": "Parameters supplied to the generate vpn device script operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Xml format representation for vpn device configuration script.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}": {
+      "put": {
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "operationId": "VirtualNetworkGatewayConnections_CreateOrUpdate",
+        "description": "Creates or updates a virtual network gateway connection in the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway connection."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+            },
+            "description": "Parameters supplied to the create or update virtual network gateway connection operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting VirtualNetworkGatewayConnection resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+            }
+          },
+          "201": {
+            "description": "Create successful. The operation returns the resulting VirtualNetworkGatewayConnection resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "operationId": "VirtualNetworkGatewayConnections_Get",
+        "description": "Gets the specified virtual network gateway connection by resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway connection."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting VirtualNetworkPeering resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "operationId": "VirtualNetworkGatewayConnections_Delete",
+        "description": "Deletes the specified virtual network Gateway connection.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway connection."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delete successful."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "Delete successful."
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "operationId": "VirtualNetworkGatewayConnections_UpdateTags",
+        "description": "Updates a virtual network gateway connection tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway connection."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update virtual network gateway connection tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting VirtualNetworkGatewayConnection resource.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnectionListEntity"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Virtual Network Gateway Connection Tags": { "$ref": "./examples/VirtualNetworkGatewayConnectionUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey": {
+      "put": {
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "operationId": "VirtualNetworkGatewayConnections_SetSharedKey",
+        "description": "The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual network gateway connection shared key for passed virtual network gateway connection in the specified resource group through Network resource provider.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The virtual network gateway connection name."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKey"
+            },
+            "description": "Parameters supplied to the Begin Set Virtual Network Gateway connection Shared key operation throughNetwork resource provider."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKey"
+            }
+          },
+          "200": {
+            "description": "Request successful. The operation returns the resulting ConnectionSharedKey resource.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKey"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "operationId": "VirtualNetworkGatewayConnections_GetSharedKey",
+        "description": "The Get VirtualNetworkGatewayConnectionSharedKey operation retrieves information about the specified virtual network gateway connection shared key through Network resource provider.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The virtual network gateway connection shared key name."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of VirtualNetworkGatewayConnection resources.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKey"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections": {
+      "get": {
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "operationId": "VirtualNetworkGatewayConnections_List",
+        "description": "The List VirtualNetworkGatewayConnections operation retrieves all the virtual network gateways connections created.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation resets the virtual network gateway connection shared key.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnectionListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey/reset": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "operationId": "VirtualNetworkGatewayConnections_ResetSharedKey",
+        "description": "The VirtualNetworkGatewayConnectionResetSharedKey operation resets the virtual network gateway connection shared key for passed virtual network gateway connection in the specified resource group through Network resource provider.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The virtual network gateway connection reset shared key Name."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionResetSharedKey"
+            },
+            "description": "Parameters supplied to the begin reset virtual network gateway connection shared key operation through network resource provider."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation sets the virtual network gateway connection shared key.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionResetSharedKey"
+            }
+          },
+          "202": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}": {
+      "put": {
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "operationId": "LocalNetworkGateways_CreateOrUpdate",
+        "description": "Creates or updates a local network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "localNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of the local network gateway."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            },
+            "description": "Parameters supplied to the create or update local network gateway operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting LocalNetworkGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting LocalNetworkGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "operationId": "LocalNetworkGateways_Get",
+        "description": "Gets the specified local network gateway in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "localNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of the local network gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting LocalNetworkGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "operationId": "LocalNetworkGateways_Delete",
+        "description": "Deletes the specified local network gateway.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "localNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of the local network gateway."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Delete successful."
+          },
+          "200": {
+            "description": "Delete successful."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "operationId": "LocalNetworkGateways_UpdateTags",
+        "description": "Updates a local network gateway tags.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "localNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "minLength": 1,
+            "type": "string",
+            "description": "The name of the local network gateway."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update local network gateway tags."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting LocalNetworkGateway resource.",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Local Network Gateway Tags": { "$ref": "./examples/LocalNetworkGatewayUpdateTags.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways": {
+      "get": {
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "operationId": "LocalNetworkGateways_List",
+        "description": "Gets all the local network gateways in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of LocalNetworkGateway resources.",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGatewayListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "VirtualNetworkGatewayIPConfigurationPropertiesFormat": {
+      "properties": {
+        "privateIPAllocationMethod": {
+          "type": "string",
+          "description": "The private IP allocation method. Possible values are: 'Static' and 'Dynamic'.",
+          "enum": [
+            "Static",
+            "Dynamic"
+          ],
+          "x-ms-enum": {
+            "name": "IPAllocationMethod",
+            "modelAsString": true
+          }
+        },
+        "subnet": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference of the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference of the public IP resource."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of VirtualNetworkGatewayIPConfiguration"
+    },
+    "VirtualNetworkGatewayIPConfiguration": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VirtualNetworkGatewayIPConfigurationPropertiesFormat",
+          "description": "Properties of the virtual network gateway ip configuration."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "IP configuration for virtual network gateway"
+    },
+    "VirtualNetworkGatewayPropertiesFormat": {
+      "properties": {
+        "ipConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayIPConfiguration"
+          },
+          "description": "IP configurations for virtual network gateway."
+        },
+        "gatewayType": {
+          "type": "string",
+          "description": "The type of this virtual network gateway. Possible values are: 'Vpn' and 'ExpressRoute'.",
+          "enum": [
+            "Vpn",
+            "ExpressRoute"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkGatewayType",
+            "modelAsString": true
+          }
+        },
+        "vpnType": {
+          "type": "string",
+          "description": "The type of this virtual network gateway. Possible values are: 'PolicyBased' and 'RouteBased'.",
+          "enum": [
+            "PolicyBased",
+            "RouteBased"
+          ],
+          "x-ms-enum": {
+            "name": "VpnType",
+            "modelAsString": true
+          }
+        },
+        "enableBgp": {
+          "type": "boolean",
+          "description": "Whether BGP is enabled for this virtual network gateway or not."
+        },
+        "activeActive": {
+          "type": "boolean",
+          "description": "ActiveActive flag"
+        },
+        "gatewayDefaultSite": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference of the LocalNetworkGateway resource which represents local network site having default routes. Assign Null value in case of removing existing default site setting."
+        },
+        "sku": {
+          "$ref": "#/definitions/VirtualNetworkGatewaySku",
+          "description": "The reference of the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network gateway."
+        },
+        "vpnClientConfiguration": {
+          "$ref": "#/definitions/VpnClientConfiguration",
+          "description": "The reference of the VpnClientConfiguration resource which represents the P2S VpnClient configurations."
+        },
+        "bgpSettings": {
+          "$ref": "#/definitions/BgpSettings",
+          "description": "Virtual network gateway's BGP speaker settings."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the VirtualNetworkGateway resource."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The provisioning state of the VirtualNetworkGateway resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "VirtualNetworkGateway properties"
+    },
+    "VpnClientRootCertificatePropertiesFormat": {
+      "properties": {
+        "publicCertData": {
+          "type": "string",
+          "description": "The certificate public data."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The provisioning state of the VPN client root certificate resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "required": [
+        "publicCertData"
+      ],
+      "description": "Properties of SSL certificates of application gateway"
+    },
+    "VpnClientRootCertificate": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VpnClientRootCertificatePropertiesFormat",
+          "description": "Properties of the vpn client root certificate."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "required": [
+        "properties"
+      ],
+      "description": "VPN client root certificate of virtual network gateway"
+    },
+    "VpnClientRevokedCertificatePropertiesFormat": {
+      "properties": {
+        "thumbprint": {
+          "type": "string",
+          "description": "The revoked VPN client certificate thumbprint."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The provisioning state of the VPN client revoked certificate resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "Properties of the revoked VPN client certificate of virtual network gateway."
+    },
+    "VpnClientRevokedCertificate": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VpnClientRevokedCertificatePropertiesFormat",
+          "description": "Properties of the vpn client revoked certificate."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "VPN client revoked certificate of virtual network gateway."
+    },
+    "VpnClientConfiguration": {
+      "properties": {
+        "vpnClientAddressPool": {
+          "$ref": "./virtualNetwork.json#/definitions/AddressSpace",
+          "description": "The reference of the address space resource which represents Address space for P2S VpnClient."
+        },
+        "vpnClientRootCertificates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VpnClientRootCertificate"
+          },
+          "description": "VpnClientRootCertificate for virtual network gateway."
+        },
+        "vpnClientRevokedCertificates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VpnClientRevokedCertificate"
+          },
+          "description": "VpnClientRevokedCertificate for Virtual network gateway."
+        },
+        "vpnClientProtocols": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "VPN client protocol enabled for the virtual network gateway.",
+            "enum": [
+              "IkeV2",
+              "SSTP"
+            ],
+            "x-ms-enum": {
+              "name": "VpnClientProtocol",
+              "modelAsString": true
+            }
+          },
+          "description": "VpnClientProtocols for Virtual network gateway."
+        },
+        "radiusServerAddress": {
+          "type": "string",
+          "description": "The radius server address property of the VirtualNetworkGateway resource for vpn client connection."
+        },
+        "radiusServerSecret": {
+          "type": "string",
+          "description": "The radius secret property of the VirtualNetworkGateway resource for vpn client connection."
+        }
+      },
+      "description": "VpnClientConfiguration for P2S client."
+    },
+    "VirtualNetworkGatewaySku": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gateway SKU name.",
+          "enum": [
+            "Basic",
+            "HighPerformance",
+            "Standard",
+            "UltraPerformance",
+            "VpnGw1",
+            "VpnGw2",
+            "VpnGw3"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkGatewaySkuName",
+            "modelAsString": true
+          }
+        },
+        "tier": {
+          "type": "string",
+          "description": "Gateway SKU tier.",
+          "enum": [
+            "Basic",
+            "HighPerformance",
+            "Standard",
+            "UltraPerformance",
+            "VpnGw1",
+            "VpnGw2",
+            "VpnGw3"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkGatewaySkuTier",
+            "modelAsString": true
+          }
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The capacity."
+        }
+      },
+      "description": "VirtualNetworkGatewaySku details"
+    },
+    "BgpSettings": {
+      "properties": {
+        "asn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The BGP speaker's ASN."
+        },
+        "bgpPeeringAddress": {
+          "type": "string",
+          "description": "The BGP peering address and BGP identifier of this BGP speaker."
+        },
+        "peerWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The weight added to routes learned from this BGP speaker."
+        }
+      },
+      "description": "BGP settings details"
+    },
+    "BgpPeerStatus": {
+      "properties": {
+        "localAddress": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The virtual network gateway's local address"
+        },
+        "neighbor": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The remote BGP peer"
+        },
+        "asn": {
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true,
+          "description": "The autonomous system number of the remote BGP peer"
+        },
+        "state": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The BGP peer state",
+          "enum": [
+            "Unknown",
+            "Stopped",
+            "Idle",
+            "Connecting",
+            "Connected"
+          ],
+          "x-ms-enum": {
+            "name": "BgpPeerState",
+            "modelAsString": true
+          }
+        },
+        "connectedDuration": {
+          "type": "string",
+          "readOnly": true,
+          "description": "For how long the peering has been up"
+        },
+        "routesReceived": {
+          "type": "integer",
+          "format": "int64",
+          "readOnly": true,
+          "description": "The number of routes learned from this peer"
+        },
+        "messagesSent": {
+          "type": "integer",
+          "format": "int64",
+          "readOnly": true,
+          "description": "The number of BGP messages sent"
+        },
+        "messagesReceived": {
+          "type": "integer",
+          "format": "int64",
+          "readOnly": true,
+          "description": "The number of BGP messages received"
+        }
+      },
+      "description": "BGP peer status details"
+    },
+    "GatewayRoute": {
+      "properties": {
+        "localAddress": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The gateway's local address"
+        },
+        "network": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The route's network prefix"
+        },
+        "nextHop": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The route's next hop"
+        },
+        "sourcePeer": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The peer this route was learned from"
+        },
+        "origin": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The source this route was learned from"
+        },
+        "asPath": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The route's AS path sequence"
+        },
+        "weight": {
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true,
+          "description": "The route's weight"
+        }
+      },
+      "description": "Gateway routing details"
+    },
+    "VirtualNetworkGateway": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VirtualNetworkGatewayPropertiesFormat",
+          "description": "Properties of the virtual network gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Gets a unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "required": [
+        "properties"
+      ],
+      "description": "A common class for general resource information"
+    },
+    "VpnClientParameters": {
+      "properties": {
+        "processorArchitecture": {
+          "type": "string",
+          "description": "VPN client Processor Architecture. Possible values are: 'AMD64' and 'X86'.",
+          "enum": [
+            "Amd64",
+            "X86"
+          ],
+          "x-ms-enum": {
+            "name": "ProcessorArchitecture",
+            "modelAsString": true
+          }
+        },
+        "authenticationMethod": {
+          "type": "string",
+          "description": "VPN client Authentication Method. Possible values are: 'EAPTLS' and 'EAPMSCHAPv2'.",
+          "enum": [
+            "EAPTLS",
+            "EAPMSCHAPv2"
+          ],
+          "x-ms-enum": {
+            "name": "AuthenticationMethod",
+            "modelAsString": true
+          }
+        },
+        "radiusServerAuthCertificate": {
+          "type": "string",
+          "description": "The public certificate data for the radius server authentication certificate as a Base-64 encoded string. Required only if external radius authentication has been configured with EAPTLS authentication."
+        },
+        "clientRootCertificates": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of client root certificates public certificate data encoded as Base-64 strings. Optional parameter for external radius based authentication with EAPTLS."
+        }
+      },
+      "description": "Vpn Client Parameters for package generation"
+    },
+    "VirtualNetworkGatewayListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGateway"
+          },
+          "description": "Gets a list of VirtualNetworkGateway resources that exists in a resource group."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the ListVirtualNetworkGateways API service call."
+    },
+    "BgpPeerStatusListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BgpPeerStatus"
+          },
+          "description": "List of BGP peers"
+        }
+      },
+      "description": "Response for list BGP peer status API service call"
+    },
+    "GatewayRouteListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GatewayRoute"
+          },
+          "description": "List of gateway routes"
+        }
+      },
+      "description": "List of virtual network gateway routes"
+    },
+    "TunnelConnectionHealth": {
+      "properties": {
+        "tunnel": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Tunnel name."
+        },
+        "connectionStatus": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Virtual network Gateway connection status",
+          "enum": [
+            "Unknown",
+            "Connecting",
+            "Connected",
+            "NotConnected"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkGatewayConnectionStatus",
+            "modelAsString": true
+          }
+        },
+        "ingressBytesTransferred": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int64",
+          "description": "The Ingress Bytes Transferred in this connection"
+        },
+        "egressBytesTransferred": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int64",
+          "description": "The Egress Bytes Transferred in this connection"
+        },
+        "lastConnectionEstablishedUtcTime": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The time at which connection was established in Utc format."
+        }
+      },
+      "description": "VirtualNetworkGatewayConnection properties"
+    },
+    "VirtualNetworkGatewayConnectionPropertiesFormat": {
+      "properties": {
+        "authorizationKey": {
+          "type": "string",
+          "description": "The authorizationKey."
+        },
+        "virtualNetworkGateway1": {
+          "$ref": "#/definitions/VirtualNetworkGateway",
+          "description": "The reference to virtual network gateway resource."
+        },
+        "virtualNetworkGateway2": {
+          "$ref": "#/definitions/VirtualNetworkGateway",
+          "description": "The reference to virtual network gateway resource."
+        },
+        "localNetworkGateway2": {
+          "$ref": "#/definitions/LocalNetworkGateway",
+          "description": "The reference to local network gateway resource."
+        },
+        "connectionType": {
+          "type": "string",
+          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "enum": [
+            "IPsec",
+            "Vnet2Vnet",
+            "ExpressRoute",
+            "VPNClient"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkGatewayConnectionType",
+            "modelAsString": true
+          }
+        },
+        "routingWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The routing weight."
+        },
+        "sharedKey": {
+          "type": "string",
+          "description": "The IPSec shared key."
+        },
+        "connectionStatus": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Virtual network Gateway connection status. Possible values are 'Unknown', 'Connecting', 'Connected' and 'NotConnected'.",
+          "enum": [
+            "Unknown",
+            "Connecting",
+            "Connected",
+            "NotConnected"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkGatewayConnectionStatus",
+            "modelAsString": true
+          }
+        },
+        "tunnelConnectionStatus": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TunnelConnectionHealth"
+          },
+          "description": "Collection of all tunnels' connection health status."
+        },
+        "egressBytesTransferred": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int64",
+          "description": "The egress bytes transferred in this connection."
+        },
+        "ingressBytesTransferred": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int64",
+          "description": "The ingress bytes transferred in this connection."
+        },
+        "peer": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to peerings resource."
+        },
+        "enableBgp": {
+          "type": "boolean",
+          "description": "EnableBgp flag"
+        },
+        "usePolicyBasedTrafficSelectors": {
+          "type": "boolean",
+          "description": "Enable policy-based traffic selectors."
+        },
+        "ipsecPolicies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IpsecPolicy"
+          },
+          "description": "The IPSec Policies to be considered by this connection."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the VirtualNetworkGatewayConnection resource."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The provisioning state of the VirtualNetworkGatewayConnection resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "required": [
+        "virtualNetworkGateway1",
+        "connectionType"
+      ],
+      "description": "VirtualNetworkGatewayConnection properties"
+    },
+    "VirtualNetworkGatewayConnection": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VirtualNetworkGatewayConnectionPropertiesFormat",
+          "description": "Properties of the virtual network gateway connection."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Gets a unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "required": [
+        "properties"
+      ],
+      "description": "A common class for general resource information"
+    },
+    "VirtualNetworkGatewayConnectionListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+          },
+          "description": "Gets a list of VirtualNetworkGatewayConnection resources that exists in a resource group."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the ListVirtualNetworkGatewayConnections API service call"
+    },
+    "ConnectionResetSharedKey": {
+      "properties": {
+        "keyLength": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "maximum": 128,
+          "description": "The virtual network connection reset shared key length, should between 1 and 128."
+        }
+      },
+      "required": [
+        "keyLength"
+      ],
+      "description": "The virtual network connection reset shared key"
+    },
+    "ConnectionSharedKey": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The virtual network connection shared key value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "description": "Response for GetConnectionSharedKey API service call"
+    },
+    "IpsecPolicy": {
+      "properties": {
+        "saLifeTimeSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The IPSec Security Association (also called Quick Mode or Phase 2 SA) lifetime in seconds for a site to site VPN tunnel."
+        },
+        "saDataSizeKilobytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The IPSec Security Association (also called Quick Mode or Phase 2 SA) payload size in KB for a site to site VPN tunnel."
+        },
+        "ipsecEncryption": {
+          "type": "string",
+          "description": "The IPSec encryption algorithm (IKE phase 1).",
+          "enum": [
+            "None",
+            "DES",
+            "DES3",
+            "AES128",
+            "AES192",
+            "AES256",
+            "GCMAES128",
+            "GCMAES192",
+            "GCMAES256"
+          ],
+          "x-ms-enum": {
+            "name": "IpsecEncryption",
+            "modelAsString": true
+          }
+        },
+        "ipsecIntegrity": {
+          "type": "string",
+          "description": "The IPSec integrity algorithm (IKE phase 1).",
+          "enum": [
+            "MD5",
+            "SHA1",
+            "SHA256",
+            "GCMAES128",
+            "GCMAES192",
+            "GCMAES256"
+          ],
+          "x-ms-enum": {
+            "name": "IpsecIntegrity",
+            "modelAsString": true
+          }
+        },
+        "ikeEncryption": {
+          "type": "string",
+          "description": "The IKE encryption algorithm (IKE phase 2).",
+          "enum": [
+            "DES",
+            "DES3",
+            "AES128",
+            "AES192",
+            "AES256"
+          ],
+          "x-ms-enum": {
+            "name": "IkeEncryption",
+            "modelAsString": true
+          }
+        },
+        "ikeIntegrity": {
+          "type": "string",
+          "description": "The IKE integrity algorithm (IKE phase 2).",
+          "enum": [
+            "MD5",
+            "SHA1",
+            "SHA256",
+            "SHA384"
+          ],
+          "x-ms-enum": {
+            "name": "IkeIntegrity",
+            "modelAsString": true
+          }
+        },
+        "dhGroup": {
+          "type": "string",
+          "description": "The DH Groups used in IKE Phase 1 for initial SA.",
+          "enum": [
+            "None",
+            "DHGroup1",
+            "DHGroup2",
+            "DHGroup14",
+            "DHGroup2048",
+            "ECP256",
+            "ECP384",
+            "DHGroup24"
+          ],
+          "x-ms-enum": {
+            "name": "DhGroup",
+            "modelAsString": true
+          }
+        },
+        "pfsGroup": {
+          "type": "string",
+          "description": "The DH Groups used in IKE Phase 2 for new child SA.",
+          "enum": [
+            "None",
+            "PFS1",
+            "PFS2",
+            "PFS2048",
+            "ECP256",
+            "ECP384",
+            "PFS24"
+          ],
+          "x-ms-enum": {
+            "name": "PfsGroup",
+            "modelAsString": true
+          }
+        }
+      },
+      "required": [
+        "saLifeTimeSeconds",
+        "saDataSizeKilobytes",
+        "ipsecEncryption",
+        "ipsecIntegrity",
+        "ikeEncryption",
+        "ikeIntegrity",
+        "dhGroup",
+        "pfsGroup"
+      ],
+      "description": "An IPSec Policy configuration for a virtual network gateway connection"
+    },
+    "LocalNetworkGatewayPropertiesFormat": {
+      "properties": {
+        "localNetworkAddressSpace": {
+          "$ref": "./virtualNetwork.json#/definitions/AddressSpace",
+          "description": "Local network site address space."
+        },
+        "gatewayIpAddress": {
+          "type": "string",
+          "description": "IP address of local network gateway."
+        },
+        "bgpSettings": {
+          "$ref": "#/definitions/BgpSettings",
+          "description": "Local network gateway's BGP speaker settings."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the LocalNetworkGateway resource."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The provisioning state of the LocalNetworkGateway resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "description": "LocalNetworkGateway properties"
+    },
+    "LocalNetworkGateway": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/LocalNetworkGatewayPropertiesFormat",
+          "description": "Properties of the local network gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "required": [
+        "properties"
+      ],
+      "description": "A common class for general resource information"
+    },
+    "LocalNetworkGatewayListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LocalNetworkGateway"
+          },
+          "description": "A list of local network gateways that exists in a resource group."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListLocalNetworkGateways API service call."
+    },
+    "virtualNetworkConnectionGatewayReference": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of VirtualNetworkGateway or LocalNetworkGateway resource."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "description": "A reference to VirtualNetworkGateway or LocalNetworkGateway resource."
+    },
+    "VirtualNetworkGatewayConnectionListEntityPropertiesFormat": {
+      "properties": {
+        "authorizationKey": {
+          "type": "string",
+          "description": "The authorizationKey."
+        },
+        "virtualNetworkGateway1": {
+          "$ref": "#/definitions/virtualNetworkConnectionGatewayReference",
+          "description": "The reference to virtual network gateway resource."
+        },
+        "virtualNetworkGateway2": {
+          "$ref": "#/definitions/virtualNetworkConnectionGatewayReference",
+          "description": "The reference to virtual network gateway resource."
+        },
+        "localNetworkGateway2": {
+          "$ref": "#/definitions/virtualNetworkConnectionGatewayReference",
+          "description": "The reference to local network gateway resource."
+        },
+        "connectionType": {
+          "type": "string",
+          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "enum": [
+            "IPsec",
+            "Vnet2Vnet",
+            "ExpressRoute",
+            "VPNClient"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkGatewayConnectionType",
+            "modelAsString": true
+          }
+        },
+        "routingWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The routing weight."
+        },
+        "sharedKey": {
+          "type": "string",
+          "description": "The IPSec shared key."
+        },
+        "connectionStatus": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Virtual network Gateway connection status. Possible values are 'Unknown', 'Connecting', 'Connected' and 'NotConnected'.",
+          "enum": [
+            "Unknown",
+            "Connecting",
+            "Connected",
+            "NotConnected"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkGatewayConnectionStatus",
+            "modelAsString": true
+          }
+        },
+        "tunnelConnectionStatus": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TunnelConnectionHealth"
+          },
+          "description": "Collection of all tunnels' connection health status."
+        },
+        "egressBytesTransferred": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int64",
+          "description": "The egress bytes transferred in this connection."
+        },
+        "ingressBytesTransferred": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int64",
+          "description": "The ingress bytes transferred in this connection."
+        },
+        "peer": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to peerings resource."
+        },
+        "enableBgp": {
+          "type": "boolean",
+          "description": "EnableBgp flag"
+        },
+        "usePolicyBasedTrafficSelectors": {
+          "type": "boolean",
+          "description": "Enable policy-based traffic selectors."
+        },
+        "ipsecPolicies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IpsecPolicy"
+          },
+          "description": "The IPSec Policies to be considered by this connection."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the VirtualNetworkGatewayConnection resource."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The provisioning state of the VirtualNetworkGatewayConnection resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+        }
+      },
+      "required": [
+        "virtualNetworkGateway1",
+        "connectionType"
+      ],
+      "description": "VirtualNetworkGatewayConnection properties"
+    },
+    "VirtualNetworkGatewayConnectionListEntity": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VirtualNetworkGatewayConnectionListEntityPropertiesFormat",
+          "description": "Properties of the virtual network gateway connection."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Gets a unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "required": [
+        "properties"
+      ],
+      "description": "A common class for general resource information"
+    },
+    "VirtualNetworkGatewayListConnectionsResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayConnectionListEntity"
+          },
+          "description": "Gets a list of VirtualNetworkGatewayConnection resources that exists in a resource group."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for the VirtualNetworkGatewayListConnections API service call"
+    },
+    "VpnDeviceScriptParameters": {
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "description": "The vendor for the vpn device."
+        },
+        "deviceFamily": {
+          "type": "string",
+          "description": "The device family for the vpn device."
+        },
+        "firmwareVersion": {
+          "type": "string",
+          "description": "The firmware version for the vpn device."
+        }
+      },
+      "description": "Vpn device configuration script generation parameters"
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/vmssNetworkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/vmssNetworkInterface.json
@@ -1,0 +1,400 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-03-30"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_ListVirtualMachineScaleSetVMNetworkInterfaces",
+        "description": "Gets information about all network interfaces in a virtual machine in a virtual machine scale set.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualMachineScaleSetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual machine scale set."
+          },
+          {
+            "name": "virtualmachineIndex",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The virtual machine index."
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "2017-03-30"
+            ],
+            "x-ms-enum": {
+              "name": "ApiVersion",
+              "modelAsString": true
+            },
+            "description": "Client API version."
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkInterface resources.",
+            "schema": {
+              "$ref": "./networkInterface.json#/definitions/NetworkInterfaceListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List virtual machine scale set vm network interfaces": { "$ref": "./examples/VmssVmNetworkInterfaceList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/networkInterfaces": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_ListVirtualMachineScaleSetNetworkInterfaces",
+        "description": "Gets all network interfaces in a virtual machine scale set.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualMachineScaleSetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual machine scale set."
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "2017-03-30"
+            ],
+            "x-ms-enum": {
+              "name": "ApiVersion",
+              "modelAsString": true
+            },
+            "description": "Client API version."
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of NetworkInterface resources.",
+            "schema": {
+              "$ref": "./networkInterface.json#/definitions/NetworkInterfaceListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List virtual machine scale set network interfaces": { "$ref": "./examples/VmssNetworkInterfaceList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_GetVirtualMachineScaleSetNetworkInterface",
+        "description": "Get the specified network interface in a virtual machine scale set.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualMachineScaleSetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual machine scale set."
+          },
+          {
+            "name": "virtualmachineIndex",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The virtual machine index."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "2017-03-30"
+            ],
+            "x-ms-enum": {
+              "name": "ApiVersion",
+              "modelAsString": true
+            },
+            "description": "Client API version."
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting NetworkInterface resource.",
+            "schema": {
+              "$ref": "./networkInterface.json#/definitions/NetworkInterface"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get virtual machine scale set network interface": { "$ref": "./examples/VmssNetworkInterfaceGet.json" }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipConfigurations": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_ListVirtualMachineScaleSetIpConfigurations",
+        "description": "Get the specified network interface ip configuration in a virtual machine scale set.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualMachineScaleSetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual machine scale set."
+          },
+          {
+            "name": "virtualmachineIndex",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The virtual machine index."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "2017-03-30"
+            ],
+            "x-ms-enum": {
+              "name": "ApiVersion",
+              "modelAsString": true
+            },
+            "description": "Client API version."
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the list of resulting NetworkInterfaceIPConfigurations resources.",
+            "schema": {
+              "$ref": "./networkInterface.json#/definitions/NetworkInterfaceIPConfigurationListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List virtual machine scale set network interface ip configurations": { "$ref": "./examples/VmssNetworkInterfaceIpConfigList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipConfigurations/{ipConfigurationName}": {
+      "get": {
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "operationId": "NetworkInterfaces_GetVirtualMachineScaleSetIpConfiguration",
+        "description": "Get the specified network interface ip configuration in a virtual machine scale set.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualMachineScaleSetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual machine scale set."
+          },
+          {
+            "name": "virtualmachineIndex",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The virtual machine index."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "name": "ipConfigurationName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the ip configuration."
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "2017-03-30"
+            ],
+            "x-ms-enum": {
+              "name": "ApiVersion",
+              "modelAsString": true
+            },
+            "description": "Client API version."
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting NetworkInterfaceIPConfiguration resource.",
+            "schema": {
+              "$ref": "./networkInterface.json#/definitions/NetworkInterfaceIPConfiguration"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get virtual machine scale set network interface": { "$ref": "./examples/VmssNetworkInterfaceIpConfigGet.json" }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/vmssPublicIpAddress.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/vmssPublicIpAddress.json
@@ -1,0 +1,261 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2017-03-30"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/publicipaddresses": {
+      "get": {
+        "operationId": "PublicIPAddresses_ListVirtualMachineScaleSetPublicIPAddresses",
+        "description": "Gets information about all public IP addresses on a virtual machine scale set level.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualMachineScaleSetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual machine scale set."
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "2017-03-30"
+            ],
+            "x-ms-enum": {
+              "name": "ApiVersion",
+              "modelAsString": true
+            },
+            "description": "Client API version."
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of PublicIPInterface resources.",
+            "schema": {
+              "$ref": "./publicIpAddress.json#/definitions/PublicIPAddressListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListVMSSPublicIP": { "$ref": "./examples/VmssPublicIpListAll.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipconfigurations/{ipConfigurationName}/publicipaddresses" : {
+      "get": {
+        "operationId": "PublicIPAddresses_ListVirtualMachineScaleSetVMPublicIPAddresses",
+        "description": "Gets information about all public IP addresses in a virtual machine IP configuration in a virtual machine scale set.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualMachineScaleSetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual machine scale set."
+          },
+          {
+            "name": "virtualmachineIndex",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The virtual machine index."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The network interface name."
+          },
+          {
+            "name": "ipConfigurationName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The IP configuration name."
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "2017-03-30"
+            ],
+            "x-ms-enum": {
+              "name": "ApiVersion",
+              "modelAsString": true
+            },
+            "description": "Client API version."
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of PublicIPAddress resources.",
+            "schema": {
+              "$ref": "./publicIpAddress.json#/definitions/PublicIPAddressListResult"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListVMSSVMPublicIP": { "$ref": "./examples/VmssVmPublicIpList.json" }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipconfigurations/{ipConfigurationName}/publicipaddresses/{publicIpAddressName}": {
+      "get": {
+        "operationId": "PublicIPAddresses_GetVirtualMachineScaleSetPublicIPAddress",
+        "description": "Get the specified public IP address in a virtual machine scale set.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualMachineScaleSetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual machine scale set."
+          },
+          {
+            "name": "virtualmachineIndex",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The virtual machine index."
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the network interface."
+          },
+          {
+            "name": "ipConfigurationName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the IP configuration."
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the public IP Address."
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "2017-03-30"
+            ],
+            "x-ms-enum": {
+              "name": "ApiVersion",
+              "modelAsString": true
+            },
+            "description": "Client API version."
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "x-ms-examples": {
+          "GetVMSSPublicIP": { "$ref": "./examples/VmssPublicIpGet.json" }
+        },
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting PublicIPAddress resource.",
+            "schema": {
+              "$ref": "./publicIpAddress.json#/definitions/PublicIPAddress"
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    }
+  }
+}

--- a/specification/network/resource-manager/readme.md
+++ b/specification/network/resource-manager/readme.md
@@ -28,8 +28,37 @@ These are the global settings for the Network API.
 title: NetworkManagementClient
 description: Network Client
 openapi-type: arm
-tag: package-2017-11
+tag: package-2018-01
 ```
+
+### Tag: package-2018-01
+
+These settings apply only when `--tag=package-2018-01` is specified on the command line.
+
+``` yaml $(tag) == 'package-2018-01'
+input-file:
+- Microsoft.Network/stable/2018-01-01/applicationGateway.json
+- Microsoft.Network/stable/2018-01-01/applicationSecurityGroup.json
+- Microsoft.Network/stable/2018-01-01/checkDnsAvailability.json
+- Microsoft.Network/stable/2018-01-01/endpointService.json
+- Microsoft.Network/stable/2018-01-01/expressRouteCircuit.json
+- Microsoft.Network/stable/2018-01-01/loadBalancer.json
+- Microsoft.Network/stable/2018-01-01/network.json
+- Microsoft.Network/stable/2018-01-01/networkInterface.json
+- Microsoft.Network/stable/2018-01-01/networkSecurityGroup.json
+- Microsoft.Network/stable/2018-01-01/networkWatcher.json
+- Microsoft.Network/stable/2018-01-01/operation.json
+- Microsoft.Network/stable/2018-01-01/publicIpAddress.json
+- Microsoft.Network/stable/2018-01-01/routeFilter.json
+- Microsoft.Network/stable/2018-01-01/routeTable.json
+- Microsoft.Network/stable/2018-01-01/serviceCommunity.json
+- Microsoft.Network/stable/2018-01-01/usage.json
+- Microsoft.Network/stable/2018-01-01/virtualNetwork.json
+- Microsoft.Network/stable/2018-01-01/virtualNetworkGateway.json
+- Microsoft.Network/stable/2018-01-01/vmssNetworkInterface.json
+- Microsoft.Network/stable/2018-01-01/vmssPublicIpAddress.json
+```
+
 
 ### Tag: package-2017-11
 
@@ -440,6 +469,7 @@ Generate all API versions currently shipped for this package
 
 ```yaml $(python) && $(multiapi)
 batch:
+  - tag: package-2018-01
   - tag: package-2017-11
   - tag: package-2017-10
   - tag: package-2017-09
@@ -449,6 +479,17 @@ batch:
   - tag: package-2016-12
   - tag: package-2016-09
   - tag: package-2015-06split
+```
+
+### Tag: package-2018-01 and python
+
+These settings apply only when `--tag=package-2018-01 --python` is specified on the command line.
+Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
+
+``` yaml $(tag) == 'package-2018-01' && $(python)
+python:
+  namespace: azure.mgmt.network.v2017_11_01
+  output-folder: $(python-sdks-folder)/azure-mgmt-network/azure/mgmt/network/v2017_11_01
 ```
 
 ### Tag: package-2017-11 and python


### PR DESCRIPTION
Fixes #1624.

This is a breaking change, but clients (including the Go client) are already broken without this, as the server is returning double-formatted values.

This leads to issues like [azure-sdk-for-go/issues/906](https://github.com/Azure/azure-sdk-for-go/issues/906).

For all spec versions where the "examples" directory "UsageList.json" item contains double-formatted responses, update the "usage.json" spec to be double-formatted. For earlier versions with integer-formatted responses (2017-06-01), do not change the format/type.

See more discussion from [August 29 last year](https://github.com/Azure/azure-rest-api-specs/pull/1603/files#r135889852) when this issue was discovered.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document. **(Link breaks for me.)**
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. **(Validation tools aren't working for me right now. But the change seems simple enough)**
