### PR TITLE
Add api to list usages of Azure SignalR resources

### DIFF
--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListUsagesByLocation.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListUsagesByLocation.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "location": "eastus",
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SignalRService/locations/eastus/usages/Usage1",
+            "currentValue": 0,
+            "limit": 100,
+            "name": {
+              "value": "Usage1",
+              "localizedValue": "Usage1"
+            },
+            "unit": "Count"
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SignalRService/locations/eastus/usages/Usage2",
+            "currentValue": 0,
+            "limit": 100,
+            "name": {
+              "value": "Usage2",
+              "localizedValue": "Usage2"
+            },
+            "unit": "Count"
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToMoreResults..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
@@ -407,6 +407,46 @@
                   }
               }
           }
+      },
+      "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/locations/{location}/usages": {
+        "get": {
+          "tags": [
+            "SignalR"
+          ],
+          "description": "List usage quotas for Azure SignalR service by location.",
+          "operationId": "Usages_List",
+          "parameters": [
+            {
+              "name": "location",
+              "in": "path",
+              "description": "the location like \"eastus\"",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "$ref": "#/parameters/ApiVersionParameter"
+            },
+            {
+              "$ref": "#/parameters/SubscriptionIdParameter"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success. The response describe the usage quotas of a subscription in specified region.",
+              "schema": {
+                "$ref": "#/definitions/SignalRUsageList"
+              }
+            }
+          },
+          "x-ms-pageable": {
+            "nextLinkName": "nextLink"
+          },
+          "x-ms-examples": {
+            "ListUsagesByLocation": {
+              "$ref": "./examples/ListUsagesByLocation.json"
+            }
+          }
+        }
       }
   },
   "definitions": {
@@ -844,7 +884,66 @@
                   "x-ms-client-flatten": false
               }
           }
+    },
+    "SignalRUsageList": {
+      "description": "Object that includes an array of SignalR resource usages and a possible link for next set.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of SignalR usages",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SignalRUsage"
+          }
+        },
+        "nextLink": {
+          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+          "type": "string"
+        }
       }
+    },
+    "SignalRUsage": {
+      "description": "Object that describes a specific usage of SignalR resources.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Fully qualified ARM resource id",
+          "type": "string"
+        },
+        "currentValue": {
+          "format": "int64",
+          "description": "Current value for the usage quota.",
+          "type": "integer"
+        },
+        "limit": {
+          "format": "int64",
+          "description": "The maximum permitted value for the usage quota. If there is no limit, this value will be -1.",
+          "type": "integer"
+        },
+        "name": {
+          "description": "Localizable String object containing the name and a localized value.",
+          "$ref": "#/definitions/SignalRUsageName"
+        },
+        "unit": {
+          "description": "Representing the units of the usage quota. Possible values are: Count, Bytes, Seconds, Percent, CountPerSecond, BytesPerSecond.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRUsageName": {
+      "description": "Localizable String object containing the name and a localized value.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The indentifier of the usage.",
+          "type": "string"
+        },
+        "localizedValue": {
+          "description": "Localized name of the usage.",
+          "type": "string"
+        }
+      }
+    }
   },
   "parameters": {
       "ApiVersionParameter": {


### PR DESCRIPTION
Add a new API for customers to list the usages of Azure SignalR resources in specific region.

### Quality of Swagger
following the instructions on  https://github.com/Azure/adx-documentation-pr/wiki/Azure-Swagger-Tools and passed all the validations listed.