### PR TITLE
Add in-body parameters for 'PUT' operation for sourceControlSyncJob

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
@@ -1295,6 +1295,28 @@
       },
       "description": "Definition of source control sync job properties."
     },
+    "SourceControlSyncJobCreateParameters": {
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SourceControlSyncJobCreateProperties",
+          "x-ms-client-flatten": true,
+          "description": "Sets the properties of the source control sync job."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "description": "The parameters supplied to the create source control sync job operation."
+    },
+    "SourceControlSyncJobCreateProperties": {
+      "properties": {
+        "commitId": {
+          "type": "string",
+          "description": "Sets the commit id of the source control sync job."
+        }
+      },
+      "description": "Definition of create source control sync job properties."
+    },
     "SourceControlSyncJobListResult": {
       "properties": {
         "value": {

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/createSourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/createSourceControlSyncJob.json
@@ -5,7 +5,12 @@
     "automationAccountName": "myAutomationAccount33",
     "sourceControlName": "MySourceControl",
     "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
-    "api-version": "2017-05-15-preview"
+    "api-version": "2017-05-15-preview",
+    "parameters": {
+      "properties": {
+        "commitId": "9de0980bfb45026a3d97a1b0522d98a9f604226e"
+      }
+    }
   },
   "responses": {
     "201": {
@@ -15,7 +20,7 @@
         "properties": {
           "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
           "creationTime": "2017-03-28T23:14:26.903+00:00",
-          "provisioningState": "Running",
+          "provisioningState": "Completed",
           "startTime": "2017-03-28T23:14:27.903+00:00",
           "endTime": "2017-03-28T23:14:28.903+00:00",
           "startedBy": "User1"

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
@@ -16,7 +16,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a1a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Running",
+              "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
               "startedBy": "User1"
@@ -27,7 +27,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a2a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Running",
+              "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
               "startedBy": "User1"
@@ -38,7 +38,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a3a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Running",
+              "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
               "startedBy": "User1"
@@ -49,7 +49,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a4a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Running",
+              "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
               "startedBy": "User1"
@@ -60,7 +60,7 @@
             "properties": {
               "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a5a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
-              "provisioningState": "Running",
+              "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
               "startedBy": "User1"

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/sourceControlSyncJob.json
@@ -71,6 +71,15 @@
             "description": "The source control sync job id."
           },
           {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./definitions.json#/definitions/SourceControlSyncJobCreateParameters"
+            },
+            "description": "The parameters supplied to the create source control sync job operation."
+          },
+          {
             "$ref": "./definitions.json#/parameters/SubscriptionIdParameter"
           },
           {


### PR DESCRIPTION
Adding the 'commitId' property to the in-body parameters for the PUT operation for sourceControlSyncJob.  Also updated the examples to show 'Completed' status for the syncJobs (makes more sense to show 'completed' with an endTime property).

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
