### PR TITLE
Revert "market-ordering: use string to persist datetime precision during serialization"

### DIFF
--- a/specification/marketplaceordering/resource-manager/Microsoft.MarketplaceOrdering/stable/2015-06-01/Agreements.json
+++ b/specification/marketplaceordering/resource-manager/Microsoft.MarketplaceOrdering/stable/2015-06-01/Agreements.json
@@ -252,6 +252,7 @@
         },
         "retrieveDatetime": {
           "type": "string",
+          "format": "date-time",
           "description": "Date and time in UTC of when the terms were accepted. This is empty if Accepted is false."
         },
         "signature": {


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#2308
Per suggestion I will revert as it is a breaking change to C#/Java