### PR TITLE
[AKS] add nodeResourceGroup property 

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersCreate_Update.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersCreate_Update.json
@@ -6,16 +6,40 @@
     "resourceName": "clustername1",
     "parameters": {
       "location": "location1",
+      "tags": {
+        "tier": "production",
+        "archv2": ""
+      },
       "properties": {
+        "kubernetesVersion": "",
         "dnsPrefix": "dnsprefix1",
         "agentPoolProfiles": [
           {
-            "count": 1,
-            "name": "agentpool1",
-            "vmSize": "Standard_D2_v2"
+            "name": "nodepool1",
+            "count": 3,
+            "vmSize": "Standard_DS1_v2",
+            "dnsPrefix": "dnsprefix1",
+            "storageProfile": "ManagedDisks",
+            "osType": "Linux"
           }
         ],
-        "kubernetesVersion": "1.7.7"
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "addonProfiles": {
+        },
+        "enableRBAC": false
       }
     }
   },
@@ -24,25 +48,26 @@
       "body": {
         "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
         "location": "location1",
-        "name": "mycluster1",
+        "name": "clustername1",
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        },
+        "type": "Microsoft.ContainerService/ManagedClusters",
         "properties": {
+          "provisioningState": "Succeeded",
+          "kubernetesVersion": "1.9.6",
+          "dnsPrefix": "dnsprefix1",
           "agentPoolProfiles": [
             {
-              "count": 1,
-              "dnsPrefix": "agentpool1dnsPrefix",
-              "fqdn": "agentpool1fqdn",
-              "name": "agentpool1",
-              "osType": "Linux",
-              "ports": [
-                1
-              ],
+              "name": "nodepool1",
+              "count": 3,
+              "vmSize": "Standard_DS1_v2",
               "storageProfile": "ManagedDisks",
-              "vmSize": "Standard_D2_v2"
+              "maxPods": 110,
+              "osType": "Linux"
             }
           ],
-          "dnsPrefix": "dnsprefix1",
-          "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
-          "kubernetesVersion": "1.7.7",
           "linuxProfile": {
             "adminUsername": "azureuser",
             "ssh": {
@@ -53,41 +78,46 @@
               ]
             }
           },
-          "provisioningState": "Succeeded",
           "servicePrincipalProfile": {
             "clientId": "clientid"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "enableRBAC": false,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "networkProfile": {
+            "networkPlugin": "kubenet",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16",
+            "dnsServiceIP": "10.0.0.10",
+            "dockerBridgeCidr": "172.17.0.1/16"
           }
-        },
-        "tags": {
-          "stage": "production",
-          "archv2": ""
-        },
-        "type": "Microsoft.ContainerService/ManagedClusters"
+        }
       }
     },
     "201": {
       "body": {
         "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
         "location": "location1",
-        "name": "mycluster1",
+        "name": "clustername1",
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        },
+        "type": "Microsoft.ContainerService/ManagedClusters",
         "properties": {
+          "provisioningState": "Creating",
+          "kubernetesVersion": "1.9.6",
+          "dnsPrefix": "dnsprefix1",
           "agentPoolProfiles": [
             {
-              "count": 1,
-              "dnsPrefix": "agentpool1dnsPrefix",
-              "fqdn": "agentpool1fqdn",
-              "name": "agentpool1",
-              "osType": "Linux",
-              "ports": [
-                1
-              ],
+              "name": "nodepool1",
+              "count": 3,
+              "vmSize": "Standard_DS1_v2",
               "storageProfile": "ManagedDisks",
-              "vmSize": "Standard_D2_v2"
+              "maxPods": 110,
+              "osType": "Linux"
             }
           ],
-          "dnsPrefix": "dnsprefix1",
-          "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
-          "kubernetesVersion": "1.7.7",
           "linuxProfile": {
             "adminUsername": "azureuser",
             "ssh": {
@@ -98,16 +128,19 @@
               ]
             }
           },
-          "provisioningState": "Succeeded",
           "servicePrincipalProfile": {
             "clientId": "clientid"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "enableRBAC": false,
+          "networkProfile": {
+            "networkPlugin": "kubenet",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16",
+            "dnsServiceIP": "10.0.0.10",
+            "dockerBridgeCidr": "172.17.0.1/16"
           }
-        },
-        "tags": {
-          "stage": "production",
-          "archv2": ""
-        },
-        "type": "Microsoft.ContainerService/ManagedClusters"
+        }
       }
     }
   }

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersGet.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersGet.json
@@ -10,25 +10,27 @@
       "body": {
         "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
         "location": "location1",
-        "name": "mycluster1",
+        "name": "clustername1",
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        },
+        "type": "Microsoft.ContainerService/ManagedClusters",
         "properties": {
+          "provisioningState": "Succeeded",
+          "kubernetesVersion": "1.9.6",
+          "dnsPrefix": "dnsprefix1",
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
           "agentPoolProfiles": [
             {
-              "count": 1,
-              "dnsPrefix": "agentpool1dnsPrefix",
-              "fqdn": "agentpool1fqdn",
-              "name": "agentpool1",
-              "osType": "Linux",
-              "ports": [
-                1
-              ],
+              "name": "nodepool1",
+              "count": 3,
+              "vmSize": "Standard_DS1_v2",
               "storageProfile": "ManagedDisks",
-              "vmSize": "Standard_D2_v2"
+              "maxPods": 110,
+              "osType": "Linux"
             }
           ],
-          "dnsPrefix": "dnsprefix1",
-          "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
-          "kubernetesVersion": "1.7.7",
           "linuxProfile": {
             "adminUsername": "azureuser",
             "ssh": {
@@ -39,16 +41,19 @@
               ]
             }
           },
-          "provisioningState": "Succeeded",
           "servicePrincipalProfile": {
             "clientId": "clientid"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "enableRBAC": false,
+          "networkProfile": {
+            "networkPlugin": "kubenet",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16",
+            "dnsServiceIP": "10.0.0.10",
+            "dockerBridgeCidr": "172.17.0.1/16"
           }
-        },
-        "tags": {
-          "stage": "production",
-          "archv2": ""
-        },
-        "type": "Microsoft.ContainerService/ManagedClusters"
+        }
       }
     }
   }

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersList.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersList.json
@@ -10,45 +10,50 @@
           {
             "id": "/subscriptions/subid1/providers/Microsoft.ContainerService/managedClusters",
             "location": "location1",
-            "name": "mycluster1",
+            "name": "clustername1",
+            "tags": {
+              "archv2": "",
+              "tier": "production"
+            },
+            "type": "Microsoft.ContainerService/ManagedClusters",
             "properties": {
+              "provisioningState": "Succeeded",
+              "kubernetesVersion": "1.9.6",
+              "dnsPrefix": "dnsprefix1",
+              "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
               "agentPoolProfiles": [
                 {
-                  "count": 1,
-                  "dnsPrefix": "agentpool1dnsPrefix",
-                  "fqdn": "agentpool1fqdn",
-                  "name": "agentpool1",
-                  "osType": "Linux",
-                  "ports": [
-                    1
-                  ],
+                  "name": "nodepool1",
+                  "count": 3,
+                  "vmSize": "Standard_DS1_v2",
                   "storageProfile": "ManagedDisks",
-                  "vmSize": "Standard_D2_v2"
+                  "maxPods": 110,
+                  "osType": "Linux"
                 }
               ],
-              "dnsPrefix": "dnsprefix1",
-              "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
-              "kubernetesVersion": "1.7.7",
               "linuxProfile": {
                 "adminUsername": "azureuser",
                 "ssh": {
                   "publicKeys": [
                     {
                       "keyData": "keydata"
-                    }
+                     }
                   ]
                 }
               },
-              "provisioningState": "Succeeded",
               "servicePrincipalProfile": {
                 "clientId": "clientid"
+              },
+              "nodeResourceGroup": "MC_rg1_clustername1_location1",
+              "enableRBAC": false,
+              "networkProfile": {
+                "networkPlugin": "kubenet",
+                "podCidr": "10.244.0.0/16",
+                "serviceCidr": "10.0.0.0/16",
+                "dnsServiceIP": "10.0.0.10",
+                "dockerBridgeCidr": "172.17.0.1/16"
               }
-            },
-            "tags": {
-              "stage": "production",
-              "archv2": ""
-            },
-            "type": "Microsoft.ContainerService/ManagedClusters"
+            }
           }
         ]
       }

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersListByResourceGroup.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersListByResourceGroup.json
@@ -9,47 +9,52 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters",
+            "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters",
             "location": "location1",
-            "name": "mycluster1",
+            "name": "clustername1",
+            "tags": {
+              "archv2": "",
+              "tier": "production"
+            },
+            "type": "Microsoft.ContainerService/ManagedClusters",
             "properties": {
+              "provisioningState": "Succeeded",
+              "kubernetesVersion": "1.9.6",
+              "dnsPrefix": "dnsprefix1",
+              "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
               "agentPoolProfiles": [
                 {
-                  "count": 1,
-                  "dnsPrefix": "agentpool1dnsPrefix",
-                  "fqdn": "agentpool1fqdn",
-                  "name": "agentpool1",
-                  "osType": "Linux",
-                  "ports": [
-                    1
-                  ],
+                  "name": "nodepool1",
+                  "count": 3,
+                  "vmSize": "Standard_DS1_v2",
                   "storageProfile": "ManagedDisks",
-                  "vmSize": "Standard_D2_v2"
+                  "maxPods": 110,
+                  "osType": "Linux"
                 }
               ],
-              "dnsPrefix": "dnsprefix1",
-              "fqdn": "dnsprefix1-123456.abc.location1.azmk8s.io",
-              "kubernetesVersion": "1.7.7",
               "linuxProfile": {
                 "adminUsername": "azureuser",
                 "ssh": {
                   "publicKeys": [
                     {
                       "keyData": "keydata"
-                    }
+                     }
                   ]
                 }
               },
-              "provisioningState": "Succeeded",
               "servicePrincipalProfile": {
                 "clientId": "clientid"
+              },
+              "nodeResourceGroup": "MC_rg1_clustername1_location1",
+              "enableRBAC": false,
+              "networkProfile": {
+                "networkPlugin": "kubenet",
+                "podCidr": "10.244.0.0/16",
+                "serviceCidr": "10.0.0.0/16",
+                "dnsServiceIP": "10.0.0.10",
+                "dockerBridgeCidr": "172.17.0.1/16"
               }
-            },
-            "tags": {
-              "stage": "production",
-              "archv2": ""
-            },
-            "type": "Microsoft.ContainerService/ManagedClusters"
+            }
           }
         ]
       }

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
@@ -1066,6 +1066,11 @@
           },
           "description": "Profile of managed cluster add-on."
         },
+        "nodeResourceGroup": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Name of the resource group containing agent pool nodes."
+        },
         "enableRBAC": {
           "type": "boolean",
           "description": "Whether to enable Kubernetes Role-Based Access Control."

--- a/specification/containerservices/resource-manager/readme.md
+++ b/specification/containerservices/resource-manager/readme.md
@@ -208,7 +208,7 @@ python:
   payload-flattening-threshold: 2
   namespace: azure.mgmt.containerservice
   package-name: azure-mgmt-containerservice
-  package-version: 4.0.0
+  package-version: 4.1.0
   clear-output-folder: true
 ```
 ``` yaml $(python) && $(python-mode) == 'update'


### PR DESCRIPTION
`nodeResourceGroup` is an optional read-only property returned for a managed cluster by the v20180331 API.

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes.
- [X] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [X] My spec meets the review criteria:
  - [X] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [X] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.