### PR TITLE
Adding support for HTTP2 to Web Apps

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/stable/2016-08-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2016-08-01/WebApps.json
@@ -16094,6 +16094,10 @@
               "description": "True if the web app has in app MySql enabled",
               "type": "boolean",
               "readOnly": true
+            },
+            "http20Enabled": {
+              "description": "Is HTTP2 enabled?",
+              "type": "boolean"
             }
           },
           "x-ms-client-flatten": true
@@ -17568,10 +17572,6 @@
             },
             "httpsOnly": {
               "description": "HttpsOnly: configures a web site to accept only https requests. Issues redirect for\nhttp requests",
-              "type": "boolean"
-            },
-            "http20Enabled": {
-              "description": "Is HTTP2 enabled?",
               "type": "boolean"
             }
           },

--- a/specification/web/resource-manager/Microsoft.Web/stable/2016-08-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2016-08-01/WebApps.json
@@ -17569,6 +17569,10 @@
             "httpsOnly": {
               "description": "HttpsOnly: configures a web site to accept only https requests. Issues redirect for\nhttp requests",
               "type": "boolean"
+            },
+            "http20Enabled": {
+              "description": "Is HTTP2 enabled?",
+              "type": "boolean"
             }
           },
           "x-ms-client-flatten": true

--- a/specification/web/resource-manager/readme.md
+++ b/specification/web/resource-manager/readme.md
@@ -294,6 +294,15 @@ batch:
   - tag: package-2015-08-preview
 ```
 
+### Tag: package-2018-02 and go
+
+These settings apply only when `--tag=package-2018-02 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2018-02' && $(go)
+output-folder: $(go-sdk-folder)/services/web/mgmt/2018-02-01/web
+```
+
 ### Tag: package-2016-09 and go
 
 These settings apply only when `--tag=package-2016-09 --go` is specified on the command line.

--- a/specification/web/resource-manager/readme.md
+++ b/specification/web/resource-manager/readme.md
@@ -289,6 +289,7 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
+  - tag: package-2018-02
   - tag: package-2016-09
   - tag: package-2015-08-preview
 ```


### PR DESCRIPTION
Based on the information in this article, I believe this is correct: https://blogs.msdn.microsoft.com/appserviceteam/2018/04/13/announcing-http2-support-in-azure-app-service/

@mcardosos @marstr @jhendrixMSFT I also added support for generating the missing `2018-02-01` Web SDK - although in my limited testing that appears to be broken due to Invalid Swagger, so I can revert this if needed:

```
* azurerm_app_service_plan.test: web.AppServicePlansClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="NoRegisteredProviderFound" Message="No registered resource provider found for location 'eastus' and API version '2018-02-01' for type 'serverFarms'. The supported api-versions are '2017-08-01, 2016-09-01, 2016-03-01, 2015-08-01, 2015-07-01, 2015-06-01, 2015-05-01, 2015-04-01, 2015-02-01, 2014-11-01, 2014-06-01, 2014-04-01, 2014-04-01-preview'. The supported locations are 'centralus, northeurope, westeurope, southeastasia, koreacentral, koreasouth, westus, eastus, japanwest, japaneast, eastasia, eastus2, northcentralus, southcentralus, brazilsouth, australiaeast, australiasoutheast, westindia, centralindia, southindia, canadacentral, canadaeast, westcentralus, ukwest, uksouth, westus2, msftwestus, msfteastus, msfteastasia, msftnortheurope, eastus2stage, eastasiastage, centralusstage, northcentralusstage, francecentral'."
```

---

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.