### PR TITLE
[Azure Search] Remove some service limits that aren't in the 2017-11-…

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11/examples/SearchServiceGetServiceStatistics.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11/examples/SearchServiceGetServiceStatistics.json
@@ -34,9 +34,7 @@
                     }
                 },
                 "limits": {
-                    "maxFieldsPerIndex": 1000,
-                    "maxFieldNestingDepthPerIndex": 10,
-                    "maxComplexCollectionFieldsPerIndex": 100
+                    "maxFieldsPerIndex": 1000
                 }
             }
         }

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11/searchservice.json
@@ -4065,18 +4065,6 @@
           "format": "int32",
           "x-nullable": true,
           "description": "The maximum allowed fields per index."
-        },
-        "maxFieldNestingDepthPerIndex": {
-          "type": "integer",
-          "format": "int32",
-          "x-nullable": true,
-          "description": "The maximum depth which you can nest sub-fields in an index, including the top-level complex field. For example, a/b/c has a nesting depth of 3."
-        },
-        "maxComplexCollectionFieldsPerIndex": {
-          "type": "integer",
-          "format": "int32",
-          "x-nullable": true,
-          "description": "The maximum number of fields of type Collection(Edm.ComplexType) allowed in an index."
         }
       },
       "description": "Represents various service level limits."


### PR DESCRIPTION
…11 API

This was an oversight when I copied the 2016-09-01-Preview spec to 2017-11-11. Some of the limits are for features that are still in preview, so I have to remove them from this version.

FYI @natinimni 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
