### PR TITLE
Updated compute spec to include properties in VMInstanceView and a new WriteAaccelerator property on disks.

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2017-12-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2017-12-01/compute.json
@@ -4312,6 +4312,10 @@
           "$ref": "#/definitions/Caching",
           "description": "Specifies the caching requirements. <br><br> Possible values are: <br><br> **None** <br><br> **ReadOnly** <br><br> **ReadWrite** <br><br> Default: **None for Standard storage. ReadOnly for Premium storage**"
         },
+        "writeAcceleratorEnabled": {
+          "type": "boolean",
+          "description": "Specifies whether writeAccelerator should be enabled or disabled on the disk."
+        },
         "createOption": {
           "$ref": "#/definitions/CreateOption",
           "description": "Specifies how the virtual machine should be created.<br><br> Possible values are:<br><br> **Attach** \\u2013 This value is used when you are using a specialized disk to create the virtual machine.<br><br> **FromImage** \\u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform image, you also use the imageReference element described above. If you are using a marketplace image, you  also use the plan element previously described."
@@ -4353,6 +4357,10 @@
         "caching": {
           "$ref": "#/definitions/Caching",
           "description": "Specifies the caching requirements. <br><br> Possible values are: <br><br> **None** <br><br> **ReadOnly** <br><br> **ReadWrite** <br><br> Default: **None for Standard storage. ReadOnly for Premium storage**"
+        },
+        "writeAcceleratorEnabled": {
+          "type": "boolean",
+          "description": "Specifies whether writeAccelerator should be enabled or disabled on the disk."
         },
         "createOption": {
           "$ref": "#/definitions/CreateOption",
@@ -4828,6 +4836,18 @@
           "type": "integer",
           "format": "int32",
           "description": "Specifies the fault domain of the virtual machine."
+        },
+        "computerName": {
+          "type": "string",
+          "description": "The computer name assigned to the virtual machine."
+        },
+        "osName": {
+          "type": "string",
+          "description": "The Operating System running on the virtual machine."
+        },	
+        "osVersion": {
+          "type": "string",
+          "description": "The version of Operating System running on the virtual machine."
         },
         "rdpThumbPrint": {
           "type": "string",
@@ -5346,6 +5366,10 @@
           "$ref": "#/definitions/Caching",
           "description": "Specifies the caching requirements. <br><br> Possible values are: <br><br> **None** <br><br> **ReadOnly** <br><br> **ReadWrite** <br><br> Default: **None for Standard storage. ReadOnly for Premium storage**"
         },
+        "writeAcceleratorEnabled": {
+          "type": "boolean",
+          "description": "Specifies whether writeAccelerator should be enabled or disabled on the disk."
+        },
         "createOption": {
           "$ref": "#/definitions/CreateOption",
           "description": "Specifies how the virtual machines in the scale set should be created.<br><br> The only allowed value is: **FromImage** \\u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform image, you also use the imageReference element described above. If you are using a marketplace image, you  also use the plan element previously described."
@@ -5389,6 +5413,10 @@
           "$ref": "#/definitions/Caching",
           "description": "The caching type."
         },
+        "writeAcceleratorEnabled": {
+          "type": "boolean",
+          "description": "Specifies whether writeAccelerator should be enabled or disabled on the disk."
+        },
         "image": {
           "$ref": "#/definitions/VirtualHardDisk",
           "description": "The Source User Image VirtualHardDisk. This VirtualHardDisk will be copied before using it to attach to the Virtual Machine. If SourceImage is provided, the destination VirtualHardDisk should not exist."
@@ -5422,6 +5450,10 @@
           "$ref": "#/definitions/Caching",
           "description": "Specifies the caching requirements. <br><br> Possible values are: <br><br> **None** <br><br> **ReadOnly** <br><br> **ReadWrite** <br><br> Default: **None for Standard storage. ReadOnly for Premium storage**"
         },
+        "writeAcceleratorEnabled": {
+          "type": "boolean",
+          "description": "Specifies whether writeAccelerator should be enabled or disabled on the disk."
+        },		
         "createOption": {
           "$ref": "#/definitions/CreateOption",
           "description": "The create option."

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2017-12-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2017-12-01/compute.json
@@ -4839,17 +4839,14 @@
         },
         "computerName": {
           "type": "string",
-		  "readOnly": true,
           "description": "The computer name assigned to the virtual machine."
         },
         "osName": {
           "type": "string",
-		  "readOnly": true,
           "description": "The Operating System running on the virtual machine."
         },	
         "osVersion": {
           "type": "string",
-		  "readOnly": true,
           "description": "The version of Operating System running on the virtual machine."
         },
         "rdpThumbPrint": {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2017-12-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2017-12-01/compute.json
@@ -4839,14 +4839,17 @@
         },
         "computerName": {
           "type": "string",
+		  "readOnly": true,
           "description": "The computer name assigned to the virtual machine."
         },
         "osName": {
           "type": "string",
+		  "readOnly": true,
           "description": "The Operating System running on the virtual machine."
         },	
         "osVersion": {
           "type": "string",
+		  "readOnly": true,
           "description": "The version of Operating System running on the virtual machine."
         },
         "rdpThumbPrint": {


### PR DESCRIPTION
Updated compute spec to include properties in VMInstanceView and a new WriteAccelerator property on disks.
The new properties exposed in VMInstanceView are ComputerName, OSName and OSVersion.
WriteAccelerator is a new property for a feature which would remain in Public Preview for some time. We are using the same API-version and this should not break anything. Because the absence of the property would not result in any change.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
