### PR TITLE
Update the output-folder to match azure-sdk-for-net paths

### DIFF
--- a/specification/cognitiveservices/data-plane/CustomVision/Prediction/readme.md
+++ b/specification/cognitiveservices/data-plane/CustomVision/Prediction/readme.md
@@ -47,7 +47,7 @@ csharp:
   license-header: MICROSOFT_MIT_NO_VERSION
   azure-arm: false
   namespace: Microsoft.Azure.CognitiveServices.Vision.CustomVision.Prediction
-  output-folder: $(csharp-sdks-folder)/CognitiveServices/dataPlane/Vision/Vision/Generated/CustomVision/Prediction
+  output-folder: $(csharp-sdks-folder)/CognitiveServices/dataPlane/Vision/CustomVision/Prediction/Generated
   clear-output-folder: true
 ```
 

--- a/specification/cognitiveservices/data-plane/CustomVision/Training/readme.md
+++ b/specification/cognitiveservices/data-plane/CustomVision/Training/readme.md
@@ -47,7 +47,7 @@ csharp:
   license-header: MICROSOFT_MIT_NO_VERSION
   azure-arm: false
   namespace: Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training
-  output-folder: $(csharp-sdks-folder)/CognitiveServices/dataPlane/Vision/Vision/Generated/CustomVision/Training
+  output-folder: $(csharp-sdks-folder)/CognitiveServices/dataPlane/Vision/CustomVision/Training/Generated
   clear-output-folder: true
 ```
 


### PR DESCRIPTION
Update the output-folder for csharp sdk to reflect the updated structure in the azure-sdk-for-net