### PR TITLE
Suppress warning regarding long running operation

### DIFF
--- a/specification/applicationinsights/resource-manager/readme.md
+++ b/specification/applicationinsights/resource-manager/readme.md
@@ -34,6 +34,11 @@ tag: package-2015-05
 ## Suppression
 ``` yaml
 directive:
+  - suppress: LongRunningOperationsWithLongRunningExtension
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Insights/components/{resourceName}/purge"].post
+    reason: Original creation of the service did not comply with current ARM schema standards. The team is aware of it and any future updates should rectify the issue.
+    
   - suppress: TrackedResourceListByImmediateParent
     where:
       - $.definitions


### PR DESCRIPTION
We have a legacy service put into place long before current ARM standards. The warning being emitted can be suppressed until the team owning the service does updates in the future to bring the service into compliance.


### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
