### PR TITLE
AzureStack Network Admin - Removed extraneous properties on Quota

### DIFF
--- a/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/LoadBalancers.json
+++ b/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/LoadBalancers.json
@@ -97,7 +97,10 @@
             },
             "allOf": [
                 {
-                    "$ref": "Network.json#/definitions/ResourceTenant"
+                    "$ref": "Network.json#/definitions/ProvisionedResource"
+                },
+                {
+                    "$ref": "Network.json#/definitions/TenantResource"
                 }
             ]
         },

--- a/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/Network.json
+++ b/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/Network.json
@@ -82,15 +82,21 @@
             },
             "x-ms-azure-resource": true
         },
-        "ResourceTenant": {
-            "description": "Base Resource Tenant Object",
+        "ProvisionedResource": {
+            "description": "Objects which have a provisioning state.",
             "type": "object",
             "properties": {
                 "provisioningState": {
                     "description": "The provisioning state.",
                     "type": "string",
                     "readOnly": true
-                },
+                }
+            }
+        },
+        "TenantResource": {
+            "description": "These resources are utilized by a single tenant.",
+            "type": "object",
+            "properties": {
                 "subscriptionId": {
                     "description": "The subscription ID.",
                     "type": "string",

--- a/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/PublicIpAddresses.json
+++ b/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/PublicIpAddresses.json
@@ -110,7 +110,10 @@
             },
             "allOf": [
                 {
-                    "$ref": "Network.json#/definitions/ResourceTenant"
+                    "$ref": "Network.json#/definitions/ProvisionedResource"
+                },
+                {
+                    "$ref": "Network.json#/definitions/TenantResource"
                 }
             ]
         },

--- a/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/Quotas.json
+++ b/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/Quotas.json
@@ -242,7 +242,7 @@
             },
             "allOf": [
                 {
-                    "$ref": "Network.json#/definitions/ResourceTenant"
+                    "$ref": "Network.json#/definitions/ProvisionedResource"
                 }
             ]
         },

--- a/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/VirtualNetworks.json
+++ b/specification/azsadmin/resource-manager/network/Microsoft.Network.Admin/preview/2015-06-15/VirtualNetworks.json
@@ -94,7 +94,10 @@
             },
             "allOf": [
                 {
-                    "$ref": "Network.json#/definitions/ResourceTenant"
+                    "$ref": "Network.json#/definitions/ProvisionedResource"
+                },
+                {
+                    "$ref": "Network.json#/definitions/TenantResource"
                 }
             ]
         },


### PR DESCRIPTION
There was a bug in which QuotaProperties was given two extra properties from a referenced definition.  I have split the referenced object into two new definitions, one which has a provisioning state (ProvisionedResource) and another which contains tenant related properties (TenantResource).  QuotaProperties now only correctly referenced ProvisionedResource.  I have also updated all resources to include the two new references.

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [X] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [X] My spec meets the review criteria:
  - [X] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [X] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
