### PR TITLE
Adding Vulnerability Assessment APIs on managed instance

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-03-01-preview/databaseVulnerabilityAssessments.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-03-01-preview/databaseVulnerabilityAssessments.json
@@ -143,11 +143,11 @@
           }
         },
         "x-ms-examples": {
-          "Create a database's vulnerability assessment with minimal parameters": {
-            "$ref": "./examples/DatabaseVulnerabilityAssessmentCreateMin.json"
-          },
           "Create a database's vulnerability assessment with all parameters": {
             "$ref": "./examples/DatabaseVulnerabilityAssessmentCreateMax.json"
+          },
+          "Create a database's vulnerability assessment with minimal parameters": {
+            "$ref": "./examples/DatabaseVulnerabilityAssessmentCreateMin.json"
           }
         }
       },
@@ -211,6 +211,10 @@
   "definitions": {
     "DatabaseVulnerabilityAssessmentProperties": {
       "description": "Properties of a database Vulnerability Assessment.",
+      "required": [
+        "storageContainerPath",
+        "storageContainerSasKey"
+      ],
       "type": "object",
       "properties": {
         "storageContainerPath": {

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/databaseVulnerabilityAssessmentScans.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/databaseVulnerabilityAssessmentScans.json
@@ -522,7 +522,7 @@
       }
     },
     "DatabaseVulnerabilityAssessmentScanExportProperties": {
-      "description": "Properties of the export operation’s result.",
+      "description": "Properties of the export operation's result.",
       "type": "object",
       "properties": {
         "exportedReportLocation": {

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/databaseVulnerabilityAssessmentScans.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/databaseVulnerabilityAssessmentScans.json
@@ -85,7 +85,7 @@
           "DatabaseVulnerabilityAssessmentScans"
         ],
         "description": "Executes a Vulnerability Assessment database scan.",
-        "operationId": "DatabaseVulnerabilityAssessmentScans_Execute",
+        "operationId": "DatabaseVulnerabilityAssessmentScans_InitiateScan",
         "parameters": [
           {
             "$ref": "#/parameters/ResourceGroupParameter"

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/DatabaseVulnerabilityAssessmentScanExport.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/DatabaseVulnerabilityAssessmentScanExport.json
@@ -1,34 +1,34 @@
 {
-    "parameters": {
-        "subscriptionId": "00000000-1111-2222-3333-444444444444",
-        "resourceGroupName": "vulnerabilityassessmenttest-4799",
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityassessmenttest-4799",
         "serverName": "vulnerabilityassessmenttest-6440",
-        "databaseName": "testdb",
-        "vulnerabilityAssessmentName": "default",
-        "vaScanId": "scan001",
-        "api-version": "2017-10-01-preview",
-        "parameters": { }
-    },
-    "responses": {
-        "200": {
-            "body": {
-                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/servers/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001/export",
-                "name": "scan001",
-                "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans/export",
-                "properties": {
-                    "exportedReportLocation": "https://myaccount.blob.core.windows.net/vulnerabilityAssessment/vulnerabilityassessmenttest-6440/testdb/scan001.xlsx"
-                }
-            }
-        },
-        "201": {
-            "body": {
-                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/servers/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001/export",
-                "name": "scan001",
-                "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans/export",
-                "properties": {
-                    "exportedReportLocation": "https://myaccount.blob.core.windows.net/vulnerabilityAssessment/vulnerabilityassessmenttest-6440/testdb/scan001.xlsx"
-                }
-            }
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "scanId": "scan001",
+    "api-version": "2017-10-01-preview",
+    "parameters": {}
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/servers/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001/export",
+        "name": "scan001",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans/export",
+        "properties": {
+          "exportedReportLocation": "https://myaccount.blob.core.windows.net/vulnerabilityAssessment/vulnerabilityassessmenttest-6440/testdb/scan001.xlsx"
         }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/servers/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001/export",
+        "name": "scan001",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans/export",
+        "properties": {
+          "exportedReportLocation": "https://myaccount.blob.core.windows.net/vulnerabilityAssessment/vulnerabilityassessmenttest-6440/testdb/scan001.xlsx"
+        }
+      }
     }
+  }
 }

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/DatabaseVulnerabilityAssessmentScanRecordsGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/DatabaseVulnerabilityAssessmentScanRecordsGet.json
@@ -1,30 +1,30 @@
 {
-    "parameters": {
-        "subscriptionId": "00000000-1111-2222-3333-444444444444",
-        "resourceGroupName": "vulnerabilityassessmenttest-4711",
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityassessmenttest-4711",
         "serverName": "vulnerabilityassessmenttest-6411",
-        "databaseName": "testdb",
-        "vulnerabilityAssessmentName": "default",
-        "scanId": "scan001",
-        "api-version": "2017-10-01-preview"
-    },
-    "responses": {
-        "200": {
-            "body": {
-                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/servers/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001",
-                "name": "scan001",
-                "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
-                "properties": {
-                    "id": "scan001",
-                    "triggerType": "OnDemand",
-                    "state": "Passed",
-                    "startTime": "2017-12-12T17:45:06Z",
-                    "endTime": "2017-12-12T17:47:06Z",
-                    "errors": [ ],
-                    "storageContainerPath": "https://myaccount.blob.core.windows.net/vulnerability-assessment",
-                    "numberOfFailedSecurityChecks": 9
-                }
-            }
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "scanId": "scan001",
+    "api-version": "2017-10-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/servers/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001",
+        "name": "scan001",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
+        "properties": {
+          "scanId": "scan001",
+          "triggerType": "OnDemand",
+          "state": "Passed",
+          "startTime": "2017-12-12T17:45:06Z",
+          "endTime": "2017-12-12T17:47:06Z",
+          "errors": [],
+          "storageContainerPath": "https://myaccount.blob.core.windows.net/vulnerability-assessment",
+          "numberOfFailedSecurityChecks": 9
         }
+      }
     }
+  }
 }

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/DatabaseVulnerabilityAssessmentScanRecordsListByDatabase.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/DatabaseVulnerabilityAssessmentScanRecordsListByDatabase.json
@@ -16,7 +16,7 @@
                         "name": "scan001",
                         "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
                         "properties": {
-                            "id": "scan001",
+                            "scanId": "scan001",
                             "triggerType": "OnDemand",
                             "state": "Passed",
                             "startTime": "2017-12-12T17:45:06Z",
@@ -31,7 +31,7 @@
                         "name": "scan002",
                         "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
                         "properties": {
-                            "id": "scan002",
+                            "scanId": "scan002",
                             "triggerType": "Recurring",
                             "state": "Failed",
                             "startTime": "2017-12-12T17:45:06Z",
@@ -46,13 +46,16 @@
                         "name": "scan003",
                         "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
                         "properties": {
-                            "id": "scan003",
+                            "scanId": "scan003",
                             "triggerType": "Recurring",
                             "state": "FailedToRun",
                             "startTime": "2017-12-12T17:45:06Z",
                             "endTime": "2017-12-12T17:47:06Z",
                             "errors": [
-                                { "code": "StorageNotFound", "message": "Storage not found" }
+                                {
+                                    "code": "StorageNotFound",
+                                    "message": "Storage not found"
+                                }
                             ],
                             "storageContainerPath": "https://myaccount.blob.core.windows.net/vulnerability-assessment",
                             "numberOfFailedSecurityChecks": 0

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/DatabaseVulnerabilityAssessmentScansExecute.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/DatabaseVulnerabilityAssessmentScansExecute.json
@@ -1,31 +1,15 @@
 {
-    "parameters": {
-        "subscriptionId": "00000000-1111-2222-3333-444444444444",
-        "resourceGroupName": "vulnerabilityassessmenttest-4711",
-        "serverName": "vulnerabilityassessmenttest-6411",
-        "databaseName": "testdb",
-        "vulnerabilityAssessmentName": "default",
-        "scanId": "scan01",
-        "api-version": "2017-10-01-preview"
-    },
-    "responses": {
-        "200": {
-            "body": {
-                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/servers/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001",
-                "name": "scan001",
-                "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
-                "properties": {
-                    "id": "scan001",
-                    "triggerType": "OnDemand",
-                    "state": "Passed",
-                    "startTime": "2017-12-12T17:45:06Z",
-                    "endTime": "2017-12-12T17:47:06Z",
-                    "errors": [ ],
-                    "storageContainerPath": "https://myaccount.blob.core.windows.net/vulnerability-assessment",
-                    "numberOfFailedSecurityChecks": 9
-                }
-            }
-        },
-        "202": {}
-    }
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityassessmenttest-4711",
+    "managedInstanceName": "vulnerabilityassessmenttest-6411",
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "scanId": "scan01",
+    "api-version": "2017-10-01-preview"
+  },
+  "responses": {
+    "200": {},
+    "202": {}
+  }
 }

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentCreateMax.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentCreateMax.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityaseessmenttest-4799",
+    "managedInstanceName": "vulnerabilityaseessmenttest-6440",
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "api-version": "2017-10-01-preview",
+    "parameters": {
+      "properties": {
+        "storageContainerPath": "https://myStorage.blob.core.windows.net/vulnerability-assessment/",
+        "storageContainerSasKey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "recurringScans": {
+          "isEnabled": true,
+          "emailSubscriptionAdmins": true,
+          "emails": [ "email1@mail.com", "email2@mail.com" ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityaseessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityaseessmenttest-6440/databases/testdb/vulnerabilityAssessments/default",
+        "name": "default",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments",
+        "properties": {
+          "storageContainerPath": "https://myStorage.blob.core.windows.net/vulnerability-assessment/",
+          "recurringScans": {
+            "isEnabled": true,
+            "emailSubscriptionAdmins": true,
+            "emails": [ "email1@mail.com", "email2@mail.com" ]
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityaseessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityaseessmenttest-6440/databases/testdb/vulnerabilityAssessments/default",
+        "name": "default",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments",
+        "properties": {
+          "storageContainerPath": "https://myStorage.blob.core.windows.net/vulnerability-assessment/",
+          "recurringScans": {
+            "isEnabled": true,
+            "emailSubscriptionAdmins": true,
+            "emails": [ "email1@mail.com", "email2@mail.com" ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentCreateMin.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentCreateMin.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityaseessmenttest-4799",
+    "managedInstanceName": "vulnerabilityaseessmenttest-6440",
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "api-version": "2017-10-01-preview",
+    "parameters": {
+      "properties": {
+        "storageContainerPath": "https://myStorage.blob.core.windows.net/vulnerability-assessment/",
+        "storageContainerSasKey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityaseessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityaseessmenttest-6440/databases/testdb/vulnerabilityAssessments/default",
+        "name": "default",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments",
+        "properties": {
+          "storageContainerPath": "https://myStorage.blob.core.windows.net/vulnerability-assessment/",
+          "recurringScans": {
+            "isEnabled": false,
+            "emailSubscriptionAdmins": false,
+            "emails": []
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityaseessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityaseessmenttest-6440/databases/testdb/vulnerabilityAssessments/default",
+        "name": "default",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments",
+        "properties": {
+          "storageContainerPath": "https://myStorage.blob.core.windows.net/vulnerability-assessment/",
+          "recurringScans": {
+            "isEnabled": false,
+            "emailSubscriptionAdmins": false,
+            "emails": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentDelete.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentDelete.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityaseessmenttest-4799",
+    "managedInstanceName": "vulnerabilityaseessmenttest-6440",
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "api-version": "2017-10-01-preview"
+  },
+  "responses": {
+    "200": {
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentGet.json
@@ -1,0 +1,27 @@
+{
+    "parameters": {
+        "subscriptionId": "00000000-1111-2222-3333-444444444444",
+        "resourceGroupName": "vulnerabilityaseessmenttest-4799",
+        "managedInstanceName": "vulnerabilityaseessmenttest-6440",
+        "databaseName": "testdb",
+        "vulnerabilityAssessmentName": "default",
+        "api-version": "2017-10-01-preview"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityaseessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityaseessmenttest-6440/databases/testdb/vulnerabilityAssessments/default",
+                "name": "default",
+                "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments",
+                "properties": {
+                    "storageContainerPath": "https://myStorage.blob.core.windows.net/vulnerability-assessment/",
+                    "recurringScans": {
+                        "isEnabled": true,
+                        "emailSubscriptionAdmins": true,
+                        "emails": [ "email1@mail.com", "email2@mail.com" ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentRuleBaselineCreate.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentRuleBaselineCreate.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityaseessmenttest-4799",
+    "managedInstanceName": "vulnerabilityaseessmenttest-6440",
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "ruleId": "VA1001",
+    "baselineName": "default",
+    "api-version": "2017-10-01-preview",
+    "parameters": {
+      "properties": {
+        "baselineResults": [
+          {
+            "result": [ "userA", "SELECT" ]
+          },
+          {
+            "result": [ "userB", "SELECT" ]
+          },
+          {
+            "result": [ "userC", "SELECT", "tableId_4" ]
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityaseessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityaseessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/rules/VA1001/baselines/default",
+        "name": "default",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/rules/baselines",
+        "properties": {
+          "baselineResults": [
+            {
+              "result": [ "userA", "SELECT" ]
+            },
+            {
+              "result": [ "userB", "SELECT" ]
+            },
+            {
+              "result": [ "userC", "SELECT", "tableId_4" ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentRuleBaselineDelete.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentRuleBaselineDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityaseessmenttest-4799",
+    "managedInstanceName": "vulnerabilityaseessmenttest-6440",
+    "databaseName": "testdb",
+    "baselineName": "default",
+    "ruleId": "VA1001",
+    "vulnerabilityAssessmentName": "default",
+    "api-version": "2017-10-01-preview"
+  },
+  "responses": {
+    "200": {
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentRuleBaselineGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentRuleBaselineGet.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityaseessmenttest-4711",
+    "managedInstanceName": "vulnerabilityaseessmenttest-6411",
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "ruleId": "VA1001",
+    "baselineName": "default",
+    "api-version": "2017-10-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityaseessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityaseessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/rules/VA1001/baselines/default",
+        "name": "default",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/rules/baselines",
+        "properties": {
+          "baselineResults": [
+            {
+              "result": [ "userA", "SELECT" ]
+            },
+            {
+              "result": [ "userB", "SELECT" ]
+            },
+            {
+              "result": [ "userC", "SELECT", "tableId_4" ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentScanExport.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentScanExport.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityassessmenttest-4799",
+    "managedInstanceName": "vulnerabilityassessmenttest-6440",
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "scanId": "scan001",
+    "api-version": "2017-10-01-preview",
+    "parameters": {}
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001/export",
+        "name": "scan001",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans/export",
+        "properties": {
+          "exportedReportLocation": "https://myaccount.blob.core.windows.net/vulnerabilityAssessment/vulnerabilityassessmenttest-6440/testdb/scan001.xlsx"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001/export",
+        "name": "scan001",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans/export",
+        "properties": {
+          "exportedReportLocation": "https://myaccount.blob.core.windows.net/vulnerabilityAssessment/vulnerabilityassessmenttest-6440/testdb/scan001.xlsx"
+        }
+      }
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentScanRecordsGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentScanRecordsGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityassessmenttest-4711",
+    "managedInstanceName": "vulnerabilityassessmenttest-6411",
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "scanId": "scan001",
+    "api-version": "2017-10-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001",
+        "name": "scan001",
+        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
+        "properties": {
+          "scanId": "scan001",
+          "triggerType": "OnDemand",
+          "state": "Passed",
+          "startTime": "2017-12-12T17:45:06Z",
+          "endTime": "2017-12-12T17:47:06Z",
+          "errors": [],
+          "storageContainerPath": "https://myaccount.blob.core.windows.net/vulnerability-assessment",
+          "numberOfFailedSecurityChecks": 9
+        }
+      }
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentScanRecordsListByDatabase.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentScanRecordsListByDatabase.json
@@ -1,0 +1,68 @@
+{
+    "parameters": {
+        "subscriptionId": "00000000-1111-2222-3333-444444444444",
+        "resourceGroupName": "vulnerabilityassessmenttest-4711",
+        "managedInstanceName": "vulnerabilityassessmenttest-6411",
+        "databaseName": "testdb",
+        "vulnerabilityAssessmentName": "default",
+        "api-version": "2017-10-01-preview"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan001",
+                        "name": "scan001",
+                        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
+                        "properties": {
+                            "scanId": "scan001",
+                            "triggerType": "OnDemand",
+                            "state": "Passed",
+                            "startTime": "2017-12-12T17:45:06Z",
+                            "endTime": "2017-12-12T17:47:06Z",
+                            "errors": [ ],
+                            "storageContainerPath": "https://myaccount.blob.core.windows.net/vulnerability-assessment",
+                            "numberOfFailedSecurityChecks": 9
+                        }
+                    },
+                    {
+                        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan002",
+                        "name": "scan002",
+                        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
+                        "properties": {
+                            "scanId": "scan002",
+                            "triggerType": "Recurring",
+                            "state": "Failed",
+                            "startTime": "2017-12-12T17:45:06Z",
+                            "endTime": "2017-12-12T17:47:06Z",
+                            "errors": [ ],
+                            "storageContainerPath": "https://myaccount.blob.core.windows.net/vulnerability-assessment",
+                            "numberOfFailedSecurityChecks": 9
+                        }
+                    },
+                    {
+                        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/vulnerabilityassessmenttest-4799/providers/Microsoft.Sql/managedInstances/vulnerabilityassessmenttest-6440/databases/testdb/vulnerabilityAssessments/default/scans/scan003",
+                        "name": "scan003",
+                        "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments/scans",
+                        "properties": {
+                            "scanId": "scan003",
+                            "triggerType": "Recurring",
+                            "state": "FailedToRun",
+                            "startTime": "2017-12-12T17:45:06Z",
+                            "endTime": "2017-12-12T17:47:06Z",
+                            "errors": [
+                                {
+                                    "code": "StorageNotFound",
+                                    "message": "Storage not found"
+                                }
+                            ],
+                            "storageContainerPath": "https://myaccount.blob.core.windows.net/vulnerability-assessment",
+                            "numberOfFailedSecurityChecks": 0
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentScansExecute.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/examples/ManagedDatabaseVulnerabilityAssessmentScansExecute.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "vulnerabilityassessmenttest-4711",
+    "managedInstanceName": "vulnerabilityassessmenttest-6411",
+    "databaseName": "testdb",
+    "vulnerabilityAssessmentName": "default",
+    "scanId": "scan01",
+    "api-version": "2017-10-01-preview"
+  },
+  "responses": {
+    "200": {},
+    "202": {}
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentBaselines.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentBaselines.json
@@ -1,0 +1,455 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2017-10-01-preview",
+    "title": "SqlManagementClient",
+    "description": "The Azure SQL Database management API provides a RESTful set of web APIs that interact with Azure SQL Database services to manage your databases. The API enables users to create, retrieve, update, and delete databases, servers, and other entities."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/vulnerabilityAssessments/{vulnerabilityAssessmentName}/rules/{ruleId}/baselines/{baselineName}": {
+      "get": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssesmentRuleBaselines"
+        ],
+        "description": "Gets a database's vulnerability assessment rule baseline.",
+        "operationId": "ManagedDatabaseVulnerabilityAssessmentRuleBaselines_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the database for which the vulnerability assessment rule baseline is defined.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "ruleId",
+            "in": "path",
+            "description": "The vulnerability assessment rule ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "baselineName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment rule baseline.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentPolicyBaselineName",
+              "modelAsString": true
+            }
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully got the vulnerability assessment rule baseline.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentRuleBaseline"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidDatabaseVulnerabilityAssessmentOperationRequest - The vulnerability assessment operation request does not exist or has no properties object.\n\n * 400 DataSecurityInvalidUserSuppliedParameter - An invalid parameter value was provided by the client.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 VulnerabilityAssessmentInvalidStorageAccount - The storage account '{0}' that was defined in the policy is invalid.\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 VulnerabilityAssessmentRuleDoesNotExists - Rule '{0}' does not exist.\n\n * 404 VulnerabilityAssessmentBaselineDoesNotExists - Baseline does not exist for rule '{0}'\n\n * 500 VulnerabilityAssessmentStorageAuthenticationFailed - Could not authenticate to storage account '{0}' .\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          }
+        },
+        "x-ms-examples": {
+          "Gets a database's vulnerability assessment rule baseline.": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentRuleBaselineGet.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssesmentRuleBaselines"
+        ],
+        "description": "Creates or updates a database's vulnerability assessment rule baseline.",
+        "operationId": "ManagedDatabaseVulnerabilityAssessmentRuleBaselines_CreateOrUpdate",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the database for which the vulnerability assessment rule baseline is defined.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "ruleId",
+            "in": "path",
+            "description": "The vulnerability assessment rule ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "baselineName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment rule baseline.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentPolicyBaselineName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The requested rule baseline resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentRuleBaseline"
+            }
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully set the vulnerability assessment rule baseline.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentRuleBaseline"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidDatabaseVulnerabilityAssessmentOperationRequest - The vulnerability assessment operation request does not exist or has no properties object.\n\n * 400 DataSecurityInvalidUserSuppliedParameter - An invalid parameter value was provided by the client.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 VulnerabilityAssessmentInvalidStorageAccount - The storage account '{0}' that was defined in the policy is invalid.\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 VulnerabilityAssessmentRuleDoesNotExists - Rule '{0}' does not exist.\n\n * 404 VulnerabilityAssessmentBaselineDoesNotExists - Baseline does not exist for rule '{0}'\n\n * 500 VulnerabilityAssessmentStorageAuthenticationFailed - Could not authenticate to storage account '{0}' .\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          }
+        },
+        "x-ms-examples": {
+          "Creates or updates a database's vulnerability assessment rule baseline.": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentRuleBaselineCreate.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssesmentRuleBaselines"
+        ],
+        "description": "Removes the database's vulnerability assessment rule baseline.",
+        "operationId": "ManagedDatabaseVulnerabilityAssessmentRuleBaselines_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the database for which the vulnerability assessment rule baseline is defined.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "ruleId",
+            "in": "path",
+            "description": "The vulnerability assessment rule ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "baselineName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment rule baseline.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentPolicyBaselineName",
+              "modelAsString": true
+            }
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully removed the database vulnerability assessment rule baseline."
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidDatabaseVulnerabilityAssessmentOperationRequest - The vulnerability assessment operation request does not exist or has no properties object.\n\n * 400 DataSecurityInvalidUserSuppliedParameter - An invalid parameter value was provided by the client.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 VulnerabilityAssessmentInvalidStorageAccount - The storage account '{0}' that was defined in the policy is invalid.\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 404 VulnerabilityAssessmentRuleDoesNotExists - Rule '{0}' does not exist.\n\n * 404 VulnerabilityAssessmentBaselineDoesNotExists - Baseline does not exist for rule '{0}'\n\n * 500 VulnerabilityAssessmentStorageAuthenticationFailed - Could not authenticate to storage account '{0}' .\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          }
+        },
+        "x-ms-examples": {
+          "Removes a database's vulnerability assessment rule baseline.": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentRuleBaselineDelete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "DatabaseVulnerabilityAssessmentRuleBaselineProperties": {
+      "description": "Properties of a database Vulnerability Assessment rule baseline.",
+      "required": [
+        "baselineResults"
+      ],
+      "type": "object",
+      "properties": {
+        "baselineResults": {
+          "description": "The rule baseline result",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DatabaseVulnerabilityAssessmentRuleBaselineItem"
+          }
+        }
+      }
+    },
+    "DatabaseVulnerabilityAssessmentRuleBaselineItem": {
+      "description": "Properties for an Azure SQL Database Vulnerability Assessment rule baseline's result.",
+      "required": [
+        "result"
+      ],
+      "type": "object",
+      "properties": {
+        "result": {
+          "description": "The rule baseline result",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Resource": {
+      "description": "ARM resource.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Resource ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "Resource name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "Resource type.",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ProxyResource": {
+      "description": "ARM proxy resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {}
+    },
+    "DatabaseVulnerabilityAssessmentRuleBaseline": {
+      "description": "A database vulnerability assessment rule baseline.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DatabaseVulnerabilityAssessmentRuleBaselineProperties",
+          "description": "Resource properties.",
+          "x-ms-client-flatten": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "The subscription ID that identifies an Azure subscription.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "client"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for the request.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "client"
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "ServerNameParameter": {
+      "name": "serverName",
+      "in": "path",
+      "description": "The name of the server.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "ManagedInstanceNameParameter": {
+      "name": "managedInstanceName",
+      "in": "path",
+      "description": "The name of the managed instance.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "DatabaseNameParameter": {
+      "name": "databaseName",
+      "in": "path",
+      "description": "The name of the database.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "BlobAuditingPolicyNameParameter": {
+      "name": "blobAuditingPolicyName",
+      "in": "path",
+      "description": "The name of the blob auditing policy.",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "default"
+      ],
+      "x-ms-parameter-location": "method"
+    },
+    "SqlVirtualMachineInstanceNameParameter": {
+      "name": "sqlVirtualMachineInstanceName",
+      "in": "path",
+      "description": "The name of the SqlVirtualMachineInstance.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "SqlVirtualMachineContainerNameParameter": {
+      "name": "sqlVirtualMachineContainerName",
+      "in": "path",
+      "description": "The name of the SqlVirtualMachineContainer.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "VirtualClusterNameParameter": {
+      "name": "virtualClusterName",
+      "in": "path",
+      "description": "The name of the virtual cluster.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentScans.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentScans.json
@@ -1,0 +1,573 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2017-10-01-preview",
+    "title": "SqlManagementClient",
+    "description": "The Azure SQL Database management API provides a RESTful set of web APIs that interact with Azure SQL Database services to manage your databases. The API enables users to create, retrieve, update, and delete databases, servers, and other entities."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/vulnerabilityAssessments/{vulnerabilityAssessmentName}/scans": {
+      "get": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssessmentScans"
+        ],
+        "description": "Lists the vulnerability assessment scans of a database.",
+        "operationId": "ManagedDatabaseVulnerabilityAssessmentScans_ListByDatabase",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/DatabaseNameParameter"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the database vulnerability assessment scan records.",
+            "schema": {
+              "$ref": "#/definitions/VulnerabilityAssessmentScanRecordListResult"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidStorageAccountName - The provided storage account is not valid or does not exist.\n\n * 400 InvalidStorageAccountCredentials - The provided storage account shared access signature is not valid.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 409 DatabaseVulnerabilityAssessmentScanIsAlreadyInProgress - Vulnerability Assessment scan is already in progress.\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Gets the list of a database vulnerability assessment scan records": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentScanRecordsListByDatabase.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/vulnerabilityAssessments/{vulnerabilityAssessmentName}/scans/{scanId}": {
+      "get": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssessmentScans"
+        ],
+        "description": "Gets a vulnerability assessment scan record of a database.",
+        "operationId": "ManagedDatabaseVulnerabilityAssessmentScans_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/DatabaseNameParameter"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "scanId",
+            "in": "path",
+            "description": "The vulnerability assessment scan Id of the scan to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the database vulnerability assessment scan record.",
+            "schema": {
+              "$ref": "#/definitions/VulnerabilityAssessmentScanRecord"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidStorageAccountName - The provided storage account is not valid or does not exist.\n\n * 400 InvalidStorageAccountCredentials - The provided storage account shared access signature is not valid.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 409 DatabaseVulnerabilityAssessmentScanIsAlreadyInProgress - Vulnerability Assessment scan is already in progress.\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          }
+        },
+        "x-ms-examples": {
+          "Gets a database vulnerability assessment scan record by scan ID": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentScanRecordsGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/vulnerabilityAssessments/{vulnerabilityAssessmentName}/scans/{scanId}/initiateScan": {
+      "post": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssessmentScansExecute"
+        ],
+        "description": "Executes a Vulnerability Assessment database scan.",
+        "operationId": "ManagedDatabaseVulnerabilityAssessmentScans_InitiateScan",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/DatabaseNameParameter"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "scanId",
+            "in": "path",
+            "description": "The vulnerability assessment scan Id of the scan to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully executed a Vulnerability Assessment database scan."
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidDatabaseVulnerabilityAssessmentOperationRequest - The vulnerability assessment operation request does not exist or has no properties object.\n\n * 400 DataSecurityInvalidUserSuppliedParameter - An invalid parameter value was provided by the client.\n\n * 400 InvalidVulnerabilityAssessmentScanIdLength - The vulnerability assessment scan ID length must be below {0} characters.\n\n * 400 InvalidStorageAccountName - The provided storage account is not valid or does not exist.\n\n * 400 InvalidStorageAccountCredentials - The provided storage account shared access signature is not valid.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 409 DatabaseVulnerabilityAssessmentScanIsAlreadyInProgress - Vulnerability Assessment scan is already in progress.\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          },
+          "202": {
+            "description": "Successfully started a Vulnerability Assessment database scan."
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Executes a database's vulnerability assessment scan.": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentScansExecute.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/vulnerabilityAssessments/{vulnerabilityAssessmentName}/scans/{scanId}/export": {
+      "post": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssessmentScansExport"
+        ],
+        "description": "Convert an existing scan result to a human readable format. If already exists nothing happens",
+        "operationId": "ManagedDatabaseVulnerabilityAssessmentScans_Export",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the scanned database.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "scanId",
+            "in": "path",
+            "description": "The vulnerability assessment scan Id.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Scan result was converted successfully.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentScansExport"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidStorageAccountName - The provided storage account is not valid or does not exist.\n\n * 400 InvalidStorageAccountCredentials - The provided storage account shared access signature is not valid.\n\n * 400 InvalidDatabaseVulnerabilityAssessmentOperationRequest - The vulnerability assessment operation request does not exist or has no properties object.\n\n * 400 DataSecurityInvalidUserSuppliedParameter - An invalid parameter value was provided by the client.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 409 DatabaseVulnerabilityAssessmentScanIsAlreadyInProgress - Vulnerability Assessment scan is already in progress.\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          },
+          "201": {
+            "description": "Scan result was converted successfully.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessmentScansExport"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Export a database's vulnerability assessment scan results.": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentScanExport.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "VulnerabilityAssessmentScanRecordListResult": {
+      "description": "A list of vulnerability assessment scan records.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Array of results.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VulnerabilityAssessmentScanRecord"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "description": "Link to retrieve next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "VulnerabilityAssessmentScanRecordProperties": {
+      "description": "Properties of a vulnerability assessment scan record.",
+      "type": "object",
+      "properties": {
+        "scanId": {
+          "description": "The scan ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "triggerType": {
+          "description": "The scan trigger type.",
+          "enum": [
+            "OnDemand",
+            "Recurring"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "VulnerabilityAssessmentScanTriggerType",
+            "modelAsString": true
+          }
+        },
+        "state": {
+          "description": "The scan status.",
+          "enum": [
+            "Passed",
+            "Failed",
+            "FailedToRun",
+            "InProgress"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "VulnerabilityAssessmentScanState",
+            "modelAsString": true
+          }
+        },
+        "startTime": {
+          "format": "date-time",
+          "description": "The scan start time (UTC).",
+          "type": "string",
+          "readOnly": true
+        },
+        "endTime": {
+          "format": "date-time",
+          "description": "The scan end time (UTC).",
+          "type": "string",
+          "readOnly": true
+        },
+        "errors": {
+          "description": "The scan errors.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VulnerabilityAssessmentScanError"
+          },
+          "readOnly": true
+        },
+        "storageContainerPath": {
+          "description": "The scan results storage container path.",
+          "type": "string",
+          "readOnly": true
+        },
+        "numberOfFailedSecurityChecks": {
+          "format": "int32",
+          "description": "The number of failed security checks.",
+          "type": "integer",
+          "readOnly": true
+        }
+      }
+    },
+    "VulnerabilityAssessmentScanError": {
+      "description": "Properties of a vulnerability assessment scan error.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The error code.",
+          "type": "string",
+          "readOnly": true
+        },
+        "message": {
+          "description": "The error message.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "Resource": {
+      "description": "ARM resource.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Resource ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "Resource name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "Resource type.",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ProxyResource": {
+      "description": "ARM proxy resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {}
+    },
+    "VulnerabilityAssessmentScanRecord": {
+      "description": "A vulnerability assessment scan record.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VulnerabilityAssessmentScanRecordProperties",
+          "description": "Resource properties.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "DatabaseVulnerabilityAssessmentScanExportProperties": {
+      "description": "Properties of the export operation's result.",
+      "type": "object",
+      "properties": {
+        "exportedReportLocation": {
+          "description": "Location of the exported report (e.g. https://myStorage.blob.core.windows.net/VaScans/scans/serverName/databaseName/scan_scanId.xlsx).",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "DatabaseVulnerabilityAssessmentScansExport": {
+      "description": "A database Vulnerability Assessment scan export resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DatabaseVulnerabilityAssessmentScanExportProperties",
+          "description": "Resource properties.",
+          "x-ms-client-flatten": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "The subscription ID that identifies an Azure subscription.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "client"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for the request.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "client"
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "ServerNameParameter": {
+      "name": "serverName",
+      "in": "path",
+      "description": "The name of the server.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "ManagedInstanceNameParameter": {
+      "name": "managedInstanceName",
+      "in": "path",
+      "description": "The name of the managed instance.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "DatabaseNameParameter": {
+      "name": "databaseName",
+      "in": "path",
+      "description": "The name of the database.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "BlobAuditingPolicyNameParameter": {
+      "name": "blobAuditingPolicyName",
+      "in": "path",
+      "description": "The name of the blob auditing policy.",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "default"
+      ],
+      "x-ms-parameter-location": "method"
+    },
+    "SqlVirtualMachineInstanceNameParameter": {
+      "name": "sqlVirtualMachineInstanceName",
+      "in": "path",
+      "description": "The name of the SqlVirtualMachineInstance.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "SqlVirtualMachineContainerNameParameter": {
+      "name": "sqlVirtualMachineContainerName",
+      "in": "path",
+      "description": "The name of the SqlVirtualMachineContainer.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "VirtualClusterNameParameter": {
+      "name": "virtualClusterName",
+      "in": "path",
+      "description": "The name of the virtual cluster.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessments.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessments.json
@@ -1,0 +1,417 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2017-10-01-preview",
+    "title": "SqlManagementClient",
+    "description": "The Azure SQL Database management API provides a RESTful set of web APIs that interact with Azure SQL Database services to manage your databases. The API enables users to create, retrieve, update, and delete databases, servers, and other entities."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/vulnerabilityAssessments/{vulnerabilityAssessmentName}": {
+      "get": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssessments"
+        ],
+        "description": "Gets the database's vulnerability assessment.",
+        "operationId": "ManagedDatabaseVulnerabilityAssessments_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the database for which the vulnerability assessment is defined.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the database vulnerability assessment.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessment"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidStorageAccountName - The provided storage account is not valid or does not exist.\n\n * 400 InvalidStorageAccountCredentials - The provided storage account shared access signature is not valid.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          }
+        },
+        "x-ms-examples": {
+          "Get a database's vulnerability assessment": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentGet.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssessments"
+        ],
+        "description": "Creates or updates the database's vulnerability assessment.",
+        "operationId": "ManagedDatabaseVulnerabilityAssessments_CreateOrUpdate",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the database for which the vulnerability assessment is defined.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The requested resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessment"
+            }
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully set the vulnerability assessment.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessment"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidStorageAccountName - The provided storage account is not valid or does not exist.\n\n * 400 InvalidStorageAccountCredentials - The provided storage account shared access signature is not valid.\n\n * 400 InvalidDatabaseVulnerabilityAssessmentOperationRequest - The vulnerability assessment operation request does not exist or has no properties object.\n\n * 400 DataSecurityInvalidUserSuppliedParameter - An invalid parameter value was provided by the client.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          },
+          "201": {
+            "description": "Successfully created the vulnerability assessment.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseVulnerabilityAssessment"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a database's vulnerability assessment with all parameters": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentCreateMax.json"
+          },
+          "Create a database's vulnerability assessment with minimal parameters": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentCreateMin.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ManagedDatabaseVulnerabilityAssessments"
+        ],
+        "description": "Removes the database's vulnerability assessment.",
+        "operationId": "ManagedDatabaseVulnerabilityAssessments_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the database for which the vulnerability assessment is defined.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vulnerabilityAssessmentName",
+            "in": "path",
+            "description": "The name of the vulnerability assessment.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "VulnerabilityAssessmentName",
+              "modelAsString": true
+            }
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully removed the database vulnerability assessment."
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidStorageAccountName - The provided storage account is not valid or does not exist.\n\n * 400 InvalidStorageAccountCredentials - The provided storage account shared access signature is not valid.\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SourceDatabaseNotFound - The source database does not exist.\n\n * 500 DatabaseIsUnavailable - Loading failed. Please try again later."
+          }
+        },
+        "x-ms-examples": {
+          "Remove a database's vulnerability assessment": {
+            "$ref": "./examples/ManagedDatabaseVulnerabilityAssessmentDelete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "DatabaseVulnerabilityAssessmentProperties": {
+      "description": "Properties of a database Vulnerability Assessment.",
+      "type": "object",
+      "properties": {
+        "storageContainerPath": {
+          "description": "A blob storage container path to hold the scan results (e.g. https://myStorage.blob.core.windows.net/VaScans/).",
+          "type": "string",
+          "x-ms-mutability": [
+            "create",
+            "update"
+          ]
+        },
+        "storageContainerSasKey": {
+          "description": "A shared access signature (SAS Key) that has write access to the blob container specified in 'storageContainerPath' parameter.",
+          "type": "string",
+          "x-ms-mutability": [
+            "create",
+            "update"
+          ]
+        },
+        "recurringScans": {
+          "$ref": "#/definitions/VulnerabilityAssessmentRecurringScansProperties",
+          "description": "The recurring scans settings"
+        }
+      }
+    },
+    "VulnerabilityAssessmentRecurringScansProperties": {
+      "description": "Properties of a Vulnerability Assessment recurring scans.",
+      "type": "object",
+      "properties": {
+        "isEnabled": {
+          "description": "Recurring scans state.",
+          "type": "boolean"
+        },
+        "emailSubscriptionAdmins": {
+          "description": "Specifies that the schedule scan notification will be is sent to the subscription administrators.",
+          "default": true,
+          "type": "boolean"
+        },
+        "emails": {
+          "description": "Specifies an array of e-mail addresses to which the scan notification is sent.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Resource": {
+      "description": "ARM resource.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Resource ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "Resource name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "Resource type.",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ProxyResource": {
+      "description": "ARM proxy resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {}
+    },
+    "DatabaseVulnerabilityAssessment": {
+      "description": "A database vulnerability assessment.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DatabaseVulnerabilityAssessmentProperties",
+          "description": "Resource properties.",
+          "x-ms-client-flatten": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "The subscription ID that identifies an Azure subscription.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "client"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for the request.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "client"
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "ServerNameParameter": {
+      "name": "serverName",
+      "in": "path",
+      "description": "The name of the server.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "ManagedInstanceNameParameter": {
+      "name": "managedInstanceName",
+      "in": "path",
+      "description": "The name of the managed instance.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "DatabaseNameParameter": {
+      "name": "databaseName",
+      "in": "path",
+      "description": "The name of the database.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "BlobAuditingPolicyNameParameter": {
+      "name": "blobAuditingPolicyName",
+      "in": "path",
+      "description": "The name of the blob auditing policy.",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "default"
+      ],
+      "x-ms-parameter-location": "method"
+    },
+    "SqlVirtualMachineInstanceNameParameter": {
+      "name": "sqlVirtualMachineInstanceName",
+      "in": "path",
+      "description": "The name of the SqlVirtualMachineInstance.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "SqlVirtualMachineContainerNameParameter": {
+      "name": "sqlVirtualMachineContainerName",
+      "in": "path",
+      "description": "The name of the SqlVirtualMachineContainer.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "VirtualClusterNameParameter": {
+      "name": "virtualClusterName",
+      "in": "path",
+      "description": "The name of the virtual cluster.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  }
+}

--- a/specification/sql/resource-manager/readme.md
+++ b/specification/sql/resource-manager/readme.md
@@ -96,6 +96,9 @@ input-file:
 - Microsoft.Sql/preview/2017-10-01-preview/databases.json
 - Microsoft.Sql/preview/2017-10-01-preview/elasticPools.json
 - Microsoft.Sql/preview/2017-10-01-preview/databaseVulnerabilityAssessmentScans.json
+- Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentBaselines.json
+- Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessments.json
+- Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentScans.json
 - Microsoft.Sql/preview/2017-10-01-preview/instanceFailoverGroups.json
 - Microsoft.Sql/preview/2017-10-01-preview/shortTermRetentionPolicies.json
 
@@ -165,6 +168,9 @@ input-file:
 - Microsoft.Sql/preview/2017-10-01-preview/cancelOperations.json
 - Microsoft.Sql/preview/2017-10-01-preview/cancelPoolOperations.json
 - Microsoft.Sql/preview/2017-10-01-preview/databaseVulnerabilityAssessmentScans.json
+- Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentBaselines.json
+- Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessments.json
+- Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentScans.json
 - Microsoft.Sql/preview/2017-10-01-preview/instanceFailoverGroups.json
 - Microsoft.Sql/preview/2017-10-01-preview/shortTermRetentionPolicies.json
 
@@ -227,6 +233,9 @@ input-file:
 - Microsoft.Sql/preview/2017-10-01-preview/cancelOperations.json
 - Microsoft.Sql/preview/2017-10-01-preview/cancelPoolOperations.json
 - Microsoft.Sql/preview/2017-10-01-preview/databaseVulnerabilityAssessmentScans.json
+- Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentBaselines.json
+- Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessments.json
+- Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentScans.json
 - Microsoft.Sql/preview/2017-10-01-preview/instanceFailoverGroups.json
 - Microsoft.Sql/preview/2017-10-01-preview/shortTermRetentionPolicies.json
 
@@ -384,6 +393,9 @@ input-file:
  - ./Microsoft.Sql/preview/2017-10-01-preview/cancelOperations.json
  - ./Microsoft.Sql/preview/2017-10-01-preview/cancelPoolOperations.json
  - ./Microsoft.Sql/preview/2017-10-01-preview/databaseVulnerabilityAssessmentScans.json
+ - ./Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentBaselines.json
+ - ./Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessments.json
+ - ./Microsoft.Sql/preview/2017-10-01-preview/managedDatabaseVulnerabilityAssessmentScans.json
  - ./Microsoft.Sql/preview/2017-10-01-preview/capabilities.json
  - ./Microsoft.Sql/preview/2017-10-01-preview/databases.json
  - ./Microsoft.Sql/preview/2017-10-01-preview/elasticPools.json


### PR DESCRIPTION
Adding Vulnerability Assessment APIs on managed instance

Those APIs are the same as the Vulnerability Assessment APIs on regular Azure db with the difference of using "/managedInstances/{managed instance name}/" instead of "/servers/{server name}/"

The Vulnerability Assessment APIs on regular Azure db are approved and can be found at:

https://github.com/Azure/azure-rest-api-specs/blob/master/specification/sql/resource-manager/Microsoft.Sql/preview/2017-03-01-preview/databaseVulnerabilityAssessmentBaselines.json

https://github.com/Azure/azure-rest-api-specs/blob/master/specification/sql/resource-manager/Microsoft.Sql/preview/2017-03-01-preview/databaseVulnerabilityAssessments.json

https://github.com/Azure/azure-rest-api-specs/blob/master/specification/sql/resource-manager/Microsoft.Sql/preview/2017-10-01-preview/databaseVulnerabilityAssessmentScans.json
