### PR TITLE
[AzureStack] Fixed readme to include update.json

### DIFF
--- a/specification/azsadmin/resource-manager/update/readme.md
+++ b/specification/azsadmin/resource-manager/update/readme.md
@@ -33,6 +33,7 @@ These settings apply only when `--tag=package-2016-05-01` is specified on the co
 
 ``` yaml $(tag) == 'package-2016-05-01'
 input-file:
+    - "Microsoft.Update.Admin/preview/2016-05-01/Update.json"
     - "Microsoft.Update.Admin/preview/2016-05-01/Updates.json"
     - "Microsoft.Update.Admin/preview/2016-05-01/UpdateLocations.json"
     - "Microsoft.Update.Admin/preview/2016-05-01/UpdateRuns.json"


### PR DESCRIPTION
I forgot to include a file in my readme.md.  This file included the operations endpoint.  All other files correctly referenced this file for the definitions contained within.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
