### PR TITLE
Fix go tag for storage management plane 2018-03-01 api version

### DIFF
--- a/specification/storage/resource-manager/readme.md
+++ b/specification/storage/resource-manager/readme.md
@@ -196,7 +196,7 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
-  - tag: package-2018-03-preview
+  - tag: package-2018-03
   - tag: package-2018-02
   - tag: package-2017-10
   - tag: package-2017-06
@@ -207,13 +207,13 @@ batch:
   - tag: package-2015-05-preview
 ```
 
-### Tag: package-2018-03-preview and go
+### Tag: package-2018-03 and go
 
-These settings apply only when `--tag=package-2018-03-preview --go` is specified on the command line.
+These settings apply only when `--tag=package-2018-03 --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
-``` yaml $(tag) == 'package-2018-03-preview' && $(go)
-output-folder: $(go-sdk-folder)/services/storage/mgmt/2018-03-01-preview/storage
+``` yaml $(tag) == 'package-2018-03' && $(go)
+output-folder: $(go-sdk-folder)/services/preview/storage/mgmt/2018-03-01-preview/storage
 ```
 
 ### Tag: package-2018-02 and go


### PR DESCRIPTION
- correcting the tag name
- moving the generated package to the preview folder since its a preview spec