### PR TITLE
update suse-leap's PIR image version (the old one is gone)

### DIFF
--- a/specification/compute/quickstart-templates/aliases.json
+++ b/specification/compute/quickstart-templates/aliases.json
@@ -32,7 +32,7 @@
           "openSUSE-Leap": {
             "publisher":"SUSE",
             "offer":"openSUSE-Leap",
-            "sku":"42.2",
+            "sku":"42.3",
             "version": "latest"
           },
           "RHEL":{


### PR DESCRIPTION
Not related with any swagger specs, but updating it as `42.2` is gone