### PR TITLE
Add missing properties for Vmss zone GA

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2017-12-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2017-12-01/compute.json
@@ -6314,6 +6314,15 @@
         "singlePlacementGroup": {
           "type": "boolean",
           "description": "When true this limits the scale set to a single placement group, of max size 100 virtual machines."
+        },
+        "zoneBalance": {
+          "type": "boolean",
+          "description": "Whether to force stictly even Virtual Machine distribution cross x-zones in case there is zone outage."
+        },
+        "platformFaultDomainCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Fault Domain count for each placement group."
         }
       },
       "description": "Describes the properties of a Virtual Machine Scale Set."


### PR DESCRIPTION
Updated compute spec to include missing properties zoneBalance and platformFaultDomainCount in VirtualMachineScaleSetProperties. We are using 2017-12-01 api version which is zone GA version. Both properties are immutable and optional. These properties are only for zone scenario, which is in public preview now.
