### PR TITLE
Add primary flag to 2015-06-15  NetworkInterfaceIPConfiguration 

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2015-06-15/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2015-06-15/networkInterface.json
@@ -275,6 +275,10 @@
         "subnet": {
           "$ref": "./virtualNetwork.json#/definitions/Subnet"
         },
+        "primary": {
+          "type": "boolean",
+          "description": "Gets whether this is a primary customer address on the network interface."
+        },
         "publicIPAddress": {
           "$ref": "./publicIpAddress.json#/definitions/PublicIPAddress"
         },


### PR DESCRIPTION
Added primary flag to 2015-06-15  NetworkInterfaceIPConfiguration object on NetworkInterface.json spec. 
This flags gets populated by api-version 2015-06-15 on Azure and AzureStack. So it is a bug that spec does not hydrate that flag. 
Related issues:  
https://github.com/Azure/azure-sdk-for-go/issues/1997
https://github.com/Azure/azure-rest-api-specs/issues/2578

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
