### PR TITLE
[AKS] Rename to "Operation" from "ComputeOperation"

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
@@ -50,7 +50,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/ComputeOperationListResult"
+              "$ref": "#/definitions/OperationListResult"
             }
           }
         },
@@ -381,20 +381,20 @@
     }
   },
   "definitions": {
-    "ComputeOperationListResult": {
+    "OperationListResult": {
       "properties": {
         "value": {
           "type": "array",
           "readOnly": true,
           "items": {
-            "$ref": "#/definitions/ComputeOperationValue"
+            "$ref": "#/definitions/OperationValue"
           },
           "description": "The list of compute operations"
         }
       },
       "description": "The List Compute Operation operation response."
     },
-    "ComputeOperationValue": {
+    "OperationValue": {
       "properties": {
         "origin": {
           "type": "string",
@@ -408,13 +408,13 @@
         },
         "display": {
           "x-ms-client-flatten": true,
-          "$ref": "#/definitions/ComputeOperationValueDisplay",
+          "$ref": "#/definitions/OperationValueDisplay",
           "description": "Describes the properties of a Compute Operation Value Display."
         }
       },
       "description": "Describes the properties of a Compute Operation value."
     },
-    "ComputeOperationValueDisplay": {
+    "OperationValueDisplay": {
       "properties": {
         "operation": {
           "type": "string",


### PR DESCRIPTION
Cleaning up a set of names that were copy-and-pasted from the Compute package. Not the end of the world, but it would be great if this could be merged before this new API is published in the Python SDK.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.