### PR TITLE
Edit property names for SourceControlSyncJob

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/definitions.json
@@ -1313,7 +1313,7 @@
     },
     "SourceControlSyncJobProperties": {
       "properties": {
-        "sourceControlSyncJobId": {
+        "syncJobId": {
           "type": "string",
           "description": "Gets the source control sync job id."
         },
@@ -1351,9 +1351,17 @@
           "readOnly": true,
           "description": "Gets the end time of the job."
         },
-        "startedBy": {
+        "startType": {
           "type": "string",
-          "description": "Gets the user who started the sync job."
+          "description": "Gets the type of start for the sync job.",
+          "enum": [
+            "AutoSync",
+            "ManualSync"
+          ],
+          "x-ms-enum": {
+            "name": "startType",
+            "modelAsString": true
+          }
         }
       },
       "description": "Definition of source control sync job properties."
@@ -1412,7 +1420,7 @@
     },
     "SourceControlSyncJobByIdProperties": {
       "properties": {
-        "sourceControlSyncJobId": {
+        "syncJobId": {
           "type": "string",
           "description": "Gets the source control sync job id."
         },
@@ -1450,30 +1458,24 @@
           "readOnly": true,
           "description": "Gets the end time of the job."
         },
-        "startedBy": {
+        "startType": {
           "type": "string",
-          "description": "Gets the user who started the sync job."
+          "description": "Gets the type of start for the sync job.",
+          "enum": [
+            "AutoSync",
+            "ManualSync"
+          ],
+          "x-ms-enum": {
+            "name": "startType",
+            "modelAsString": true
+          }
         },
-        "errors": {
-          "description": "Error details of the source control sync job.",
-          "$ref": "#/definitions/SourceControlSyncJobByIdErrors"
+        "exception": {
+          "type": "string",
+          "description": "Gets the exceptions that occured while running the sync job."
         }
       },
       "description": "Definition of source control sync job properties."
-    },
-    "SourceControlSyncJobByIdErrors": {
-      "type": "object",
-      "properties": {
-        "code": {
-          "type": "string",
-          "description": "Gets the error code for the job."
-        },
-        "message": {
-          "type": "string",
-          "description": "Gets the error message for the job."
-        }
-      },
-      "description": "Error details of the source control sync job."
     },
     "ErrorResponse": {
       "type": "object",

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/createSourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/createSourceControlSyncJob.json
@@ -18,12 +18,12 @@
       "body": {
         "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
         "properties": {
-          "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
+          "syncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
           "creationTime": "2017-03-28T23:14:26.903+00:00",
           "provisioningState": "Completed",
           "startTime": "2017-03-28T23:14:27.903+00:00",
           "endTime": "2017-03-28T23:14:28.903+00:00",
-          "startedBy": "User1"
+          "startType": "AutoSync"
         }
       }
     }

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getAllSourceControlSyncJobs.json
@@ -14,56 +14,56 @@
           {
             "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a1a",
             "properties": {
-              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a1a",
+              "syncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a1a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
               "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
-              "startedBy": "User1"
+              "startType": "AutoSync"
             }
           },
           {
             "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a2a",
             "properties": {
-              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a2a",
+              "syncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a2a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
               "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
-              "startedBy": "User1"
+              "startType": "AutoSync"
             }
           },
           {
             "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a3a",
             "properties": {
-              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a3a",
+              "syncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a3a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
               "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
-              "startedBy": "User1"
+              "startType": "AutoSync"
             }
           },
           {
             "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a4a",
             "properties": {
-              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a4a",
+              "syncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a4a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
               "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
-              "startedBy": "User1"
+              "startType": "AutoSync"
             }
           },
           {
             "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a5a",
             "properties": {
-              "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a5a",
+              "syncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a5a",
               "creationTime": "2017-03-28T23:14:26.903+00:00",
               "provisioningState": "Completed",
               "startTime": "2017-03-28T23:14:27.903+00:00",
               "endTime": "2017-03-28T23:14:28.903+00:00",
-              "startedBy": "User1"
+              "startType": "AutoSync"
             }
           }
         ]

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getSourceControlSyncJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJob/getSourceControlSyncJob.json
@@ -13,16 +13,13 @@
       "body": {
         "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/sourceControls/MySourceControl/sourceControlSyncJobs/ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
         "properties": {
-          "sourceControlSyncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
+          "syncJobId": "ce6fe3e3-9db3-4096-a6b4-82bfb4c10a9a",
           "creationTime": "2017-03-28T23:14:26.903+00:00",
           "provisioningState": "Completed",
           "startTime": "2017-03-28T23:14:27.903+00:00",
           "endTime": "2017-03-28T23:14:28.903+00:00",
-          "startedBy": "User1",
-          "errors": {
-            "code": "0",
-            "message": ""
-          }
+          "startType": "AutoSync",
+          "exception": ""
         }
       }
     }


### PR DESCRIPTION
Changing the "sourceControlSyncJobId" property to "syncJobId", and the "startedBy" property to "startType".  Replacing the "errors" property with "exception" in the SourceControlSyncJobByIdProperties.  Updating examples to reflect changes as well.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
