### PR TITLE
Change operationIds of SignalRService from Signalr to SignalR

### DIFF
--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
@@ -10,7 +10,9 @@
         "tier": "Basic",
         "capacity": 1
       },
-      "properties": {}
+      "properties": {
+        "hostNamePrefix": null
+      }
     },
     "api-version": "2018-03-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
@@ -31,7 +33,8 @@
           "externalIP": "10.0.0.1",
           "hostName": "myservice.service.signalr.net",
           "publicPort": 5001,
-          "serverPort": 5002
+          "serverPort": 5002,
+          "hostNamePrefix": null
         },
         "location": "eastus",
         "tags": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/Get.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/Get.json
@@ -19,7 +19,8 @@
           "externalIP": "10.0.0.1",
           "hostName": "myservice.service.signalr.net",
           "publicPort": 5001,
-          "serverPort": 5002
+          "serverPort": 5002,
+          "hostNamePrefix": null
         },
         "location": "eastus",
         "tags": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListByResourceGroup.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListByResourceGroup.json
@@ -20,7 +20,8 @@
               "externalIP": "10.0.0.1",
               "hostName": "myservice.service.signalr.net",
               "publicPort": 5001,
-              "serverPort": 5002
+              "serverPort": 5002,
+              "hostNamePrefix": null
             },
             "location": "eastus",
             "tags": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListBySubscription.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListBySubscription.json
@@ -19,7 +19,8 @@
               "externalIP": "10.0.0.1",
               "hostName": "myservice.service.signalr.net",
               "publicPort": 5001,
-              "serverPort": 5002
+              "serverPort": 5002,
+              "hostNamePrefix": null
             },
             "location": "eastus",
             "tags": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/Update.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/Update.json
@@ -9,7 +9,9 @@
         "tier": "Basic",
         "capacity": 1
       },
-      "properties": {}
+      "properties": {
+        "hostNamePrefix": null
+      }
     },
     "api-version": "2018-03-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
@@ -30,7 +32,8 @@
           "externalIP": "10.0.0.1",
           "hostName": "myservice.service.signalr.net",
           "publicPort": 5001,
-          "serverPort": 5002
+          "serverPort": 5002,
+          "hostNamePrefix": null
         },
         "location": "eastus",
         "tags": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
@@ -578,7 +578,6 @@
     "SignalRResource": {
       "description": "A class represent a SignalR service resource.",
       "type": "object",
-      "x-ms-client-name": "SignalRResourceList",
       "allOf": [
         {
           "$ref": "#/definitions/TrackedResource"
@@ -587,7 +586,6 @@
       "properties": {
         "sku": {
           "$ref": "#/definitions/ResourceSku",
-          "x-ms-client-name": "signalrsku",
           "description": "SKU of the service."
         },
         "properties": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
@@ -22,7 +22,7 @@
           "SignalR"
         ],
         "description": "Lists all of the available REST API operations of the Microsoft.SignalRService provider.",
-        "operationId": "Signalr_ListOperations",
+        "operationId": "SignalR_ListOperations",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -52,7 +52,7 @@
           "SignalR"
         ],
         "description": "Checks that the SignalR name is valid and is not already in use.",
-        "operationId": "Signalr_CheckNameAvailability",
+        "operationId": "SignalR_CheckNameAvailability",
         "parameters": [
           {
             "name": "parameters",
@@ -91,7 +91,7 @@
           "SignalR"
         ],
         "description": "Handles requests to list all resources in a subscription.",
-        "operationId": "Signalr_ListBySubscription",
+        "operationId": "SignalR_ListBySubscription",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -124,7 +124,7 @@
           "SignalR"
         ],
         "description": "Handles requests to list all resources in a resource group.",
-        "operationId": "Signalr_ListByResourceGroup",
+        "operationId": "SignalR_ListByResourceGroup",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -160,7 +160,7 @@
           "SignalR"
         ],
         "description": "Get the access keys of the SignalR resource.",
-        "operationId": "Signalr_ListKeys",
+        "operationId": "SignalR_ListKeys",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -196,7 +196,7 @@
           "SignalR"
         ],
         "description": "Regenerate SignalR service access key. PrimaryKey and SecondaryKey cannot be regenerated at the same time.",
-        "operationId": "Signalr_RegenerateKey",
+        "operationId": "SignalR_RegenerateKey",
         "parameters": [
           {
             "name": "parameters",
@@ -242,7 +242,7 @@
           "SignalR"
         ],
         "description": "Get the SignalR service and its properties.",
-        "operationId": "Signalr_Get",
+        "operationId": "SignalR_Get",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -276,7 +276,7 @@
           "SignalR"
         ],
         "description": "Create a new SignalR service and update an exiting SignalR service.",
-        "operationId": "Signalr_CreateOrUpdate",
+        "operationId": "SignalR_CreateOrUpdate",
         "parameters": [
           {
             "name": "parameters",
@@ -323,7 +323,7 @@
           "SignalR"
         ],
         "description": "Operation to delete a SignalR service.",
-        "operationId": "Signalr_Delete",
+        "operationId": "SignalR_Delete",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -358,7 +358,7 @@
           "SignalR"
         ],
         "description": "Operation to update an exiting SignalR service.",
-        "operationId": "Signalr_Update",
+        "operationId": "SignalR_Update",
         "parameters": [
           {
             "name": "parameters",
@@ -578,7 +578,7 @@
     "SignalRResource": {
       "description": "A class represent a SignalR service resource.",
       "type": "object",
-      "x-ms-client-name": "SignalrResourceList",
+      "x-ms-client-name": "SignalRResourceList",
       "allOf": [
         {
           "$ref": "#/definitions/TrackedResource"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
@@ -1,889 +1,891 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2018-03-01-preview",
-    "title": "SignalRManagementClient",
-    "description": "REST API for Azure SignalR Service"
+      "version": "2018-03-01-preview",
+      "title": "SignalrManagementClient",
+      "description": "REST API for Azure SignalR Service"
   },
   "host": "management.azure.com",
   "schemes": [
-    "https"
+      "https"
   ],
   "consumes": [
-    "application/json"
+      "application/json"
   ],
   "produces": [
-    "application/json"
+      "application/json"
   ],
   "paths": {
-    "/providers/Microsoft.SignalRService/operations": {
-      "get": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Lists all of the available REST API operations of the Microsoft.SignalRService provider.",
-        "operationId": "SignalR_ListOperations",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
+      "/providers/Microsoft.SignalRService/operations": {
+          "get": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Lists all of the available REST API operations of the Microsoft.SignalRService provider.",
+              "operationId": "Operations_List",
+              "parameters": [
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Success. The response describes the list of operations.",
+                      "schema": {
+                          "$ref": "#/definitions/OperationList"
+                      }
+                  }
+              },
+              "x-ms-pageable": {
+                  "nextLinkName": "nextLink"
+              },
+              "x-ms-examples": {
+                  "ListOperations": {
+                      "$ref": "./examples/ListOperations.json"
+                  }
+              }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success. The response describes the list of operations.",
-            "schema": {
-              "$ref": "#/definitions/OperationList"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        },
-        "x-ms-examples": {
-          "ListOperations": {
-            "$ref": "./examples/ListOperations.json"
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/checkNameAvailability": {
-      "post": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Checks that the SignalR name is valid and is not already in use.",
-        "operationId": "SignalR_CheckNameAvailability",
-        "parameters": [
-          {
-            "name": "parameters",
-            "in": "body",
-            "description": "Parameters supplied to the operation.",
-            "required": false,
-            "schema": {
-              "$ref": "#/definitions/NameAvailabilityParameters"
-            }
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success. The response describes the name availability.",
-            "schema": {
-              "$ref": "#/definitions/NameAvailability"
-            }
-          }
-        },
-        "x-ms-examples": {
-          "CheckNameAvailability": {
-            "$ref": "./examples/CheckNameAvailability.json"
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/SignalR": {
-      "get": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Handles requests to list all resources in a subscription.",
-        "operationId": "SignalR_ListBySubscription",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success. The response describes the list of SignalR services in the subscription.",
-            "schema": {
-              "$ref": "#/definitions/SignalRResourceList"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        },
-        "x-ms-examples": {
-          "ListBySubscription": {
-            "$ref": "./examples/ListBySubscription.json"
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR": {
-      "get": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Handles requests to list all resources in a resource group.",
-        "operationId": "SignalR_ListByResourceGroup",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success. The response describes the list of SignalR services in a resourceGroup.",
-            "schema": {
-              "$ref": "#/definitions/SignalRResourceList"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        },
-        "x-ms-examples": {
-          "ListByResourceGroup": {
-            "$ref": "./examples/ListByResourceGroup.json"
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}/listKeys": {
-      "post": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Get the access keys of the SignalR resource.",
-        "operationId": "SignalR_ListKeys",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/SignalRServiceName"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success. The response describes SignalR service access keys.",
-            "schema": {
-              "$ref": "#/definitions/SignalRKeys"
-            }
-          }
-        },
-        "x-ms-examples": {
-          "ListKeys": {
-            "$ref": "./examples/ListKeys.json"
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}/regenerateKey": {
-      "post": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Regenerate SignalR service access key. PrimaryKey and SecondaryKey cannot be regenerated at the same time.",
-        "operationId": "SignalR_RegenerateKey",
-        "parameters": [
-          {
-            "name": "parameters",
-            "in": "body",
-            "description": "Parameter that describes the Regenerate Key Operation.",
-            "required": false,
-            "schema": {
-              "$ref": "#/definitions/RegenerateKeyParameters"
-            }
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/SignalRServiceName"
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created and an async operation is excuting in background to make the new key to take effect. The response contains new keys and a Location header to query the async operation result.",
-            "schema": {
-              "$ref": "#/definitions/SignalRKeys"
-            }
-          }
-        },
-        "x-ms-long-running-operation": true,
-        "x-ms-examples": {
-          "RegenerateKey": {
-            "$ref": "./examples/RegenerateKey.json"
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}": {
-      "get": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Get the SignalR service and its properties.",
-        "operationId": "SignalR_Get",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/SignalRServiceName"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success. The response describe the corresponding SingalR service.",
-            "schema": {
-              "$ref": "#/definitions/SignalRResource"
-            }
-          }
-        },
-        "x-ms-examples": {
-          "Get": {
-            "$ref": "./examples/Get.json"
-          }
-        }
       },
-      "put": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Create a new SignalR service and update an exiting SignalR service.",
-        "operationId": "SignalR_CreateOrUpdate",
-        "parameters": [
-          {
-            "name": "parameters",
-            "in": "body",
-            "description": "Parameters for the create or update operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/definitions/SignalRCreateParameters"
-            }
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/SignalRServiceName"
+      "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/checkNameAvailability": {
+          "post": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Checks that the SignalR name is valid and is not already in use.",
+              "operationId": "Signalr_CheckNameAvailability",
+              "parameters": [
+                  {
+                      "name": "parameters",
+                      "in": "body",
+                      "description": "Parameters supplied to the operation.",
+                      "required": false,
+                      "schema": {
+                          "$ref": "#/definitions/NameAvailabilityParameters"
+                      }
+                  },
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SubscriptionIdParameter"
+                  }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Success. The response describes the name availability.",
+                      "schema": {
+                          "$ref": "#/definitions/NameAvailability"
+                      }
+                  }
+              },
+              "x-ms-examples": {
+                  "CheckNameAvailability": {
+                      "$ref": "./examples/CheckNameAvailability.json"
+                  }
+              }
           }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created. The response describes the new service and contains a Location header to query the operation result.",
-            "schema": {
-              "$ref": "#/definitions/SignalRResource"
-            }
-          },
-          "202": {
-            "description": "Accepted. The response indicates the exiting SingalR service is now updating  and contains a Location header to query the operation result.."
-          }
-        },
-        "x-ms-long-running-operation": true,
-        "x-ms-examples": {
-          "CreateOrUpdate": {
-            "$ref": "./examples/CreateOrUpdate.json"
-          }
-        }
       },
-      "delete": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Operation to delete a SignalR service.",
-        "operationId": "SignalR_Delete",
-        "parameters": [
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/SignalRServiceName"
+      "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/SignalR": {
+          "get": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Handles requests to list all resources in a subscription.",
+              "operationId": "Signalr_ListBySubscription",
+              "parameters": [
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SubscriptionIdParameter"
+                  }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Success. The response describes the list of SignalR services in the subscription.",
+                      "schema": {
+                          "$ref": "#/definitions/SignalrResourceList"
+                      }
+                  }
+              },
+              "x-ms-pageable": {
+                  "nextLinkName": "nextLink"
+              },
+              "x-ms-examples": {
+                  "ListBySubscription": {
+                      "$ref": "./examples/ListBySubscription.json"
+                  }
+              }
           }
-        ],
-        "responses": {
-          "202": {
-            "description": "Accepted. The response indicates the delete operation is performed in the background."
-          },
-          "204": {
-            "description": "Success. The response indicates the resource is already deleted."
-          }
-        },
-        "x-ms-long-running-operation": true,
-        "x-ms-examples": {
-          "Delete": {
-            "$ref": "./examples/Delete.json"
-          }
-        }
       },
-      "patch": {
-        "tags": [
-          "SignalR"
-        ],
-        "description": "Operation to update an exiting SignalR service.",
-        "operationId": "SignalR_Update",
-        "parameters": [
-          {
-            "name": "parameters",
-            "in": "body",
-            "description": "Parameters for the update operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/definitions/SignalRUpdateParameters"
-            }
-          },
-          {
-            "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/ResourceGroupParameter"
-          },
-          {
-            "$ref": "#/parameters/SignalRServiceName"
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR": {
+          "get": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Handles requests to list all resources in a resource group.",
+              "operationId": "Signalr_ListByResourceGroup",
+              "parameters": [
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SubscriptionIdParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/ResourceGroupParameter"
+                  }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Success. The response describes the list of SignalR services in a resourceGroup.",
+                      "schema": {
+                          "$ref": "#/definitions/SignalrResourceList"
+                      }
+                  }
+              },
+              "x-ms-pageable": {
+                  "nextLinkName": "nextLink"
+              },
+              "x-ms-examples": {
+                  "ListByResourceGroup": {
+                      "$ref": "./examples/ListByResourceGroup.json"
+                  }
+              }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success. The response describes a SingalR service which is not up-to-date.",
-            "schema": {
-              "$ref": "#/definitions/SignalRResource"
-            }
+      },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}/listKeys": {
+          "post": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Get the access keys of the SignalR resource.",
+              "operationId": "Signalr_ListKeys",
+              "parameters": [
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SubscriptionIdParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/ResourceGroupParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SignalrServiceName"
+                  }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Success. The response describes SignalR service access keys.",
+                      "schema": {
+                          "$ref": "#/definitions/SignalrKeys"
+                      }
+                  }
+              },
+              "x-ms-examples": {
+                  "ListKeys": {
+                      "$ref": "./examples/ListKeys.json"
+                  }
+              }
+          }
+      },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}/regenerateKey": {
+          "post": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Regenerate SignalR service access key. PrimaryKey and SecondaryKey cannot be regenerated at the same time.",
+              "operationId": "Signalr_RegenerateKey",
+              "parameters": [
+                  {
+                      "name": "parameters",
+                      "in": "body",
+                      "description": "Parameter that describes the Regenerate Key Operation.",
+                      "required": false,
+                      "schema": {
+                          "$ref": "#/definitions/RegenerateKeyParameters"
+                      }
+                  },
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SubscriptionIdParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/ResourceGroupParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SignalrServiceName"
+                  }
+              ],
+              "responses": {
+                  "201": {
+                      "description": "Created and an async operation is excuting in background to make the new key to take effect. The response contains new keys and a Location header to query the async operation result.",
+                      "schema": {
+                          "$ref": "#/definitions/SignalrKeys"
+                      }
+                  }
+              },
+              "x-ms-long-running-operation": true,
+              "x-ms-examples": {
+                  "RegenerateKey": {
+                      "$ref": "./examples/RegenerateKey.json"
+                  }
+              }
+          }
+      },
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}": {
+          "get": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Get the SignalR service and its properties.",
+              "operationId": "Signalr_Get",
+              "parameters": [
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SubscriptionIdParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/ResourceGroupParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SignalrServiceName"
+                  }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Success. The response describe the corresponding SingalR service.",
+                      "schema": {
+                          "$ref": "#/definitions/SignalrResource"
+                      }
+                  }
+              },
+              "x-ms-examples": {
+                  "Get": {
+                      "$ref": "./examples/Get.json"
+                  }
+              }
           },
-          "202": {
-            "description": "Accepted. The response indicates the exiting SingalR service is now updating  and contains a Location header to query the operation result.."
+          "put": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Create a new SignalR service and update an exiting SignalR service.",
+              "operationId": "Signalr_CreateOrUpdate",
+              "parameters": [
+                  {
+                      "name": "parameters",
+                      "in": "body",
+                      "description": "Parameters for the create or update operation",
+                      "required": false,
+                      "schema": {
+                          "$ref": "#/definitions/SignalrCreateParameters"
+                      }
+                  },
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SubscriptionIdParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/ResourceGroupParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SignalrServiceName"
+                  }
+              ],
+              "responses": {
+                  "201": {
+                      "description": "Created. The response describes the new service and contains a Location header to query the operation result.",
+                      "schema": {
+                          "$ref": "#/definitions/SignalrResource"
+                      }
+                  },
+                  "202": {
+                      "description": "Accepted. The response indicates the exiting SingalR service is now updating  and contains a Location header to query the operation result.."
+                  }
+              },
+              "x-ms-long-running-operation": true,
+              "x-ms-examples": {
+                  "CreateOrUpdate": {
+                      "$ref": "./examples/CreateOrUpdate.json"
+                  }
+              }
+          },
+          "delete": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Operation to delete a SignalR service.",
+              "operationId": "Signalr_Delete",
+              "parameters": [
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SubscriptionIdParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/ResourceGroupParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SignalrServiceName"
+                  }
+              ],
+              "responses": {
+                  "202": {
+                      "description": "Accepted. The response indicates the delete operation is performed in the background."
+                  },
+                  "204": {
+                      "description": "Success. The response indicates the resource is already deleted."
+                  }
+              },
+              "x-ms-long-running-operation": true,
+              "x-ms-examples": {
+                  "Delete": {
+                      "$ref": "./examples/Delete.json"
+                  }
+              }
+          },
+          "patch": {
+              "tags": [
+                  "Signalr"
+              ],
+              "description": "Operation to update an exiting SignalR service.",
+              "operationId": "Signalr_Update",
+              "parameters": [
+                  {
+                      "name": "parameters",
+                      "in": "body",
+                      "description": "Parameters for the update operation",
+                      "required": false,
+                      "schema": {
+                          "$ref": "#/definitions/SignalrUpdateParameters"
+                      }
+                  },
+                  {
+                      "$ref": "#/parameters/ApiVersionParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SubscriptionIdParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/ResourceGroupParameter"
+                  },
+                  {
+                      "$ref": "#/parameters/SignalrServiceName"
+                  }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Success. The response describes a SingalR service which is not up-to-date.",
+                      "schema": {
+                          "$ref": "#/definitions/SignalrResource"
+                      }
+                  },
+                  "202": {
+                      "description": "Accepted. The response indicates the exiting SingalR service is now updating  and contains a Location header to query the operation result.."
+                  }
+              },
+              "x-ms-long-running-operation": true,
+              "x-ms-examples": {
+                  "Update": {
+                      "$ref": "./examples/Update.json"
+                  }
+              }
           }
-        },
-        "x-ms-long-running-operation": true,
-        "x-ms-examples": {
-          "Update": {
-            "$ref": "./examples/Update.json"
-          }
-        }
       }
-    }
   },
   "definitions": {
-    "OperationList": {
-      "description": "Result of the request to list REST API operations. It contains a list of operations.",
-      "type": "object",
-      "properties": {
-        "value": {
-          "description": "List of operations supported by the resource provider.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Operation"
-          }
-        },
-        "nextLink": {
-          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
-          "type": "string"
-        }
-      }
-    },
-    "Operation": {
-      "description": "REST API operation supported by SignalR resource provider.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Name of the operation with format: {provider}/{resource}/{operation}",
-          "type": "string"
-        },
-        "display": {
-          "$ref": "#/definitions/OperationDisplay",
-          "description": "The object that describes the operation."
-        },
-        "origin": {
-          "description": "Optional. The intended executor of the operation; governs the display of the operation in the RBAC UX and the audit logs UX.",
-          "type": "string"
-        },
-        "properties": {
-          "$ref": "#/definitions/OperationProperties",
-          "description": "Extra properties for the operation.",
-          "x-ms-client-flatten": false
-        }
-      }
-    },
-    "OperationDisplay": {
-      "description": "The object that describes a operation.",
-      "type": "object",
-      "properties": {
-        "provider": {
-          "description": "Friendly name of the resource provider",
-          "type": "string"
-        },
-        "resource": {
-          "description": "Resource type on which the operation is performed.",
-          "type": "string"
-        },
-        "operation": {
-          "description": "The localized friendly name for the operation.",
-          "type": "string"
-        },
-        "description": {
-          "description": "The localized friendly description for the operation",
-          "type": "string"
-        }
-      }
-    },
-    "OperationProperties": {
-      "description": "Extra Operation properties.",
-      "type": "object",
-      "properties": {
-        "serviceSpecification": {
-          "$ref": "#/definitions/ServiceSpecification",
-          "description": "The service specifications."
-        }
-      }
-    },
-    "ServiceSpecification": {
-      "description": "An object that describes a specification.",
-      "type": "object",
-      "properties": {
-        "metricSpecifications": {
-          "description": "Specifications of the Metrics for Azure Monitoring.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MetricSpecification"
-          }
-        }
-      }
-    },
-    "MetricSpecification": {
-      "description": "Specifications of the Metrics for Azure Monitoring.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Name of the metric.",
-          "type": "string"
-        },
-        "displayName": {
-          "description": "Localized friendly display name of the metric.",
-          "type": "string"
-        },
-        "displayDescription": {
-          "description": "Localized friendly description of the metric.",
-          "type": "string"
-        },
-        "unit": {
-          "description": "The unit that makes sense for the metric.",
-          "type": "string"
-        },
-        "aggregationType": {
-          "description": "Only provide one value for this field. Valid values: Average, Minimum, Maximum, Total, Count.",
-          "type": "string"
-        },
-        "fillGapWithZero": {
-          "description": "Optional. If set to true, then zero will be returned for time duration where no metric is emitted/published. \r\nEx. a metric that returns the number of times a particular error code was emitted. The error code may not appear \r\noften, instead of the RP publishing 0, Shoebox can auto fill in 0s for time periods where nothing was emitted.",
-          "type": "string"
-        },
-        "category": {
-          "description": "The name of the metric category that the metric belongs to. A metric can only belong to a single category.",
-          "type": "string"
-        }
-      }
-    },
-    "NameAvailabilityParameters": {
-      "description": "Data POST-ed to the nameAvailability action",
-      "required": [
-        "type",
-        "name"
-      ],
-      "type": "object",
-      "properties": {
-        "type": {
-          "description": "The resource type. Should be always \"Microsoft.SignalRService/SignalR\".",
-          "type": "string"
-        },
-        "name": {
-          "description": "The SignalR service name to validate. e.g.\"my-signalR-name-here\"",
-          "type": "string"
-        }
-      }
-    },
-    "NameAvailability": {
-      "description": "Result of the request to check name availability. It contains a flag and possible reason of failure.",
-      "type": "object",
-      "properties": {
-        "nameAvailable": {
-          "description": "Indicates whether the name is available or not.",
-          "type": "boolean"
-        },
-        "reason": {
-          "description": "The reason of the availability. Required if name is not available.",
-          "type": "string"
-        },
-        "message": {
-          "description": "The message of the operation.",
-          "type": "string"
-        }
-      }
-    },
-    "SignalRResourceList": {
-      "description": "Object that includes an array of SignalR services and a possible link for next set.",
-      "type": "object",
-      "properties": {
-        "value": {
-          "description": "List of SignalR services",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SignalRResource"
-          }
-        },
-        "nextLink": {
-          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
-          "type": "string"
-        }
-      }
-    },
-    "SignalRResource": {
-      "description": "A class represent a SignalR service resource.",
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/TrackedResource"
-        }
-      ],
-      "properties": {
-        "sku": {
-          "$ref": "#/definitions/ResourceSku",
-          "description": "SKU of the service."
-        },
-        "properties": {
-          "$ref": "#/definitions/SignalRProperties",
-          "description": "The properties of the service.",
-          "x-ms-client-flatten": true
-        },
-        "id": {
-          "description": "Fully qualified resource Id for the resource.",
-          "type": "string",
-          "readOnly": true
-        },
-        "name": {
-          "description": "The name of the resouce.",
-          "type": "string",
-          "readOnly": true
-        },
-        "type": {
-          "description": "The type of the service - e.g. \"Microsoft.SignalRService/SignalR\"",
-          "type": "string",
-          "readOnly": true
-        }
-      }
-    },
-    "TrackedResource": {
-      "description": "The resource model definition for a ARM tracked top level resource.",
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Resource"
-        }
-      ],
-      "properties": {
-        "location": {
-          "description": "The GEO location of the SignalR service. e.g. West US | East US | North Central US | South Central US.",
-          "type": "string",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
-        },
-        "tags": {
-          "description": "Tags of the service which is a list of key value pairs that describe the resource.",
+      "OperationList": {
+          "description": "Result of the request to list REST API operations. It contains a list of operations.",
           "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-ms-mutability": [
-            "read",
-            "create",
-            "update"
-          ]
-        }
-      }
-    },
-    "Resource": {
-      "description": "The core properties of ARM resources.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Fully qualified resource Id for the resource.",
-          "type": "string",
-          "readOnly": true
-        },
-        "name": {
-          "description": "The name of the resouce.",
-          "type": "string",
-          "readOnly": true
-        },
-        "type": {
-          "description": "The type of the service - e.g. \"Microsoft.SignalRService/SignalR\"",
-          "type": "string",
-          "readOnly": true
-        }
+          "properties": {
+              "value": {
+                  "description": "List of operations supported by the resource provider.",
+                  "type": "array",
+                  "items": {
+                      "$ref": "#/definitions/Operation"
+                  }
+              },
+              "nextLink": {
+                  "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+                  "type": "string"
+              }
+          }
       },
-      "x-ms-azure-resource": true
-    },
-    "ResourceSku": {
-      "description": "The billing information of the resource.(e.g. basic vs. standard)",
-      "required": [
-        "name"
-      ],
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "The name of the SKU. This is typically a letter + number code, such as A0 or P3.  Required (if sku is specified)",
-          "type": "string"
-        },
-        "tier": {
-          "description": "The tier of this particular SKU. Optional.",
-          "enum": [
-            "Free",
-            "Basic",
-            "Premium"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "SignalRSkuTier",
-            "modelAsString": true
-          }
-        },
-        "size": {
-          "description": "Optional, string. When the name field is the combination of tier and some other value, this would be the standalone code.",
-          "type": "string"
-        },
-        "family": {
-          "description": "Optional, string. If the service has different generations of hardware, for the same SKU, then that can be captured here.",
-          "type": "string"
-        },
-        "capacity": {
-          "format": "int32",
-          "description": "Optional, integer. If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not \r\npossible for the resource this may be omitted.",
-          "type": "integer"
-        }
-      }
-    },
-    "SignalRProperties": {
-      "description": "A class that describes the properties of the SignalR service that should contain more read-only properties than AzSignalR.Models.SignalRCreateOrUpdateProperties",
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SignalRCreateOrUpdateProperties"
-        }
-      ],
-      "properties": {
-        "provisioningState": {
-          "description": "Provisioning state of the resource.",
-          "enum": [
-            "Succeeded",
-            "Failed",
-            "Canceled",
-            "Creating",
-            "Updating",
-            "Deleting",
-            "Moving"
-          ],
-          "type": "string",
-          "readOnly": true,
-          "x-ms-enum": {
-            "name": "ProvisioningState",
-            "modelAsString": true
-          }
-        },
-        "externalIP": {
-          "description": "The publicly accessible IP of the SignalR service.",
-          "type": "string",
-          "readOnly": true
-        },
-        "hostName": {
-          "description": "FQDN of the SignalR service instance. Format: xxx.service.signalr.net",
-          "type": "string",
-          "readOnly": true
-        },
-        "publicPort": {
-          "format": "int32",
-          "description": "The publicly accessibly port of the SignalR service which is designed for browser/client side usage.",
-          "type": "integer",
-          "readOnly": true
-        },
-        "serverPort": {
-          "format": "int32",
-          "description": "The publicly accessibly port of the SignalR service which is designed for customer server side usage.",
-          "type": "integer",
-          "readOnly": true
-        }
-      }
-    },
-    "SignalRCreateOrUpdateProperties": {
-      "description": "Settings used to provision or configure the resource.",
-      "type": "object",
-      "properties": {
-        "hostNamePrefix": {
-          "description": "Prefix for the hostName of the SignalR service. Retained for future use.\r\nThe hostname will be of format: &lt;hostNamePrefix&gt;.service.signalr.net.",
-          "type": "string"
-        }
-      }
-    },
-    "SignalRKeys": {
-      "description": "A class represents the access keys of SignalR service.",
-      "type": "object",
-      "properties": {
-        "primaryKey": {
-          "description": "The primary access key.",
-          "type": "string"
-        },
-        "secondaryKey": {
-          "description": "The secondary access key.",
-          "type": "string"
-        }
-      }
-    },
-    "RegenerateKeyParameters": {
-      "description": "Parameters describes the request to regenerate access keys",
-      "type": "object",
-      "properties": {
-        "keyType": {
-          "description": "The keyType to regenerate. Must be either 'primary' or 'secondary'(case-insensitive).",
-          "enum": [
-            "Primary",
-            "Secondary"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "KeyType",
-            "modelAsString": true
-          }
-        }
-      }
-    },
-    "SignalRCreateParameters": {
-      "description": "Parameters for SignalR service create/update operation.\r\n\r\nKeep the same schema as AzSignalR.Models.SignalRResource",
-      "required": [
-        "location"
-      ],
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SignalRUpdateParameters"
-        }
-      ],
-      "properties": {
-        "location": {
-          "description": "Azure GEO region: e.g. West US | East US | North Central US | South Central US | West Europe | North Europe | East Asia | Southeast Asia | etc. \r\nThe geo region of a resource never changes after it is created.",
-          "type": "string"
-        }
-      }
-    },
-    "SignalRUpdateParameters": {
-      "description": "Parameters for SignalR service update operation",
-      "type": "object",
-      "properties": {
-        "tags": {
-          "description": "A list of key value pairs that describe the resource.",
+      "Operation": {
+          "description": "REST API operation supported by SignalR resource provider.",
           "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "properties": {
+              "name": {
+                  "description": "Name of the operation with format: {provider}/{resource}/{operation}",
+                  "type": "string"
+              },
+              "display": {
+                  "$ref": "#/definitions/OperationDisplay",
+                  "description": "The object that describes the operation."
+              },
+              "origin": {
+                  "description": "Optional. The intended executor of the operation; governs the display of the operation in the RBAC UX and the audit logs UX.",
+                  "type": "string"
+              },
+              "properties": {
+                  "$ref": "#/definitions/OperationProperties",
+                  "description": "Extra properties for the operation.",
+                  "x-ms-client-flatten": false
+              }
           }
-        },
-        "sku": {
-          "$ref": "#/definitions/ResourceSku",
-          "description": "The billing information of the resource.(e.g. basic vs. standard)"
-        },
-        "properties": {
-          "$ref": "#/definitions/SignalRCreateOrUpdateProperties",
-          "description": "Settings used to provision or configure the resource",
-          "x-ms-client-flatten": false
-        }
+      },
+      "OperationDisplay": {
+          "description": "The object that describes a operation.",
+          "type": "object",
+          "properties": {
+              "provider": {
+                  "description": "Friendly name of the resource provider",
+                  "type": "string"
+              },
+              "resource": {
+                  "description": "Resource type on which the operation is performed.",
+                  "type": "string"
+              },
+              "operation": {
+                  "description": "The localized friendly name for the operation.",
+                  "type": "string"
+              },
+              "description": {
+                  "description": "The localized friendly description for the operation",
+                  "type": "string"
+              }
+          }
+      },
+      "OperationProperties": {
+          "description": "Extra Operation properties.",
+          "type": "object",
+          "properties": {
+              "serviceSpecification": {
+                  "$ref": "#/definitions/ServiceSpecification",
+                  "description": "The service specifications."
+              }
+          }
+      },
+      "ServiceSpecification": {
+          "description": "An object that describes a specification.",
+          "type": "object",
+          "properties": {
+              "metricSpecifications": {
+                  "description": "Specifications of the Metrics for Azure Monitoring.",
+                  "type": "array",
+                  "items": {
+                      "$ref": "#/definitions/MetricSpecification"
+                  }
+              }
+          }
+      },
+      "MetricSpecification": {
+          "description": "Specifications of the Metrics for Azure Monitoring.",
+          "type": "object",
+          "properties": {
+              "name": {
+                  "description": "Name of the metric.",
+                  "type": "string"
+              },
+              "displayName": {
+                  "description": "Localized friendly display name of the metric.",
+                  "type": "string"
+              },
+              "displayDescription": {
+                  "description": "Localized friendly description of the metric.",
+                  "type": "string"
+              },
+              "unit": {
+                  "description": "The unit that makes sense for the metric.",
+                  "type": "string"
+              },
+              "aggregationType": {
+                  "description": "Only provide one value for this field. Valid values: Average, Minimum, Maximum, Total, Count.",
+                  "type": "string"
+              },
+              "fillGapWithZero": {
+                  "description": "Optional. If set to true, then zero will be returned for time duration where no metric is emitted/published. \r\nEx. a metric that returns the number of times a particular error code was emitted. The error code may not appear \r\noften, instead of the RP publishing 0, Shoebox can auto fill in 0s for time periods where nothing was emitted.",
+                  "type": "string"
+              },
+              "category": {
+                  "description": "The name of the metric category that the metric belongs to. A metric can only belong to a single category.",
+                  "type": "string"
+              }
+          }
+      },
+      "NameAvailabilityParameters": {
+          "description": "Data POST-ed to the nameAvailability action",
+          "required": [
+              "type",
+              "name"
+          ],
+          "type": "object",
+          "properties": {
+              "type": {
+                  "description": "The resource type. Should be always \"Microsoft.SignalRService/SignalR\".",
+                  "type": "string"
+              },
+              "name": {
+                  "description": "The SignalR service name to validate. e.g.\"my-signalR-name-here\"",
+                  "type": "string"
+              }
+          }
+      },
+      "NameAvailability": {
+          "description": "Result of the request to check name availability. It contains a flag and possible reason of failure.",
+          "type": "object",
+          "properties": {
+              "nameAvailable": {
+                  "description": "Indicates whether the name is available or not.",
+                  "type": "boolean"
+              },
+              "reason": {
+                  "description": "The reason of the availability. Required if name is not available.",
+                  "type": "string"
+              },
+              "message": {
+                  "description": "The message of the operation.",
+                  "type": "string"
+              }
+          }
+      },
+      "SignalrResourceList": {
+          "description": "Object that includes an array of SignalR services and a possible link for next set.",
+          "type": "object",
+          "properties": {
+              "value": {
+                  "description": "List of SignalR services",
+                  "type": "array",
+                  "items": {
+                      "$ref": "#/definitions/SignalrResource"
+                  }
+              },
+              "nextLink": {
+                  "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+                  "type": "string"
+              }
+          }
+      },
+      "SignalrResource": {
+          "description": "A class represent a SignalR service resource.",
+          "type": "object",
+          "allOf": [
+              {
+                  "$ref": "#/definitions/TrackedResource"
+              }
+          ],
+          "properties": {
+              "sku": {
+                  "$ref": "#/definitions/ResourceSku",
+                  "description": "SKU of the service."
+              },
+              "properties": {
+                  "$ref": "#/definitions/SignalrProperties",
+                  "description": "The properties of the service.",
+                  "x-ms-client-flatten": true
+              },
+              "id": {
+                  "description": "Fully qualified resource Id for the resource.",
+                  "type": "string",
+                  "readOnly": true
+              },
+              "name": {
+                  "description": "The name of the resouce.",
+                  "type": "string",
+                  "readOnly": true
+              },
+              "type": {
+                  "description": "The type of the service - e.g. \"Microsoft.SignalRService/SignalR\"",
+                  "type": "string",
+                  "readOnly": true
+              }
+          }
+      },
+      "TrackedResource": {
+          "description": "The resource model definition for a ARM tracked top level resource.",
+          "type": "object",
+          "allOf": [
+              {
+                  "$ref": "#/definitions/Resource"
+              }
+          ],
+          "properties": {
+              "location": {
+                  "description": "The GEO location of the SignalR service. e.g. West US | East US | North Central US | South Central US.",
+                  "type": "string",
+                  "x-ms-mutability": [
+                      "read",
+                      "create"
+                  ]
+              },
+              "tags": {
+                  "description": "Tags of the service which is a list of key value pairs that describe the resource.",
+                  "type": "object",
+                  "additionalProperties": {
+                      "type": "string"
+                  },
+                  "x-ms-mutability": [
+                      "read",
+                      "create",
+                      "update"
+                  ]
+              }
+          }
+      },
+      "Resource": {
+          "description": "The core properties of ARM resources.",
+          "type": "object",
+          "properties": {
+              "id": {
+                  "description": "Fully qualified resource Id for the resource.",
+                  "type": "string",
+                  "readOnly": true
+              },
+              "name": {
+                  "description": "The name of the resouce.",
+                  "type": "string",
+                  "readOnly": true
+              },
+              "type": {
+                  "description": "The type of the service - e.g. \"Microsoft.SignalRService/SignalR\"",
+                  "type": "string",
+                  "readOnly": true
+              }
+          },
+          "x-ms-azure-resource": true
+      },
+      "ResourceSku": {
+          "description": "The billing information of the resource.(e.g. basic vs. standard)",
+          "required": [
+              "name"
+          ],
+          "type": "object",
+          "properties": {
+              "name": {
+                  "description": "The name of the SKU. This is typically a letter + number code, such as A0 or P3.  Required (if sku is specified)",
+                  "type": "string"
+              },
+              "tier": {
+                  "description": "The tier of this particular SKU. Optional.",
+                  "enum": [
+                      "Free",
+                      "Basic",
+                      "Premium"
+                  ],
+                  "type": "string",
+                  "x-ms-enum": {
+                      "name": "SignalrSkuTier",
+                      "modelAsString": true
+                  }
+              },
+              "size": {
+                  "description": "Optional, string. When the name field is the combination of tier and some other value, this would be the standalone code.",
+                  "type": "string"
+              },
+              "family": {
+                  "description": "Optional, string. If the service has different generations of hardware, for the same SKU, then that can be captured here.",
+                  "type": "string"
+              },
+              "capacity": {
+                  "format": "int32",
+                  "description": "Optional, integer. If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not \r\npossible for the resource this may be omitted.",
+                  "type": "integer"
+              }
+          }
+      },
+      "SignalrProperties": {
+          "description": "A class that describes the properties of the SignalR service that should contain more read-only properties than AzSignalR.Models.SignalRCreateOrUpdateProperties",
+          "type": "object",
+          "allOf": [
+              {
+                  "$ref": "#/definitions/SignalrCreateOrUpdateProperties"
+              }
+          ],
+          "properties": {
+              "provisioningState": {
+                  "description": "Provisioning state of the resource.",
+                  "enum": [
+                      "Unknown",
+                      "Succeeded",
+                      "Failed",
+                      "Canceled",
+                      "Running",
+                      "Creating",
+                      "Updating",
+                      "Deleting",
+                      "Moving"
+                  ],
+                  "type": "string",
+                  "readOnly": true,
+                  "x-ms-enum": {
+                      "name": "ProvisioningState",
+                      "modelAsString": true
+                  }
+              },
+              "externalIP": {
+                  "description": "The publicly accessible IP of the SignalR service.",
+                  "type": "string",
+                  "readOnly": true
+              },
+              "hostName": {
+                  "description": "FQDN of the SignalR service instance. Format: xxx.service.signalr.net",
+                  "type": "string",
+                  "readOnly": true
+              },
+              "publicPort": {
+                  "format": "int32",
+                  "description": "The publicly accessibly port of the SignalR service which is designed for browser/client side usage.",
+                  "type": "integer",
+                  "readOnly": true
+              },
+              "serverPort": {
+                  "format": "int32",
+                  "description": "The publicly accessibly port of the SignalR service which is designed for customer server side usage.",
+                  "type": "integer",
+                  "readOnly": true
+              }
+          }
+      },
+      "SignalrCreateOrUpdateProperties": {
+          "description": "Settings used to provision or configure the resource.",
+          "type": "object",
+          "properties": {
+              "hostNamePrefix": {
+                  "description": "Prefix for the hostName of the SignalR service. Retained for future use.\r\nThe hostname will be of format: &lt;hostNamePrefix&gt;.service.signalr.net.",
+                  "type": "string"
+              }
+          }
+      },
+      "SignalrKeys": {
+          "description": "A class represents the access keys of SignalR service.",
+          "type": "object",
+          "properties": {
+              "primaryKey": {
+                  "description": "The primary access key.",
+                  "type": "string"
+              },
+              "secondaryKey": {
+                  "description": "The secondary access key.",
+                  "type": "string"
+              }
+          }
+      },
+      "RegenerateKeyParameters": {
+          "description": "Parameters describes the request to regenerate access keys",
+          "type": "object",
+          "properties": {
+              "keyType": {
+                  "description": "The keyType to regenerate. Must be either 'primary' or 'secondary'(case-insensitive).",
+                  "enum": [
+                      "Primary",
+                      "Secondary"
+                  ],
+                  "type": "string",
+                  "x-ms-enum": {
+                      "name": "KeyType",
+                      "modelAsString": true
+                  }
+              }
+          }
+      },
+      "SignalrCreateParameters": {
+          "description": "Parameters for SignalR service create/update operation.\r\n\r\nKeep the same schema as AzSignalR.Models.SignalRResource",
+          "required": [
+              "location"
+          ],
+          "type": "object",
+          "allOf": [
+              {
+                  "$ref": "#/definitions/SignalrUpdateParameters"
+              }
+          ],
+          "properties": {
+              "location": {
+                  "description": "Azure GEO region: e.g. West US | East US | North Central US | South Central US | West Europe | North Europe | East Asia | Southeast Asia | etc. \r\nThe geo region of a resource never changes after it is created.",
+                  "type": "string"
+              }
+          }
+      },
+      "SignalrUpdateParameters": {
+          "description": "Parameters for SignalR service update operation",
+          "type": "object",
+          "properties": {
+              "tags": {
+                  "description": "A list of key value pairs that describe the resource.",
+                  "type": "object",
+                  "additionalProperties": {
+                      "type": "string"
+                  }
+              },
+              "sku": {
+                  "$ref": "#/definitions/ResourceSku",
+                  "description": "The billing information of the resource.(e.g. basic vs. standard)"
+              },
+              "properties": {
+                  "$ref": "#/definitions/SignalrCreateOrUpdateProperties",
+                  "description": "Settings used to provision or configure the resource",
+                  "x-ms-client-flatten": false
+              }
+          }
       }
-    }
   },
   "parameters": {
-    "ApiVersionParameter": {
-      "name": "api-version",
-      "in": "query",
-      "description": "Client Api Version.",
-      "required": true,
-      "type": "string"
-    },
-    "SubscriptionIdParameter": {
-      "name": "subscriptionId",
-      "in": "path",
-      "description": "Gets subscription Id which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
-      "required": true,
-      "type": "string"
-    },
-    "ResourceGroupParameter": {
-      "name": "resourceGroupName",
-      "in": "path",
-      "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
-      "required": true,
-      "type": "string",
-      "x-ms-parameter-location": "method"
-    },
-    "SignalRServiceName": {
-      "name": "resourceName",
-      "in": "path",
-      "description": "The name of the SignalR resource.",
-      "required": true,
-      "type": "string",
-      "x-ms-parameter-location": "method"
-    }
+      "ApiVersionParameter": {
+          "name": "api-version",
+          "in": "query",
+          "description": "Client Api Version.",
+          "required": true,
+          "type": "string"
+      },
+      "SubscriptionIdParameter": {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Gets subscription Id which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+          "required": true,
+          "type": "string"
+      },
+      "ResourceGroupParameter": {
+          "name": "resourceGroupName",
+          "in": "path",
+          "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
+          "required": true,
+          "type": "string",
+          "x-ms-parameter-location": "method"
+      },
+      "SignalrServiceName": {
+          "name": "resourceName",
+          "in": "path",
+          "description": "The name of the SignalR resource.",
+          "required": true,
+          "type": "string",
+          "x-ms-parameter-location": "method"
+      }
   },
   "securityDefinitions": {
-    "azure_auth": {
-      "flow": "implicit",
-      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
-      "scopes": {
-        "user_impersonation": "impersonate your user account"
-      },
-      "type": "oauth2",
-      "description": "Azure Active Directory OAuth2 Flow"
-    }
+      "azure_auth": {
+          "flow": "implicit",
+          "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+          "scopes": {
+              "user_impersonation": "impersonate your user account"
+          },
+          "type": "oauth2",
+          "description": "Azure Active Directory OAuth2 Flow"
+      }
   },
   "security": [
-    {
-      "azure_auth": [
-        "user_impersonation"
-      ]
-    }
+      {
+          "azure_auth": [
+              "user_impersonation"
+          ]
+      }
   ]
 }


### PR DESCRIPTION
We used `Signalr` because the python SDK class names will look better(`signalr_XXX` instead of `signal_rXXX`). But I confirmed with Python SDK team the names are transparent to customers hence that won’t be an issue.  In this PR, we are going roll back the original `SignalR`

Tested on local follow https://github.com/Azure/adx-documentation-pr/wiki/Azure-Swagger-Tools. All validations passed.