### PR TITLE
Fix links duplicate

### DIFF
--- a/profile/2017-03-09-profile.json
+++ b/profile/2017-03-09-profile.json
@@ -73,7 +73,6 @@
 				"2016-02-01": [
 					"deployments",
 					"deployments/operations",
-					"links",
 					"locations",
 					"operations",
 					"providers",
@@ -104,8 +103,8 @@
 				"operations",
 				"storageAccounts",
 				"usages"
-			]        
-        }        
+			]
+        }
     },
     "data-plane": {
         "microsoft.keyvault": {


### PR DESCRIPTION
`links` was duplicated in both 2016-02-01 / 2016-09-01. This PR fixed it but keeping 2016-09-01.

@bganapa please review

FYI @johanste 