### PR TITLE
update SUSE-leap distro version in the alias document

### DIFF
--- a/arm-compute/quickstart-templates/aliases.json
+++ b/arm-compute/quickstart-templates/aliases.json
@@ -32,7 +32,7 @@
           "openSUSE-Leap": {
             "publisher":"SUSE",
             "offer":"openSUSE-Leap",
-            "sku":"42.2",
+            "sku":"42.3",
             "version": "latest"
           },
           "RHEL":{


### PR DESCRIPTION
This should be the last update on this file.
I am updating CLI to use the right file under `specification` folder, and will remove this folder in the near future