### PR TITLE
AzureBridgeAdmin readme.md missing preview folder

### DIFF
--- a/specification/azsadmin/resource-manager/azurebridge/readme.md
+++ b/specification/azsadmin/resource-manager/azurebridge/readme.md
@@ -1,11 +1,11 @@
 # AzureBridge Admin
-    
+
 > see https://aka.ms/autorest
 
 This is the AutoRest configuration file for AzureBridge Admin.
 
 ---
-## Getting Started 
+## Getting Started
 To build the SDK for AzureBridge Admin, simply [Install AutoRest](https://aka.ms/autorest/install) and in this folder, run:
 
 > `autorest`
@@ -17,7 +17,7 @@ To see additional help and options, run:
 
 ## Configuration
 
-### Basic Information 
+### Basic Information
 These are the global settings for the AzureBridge API.
 
 ``` yaml
@@ -33,16 +33,16 @@ These settings apply only when `--tag=package-2015-06-01-preview` is specified o
 
 ``` yaml $(tag) == 'package-2015-06-01-preview'
 input-file:
-    - Microsoft.AzureBridge.Admin/2016-01-01/AzureBridge.json
-    - Microsoft.AzureBridge.Admin/2016-01-01/DownloadedProduct.json
-    - Microsoft.AzureBridge.Admin/2016-01-01/Product.json
-    - Microsoft.AzureBridge.Admin/2016-01-01/Activation.json
+    - Microsoft.AzureBridge.Admin/preview/2016-01-01/AzureBridge.json
+    - Microsoft.AzureBridge.Admin/preview/2016-01-01/DownloadedProduct.json
+    - Microsoft.AzureBridge.Admin/preview/2016-01-01/Product.json
+    - Microsoft.AzureBridge.Admin/preview/2016-01-01/Activation.json
 ```
 
 ---
 # Code Generation
 
-## C# 
+## C#
 
 ``` yaml $(csharp)
 csharp:


### PR DESCRIPTION
The readme.md has the wrong file paths.  

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
