### PR TITLE
Fix Automation swagger spec errors in the AutomationAccount and Webhook areas

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
@@ -370,9 +370,6 @@
           "description": "Gets or sets the tags attached to the resource."
         }
       },
-      "required": [
-        "properties"
-      ],
       "description": "The parameters supplied to the update automation account operation."
     },
     "AutomationAccount": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
@@ -3740,9 +3740,6 @@
           "description": "Gets or sets the value of the webhook."
         }
       },
-      "required": [
-        "name"
-      ],
       "description": "The parameters supplied to the update webhook operation."
     }
   },

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
@@ -3686,7 +3686,8 @@
           "description": "Gets or sets the webhook properties."
         }
       },
-      "description": "Definition of the webhook type."
+      "description": "Definition of the webhook type.",
+      "x-ms-azure-resource": true
     },
     "WebhookListResult": {
       "properties": {


### PR DESCRIPTION
Fixing the following errors in the Automation swagger spec:

- (PatchBodyParametersSchema/R2016/RPCViolation): Properties of a PATCH request body must not be required. PATCH operation: 'AutomationAccount_Update' Model Definition: 'AutomationAccountUpdateParameters' Property: 'properties'
- (PatchBodyParametersSchema/R2016/RPCViolation): Properties of a PATCH request body must not be required. PATCH operation: 'Webhook_Update' Model Definition: 'WebhookUpdateParameters' Property: 'name'
- (XmsResourceInPutResponse/R2062/RPCViolation): The 200 response model for an ARM PUT operation must have x-ms-azure-resource extension set to true in its hierarchy. Operation: 'Webhook_CreateOrUpdate' Model: 'Webhook'

The intent of this PR is to address these errors only. The entire Automation swagger spec contains other errors, and they will be addressed by separate PRs.

---

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes.
- [X] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [X] My spec meets the review criteria:
  - [X] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [X] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
