### PR TITLE
Fix go tags

### DIFF
--- a/specification/applicationinsights/data-plane/readme.md
+++ b/specification/applicationinsights/data-plane/readme.md
@@ -58,3 +58,20 @@ directive:
   - reason: Don't expose the GET endpoint since it's behavior is more limited than POST
     remove-operation: GetQuery
 ```
+
+### Go multi-api
+
+``` yaml $(go) && $(multiapi)
+batch:
+  - tag: v1
+```
+
+### Tag: v1 and go
+
+These settings apply only when `--tag=v1 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'v1' && $(go)
+output-folder: $(go-sdk-folder)/services/appinsights/v1/appinsights
+```
+

--- a/specification/azsadmin/resource-manager/InfrastructureInsights/readme.md
+++ b/specification/azsadmin/resource-manager/InfrastructureInsights/readme.md
@@ -100,12 +100,12 @@ go:
   namespace: infrastructureinsights
 ```
 
-### Tag: package--2016-05-01 and go
+### Tag: package-2016-05-01 and go
 
-These settings apply only when `--tag=package--2016-05-01 --go` is specified on the command line.
+These settings apply only when `--tag=package-2016-05-01 --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
-``` yaml $(tag)=='package--2016-05-01' && $(go)
+``` yaml $(tag)=='package-2016-05-01' && $(go)
 output-folder: $(go-sdk-folder)/services/azsadmin/mgmt/2016-05-01/infrastructureinsights
 ```
 

--- a/specification/batch/data-plane/readme.md
+++ b/specification/batch/data-plane/readme.md
@@ -274,6 +274,24 @@ batch:
   - tag: package-2017-05.5.0
 ```
 
+### Tag: package-2017-09.6.0 and go
+
+These settings apply only when `--tag=package-2017-09.6.0 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2017-09.6.0' && $(go)
+output-folder: $(go-sdk-folder)/services/batch/2017-09.6.0/batch
+```
+
+### Tag: package-2017-06.5.1 and go
+
+These settings apply only when `--tag=package-2017-06.5.1 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2017-06.5.1' && $(go)
+output-folder: $(go-sdk-folder)/services/batch/2017-06.5.1/batch
+```
+
 ### Tag: package-2017-05.5.0 and go
 
 These settings apply only when `--tag=package-2017-05.5.0 --go` is specified on the command line.
@@ -281,6 +299,42 @@ Please also specify `--go-sdk-folder=<path to the root directory of your azure-s
 
 ``` yaml $(tag)=='package-2017-05.5.0' && $(go)
 output-folder: $(go-sdk-folder)/services/batch/2017-05-01.5.0/batch
+```
+
+### Tag: package-2017-01.4.0 and go
+
+These settings apply only when `--tag=package-2017-01.4.0 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2017-01.4.0' && $(go)
+output-folder: $(go-sdk-folder)/services/batch/2017-01.4.0/batch
+```
+
+### Tag: package-2016-07.3.1 and go
+
+These settings apply only when `--tag=package-2016-07.3.1 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2016-07.3.1' && $(go)
+output-folder: $(go-sdk-folder)/services/batch/2016-07.3.1/batch
+```
+
+### Tag: package-2016-02.3.0 and go
+
+These settings apply only when `--tag=package-2016-02.3.0 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2016-02.3.0' && $(go)
+output-folder: $(go-sdk-folder)/services/batch/2016-02.3.0/batch
+```
+
+### Tag: package-2015-12.2.2 and go
+
+These settings apply only when `--tag=package-2017-05.5.0 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2017-05.5.0' && $(go)
+output-folder: $(go-sdk-folder)/services/batch/2015-12.2.2/batch
 ```
 
 

--- a/specification/batch/data-plane/readme.md
+++ b/specification/batch/data-plane/readme.md
@@ -280,7 +280,7 @@ These settings apply only when `--tag=package-2017-09.6.0 --go` is specified on 
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag)=='package-2017-09.6.0' && $(go)
-output-folder: $(go-sdk-folder)/services/batch/2017-09.6.0/batch
+output-folder: $(go-sdk-folder)/services/batch/2017-09-01.6.0/batch
 ```
 
 ### Tag: package-2017-06.5.1 and go
@@ -289,7 +289,7 @@ These settings apply only when `--tag=package-2017-06.5.1 --go` is specified on 
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag)=='package-2017-06.5.1' && $(go)
-output-folder: $(go-sdk-folder)/services/batch/2017-06.5.1/batch
+output-folder: $(go-sdk-folder)/services/batch/2017-06-01.5.1/batch
 ```
 
 ### Tag: package-2017-05.5.0 and go
@@ -307,7 +307,7 @@ These settings apply only when `--tag=package-2017-01.4.0 --go` is specified on 
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag)=='package-2017-01.4.0' && $(go)
-output-folder: $(go-sdk-folder)/services/batch/2017-01.4.0/batch
+output-folder: $(go-sdk-folder)/services/batch/2017-01-01.4.0/batch
 ```
 
 ### Tag: package-2016-07.3.1 and go
@@ -316,7 +316,7 @@ These settings apply only when `--tag=package-2016-07.3.1 --go` is specified on 
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag)=='package-2016-07.3.1' && $(go)
-output-folder: $(go-sdk-folder)/services/batch/2016-07.3.1/batch
+output-folder: $(go-sdk-folder)/services/batch/2016-07-01.3.1/batch
 ```
 
 ### Tag: package-2016-02.3.0 and go
@@ -325,7 +325,7 @@ These settings apply only when `--tag=package-2016-02.3.0 --go` is specified on 
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag)=='package-2016-02.3.0' && $(go)
-output-folder: $(go-sdk-folder)/services/batch/2016-02.3.0/batch
+output-folder: $(go-sdk-folder)/services/batch/2016-02-01.3.0/batch
 ```
 
 ### Tag: package-2015-12.2.2 and go
@@ -334,7 +334,7 @@ These settings apply only when `--tag=package-2017-05.5.0 --go` is specified on 
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag)=='package-2017-05.5.0' && $(go)
-output-folder: $(go-sdk-folder)/services/batch/2015-12.2.2/batch
+output-folder: $(go-sdk-folder)/services/batch/2015-12-01.2.2/batch
 ```
 
 

--- a/specification/consumption/resource-manager/readme.md
+++ b/specification/consumption/resource-manager/readme.md
@@ -179,7 +179,7 @@ These settings apply only when `--tag=package-2017-12-preview --go` is specified
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag) == 'package-2017-12-preview' && $(go)
-output-folder: $(go-sdk-folder)/services/consumption/mgmt/package-2017-12-preview/consumption
+output-folder: $(go-sdk-folder)/services/consumption/mgmt/2017-12-preview/consumption
 ```
 
 ### Tag: package-2018-01 and go

--- a/specification/consumption/resource-manager/readme.md
+++ b/specification/consumption/resource-manager/readme.md
@@ -166,27 +166,27 @@ Please also specify `--go-sdk-folder=<path to the root directory of your azure-s
 output-folder: $(go-sdk-folder)/services/consumption/mgmt/2017-04-24-preview/consumption
 ```
 
-### Tag: package-2017-11-30 and go
-These settings apply only when `--tag=package-2017-11-30 --go` is specified on the command line.
+### Tag: package-2017-11 and go
+These settings apply only when `--tag=package-2017-11 --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
-``` yaml $(tag) == 'package-2017-11-30' && $(go)
+``` yaml $(tag) == 'package-2017-11' && $(go)
 output-folder: $(go-sdk-folder)/services/consumption/mgmt/2017-11-30/consumption
 ```
 
-### Tag: package-2017-12-30-preview and go
-These settings apply only when `--tag=package-2017-12-30-preview --go` is specified on the command line.
+### Tag: package-2017-12-preview and go
+These settings apply only when `--tag=package-2017-12-preview --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
-``` yaml $(tag) == 'package-2017-12-30-preview' && $(go)
-output-folder: $(go-sdk-folder)/services/consumption/mgmt/2017-12-30-preview/consumption
+``` yaml $(tag) == 'package-2017-12-preview' && $(go)
+output-folder: $(go-sdk-folder)/services/consumption/mgmt/package-2017-12-preview/consumption
 ```
 
-### Tag: package-2018-01-31 and go
-These settings apply only when `--tag=package-2018-01-31 --go` is specified on the command line.
+### Tag: package-2018-01 and go
+These settings apply only when `--tag=package-2018-01 --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
-``` yaml $(tag) == 'package-2018-01-31' && $(go)
+``` yaml $(tag) == 'package-2018-01' && $(go)
 output-folder: $(go-sdk-folder)/services/consumption/mgmt/2018-01-31/consumption
 ```
 

--- a/specification/consumption/resource-manager/readme.md
+++ b/specification/consumption/resource-manager/readme.md
@@ -179,7 +179,7 @@ These settings apply only when `--tag=package-2017-12-preview --go` is specified
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag) == 'package-2017-12-preview' && $(go)
-output-folder: $(go-sdk-folder)/services/consumption/mgmt/2017-12-preview/consumption
+output-folder: $(go-sdk-folder)/services/consumption/mgmt/2017-12-30-preview/consumption
 ```
 
 ### Tag: package-2018-01 and go

--- a/specification/hanaonazure/resource-manager/readme.md
+++ b/specification/hanaonazure/resource-manager/readme.md
@@ -119,7 +119,7 @@ batch:
 These settings apply only when `--tag=package-2017-11 --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
-``` yaml $(go) && $(tag) == 'package-2017-11'
+``` yaml $(tag) == 'package-2017-11' && $(go)
 output-folder: $(go-sdk-folder)/services/hanaonazure/mgmt/2017-11-03-preview/hanaonazure
 ```
 
@@ -128,7 +128,7 @@ output-folder: $(go-sdk-folder)/services/hanaonazure/mgmt/2017-11-03-preview/han
 These settings apply only when `--tag=package-2017-06 --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
-``` yaml $(go) && $(tag) == 'package-2017-06'
+``` yaml $(tag) == 'package-2017-06' && $(go)
 output-folder: $(go-sdk-folder)/services/hanaonazure/mgmt/2017-06-15-preview/hanaonazure
 ```
 

--- a/specification/machinelearningcompute/resource-manager/readme.md
+++ b/specification/machinelearningcompute/resource-manager/readme.md
@@ -135,6 +135,15 @@ Please also specify `--go-sdk-folder=<path to the root directory of your azure-s
 output-folder: $(go-sdk-folder)/services/machinelearning/mgmt/2017-08-01-preview/compute
 ```
 
+### Tag: package-2017-06-preview and go
+
+These settings apply only when `--tag=package-package-2017-06-preview --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2017-06-preview' && $(go)
+output-folder: $(go-sdk-folder)/services/machinelearning/mgmt/2017-06-01-preview/compute
+```
+
 
 ## Java
 

--- a/specification/managementpartner/resource-manager/readme.md
+++ b/specification/managementpartner/resource-manager/readme.md
@@ -50,6 +50,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
+  - repo: azure-sdk-for-go
 ```
 
 ## C# 
@@ -64,6 +65,33 @@ csharp:
   namespace: Microsoft.Azure.Management.ManagementPartner
   output-folder: $(csharp-sdks-folder)/ManagementPartner/Management.ManagementPartner/Generated
   clear-output-folder: true
+```
+
+## Go
+
+These settings apply only when `--go` is specified on the command line.
+
+``` yaml $(go)
+go:
+  license-header: MICROSOFT_APACHE_NO_VERSION
+  clear-output-folder: true
+  namespace: managementpartner
+```
+
+### Go multi-api
+
+``` yaml $(go) && $(multiapi)
+batch:
+  - tag: package-2018-02
+```
+
+### Tag: package-2018-02 and go
+
+These settings apply only when `--tag=package-2018-02 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2018-02' && $(go)
+output-folder: $(go-sdk-folder)/services/managementpartner/mgmt/2018-02-01/managementpartner
 ```
 
 ## Python

--- a/specification/monitor/resource-manager/readme.md
+++ b/specification/monitor/resource-manager/readme.md
@@ -121,6 +121,16 @@ go:
 ``` yaml $(go) && $(multiapi)
 batch:
   - tag: package-2017-08
+  - tag: package-2017-09
+```
+
+### Tag: package-2017-09 and go
+
+These settings apply only when `--tag=package-2017-09 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2017-09' && $(go)
+output-folder: $(go-sdk-folder)/services/monitor/mgmt/2018-03-01/insights
 ```
 
 ### Tag: package-2017-08 and go

--- a/specification/network/resource-manager/readme.md
+++ b/specification/network/resource-manager/readme.md
@@ -365,6 +365,9 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
+  - tag: package-2018-01
+  - tag: package-2017-11
+  - tag: package-2017-10
   - tag: package-2017-09
   - tag: package-2017-08
   - tag: package-2017-06
@@ -375,6 +378,33 @@ batch:
   - tag: package-2016-03
   - tag: package-2015-06split
   - tag: package-2015-05-preview
+```
+
+### Tag: package-2018-01 and go
+
+These settings apply only when `--tag=package-2018-01 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2018-01' && $(go)
+output-folder: $(go-sdk-folder)/services/network/mgmt/2018-01-01/network
+```
+
+### Tag: package-2017-11 and go
+
+These settings apply only when `--tag=package-2017-11 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2017-11' && $(go)
+output-folder: $(go-sdk-folder)/services/network/mgmt/2017-11-01/network
+```
+
+### Tag: package-2017-10 and go
+
+These settings apply only when `--tag=package-2017-10 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2017-10' && $(go)
+output-folder: $(go-sdk-folder)/services/network/mgmt/2017-10-01/network
 ```
 
 ### Tag: package-2017-09 and go

--- a/specification/recoveryservices/resource-manager/readme.md
+++ b/specification/recoveryservices/resource-manager/readme.md
@@ -118,17 +118,7 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
-  - tag: package-2016-12
   - tag: package-2016-06
-```
-
-### Tag: package-2016-12 and go
-
-These settings apply only when `--tag=package-2016-12 --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag)=='package-2016-12' && $(go)
-output-folder: $(go-sdk-folder)/services/recoveryservices/mgmt/2016-12-01/recoveryservices
 ```
 
 ### Tag: package-2016-06 and go

--- a/specification/recoveryservicesbackup/resource-manager/readme.md
+++ b/specification/recoveryservicesbackup/resource-manager/readme.md
@@ -158,6 +158,7 @@ go:
 ``` yaml $(go) && $(multiapi)
 batch:
   - tag: package-2017-07
+  - tag: package-2016-06
 ```
 
 ### Tag: package-2017-07 and go
@@ -167,4 +168,13 @@ Please also specify `--go-sdk-folder=<path to the root directory of your azure-s
 
 ``` yaml $(tag)=='package-2017-07' && $(go)
 output-folder: $(go-sdk-folder)/services/recoveryservices/mgmt/2017-07-01/backup
+```
+
+### Tag: package-2016-06 and go
+
+These settings apply only when `--tag=package-2016-06 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2016-06' && $(go)
+output-folder: $(go-sdk-folder)/services/recoveryservices/mgmt/2016-06-01/backup
 ```

--- a/specification/servicefabric/data-plane/readme.md
+++ b/specification/servicefabric/data-plane/readme.md
@@ -133,6 +133,7 @@ batch:
   - tag: "1.0.0"
   - tag: "5.6"
   - tag: "6.0"
+  - tag: "6.1"
 ```
 
 ### Tag: 1.0.0 and go
@@ -157,6 +158,14 @@ These settings apply only when `--tag=6.0 --go` is specified on the command line
 
 ``` yaml $(tag) == '6.0' && $(go)
 output-folder: $(go-sdk-folder)/services/servicefabric/6.0/servicefabric
+```
+
+### Tag: 6.1 and go
+
+These settings apply only when `--tag=6.1 --go` is specified on the command line.
+
+``` yaml $(tag) == '6.1' && $(go)
+output-folder: $(go-sdk-folder)/services/servicefabric/6.1/servicefabric
 ```
 
 

--- a/specification/storage/resource-manager/readme.md
+++ b/specification/storage/resource-manager/readme.md
@@ -146,12 +146,22 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
+  - tag: package-2017-10
   - tag: package-2017-06
   - tag: package-2016-12
   - tag: package-2016-05
   - tag: package-2016-01
   - tag: package-2015-06
   - tag: package-2015-05-preview
+```
+
+### Tag: package-2017-10 and go
+
+These settings apply only when `--tag=package-2017-10 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2017-10' && $(go)
+output-folder: $(go-sdk-folder)/services/storage/mgmt/2017-10-01/storage
 ```
 
 ### Tag: package-2017-06 and go

--- a/specification/timeseriesinsights/resource-manager/readme.md
+++ b/specification/timeseriesinsights/resource-manager/readme.md
@@ -107,7 +107,7 @@ Please also specify `--go-sdk-folder=<path to the root directory of your azure-s
 output-folder: $(go-sdk-folder)/services/timeseriesinsights/mgmt/2017-11-15/timeseriesinsights
 ```
 
-### Tag: package-2017-11-15 and go
+### Tag: package-2017-02-preview and go
 
 These settings apply only when `--tag=package-2017-02-preview --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.

--- a/specification/trafficmanager/resource-manager/readme.md
+++ b/specification/trafficmanager/resource-manager/readme.md
@@ -182,7 +182,7 @@ Please also specify `--go-sdk-folder=<path to the root directory of your azure-s
 output-folder: $(go-sdk-folder)/services/trafficmanager/mgmt/2017-03-01/trafficmanager
 ```
 
-### Tag: package-2015-11-01 and go
+### Tag: package-2015-11 and go
 
 These settings apply only when `--tag=package-2015-11 --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.


### PR DESCRIPTION
Doing a big scrub of the Go tags before the v14 release of the [Azure/azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go) later this afternoon.
