### PR TITLE
[AKS] suppress two autorest ARM linter errors

### DIFF
--- a/specification/containerservices/resource-manager/readme.md
+++ b/specification/containerservices/resource-manager/readme.md
@@ -296,3 +296,15 @@ java:
 regenerate-manager: true
 generate-interface: true
 ```
+
+## Suppression
+
+``` yaml
+directive:
+  - suppress: DefinitionsPropertiesNamesCamelCase
+    from: managedClusters.json
+    reason: Name chamge of "enableRBAC" property would break compatibility
+  - suppress: TrackedResourcePatchOperation
+    from: containerService.json
+    reason: ACS service is deprecated so a PATCH endpoint won't be implemented
+```


### PR DESCRIPTION
Suppresses two `autorest --azure-validator` errors that the AKS swagger currently emits.
cc: @ifeoluwaokunoren @ravbhatnagar @vladimirjoanovic 

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
