### PR TITLE
Add description clarifying the encoding requirements for KeyOperationsParameters.Value

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/2016-10-01/keyvault.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/2016-10-01/keyvault.json
@@ -3974,6 +3974,7 @@
         },
         "value": {
           "type": "string",
+          "description": "an unpadded, url-encoded, base-64 string",
           "format": "base64url"
         }
       },


### PR DESCRIPTION
Moved change from the Go SDK: https://github.com/Azure/azure-sdk-for-go/pull/2061

It seems the swagger doc is clearer than the generated Go comment, with `"format": "base64url"`, so an option to this PR would be to improve the Go generator, I guess.
