### PR TITLE
correct API version for SourceControl and SourceControlSyncJob, update provisioning state enum

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
@@ -808,7 +808,7 @@
           "type": "string",
           "description": "Gets the provisioning state of the job.",
           "enum": [
-            "Succeeded",
+            "Completed",
             "Failed",
             "Running"
           ],
@@ -882,7 +882,7 @@
           "type": "string",
           "description": "Gets the provisioning state of the job.",
           "enum": [
-            "Succeeded",
+            "Completed",
             "Failed",
             "Running"
           ],

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/createOrUpdateSourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/createOrUpdateSourceControl.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "rg",
     "automationAccountName": "sampleAccount9",
     "sourceControlName": "sampleSourceControl",
-    "api-version": "2015-10-31",
+    "api-version": "2017-05-15-preview",
     "parameters": {
       "properties": {
         "repoUrl": "https://sampleUser.visualstudio.com/myProject/_git/myRepository",

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/deleteSourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/deleteSourceControl.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "rg",
     "automationAccountName": "sampleAccount9",
     "sourceControlName": "sampleSourceControl",
-    "api-version": "2015-10-31"
+    "api-version": "2017-05-15-preview"
   },
   "responses": {
     "200": {}

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getAllSourceControls.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getAllSourceControls.json
@@ -3,7 +3,7 @@
 		"subscriptionId": "subid",
 		"resourceGroupName": "rg",
 		"automationAccountName": "sampleAccount9",
-		"api-version": "2015-10-31"
+		"api-version": "2017-05-15-preview"
   },
   "responses": {
       "200": {

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getSourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/getSourceControl.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "rg",
     "automationAccountName": "sampleAccount9",
     "sourceControlName": "sampleSourceControl",
-    "api-version": "2015-10-31"
+    "api-version": "2017-05-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/updateSourceControl_patch.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControl/updateSourceControl_patch.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "rg",
     "automationAccountName": "sampleAccount9",
     "sourceControlName": "sampleSourceControl",
-    "api-version": "2015-10-31",
+    "api-version": "2017-05-15-preview",
     "parameters": {
       "properties": {
         "branch": "master",

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/createSourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/createSourceControlSyncJob.json
@@ -5,7 +5,7 @@
     "automationAccountName": "myAutomationAccount33",
     "sourceControlName": "MySourceControl",
     "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
-    "api-version": "2015-10-31"
+    "api-version": "2017-05-15-preview"
   },
   "responses": {
     "201": {

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "rg",
     "automationAccountName": "myAutomationAccount33",
     "sourceControlName": "MySourceControl",
-    "api-version": "2015-10-31"
+    "api-version": "2017-05-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getSourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getSourceControlSyncJob.json
@@ -5,7 +5,7 @@
     "automationAccountName": "myAutomationAccount33",
     "sourceControlName": "MySourceControl",
     "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
-    "api-version": "2015-10-31"
+    "api-version": "2017-05-15-preview"
   },
   "responses": {
     "200": {

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControl.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControl.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "AutomationManagement",
-    "version": "2015-10-31"
+    "version": "2017-05-15-preview"
   },
   "host": "management.azure.com",
   "schemes": [

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControlSyncJob.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "AutomationManagement",
-    "version": "2015-10-31"
+    "version": "2017-05-15-preview"
   },
   "host": "management.azure.com",
   "schemes": [


### PR DESCRIPTION
Correcting API version for SourceControl and SourceControlSyncJob resources.
Changed one enum value for SourceControlSyncJob provisioning state (in definitions).

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [X] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [X] My spec meets the review criteria:
  - [X] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [X] The spec follows the guidelines described in the [Swagger checklist](../documentation/swagger-checklist.md) document.
  - [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR. 
