### PR TITLE
Made multiple ExpressRouteCrossConnection's properties read-only

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/expressRouteCrossConnection.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/expressRouteCrossConnection.json
@@ -756,6 +756,7 @@
           }
         },
         "serviceProviderNotes": {
+          "readOnly": true,
           "type": "string",
           "description": "Additional read only notes set by the connectivity provider."
         },
@@ -875,6 +876,7 @@
           "description": "The GatewayManager Etag."
         },
         "lastModifiedBy": {
+          "readOnly": true,
           "type": "string",
           "description": "Gets whether the provider or the customer last modified the peering."
         },


### PR DESCRIPTION
Noticed that a few properties that look like read-only properties aren't marked as such.

---

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
