### PR TITLE
HDInsight Python conf

### DIFF
--- a/specification/hdinsight/resource-manager/readme.md
+++ b/specification/hdinsight/resource-manager/readme.md
@@ -61,8 +61,13 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-go
+  - repo: azure-libraries-for-java
+  - repo: azure-sdk-for-python
 ```
 
+## Python
+
+See configuration in [readme.python.md](./readme.python.md)
 
 ## Go
 

--- a/specification/hdinsight/resource-manager/readme.python.md
+++ b/specification/hdinsight/resource-manager/readme.python.md
@@ -1,0 +1,27 @@
+## Python
+
+These settings apply only when `--python` is specified on the command line.
+Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
+Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
+
+``` yaml $(python)
+python-mode: create
+python:
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  payload-flattening-threshold: 2
+  namespace: azure.mgmt.hdinsight
+  package-name: azure-mgmt-hdinsight
+  package-version: 0.1.0
+  clear-output-folder: true
+```
+``` yaml $(python) && $(python-mode) == 'update'
+python:
+  no-namespace-folders: true
+  output-folder: $(python-sdks-folder)/azure-mgmt-hdinsight/azure/mgmt/hdinsight
+```
+``` yaml $(python) && $(python-mode) == 'create'
+python:
+  basic-setup-py: true
+  output-folder: $(python-sdks-folder)/azure-mgmt-hdinsight
+```


### PR DESCRIPTION
@fearthecowboy This is the first time I do a "readme.python.conf" and it works like a charm our of the box.

@marstr @salameer @daschult I still left a "Python" section in the main Readme with a link to the Python readme. I feel it's important, in order for service team to understand they have a Python conf. Can be discussed tomorrow if you want.