### PR TITLE
Fixing schedule.json and definition file to conform to 200 response code from the API.

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
@@ -3025,6 +3025,7 @@
       "description": "Definition of schedule parameters."
     },
     "Schedule": {
+      "x-ms-azure-resource": true,
       "properties": {
         "id": {
           "type": "string",
@@ -3047,8 +3048,7 @@
           "description": "Gets or sets the properties of the schedule."
         }
       },
-      "description": "Definition of the schedule.",
-      "x-ms-azure-resource": true
+      "description": "Definition of the schedule."
     },
     "ScheduleUpdateProperties": {
       "properties": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/definitions.json
@@ -3047,7 +3047,8 @@
           "description": "Gets or sets the properties of the schedule."
         }
       },
-      "description": "Definition of the schedule."
+      "description": "Definition of the schedule.",
+      "x-ms-azure-resource": true
     },
     "ScheduleUpdateProperties": {
       "properties": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/examples/createOrUpdateSchedule.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/examples/createOrUpdateSchedule.json
@@ -18,7 +18,7 @@
     }
   },
   "responses": {
-    "201": {
+    "200": {
       "headers": {},
       "body": {
         "id": "/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Automation/automationAccounts/myAutomationAccount33/schedules/mySchedule",

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/schedule.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/schedule.json
@@ -86,8 +86,8 @@
           }
         ],
         "responses": {
-          "201": {
-            "description": "Created",
+          "200": {
+            "description": "OK",
             "schema": {
               "$ref": "./definitions.json#/definitions/Schedule"
             }


### PR DESCRIPTION
I am replacing the 201 response code with the 200 response code as the cmdlet for creating a new schedule returns 200, not 201. 

The definitions.json must also be changed in order to pass autorest.

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
