### PR TITLE
Add a new tier for Azure SignalR serivce

### DIFF
--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
@@ -6,8 +6,8 @@
         "key1": "value1"
       },
       "sku": {
-        "name": "Basic_DS2",
-        "tier": "Basic",
+        "name": "Standard_S1",
+        "tier": "Standard",
         "capacity": 1
       },
       "properties": {
@@ -23,9 +23,9 @@
     "201": {
       "body": {
         "sku": {
-          "name": "Basic_DS2",
-          "tier": "Basic",
-          "size": "DS2",
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
           "capacity": 1
         },
         "properties": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
@@ -682,10 +682,11 @@
                   "type": "string"
               },
               "tier": {
-                  "description": "The tier of this particular SKU. Optional.",
+                  "description": "Optional tier of this particular SKU. `Basic` is deprecated, use `Standard` instead for Basic tier",
                   "enum": [
                       "Free",
                       "Basic",
+                      "Standard",
                       "Premium"
                   ],
                   "type": "string",


### PR DESCRIPTION
A new tier `Standard` is now supported in Azure SignalR service that will be new default tier.  Examples are also updated.

Quality: spec file and exampels are tested following https://github.com/Azure/adx-documentation-pr/wiki/Azure-Swagger-Tools.