### PR TITLE
Remove subscriptionId uuid format for IotCentral

### DIFF
--- a/specification/iotcentral/resource-manager/Microsoft.IoTCentral/preview/2017-07-01-privatepreview/iotcentral.json
+++ b/specification/iotcentral/resource-manager/Microsoft.IoTCentral/preview/2017-07-01-privatepreview/iotcentral.json
@@ -680,19 +680,14 @@
       "in": "path",
       "description": "The subscription identifier.",
       "required": true,
-      "type": "string",
-      "format": "uuid"
+      "type": "string"
     },
     "api-version": {
       "name": "api-version",
-      "enum": [
-        "2017-07-01-privatepreview"
-      ],
       "in": "query",
       "description": "The version of the API.",
       "required": true,
-      "type": "string",
-      "minLength": 10
+      "type": "string"
     },
     "resourceGroupName": {
       "name": "resourceGroupName",
@@ -700,9 +695,7 @@
       "description": "The name of the resource group that contains the IoT Central application.",
       "required": true,
       "type": "string",
-      "x-ms-parameter-location": "method",
-      "minLength": 1,
-      "maxLength": 64
+      "x-ms-parameter-location": "method"
     },
     "resourceName": {
       "name": "resourceName",
@@ -711,8 +704,6 @@
       "required": true,
       "type": "string",
       "x-ms-parameter-location": "method",
-      "minLength": 1,
-      "maxLength": 100,
       "x-comment": "validation must match #/definitions/Resource"
     }
   }


### PR DESCRIPTION
This change removes `format: uuid` from IotCentral's swagger file. 

* SubscriptionIds should be treated as strings, the additional guid validation is causing issues in the C# SDK.
* Removing unneeded max length and enum validations

//cc @vishwam