### PR TITLE
[Cognitive Services] Stop override LUIS client class names, revert a case change in CustomVision.

### DIFF
--- a/specification/cognitiveservices/data-plane/CustomVision/Prediction/stable/v2.0/Prediction.json
+++ b/specification/cognitiveservices/data-plane/CustomVision/Prediction/stable/v2.0/Prediction.json
@@ -10,7 +10,7 @@
         "https"
     ],
     "paths": {
-        "/prediction/{projectId}/url": {
+        "/Prediction/{projectId}/url": {
             "post": {
                 "tags": [
                     "ImagePredictionApi"
@@ -85,7 +85,7 @@
                 }
             }
         },
-        "/prediction/{projectId}/image": {
+        "/Prediction/{projectId}/image": {
             "post": {
                 "tags": [
                     "ImagePredictionApi"
@@ -154,7 +154,7 @@
                 }
             }
         },
-        "/prediction/{projectId}/url/nostore": {
+        "/Prediction/{projectId}/url/nostore": {
             "post": {
                 "tags": [
                     "ImagePredictionApi"
@@ -229,7 +229,7 @@
                 }
             }
         },
-        "/prediction/{projectId}/image/nostore": {
+        "/Prediction/{projectId}/image/nostore": {
             "post": {
                 "tags": [
                     "ImagePredictionApi"

--- a/specification/cognitiveservices/data-plane/CustomVision/Training/stable/v2.0/Training.json
+++ b/specification/cognitiveservices/data-plane/CustomVision/Training/stable/v2.0/Training.json
@@ -10,7 +10,7 @@
         "https"
     ],
     "paths": {
-        "/training/domains": {
+        "/Training/domains": {
             "get": {
                 "tags": [
                     "DomainsApi"
@@ -48,7 +48,7 @@
                 }
             }
         },
-        "/training/domains/{domainId}": {
+        "/Training/domains/{domainId}": {
             "get": {
                 "tags": [
                     "DomainsApi"
@@ -91,7 +91,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/tagged": {
+        "/Training/projects/{projectId}/images/tagged": {
             "get": {
                 "tags": [
                     "ImageApi"
@@ -191,7 +191,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/untagged": {
+        "/Training/projects/{projectId}/images/untagged": {
             "get": {
                 "tags": [
                     "ImageApi"
@@ -278,7 +278,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/tagged/count": {
+        "/Training/projects/{projectId}/images/tagged/count": {
             "get": {
                 "tags": [
                     "ImageApi"
@@ -346,7 +346,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/untagged/count": {
+        "/Training/projects/{projectId}/images/untagged/count": {
             "get": {
                 "tags": [
                     "ImageApi"
@@ -401,7 +401,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/id": {
+        "/Training/projects/{projectId}/images/id": {
             "get": {
                 "tags": [
                     "ImageApi"
@@ -471,7 +471,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images": {
+        "/Training/projects/{projectId}/images": {
             "post": {
                 "tags": [
                     "ImageApi"
@@ -583,7 +583,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/files": {
+        "/Training/projects/{projectId}/images/files": {
             "post": {
                 "tags": [
                     "ImageApi"
@@ -642,7 +642,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/urls": {
+        "/Training/projects/{projectId}/images/urls": {
             "post": {
                 "tags": [
                     "ImageApi"
@@ -701,7 +701,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/predictions": {
+        "/Training/projects/{projectId}/images/predictions": {
             "post": {
                 "tags": [
                     "ImageApi"
@@ -760,7 +760,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/tags": {
+        "/Training/projects/{projectId}/images/tags": {
             "post": {
                 "tags": [
                     "ImageApi"
@@ -877,7 +877,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/images/regions": {
+        "/Training/projects/{projectId}/images/regions": {
             "post": {
                 "tags": [
                     "ImageApi"
@@ -982,7 +982,7 @@
                 }
             }
         },
-        "/training/{projectId}/images/{imageId}/regionproposals": {
+        "/Training/{projectId}/images/{imageId}/regionproposals": {
             "post": {
                 "tags": [
                     "ImageRegionProposalApi"
@@ -1033,7 +1033,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/predictions": {
+        "/Training/projects/{projectId}/predictions": {
             "delete": {
                 "tags": [
                     "PredictionsApi"
@@ -1081,7 +1081,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/predictions/query": {
+        "/Training/projects/{projectId}/predictions/query": {
             "post": {
                 "tags": [
                     "PredictionsApi"
@@ -1139,7 +1139,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/quicktest/url": {
+        "/Training/projects/{projectId}/quicktest/url": {
             "post": {
                 "tags": [
                     "PredictionsApi"
@@ -1206,7 +1206,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/quicktest/image": {
+        "/Training/projects/{projectId}/quicktest/image": {
             "post": {
                 "tags": [
                     "PredictionsApi"
@@ -1267,7 +1267,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/train": {
+        "/Training/projects/{projectId}/train": {
             "post": {
                 "tags": [
                     "ProjectApi"
@@ -1310,7 +1310,7 @@
                 }
             }
         },
-        "/training/projects": {
+        "/Training/projects": {
             "get": {
                 "tags": [
                     "ProjectApi"
@@ -1405,7 +1405,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}": {
+        "/Training/projects/{projectId}": {
             "get": {
                 "tags": [
                     "ProjectApi"
@@ -1537,7 +1537,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/iterations": {
+        "/Training/projects/{projectId}/iterations": {
             "get": {
                 "tags": [
                     "ProjectApi"
@@ -1584,7 +1584,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/iterations/{iterationId}": {
+        "/Training/projects/{projectId}/iterations/{iterationId}": {
             "get": {
                 "tags": [
                     "ProjectApi"
@@ -1743,7 +1743,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/iterations/{iterationId}/performance": {
+        "/Training/projects/{projectId}/iterations/{iterationId}/performance": {
             "get": {
                 "tags": [
                     "ProjectApi"
@@ -1811,7 +1811,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/iterations/{iterationId}/performance/images": {
+        "/Training/projects/{projectId}/iterations/{iterationId}/performance/images": {
             "get": {
                 "tags": [
                     "ProjectApi"
@@ -1911,7 +1911,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/iterations/{iterationId}/performance/images/count": {
+        "/Training/projects/{projectId}/iterations/{iterationId}/performance/images/count": {
             "get": {
                 "tags": [
                     "ProjectApi"
@@ -1979,7 +1979,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/iterations/{iterationId}/export": {
+        "/Training/projects/{projectId}/iterations/{iterationId}/export": {
             "get": {
                 "tags": [
                     "ProjectApi"
@@ -2101,7 +2101,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/tags/{tagId}": {
+        "/Training/projects/{projectId}/tags/{tagId}": {
             "get": {
                 "tags": [
                     "TagsApi"
@@ -2269,7 +2269,7 @@
                 }
             }
         },
-        "/training/projects/{projectId}/tags": {
+        "/Training/projects/{projectId}/tags": {
             "get": {
                 "tags": [
                     "TagsApi"

--- a/specification/cognitiveservices/data-plane/LUIS/Authoring/readme.md
+++ b/specification/cognitiveservices/data-plane/LUIS/Authoring/readme.md
@@ -66,7 +66,6 @@ swagger-to-sdk:
 These settings apply only when `--csharp` is specified on the command line.
 ``` yaml $(csharp)
 csharp:
-  override-client-name: LuisAuthoringAPI
   sync-methods: None
   license-header: MICROSOFT_MIT_NO_VERSION
   azure-arm: false

--- a/specification/cognitiveservices/data-plane/LUIS/Runtime/readme.md
+++ b/specification/cognitiveservices/data-plane/LUIS/Runtime/readme.md
@@ -43,7 +43,6 @@ swagger-to-sdk:
 These settings apply only when `--csharp` is specified on the command line.
 ``` yaml $(csharp)
 csharp:
-  override-client-name: LuisRuntimeAPI
   sync-methods: None
   license-header: MICROSOFT_MIT_NO_VERSION
   azure-arm: false


### PR DESCRIPTION
1. Client class names, addition to https://github.com/Azure/azure-rest-api-specs/pull/3365
2. Revert a case change in CustomVision, (XUnit HttpMockServer is case sensitive)

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
