### PR TITLE
[AKS] remove unsupported VM types

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-07-01/containerService.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-07-01/containerService.json
@@ -319,7 +319,6 @@
       },
       "description": "Size of agent VMs.",
       "enum": [
-        "Standard_A0",
         "Standard_A1",
         "Standard_A10",
         "Standard_A11",
@@ -338,8 +337,6 @@
         "Standard_A8_v2",
         "Standard_A8m_v2",
         "Standard_A9",
-        "Standard_B1ms",
-        "Standard_B1s",
         "Standard_B2ms",
         "Standard_B2s",
         "Standard_B4ms",

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-08-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-08-31/managedClusters.json
@@ -426,7 +426,6 @@
       },
       "description": "Size of agent VMs.",
       "enum": [
-        "Standard_A0",
         "Standard_A1",
         "Standard_A10",
         "Standard_A11",
@@ -445,8 +444,6 @@
         "Standard_A8_v2",
         "Standard_A8m_v2",
         "Standard_A9",
-        "Standard_B1ms",
-        "Standard_B1s",
         "Standard_B2ms",
         "Standard_B2s",
         "Standard_B4ms",


### PR DESCRIPTION
Some SKUs don't have enough RAM to support Kubernetes workloads reliably, so we're removing support for those types. This change won't accomplish that validation, but will prevent SDK users from
being led astray and trying to provision those types.

cc: @weinong


### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes.
- [X] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [X] My spec meets the review criteria:
  - [X] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [X] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
