### PR TITLE
[Azure Search] Fixed incorrectly-cased path in Readme.md

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md
@@ -33,7 +33,7 @@ These settings apply only when `--tag=package-2017-11-preview` is specified on t
 
 ``` yaml $(tag) == 'package-2017-11-preview'
 input-file:
-- preview/2017-11-11-Preview/searchindex.json
+- preview/2017-11-11-preview/searchindex.json
 ```
 ### Tag: package-2017-11
 


### PR DESCRIPTION
I ran the AutoRest validator on Windows, where the file system is case-insensitive, but when running AutoRest to generate code it fails because GitHub is case-sensitive. Blarg.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
