### PR TITLE
Update base-branch for Swagger -> SDK tooling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
     fi
   - >-
     if [[ $MODE == 'go' ]]; then
-      $DOCKER_CMD Azure/azure-sdk-for-go -o dev -v
+      $DOCKER_CMD Azure/azure-sdk-for-go -o latest -v
     fi
   - >-
     if [[ $MODE == 'java' ]]; then


### PR DESCRIPTION
As per Azure/azure-sdk-for-go#1066, and some related conversations with @jhendrixMSFT, we've decided to have the automated PRs target a branch called latest.

This PR should be merged after Azure/azure-sdk-for-go#1095.