### PR TITLE
RunCommands 2018-06-01

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/examples/VirtualMachineRunCommand.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/examples/VirtualMachineRunCommand.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "crptestar98131",
     "vmName": "vm3036",
     "$top": "1",
-    "api-version": "2017-12-01",
+    "api-version": "2018-06-01",
     "monitor": "true",
     "parameters": {
       "commandId": "RunPowerShellScript"

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/examples/VirtualMachineRunCommand.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/examples/VirtualMachineRunCommand.json
@@ -13,26 +13,20 @@
   "responses": {
     "200": {
       "body": {
-        "startTime": "2017-06-16T16:01:37.8958419-07:00",
-        "endTime": "2017-06-16T16:10:11.2897717-07:00",
-        "status": "Succeeded",
-        "properties": {
-          "output": [
-            {
-              "code": "ComponentStatus/StdOut/succeeded",
-              "level": "Info",
-              "displayStatus": "Provisioning succeeded",
-              "message": "This is a sample script with parameters value1 value2"
-            },
-            {
-              "code":"ComponentStatus/StdErr/succeeded",
-              "level":"Info",
-              "displayStatus":"Provisioning succeeded",
-              "message":""
-            }
-          ]
-        },
-        "name":"289dbc84-3c84-4a86-9e40-bbd4d61edcaf"
+        "value": [
+          {
+            "code": "ComponentStatus/StdOut/succeeded",
+            "level": "Info",
+            "displayStatus": "Provisioning succeeded",
+            "message": "This is a sample script with parameters value1 value2"
+          },
+          {
+            "code": "ComponentStatus/StdErr/succeeded",
+            "level": "Info",
+            "displayStatus": "Provisioning succeeded",
+            "message": ""
+          }
+        ]
       }
     },
     "202": {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/examples/VirtualMachineRunCommandGet.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/examples/VirtualMachineRunCommandGet.json
@@ -3,7 +3,7 @@
     "subscriptionId": "24fb23e3-6ba3-41f0-9b6e-e41131d5d61e",
     "location": "SoutheastAsia",
     "commandId": "RunPowerShellScript",
-    "api-version": "2017-12-01"
+    "api-version": "2018-06-01"
   },
   "responses": {
     "200": {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/examples/VirtualMachineRunCommandList.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/examples/VirtualMachineRunCommandList.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "subid",
     "location": "SoutheastAsia",
-    "api-version": "2017-12-01"
+    "api-version": "2018-06-01"
   },
   "responses": {
     "200": {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/runCommands.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2018-06-01/runCommands.json
@@ -1,0 +1,461 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "RunCommandsClient",
+    "description": "The Run Commands Client.",
+    "version": "2018-06-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json",
+    "text/json"
+  ],
+  "produces": [
+    "application/json",
+    "text/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/runCommands": {
+      "get": {
+        "tags": [
+          "VirtualMachineRunCommands"
+        ],
+        "operationId": "VirtualMachineRunCommands_List",
+        "x-ms-examples": {
+          "VirtualMachineRunCommandList": { "$ref": "./examples/VirtualMachineRunCommandList.json" }
+        },
+        "description": "Lists all available run commands for a subscription in a location.",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The location upon which run commands is queried.",
+            "pattern": "^[-\\w\\._]+$"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/RunCommandListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/runCommands/{commandId}": {
+      "get": {
+        "tags": [
+          "VirtualMachineRunCommands"
+        ],
+        "operationId": "VirtualMachineRunCommands_Get",
+        "x-ms-examples": {
+          "VirtualMachineRunCommandGet": { "$ref": "./examples/VirtualMachineRunCommandGet.json" }
+        },
+        "description": "Gets specific run command for a subscription in a location.",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The location upon which run commands is queried.",
+            "pattern": "^[-\\w\\._]+$"
+          },
+          {
+            "name": "commandId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The command id."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/RunCommandDocument"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/runCommand": {
+      "post": {
+        "tags": [
+          "VirtualMachines"
+        ],
+        "operationId": "VirtualMachines_RunCommand",
+        "x-ms-examples": {
+          "VirtualMachineRunCommand": { "$ref": "./examples/VirtualMachineRunCommand.json" }
+        },
+        "description": "Run command on the VM.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "vmName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual machine."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RunCommandInput"
+            },
+            "description": "Parameters supplied to the Run command operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/RunCommandResult"
+            }
+          },
+          "202": {
+            "description": "Accepted"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/runCommand": {
+      "post": {
+        "tags": [
+          "VirtualMachineScaleSetVMs"
+        ],
+        "operationId": "VirtualMachineScaleSetVMs_RunCommand",
+        "description": "Run command on a virtual machine in a VM scale set.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "vmScaleSetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the VM scale set."
+          },
+          {
+            "name": "instanceId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The instance ID of the virtual machine."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RunCommandInput"
+            },
+            "description": "Parameters supplied to the Run command operation."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/RunCommandResult"
+            }
+          },
+          "202": {
+            "description": "Accepted"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "RunCommandInputParameter": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The run command parameter name."
+        },
+        "value": {
+          "type": "string",
+          "description": "The run command parameter value."
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "description": "Describes the properties of a run command parameter."
+    },
+    "RunCommandInput": {
+      "properties": {
+        "commandId": {
+          "type": "string",
+          "description": "The run command id."
+        },
+        "script": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. The script to be executed.  When this value is given, the given script will override the default script of the command."
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RunCommandInputParameter"
+          },
+          "description": "The run command parameters."
+        }
+      },
+      "required": [
+        "commandId"
+      ],
+      "description": "Capture Virtual Machine parameters."
+    },
+    "RunCommandParameterDefinition": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The run command parameter name."
+        },
+        "type": {
+          "type": "string",
+          "description": "The run command parameter type."
+        },
+        "defaultValue": {
+          "type": "string",
+          "description": "The run command parameter default value."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "The run command parameter required.",
+          "default": false
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "description": "Describes the properties of a run command parameter."
+    },
+    "RunCommandDocumentBase": {
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "description": "The VM run command schema."
+        },
+        "id": {
+          "type": "string",
+          "description": "The VM run command id."
+        },
+        "osType": {
+          "type": "string",
+          "description": "The Operating System type.",
+          "enum": [
+            "Windows",
+            "Linux"
+          ],
+          "x-ms-enum": {
+            "name": "OperatingSystemTypes",
+            "modelAsString": false
+          }
+        },
+        "label": {
+          "type": "string",
+          "description": "The VM run command label."
+        },
+        "description": {
+          "type": "string",
+          "description": "The VM run command description."
+        }
+      },
+      "required": [
+        "$schema",
+        "id",
+        "osType",
+        "label",
+        "description"
+      ],
+      "description": "Describes the properties of a Run Command metadata."
+    },
+    "RunCommandDocument": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/RunCommandDocumentBase"
+        }
+      ],
+      "properties": {
+        "script": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The script to be executed."
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RunCommandParameterDefinition"
+          },
+          "description": "The parameters used by the script."
+        }
+      },
+      "required": [
+        "script"
+      ],
+      "description": "Describes the properties of a Run Command."
+    },
+    "RunCommandListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RunCommandDocumentBase"
+          },
+          "description": "The list of virtual machine run commands."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The uri to fetch the next page of run commands. Call ListNext() with this to fetch the next page of run commands."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "description": "The List Virtual Machine operation response."
+    },
+    "InstanceViewStatus": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The status code."
+        },
+        "level": {
+          "type": "string",
+          "description": "The level code.",
+          "enum": [
+            "Info",
+            "Warning",
+            "Error"
+          ],
+          "x-ms-enum": {
+            "name": "StatusLevelTypes",
+            "modelAsString": false
+          }
+        },
+        "displayStatus": {
+          "type": "string",
+          "description": "The short localizable label for the status."
+        },
+        "message": {
+          "type": "string",
+          "description": "The detailed status message, including for alerts and error messages."
+        },
+        "time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time of the status."
+        }
+      },
+      "description": "Instance view status."
+    },
+    "RunCommandResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstanceViewStatus"
+          },
+          "description": "Run command operation response."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    }
+  }
+}

--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -184,6 +184,7 @@ These settings apply only when `--tag=package-compute-only-2018-06` is specified
 ``` yaml $(tag) == 'package-compute-only-2018-06'
 input-file:
 - Microsoft.Compute/stable/2018-06-01/compute.json
+- Microsoft.Compute/stable/2018-06-01/runCommands.json
 - Microsoft.Compute/stable/2018-06-01/gallery.json
 ```
 


### PR DESCRIPTION
For Azure Profile to work properly, we need either:
- Each Swagger files to own his operation group
- If plug into another operation group from another file, to be consistent with that file.

However, "runCommands" plugs into the operation group `VirtualMachines` the operation `RunCommand`. Being that latest VirtualMachines is 2018-06-01 and latest `runCommands` is 2018-04-01, this breaks the contract and creates Readme that cannot be used for Azure Profile.

Discussed with @hyonholee the first time this occured that in theory when a new Compute is out, RunCommands is out at the same time and this just requires copying the file.

Note that the examples were copied without the Swagger, with the wrong api-version content.