### PR TITLE
Fail live validation on no traffic

### DIFF
--- a/scripts/liveValidation.js
+++ b/scripts/liveValidation.js
@@ -101,6 +101,7 @@ async function runScript() {
     console.log(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
     if (validationResult.totalOperationCount === 0) {
         console.log(`There was no traffic detected for the provided RP and API version:${resourceProvider}-${apiVersion}. Please make sure there is traffic so the changes can be validated.`);
+        process.exitCode = 1;
     } else if (failingOperations.length > 0 || noTrafficOperations.length > 0) {
         console.log(`The changes in the specs introduced by this PR potentially do not reflect the Service API.`);
 


### PR DESCRIPTION
- Set exit Code to 1 when no traffic is detected for the RP and api version where the changes happened.