### PR TITLE
Fix - DataMigration assigns a single discriminator value to multiple model types

### DIFF
--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/ConnectToSourceSqlServerTask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/ConnectToSourceSqlServerTask.json
@@ -38,16 +38,16 @@
       "type": "object",
       "description": "Output for the task that validates connection to SQL Server and also validates source server requirements",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "resultType": {
           "description": "Type of result - database level or task level",
           "type": "string"
         }
       },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ],
       "required": [ "resultType" ],
       "discriminator": "resultType"
     },

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/ConnectToTargetSqlDbTask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/ConnectToTargetSqlDbTask.json
@@ -34,6 +34,11 @@
       "type": "object",
       "description": "Output for the task that validates connection to SQL DB and target server requirements",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "databases": {
           "type": "string",
           "description": "Source databases as a map from database name to database id",
@@ -52,12 +57,7 @@
           "description": "Target server brand version",
           "readOnly": true
         }
-      },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ]
+      }
     }
   }
 }

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/GetUserTablesSqlTask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/GetUserTablesSqlTask.json
@@ -42,6 +42,11 @@
       "type": "object",
       "description": "Output of the task that collects user tables for the given list of databases",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "databasesToTables": {
           "type": "string",
           "description": "Mapping from database name to list of tables",
@@ -61,12 +66,7 @@
           },
           "readOnly": true
         }
-      },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ]
+      }
     },
     "DatabaseTable": {
       "type": "object",

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/MigrateSqlServerSqlDbTask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/MigrateSqlServerSqlDbTask.json
@@ -46,16 +46,16 @@
       "type": "object",
       "description": "Output for the task that migrates on-prem SQL Server databases to Azure SQL Database",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "resultType": {
           "description": "Result type",
           "type": "string"
         }
       },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ],
       "required": [ "resultType" ],
       "discriminator": "resultType"
     },

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/TasksCommon.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2017-11-15-preview/definitions/TasksCommon.json
@@ -17,17 +17,6 @@
   },
   "paths": {},
   "definitions": {
-    "TaskOutput": {
-      "type": "object",
-      "description": "Base class for all DMS task outputs",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Result identifier",
-          "readOnly": true
-        }
-      }
-    },
     "Database": {
       "type": "object",
       "description": "Information about a single database",

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/ConnectToSourceSqlServerTask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/ConnectToSourceSqlServerTask.json
@@ -38,16 +38,16 @@
       "type": "object",
       "description": "Output for the task that validates connection to SQL Server and also validates source server requirements",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "resultType": {
           "description": "Type of result - database level or task level",
           "type": "string"
         }
       },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ],
       "required": [ "resultType" ],
       "discriminator": "resultType"
     },

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/ConnectToTargetSqlDbTask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/ConnectToTargetSqlDbTask.json
@@ -34,6 +34,11 @@
       "type": "object",
       "description": "Output for the task that validates connection to SQL DB and target server requirements",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "databases": {
           "type": "string",
           "description": "Source databases as a map from database name to database id",
@@ -52,12 +57,7 @@
           "description": "Target server brand version",
           "readOnly": true
         }
-      },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ]
+      }
     }
   }
 }

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/ConnectToTargetSqlMITask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/ConnectToTargetSqlMITask.json
@@ -34,6 +34,11 @@
       "type": "object",
       "description": "Output for the task that validates connection to Azure SQL Database Managed Instance.",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "targetServerVersion": {
           "type": "string",
           "description": "Target server version",
@@ -52,12 +57,7 @@
           },
           "readOnly": true
         }
-      },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ]
+      }
     }
   }
 }

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/GetUserTablesSqlTask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/GetUserTablesSqlTask.json
@@ -42,6 +42,11 @@
       "type": "object",
       "description": "Output of the task that collects user tables for the given list of databases",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "databasesToTables": {
           "type": "string",
           "description": "Mapping from database name to list of tables",
@@ -61,12 +66,7 @@
           },
           "readOnly": true
         }
-      },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ]
+      }
     },
     "DatabaseTable": {
       "type": "object",

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/MigrateSqlServerSqlDbTask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/MigrateSqlServerSqlDbTask.json
@@ -46,16 +46,16 @@
       "type": "object",
       "description": "Output for the task that migrates on-prem SQL Server databases to Azure SQL Database",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "resultType": {
           "description": "Result type",
           "type": "string"
         }
       },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ],
       "required": [ "resultType" ],
       "discriminator": "resultType"
     },

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/MigrateSqlServerSqlMITask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/MigrateSqlServerSqlMITask.json
@@ -51,16 +51,16 @@
       "type": "object",
       "description": "Output for task that migrates SQL Server databases to Azure SQL Database Managed Instance.",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "resultType": {
           "description": "Result type",
           "type": "string"
         }
       },
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ],
       "required": [ "resultType" ],
       "discriminator": "resultType"
     },

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/TasksCommon.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/TasksCommon.json
@@ -17,17 +17,6 @@
   },
   "paths": {},
   "definitions": {
-    "TaskOutput": {
-      "type": "object",
-      "description": "Base class for all DMS task outputs",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Result identifier",
-          "readOnly": true
-        }
-      }
-    },
     "Database": {
       "type": "object",
       "description": "Information about a single database",

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/ValidateMigrationInputSqlServerSqlMITask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/preview/2018-03-15-preview/definitions/ValidateMigrationInputSqlServerSqlMITask.json
@@ -50,12 +50,12 @@
     "ValidateMigrationInputSqlServerSqlMITaskOutput": {
       "type": "object",
       "description": "Output for task that validates migration input for SQL to Azure SQL Managed Instance migrations",
-      "allOf": [
-        {
-          "$ref": "./TasksCommon.json#/definitions/TaskOutput"
-        }
-      ],
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Result identifier",
+          "readOnly": true
+        },
         "name": {
           "type": "string",
           "description": "Name of database",
@@ -85,7 +85,7 @@
           },
           "readOnly": true
         },
-        "backupStorageAccountErrors" : {
+        "backupStorageAccountErrors": {
           "description": "Errors associated with the storage account provided.",
           "type": "array",
           "items": {


### PR DESCRIPTION
This is to resolve - https://github.com/Azure/azure-rest-api-specs/issues/2728

> The model hierarchy looks like this right now:
```
> TaskOutput.MigrateSqlServerSqlDbTaskOutput.MigrateSqlServerSqlDbTaskOutputError: ErrorOutput
> TaskOutput.MigrateSqlServerSqlMITaskOutput.MigrateSqlServerSqlMITaskOutputError: ErrorOutput
```
> For a given discriminator name (such as TaskOutput.MigrateSqlServerSqlDbTaskOutput.MigrateSqlServerSqlDbTaskOutputError), all of the possible values (such as ErrorOutput) must be distinct.
> Please change the discriminator values to DbErrorOutput and MIErrorOutput, or whatever values you prefer, as long as they are distinct.
> 

Instead of changing the discriminator, removing the common base class so that the discriminator values do not apply for the same object.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
