### PR TITLE
Add a directive for node and TS to delete format: "date-time".

### DIFF
--- a/specification/marketplaceordering/resource-manager/readme.md
+++ b/specification/marketplaceordering/resource-manager/readme.md
@@ -130,6 +130,24 @@ directive:
     transform: delete $.format
 ```
 
+## Node.js
+
+``` yaml $(nodejs)
+directive:
+  - from: swagger-document
+    where: $.definitions.AgreementProperties.properties.retrieveDatetime
+    transform: delete $.format
+```
+
+## TypeScript
+
+``` yaml $(typescript)
+directive:
+  - from: swagger-document
+    where: $.definitions.AgreementProperties.properties.retrieveDatetime
+    transform: delete $.format
+```
+
 ## Go
 
 These settings apply only when `--go` is specified on the command line.


### PR DESCRIPTION
- JS only supports precision upto milliseconds, whereas the server sends Date in ISO8601 format with precision upto µseconds. Corresponding issue https://github.com/Azure/azure-sdk-for-node/issues/2423#issuecomment-369006118