### PR TITLE
[AKS] remove "KeyVaultSecretRef" and rename to "ManagedClusterServicePrincipalProfile"

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
@@ -750,28 +750,7 @@
         "Standard_NV6"
       ]
     },
-    "KeyVaultSecretRef": {
-      "properties": {
-        "vaultID": {
-          "type": "string",
-          "description": "Key vault identifier."
-        },
-        "secretName": {
-          "type": "string",
-          "description": "The secret name."
-        },
-        "version": {
-          "type": "string",
-          "description": "The secret version."
-        }
-      },
-      "description": "Reference to a secret stored in Azure Key Vault.",
-      "required": [
-        "vaultID",
-        "secretName"
-      ]
-    },
-    "ContainerServiceServicePrincipalProfile": {
+    "ManagedClusterServicePrincipalProfile": {
       "properties": {
         "clientId": {
           "type": "string",
@@ -780,13 +759,9 @@
         "secret": {
           "type": "string",
           "description": "The secret password associated with the service principal in plain text."
-        },
-        "keyVaultSecretRef": {
-          "$ref": "#/definitions/KeyVaultSecretRef",
-          "description": "Reference to a secret stored in Azure Key Vault."
         }
       },
-      "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs. Either secret or keyVaultSecretRef must be specified.",
+      "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs.",
       "required": [
         "clientId"
       ]
@@ -1121,8 +1096,8 @@
           "description": "Profile for Linux VMs in the container service cluster."
         },
         "servicePrincipalProfile": {
-          "$ref": "#/definitions/ContainerServiceServicePrincipalProfile",
-          "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs. Either secret or keyVaultSecretRef must be specified."
+          "$ref": "#/definitions/ManagedClusterServicePrincipalProfile",
+          "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs."
         },
         "addonProfiles": {
           "additionalProperties": {


### PR DESCRIPTION
This was mistakenly copied from `ContainerServiceServicePrincipalProfile` and was never supported by AKS. 

Since this swagger is built along with the ACS API, this requires renaming the class so their definitions can differ. This may be a **breaking change** for generated SDKs.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
