### PR TITLE
[AKS] remove unsupported properties from managed cluster agent pool

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersCreate_Update.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/examples/ManagedClustersCreate_Update.json
@@ -18,8 +18,6 @@
             "name": "nodepool1",
             "count": 3,
             "vmSize": "Standard_DS1_v2",
-            "dnsPrefix": "dnsprefix1",
-            "storageProfile": "ManagedDisks",
             "osType": "Linux"
           }
         ],

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
@@ -867,18 +867,10 @@
           "$ref": "#/definitions/ContainerServiceOSDisk",
           "description": "OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
         },
-        "dnsPrefix": {
-          "type": "string",
-          "description": "DNS prefix to be used to create the FQDN for the agent pool."
-        },
-        "fqdn": {
-          "readOnly": true,
-          "type": "string",
-          "description": "FDQN for the agent pool."
-        },
         "storageProfile": {
+          "readOnly": true,
           "$ref": "#/definitions/ContainerServiceStorageProfile",
-          "description": "Storage profile specifies what kind of storage used. Choose from StorageAccount and ManagedDisks. Leave it empty, we will choose for you based on the orchestrator choice."
+          "description": "Storage profile specifies what kind of storage used. Defaults to ManagedDisks."
         },
         "vnetSubnetID": {
           "$ref": "#/definitions/ContainerServiceVnetSubnetID",

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
@@ -876,15 +876,6 @@
           "type": "string",
           "description": "FDQN for the agent pool."
         },
-        "ports": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 65535
-          },
-          "description": "Ports number array used to expose on this agent pool. The default opened ports are different based on your choice of orchestrator."
-        },
         "storageProfile": {
           "$ref": "#/definitions/ContainerServiceStorageProfile",
           "description": "Storage profile specifies what kind of storage used. Choose from StorageAccount and ManagedDisks. Leave it empty, we will choose for you based on the orchestrator choice."


### PR DESCRIPTION
These fields were mistakenly copied from `ContainerServiceAgentPoolProfile` and was never supported by AKS. `storageProfile` is supported but only accepts "ManagedDisks" (the default if empty), so making it read-only is a compromise between retaining a property that is in the data model and preventing user confusion.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
