### PR TITLE
Fix ACS swagger spec error in array definition

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-09-30/location.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-09-30/location.json
@@ -124,8 +124,10 @@
       "properties": {
         "orchestrators": {
           "type": "array",
-          "$ref": "#/definitions/OrchestratorVersionProfile",
-          "description": "List of orchstrator version profiles."
+          "items": {
+            "$ref": "#/definitions/OrchestratorVersionProfile"
+          },
+          "description": "List of orchestrator version profiles."
         }
       },
       "required": [

--- a/specification/containerservices/resource-manager/readme.md
+++ b/specification/containerservices/resource-manager/readme.md
@@ -137,6 +137,7 @@ python:
   payload-flattening-threshold: 2
   namespace: azure.mgmt.containerservice
   package-name: azure-mgmt-containerservice
+  package-version: 3.0.1
   clear-output-folder: true
 ```
 ``` yaml $(python) && $(python-mode) == 'update'


### PR DESCRIPTION
When trying to use the `listOrchestrators` endpoint in an `az` CLI PR, I hit the dreaded deserialization errors that suggest malformed swagger. Eventually I found this bug and fixed it.

I've tested this by regenerating the azure-sdk-for-python locally and calling the endpoint and seeing a successful deserialization through the SDK.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
