### PR TITLE
Fix subscription paramter in SubscriptionClient

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2016-06-01/subscriptions.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2016-06-01/subscriptions.json
@@ -321,7 +321,7 @@
       "required": true,
       "type": "string",
       "description": "The ID of the target subscription.",
-      "x-ms-parameter-location": "client"
+      "x-ms-parameter-location": "method"
     },
     "ApiVersionParameter": {
       "name": "api-version",


### PR DESCRIPTION
Fix regression introduced by https://github.com/Azure/azure-rest-api-specs/pull/2670
SubscriptionId needs to be a global parameter, but a method one.