### PR TITLE
Allow Ruby failure on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
     - env: MODE=azurebot PR_ONLY=true
     - env: MODE=liveValidation PR_ONLY=true
     - env: MODE=java
+    - env: MODE=ruby
     - env: MODE=go
     - env: MODE=node
 before_install:


### PR DESCRIPTION
Ruby has still the old configuration options into the SwaggerToSdk conf file here:
https://github.com/Azure/azure-sdk-for-ruby/blob/master/swagger_to_sdk_config.json

This is highly deprecated, and this is not how @sarangan12 generates the Ruby packages right now. This makes the CI testing of Ruby generation highly unstable, and misleading. Example:
https://github.com/Azure/azure-rest-api-specs/pull/2617

I recommend allowing failure of Ruby CI, until @sarangan12 has the time to catch-up the new Readme syntax and we can trust this build again.

FYI @mcardosos 