### PR TITLE
[Do not merge] CDN in all languages in conf

### DIFF
--- a/specification/cdn/resource-manager/readme.csharp.md
+++ b/specification/cdn/resource-manager/readme.csharp.md
@@ -5,7 +5,6 @@ Please also specify `--csharp-sdks-folder=<path to "SDKs" directory of your azur
 
 ``` yaml $(csharp)
 csharp:
-  # last generated with AutoRest.1.0.0-Nightly20170212
   azure-arm: true
   license-header: MICROSOFT_MIT_NO_VERSION
   namespace: Microsoft.Azure.Management.Cdn

--- a/specification/cdn/resource-manager/readme.csharp.md
+++ b/specification/cdn/resource-manager/readme.csharp.md
@@ -1,0 +1,15 @@
+## C# 
+
+These settings apply only when `--csharp` is specified on the command line.
+Please also specify `--csharp-sdks-folder=<path to "SDKs" directory of your azure-sdk-for-net clone>`.
+
+``` yaml $(csharp)
+csharp:
+  # last generated with AutoRest.1.0.0-Nightly20170212
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  namespace: Microsoft.Azure.Management.Cdn
+  payload-flattening-threshold: 2
+  output-folder: $(csharp-sdks-folder)/Cdn/Management.Cdn/Generated
+  clear-output-folder: true
+```

--- a/specification/cdn/resource-manager/readme.go.md
+++ b/specification/cdn/resource-manager/readme.go.md
@@ -1,0 +1,66 @@
+## Go
+
+These settings apply only when `--go` is specified on the command line.
+
+``` yaml $(go)
+go:
+  license-header: MICROSOFT_APACHE_NO_VERSION
+  namespace: cdn
+  clear-output-folder: true
+```
+
+### Go multi-api
+
+``` yaml $(go) && $(multiapi)
+batch:
+  - tag: package-2017-10
+  - tag: package-2017-04
+  - tag: package-2016-10
+  - tag: package-2016-04
+  - tag: package-2015-06
+```
+
+### Tag: package-2017-10 and go
+
+These settings apply only when `--tag=package-2017-10 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2017-10' && $(go)
+output-folder: $(go-sdk-folder)/services/cdn/mgmt/2017-10-12/cdn
+```
+
+### Tag: package-2017-04 and go
+
+These settings apply only when `--tag=package-2017-04 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2017-04' && $(go)
+output-folder: $(go-sdk-folder)/services/cdn/mgmt/2017-04-02/cdn
+```
+
+### Tag: package-2016-10 and go
+
+These settings apply only when `--tag=package-2016-10 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2016-10'  && $(go)
+output-folder: $(go-sdk-folder)/services/cdn/mgmt/2016-10-02/cdn
+```
+
+### Tag: package-2016-04 and go
+
+These settings apply only when `--tag=package-2016-04 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2016-04' && $(go)
+output-folder: $(go-sdk-folder)/services/cdn/mgmt/2016-04-02/cdn
+```
+
+### Tag: package-2015-06 and go
+
+These settings apply only when `--tag=package-2015-06 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2015-06' && $(go)
+output-folder: $(go-sdk-folder)/services/cdn/mgmt/2015-06-01/cdn
+```

--- a/specification/cdn/resource-manager/readme.java.md
+++ b/specification/cdn/resource-manager/readme.java.md
@@ -1,0 +1,14 @@
+## Java
+
+These settings apply only when `--java` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-libraries-for-java clone>`.
+
+``` yaml $(java)
+java:
+  azure-arm: true
+  fluent: true
+  namespace: com.microsoft.azure.management.cdn
+  license-header: MICROSOFT_MIT_NO_CODEGEN
+  payload-flattening-threshold: 1
+  output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-cdn
+```

--- a/specification/cdn/resource-manager/readme.md
+++ b/specification/cdn/resource-manager/readme.md
@@ -89,7 +89,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-libraries-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-csharp
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby
 ```

--- a/specification/cdn/resource-manager/readme.md
+++ b/specification/cdn/resource-manager/readme.md
@@ -89,131 +89,32 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-libraries-for-java
   - repo: azure-sdk-for-go
+  - repo: azure-sdk-for-csharp
+  - repo: azure-sdk-for-node
+  - repo: azure-sdk-for-ruby
 ```
 
 
 ## C# 
 
-These settings apply only when `--csharp` is specified on the command line.
-Please also specify `--csharp-sdks-folder=<path to "SDKs" directory of your azure-sdk-for-net clone>`.
-
-``` yaml $(csharp)
-csharp:
-  # last generated with AutoRest.1.0.0-Nightly20170212
-  azure-arm: true
-  license-header: MICROSOFT_MIT_NO_VERSION
-  namespace: Microsoft.Azure.Management.Cdn
-  payload-flattening-threshold: 2
-  output-folder: $(csharp-sdks-folder)/Cdn/Management.Cdn/Generated
-  clear-output-folder: true
-```
+See configuration in [readme.csharp.md](./readme.csharp.md)
 
 ## Python
 
-These settings apply only when `--python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
-
-``` yaml $(python)
-python-mode: create
-python:
-  azure-arm: true
-  license-header: MICROSOFT_MIT_NO_VERSION
-  payload-flattening-threshold: 2
-  namespace: azure.mgmt.cdn
-  package-name: azure-mgmt-cdn
-  clear-output-folder: true
-```
-``` yaml $(python) && $(python-mode) == 'update'
-python:
-  no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-cdn/azure/mgmt/cdn
-```
-``` yaml $(python) && $(python-mode) == 'create'
-python:
-  basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-cdn
-```
+See configuration in [readme.python.md](./readme.python.md)
 
 ## Go
 
-These settings apply only when `--go` is specified on the command line.
-
-``` yaml $(go)
-go:
-  license-header: MICROSOFT_APACHE_NO_VERSION
-  namespace: cdn
-  clear-output-folder: true
-```
-
-### Go multi-api
-
-``` yaml $(go) && $(multiapi)
-batch:
-  - tag: package-2017-10
-  - tag: package-2017-04
-  - tag: package-2016-10
-  - tag: package-2016-04
-  - tag: package-2015-06
-```
-
-### Tag: package-2017-10 and go
-
-These settings apply only when `--tag=package-2017-10 --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag) == 'package-2017-10' && $(go)
-output-folder: $(go-sdk-folder)/services/cdn/mgmt/2017-10-12/cdn
-```
-
-### Tag: package-2017-04 and go
-
-These settings apply only when `--tag=package-2017-04 --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag) == 'package-2017-04' && $(go)
-output-folder: $(go-sdk-folder)/services/cdn/mgmt/2017-04-02/cdn
-```
-
-### Tag: package-2016-10 and go
-
-These settings apply only when `--tag=package-2016-10 --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag) == 'package-2016-10'  && $(go)
-output-folder: $(go-sdk-folder)/services/cdn/mgmt/2016-10-02/cdn
-```
-
-### Tag: package-2016-04 and go
-
-These settings apply only when `--tag=package-2016-04 --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag) == 'package-2016-04' && $(go)
-output-folder: $(go-sdk-folder)/services/cdn/mgmt/2016-04-02/cdn
-```
-
-### Tag: package-2015-06 and go
-
-These settings apply only when `--tag=package-2015-06 --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag) == 'package-2015-06' && $(go)
-output-folder: $(go-sdk-folder)/services/cdn/mgmt/2015-06-01/cdn
-```
-
+See configuration in [readme.go.md](./readme.go.md)
 
 ## Java
 
-These settings apply only when `--java` is specified on the command line.
-Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-libraries-for-java clone>`.
+See configuration in [readme.java.md](./readme.java.md)
 
-``` yaml $(java)
-java:
-  azure-arm: true
-  fluent: true
-  namespace: com.microsoft.azure.management.cdn
-  license-header: MICROSOFT_MIT_NO_CODEGEN
-  payload-flattening-threshold: 1
-  output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-cdn
-```
+## Node
+
+See configuration in [readme.node.md](./readme.node.md)
+
+## Ruby
+
+See configuration in [readme.ruby.md](./readme.ruby.md)

--- a/specification/cdn/resource-manager/readme.nodejs.md
+++ b/specification/cdn/resource-manager/readme.nodejs.md
@@ -1,0 +1,13 @@
+## Node
+
+These settings apply only when `--nodejs` is specified on the command line.
+Please also specify `--node-sdks-folder=<path to the root directory of your azure-sdk-for-node clone>`.
+
+``` yaml $(nodejs)
+nodejs:
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  payload-flattening-threshold: 2
+  package-name: azure-mgmt-cdn
+  output-folder: $(node-sdks-folder)/lib/services/cdnManagement/lib
+```

--- a/specification/cdn/resource-manager/readme.nodejs.md
+++ b/specification/cdn/resource-manager/readme.nodejs.md
@@ -8,6 +8,6 @@ nodejs:
   azure-arm: true
   license-header: MICROSOFT_MIT_NO_VERSION
   payload-flattening-threshold: 2
-  package-name: azure-mgmt-cdn
+  package-name: azure-arm-cdn
   output-folder: $(node-sdks-folder)/lib/services/cdnManagement/lib
 ```

--- a/specification/cdn/resource-manager/readme.python.md
+++ b/specification/cdn/resource-manager/readme.python.md
@@ -1,0 +1,27 @@
+## Python
+
+These settings apply only when `--python` is specified on the command line.
+Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
+Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
+
+``` yaml $(python)
+python-mode: create
+python:
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  payload-flattening-threshold: 2
+  namespace: azure.mgmt.cdn
+  package-name: azure-mgmt-cdn
+  package-version: 2.0.0
+  clear-output-folder: true
+```
+``` yaml $(python) && $(python-mode) == 'update'
+python:
+  no-namespace-folders: true
+  output-folder: $(python-sdks-folder)/azure-mgmt-cdn/azure/mgmt/cdn
+```
+``` yaml $(python) && $(python-mode) == 'create'
+python:
+  basic-setup-py: true
+  output-folder: $(python-sdks-folder)/azure-mgmt-cdn
+```

--- a/specification/cdn/resource-manager/readme.ruby.md
+++ b/specification/cdn/resource-manager/readme.ruby.md
@@ -26,7 +26,7 @@ Please also specify `--ruby-sdks-folder=<path to the root directory of your azur
 
 ``` yaml $(tag) == 'package-2017-10' && $(ruby)
 namespace: "Azure::CDN::Mgmt::V2017_10_23"
-output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2017-10-12
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_cdn/lib/2017-10-12
 ```
 
 
@@ -37,7 +37,7 @@ Please also specify `--ruby-sdks-folder=<path to the root directory of your azur
 
 ``` yaml $(tag) == 'package-2017-04' && $(ruby)
 namespace: "Azure::CDN::Mgmt::V2017_04_02"
-output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2017-04-02
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_cdn/lib/2017-04-02
 ```
 
 ### Tag: package-2016-10 and ruby
@@ -47,7 +47,7 @@ Please also specify `--ruby-sdks-folder=<path to the root directory of your azur
 
 ``` yaml $(tag) == 'package-2016-10'  && $(ruby)
 namespace: "Azure::CDN::Mgmt::V2016_10_02"
-output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2016-10-02
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_cdn/lib/2016-10-02
 ```
 
 ### Tag: package-2016-04 and ruby
@@ -57,7 +57,7 @@ Please also specify `--ruby-sdks-folder=<path to the root directory of your azur
 
 ``` yaml $(tag) == 'package-2016-04'  && $(ruby)
 namespace: "Azure::CDN::Mgmt::V2016_04_02"
-output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2016-04-02
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_cdn/lib/2016-04-02
 ```
 
 ### Tag: package-2015-06 and ruby
@@ -67,5 +67,5 @@ Please also specify `--ruby-sdks-folder=<path to the root directory of your azur
 
 ``` yaml $(tag) == 'package-2015-06' && $(ruby)
 namespace: "Azure::CDN::Mgmt::V2015_06_01"
-output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2015-06-01
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_cdn/lib/2015-06-01
 ```

--- a/specification/cdn/resource-manager/readme.ruby.md
+++ b/specification/cdn/resource-manager/readme.ruby.md
@@ -1,0 +1,49 @@
+## Ruby
+
+These settings apply only when `--ruby` is specified on the command line.
+
+``` yaml $(ruby)
+ruby:
+  package-name: azure_mgmt_cdn
+  package-version": "0.15.2"
+```
+
+### Ruby multi-api
+
+``` yaml $(ruby) && $(multiapi)
+batch:
+  - tag: package-2017-04
+  - tag: package-2016-10
+  - tag: package-2015-06
+```
+
+
+### Tag: package-2017-04 and ruby
+
+These settings apply only when `--tag=package-2017-04 --ruby` is specified on the command line.
+Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
+
+``` yaml $(tag) == 'package-2017-04' && $(ruby)
+namespace: "Azure::CDN::Mgmt::V2017_04_02"
+output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2017-04-02
+```
+
+### Tag: package-2016-10 and ruby
+
+These settings apply only when `--tag=package-2016-10 --ruby` is specified on the command line.
+Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
+
+``` yaml $(tag) == 'package-2016-10'  && $(ruby)
+namespace: "Azure::CDN::Mgmt::V2016_10_02"
+output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2016-10-02
+```
+
+### Tag: package-2015-06 and ruby
+
+These settings apply only when `--tag=package-2015-06 --ruby` is specified on the command line.
+Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
+
+``` yaml $(tag) == 'package-2015-06' && $(ruby)
+namespace: "Azure::CDN::Mgmt::V2015_06_01"
+output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2015-06-01
+```

--- a/specification/cdn/resource-manager/readme.ruby.md
+++ b/specification/cdn/resource-manager/readme.ruby.md
@@ -5,16 +5,28 @@ These settings apply only when `--ruby` is specified on the command line.
 ``` yaml $(ruby)
 ruby:
   package-name: azure_mgmt_cdn
-  package-version": "0.15.2"
+  package-version": "0.16.0"
 ```
 
 ### Ruby multi-api
 
 ``` yaml $(ruby) && $(multiapi)
 batch:
+  - tag: package-2017-10
   - tag: package-2017-04
   - tag: package-2016-10
+  - tag: package-2016-04
   - tag: package-2015-06
+```
+
+### Tag: package-2017-10 and ruby
+
+These settings apply only when `--tag=package-2017-10 --ruby` is specified on the command line.
+Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
+
+``` yaml $(tag) == 'package-2017-10' && $(ruby)
+namespace: "Azure::CDN::Mgmt::V2017_10_23"
+output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2017-10-12
 ```
 
 
@@ -36,6 +48,16 @@ Please also specify `--ruby-sdks-folder=<path to the root directory of your azur
 ``` yaml $(tag) == 'package-2016-10'  && $(ruby)
 namespace: "Azure::CDN::Mgmt::V2016_10_02"
 output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2016-10-02
+```
+
+### Tag: package-2016-04 and ruby
+
+These settings apply only when `--tag=package-2016-04 --ruby` is specified on the command line.
+Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
+
+``` yaml $(tag) == 'package-2016-04'  && $(ruby)
+namespace: "Azure::CDN::Mgmt::V2016_04_02"
+output-folder: $(ruby-sdk-folder)/management/azure_mgmt_cdn/lib/2016-04-02
 ```
 
 ### Tag: package-2015-06 and ruby


### PR DESCRIPTION
This PR to show what should look like the common process when all languages will be plugged. This is for CSharp, Java, Python, Node, Go and Ruby

- [x] @shahabhijeet I moved the CSharp configuration into `readme.csharp.md`. This is absolutely transparent, Autorest manages these sub-files automatically.
- [ ] @daschult I moved the Java configuration into `readme.java.md`. This is absolutely transparent, Autorest manages these sub-files automatically.
- [x] @marstr I moved the Go configuration into `readme.go.md`. This is absolutely transparent, Autorest manages these sub-files automatically.
- [x] @amarzavery I manually wrote `readme.nodejs.md` from the info you gave to me. Please review. :)
- [ ] @sarangan12 I manually wrote `readme.ruby.md` from your current swaggertosdk conf into the new format. Please review this is equivalent. This is not ready, since the new system cannot handle correctly `generated_relative_base_directory` that you need. I have to think about this a little more.

Will keep this PR open until all languages gives good result for the automation system. Then, CDN will be an example on how to write the new generation format.

Edit: adding checkbox for "tested and correct".