### PR TITLE
Fix typo in enum modes in spell check json

### DIFF
--- a/specification/cognitiveservices/data-plane/SpellCheck/stable/V1.0/SpellCheck.json
+++ b/specification/cognitiveservices/data-plane/SpellCheck/stable/V1.0/SpellCheck.json
@@ -191,8 +191,8 @@
             "required": false,
             "type": "string",
             "enum": [
-              "Proof",
-              "Spell"
+              "proof",
+              "spell"
             ],
             "x-ms-enum": {
               "name": "Mode",


### PR DESCRIPTION
This is a minor fix to the spellcheck.json. The service expects "proof"/"spell". But, it is added in the swagger file as "Proof"/"Spell". This PR is to fix it. 

If the SDKs have been released already, this will not be a breaking change. But more as a bug fix. 

@ashku-ms @olydis Please review and approve