### PR TITLE
[Automation] Provisioning State Enum to String in DSCCompilationJob

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2018-01-15/dscCompilationJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2018-01-15/dscCompilationJob.json
@@ -383,8 +383,9 @@
           "x-nullable": false
         },
         "provisioningState": {
-          "$ref": "#/definitions/JobProvisioningStateProperty",
-          "description": "The current provisioning state of the job."
+          "type": "string",
+          "description": "The current provisioning state of the job.",
+          "readOnly": true
         },
         "runOn": {
           "type": "string",
@@ -589,26 +590,6 @@
         }
       },
       "description": "Definition of the job stream."
-    },
-    "JobProvisioningStateProperty": {
-      "properties": {
-        "provisioningState": {
-          "readOnly": true,
-          "type": "string",
-          "description": "The provisioning state of the resource.",
-          "enum": [
-            "Failed",
-            "Succeeded",
-            "Suspended",
-            "Processing"
-          ],
-          "x-ms-enum": {
-            "name": "JobProvisioningState",
-            "modelAsString": true
-          }
-        }
-      },
-      "description": "The provisioning state property."
     }
   },
   "parameters": {}


### PR DESCRIPTION
Provisioning State converted to String from Enum for solving the current SDK serialization issues hitting us.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
