### PR TITLE
Added OAuth2 GET and POST to GraphRBAC.json spec

### DIFF
--- a/specification/graphrbac/data-plane/stable/1.6/graphrbac.json
+++ b/specification/graphrbac/data-plane/stable/1.6/graphrbac.json
@@ -1639,6 +1639,7 @@
           "in" : "body",
           "name" : "body",
           "required" : false,
+          "description": "The relevant app Service Principal Object Id and the Service Principal Objecit Id you want to grant.",
           "schema" : {
             "$ref" : "#/definitions/Permissions"
               },

--- a/specification/graphrbac/data-plane/stable/1.6/graphrbac.json
+++ b/specification/graphrbac/data-plane/stable/1.6/graphrbac.json
@@ -1003,7 +1003,7 @@
           "ServicePrincipal"
         ],
         "operationId": "ServicePrincipals_Get",
-        "description": "Gets service principal information from the directory.",
+        "description": "Gets service principal information from the directory. Query by objectId or pass a filter to query by appId",
         "parameters": [
           {
             "name": "objectId",
@@ -1588,6 +1588,77 @@
             "description": "OK. The operation was successful.",
             "schema": {
               "$ref": "#/definitions/Domain"
+            }
+          }
+        }
+      }
+    },
+    "/{tenantID}/oauth2PermissionGrants" : {
+      "get" : {
+       "tags": [
+         "OAuth2Permissions_get"
+       ],
+        "operationId": "OAuth2_Get",
+        "description": "Queries OAuth2 permissions for the relevant SP ObjectId of an app.",
+        "produces" : [ "application/json" ],
+        "parameters" : [
+        {
+          "name" : "$filter",
+          "in" : "query",
+          "required" : false,
+          "type" : "string",
+          "x-example" : "clientId+eq+'61ed44c3-5a1d-4639-a215-07f25129c6c3'",
+          "description": "This is the Service Principal ObjectId associated with the app"
+        },
+        {
+          "$ref": "#/parameters/ApiVersionParameter"
+        },
+        {
+          "$ref": "#/parameters/tenantIDInPath"
+        }
+       ],
+        "responses" : {
+          "200" : {
+            "description" : "OK. The operation was successful.",
+            "schema" : {
+              "$ref" : "#/definitions/Permissions"
+            }
+          }
+        }
+      },
+      "post" : {
+       "tags": [
+         "OAuth2Permissions_post"
+       ],
+        "consumes" : [ "application/json" ],
+        "operationId": "OAuth2_Post",
+        "description": "Grants OAuth2 permissions for the relevant resource Ids of an app.",
+        "produces" : [ "application/json" ],
+        "parameters" : [ 
+          {
+          "in" : "body",
+          "name" : "body",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/Permissions"
+              },
+              "x-examples" : {
+                  "application/json" : "{\n\t\"odata.type\": \"Microsoft.DirectoryServices.OAuth2PermissionGrant\",\n\t\"clientId\": \"39afbaa2-4a5c-4f5b-9ee3-2c83f09bbc87\", \n\t\"consentType\": \"AllPrincipals\",\n\t\"principalId\": null,\n\t\"resourceId\": \"d3247842-c517-4520-80a7-332690ae2fe4\",\n\t\"scope\": \"user_impersonation\",\n    \"startTime\": \"0001-01-01T00:00:00\",\n    \"expiryTime\": \"9000-01-01T00:00:00\"\n}",
+                  "description": "These are the values required to grant permission to a resourceId for an app, only one operation is allowed per request"
+                }
+          },
+          {
+          "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+              "$ref": "#/parameters/tenantIDInPath"
+          }
+        ],
+        "responses" : {
+          "201" : {
+            "description" : "OK. The operation was successful.",
+            "schema" : {
+              "$ref" : "#/definitions/Permissions"
             }
           }
         }
@@ -2985,6 +3056,52 @@
         }
       },
       "description": "Server response for Get tenant domains API call."
+    },
+    "Permissions" : {
+      "properties" : {
+        "odata.type" : {
+          "type" : "string",
+          "description": "Microsoft.DirectoryServices.OAuth2PermissionGrant"
+        },
+        "clientId" : {
+          "type" : "string",
+          "description": "The objectId of the Service Principal associated with the app"
+        },
+        "consentType" : {
+          "type" : "string",
+          "description": "Typically set to AllPrincipals"
+        },
+        "principalId" : {
+          "type" : "object",
+          "description": "Set to null if AllPrincipals is set"
+        },
+        "resourceId" : {
+          "type" : "string",
+          "description" : "Service Principal Id of the resource you want to grant"
+        },
+        "scope" : {
+          "type" : "string",
+          "description": "Typically set to user_impersonation"
+        },
+        "startTime" : {
+          "type" : "string",
+          "description" : "Start time for TTL"
+        },
+        "expiryTime" : {
+          "type" : "string",
+          "description" : "Expiry time for TTL"
+        }
+      },
+      "example" : {
+        "odata.type" : "odata.type",
+        "resourceId" : "resourceId",
+        "clientId" : "clientId",
+        "scope" : "scope",
+        "expiryTime" : "expiryTime",
+        "consentType" : "consentType",
+        "principalId" : "",
+        "startTime" : "startTime"
+      }
     }
   },
   "parameters": {


### PR DESCRIPTION
### Purpose of PR

This is needed so that we can programmatically grant OAuth2 consent to an application in Azure Active Directory - we need this in the Python and Go SDKs for Azure. This is the supported and correct way to do this respecting customer approval workflows. Example use case includes Azure Kubernetes Service RBAC integration with Azure Active Directory.

Added to stable. What has been added:

**In paths**:
```
    "/{tenantID}/oauth2PermissionGrants" : {
        "get" : {
         "tags": [
           "OAuth2"
         ],
          "operationId": "OAuth2_Get",
          "produces" : [ "application/json" ],
          "parameters" : [
          {
            "name" : "$filter",
            "in" : "query",
            "required" : false,
            "type" : "string",
            "x-example" : "clientId+eq+'61ed44c3-5a1d-4639-a215-07f25129c6c3'"
          },
          {
            "$ref": "#/parameters/ApiVersionParameter"
          },
          {
            "$ref": "#/parameters/tenantIDInPath"
          }
         ],
          "responses" : {
            "200" : {
              "description" : "OK. The operation was successful.",
              "schema" : {
                "$ref" : "#/definitions/OAuth2"
              }
            }
          }
        },
        "post" : {
         "tags": [
           "OAuth2"
         ],
          "consumes" : [ "application/json" ],
          "operationId": "OAuth2_Post",
          "produces" : [ "application/json" ],
          "parameters" : [ 
            {
            "in" : "body",
            "name" : "body",
            "required" : false,
            "schema" : {
              "$ref" : "#/definitions/OAuth2"
                },
                "x-examples" : {
                    "application/json" : "{\n\t\"odata.type\": \"Microsoft.DirectoryServices.OAuth2PermissionGrant\",\n\t\"clientId\": \"39afbaa2-4a5c-4f5b-9ee3-2c83f09bbc87\", \n\t\"consentType\": \"AllPrincipals\",\n\t\"principalId\": null,\n\t\"resourceId\": \"d3247842-c517-4520-80a7-332690ae2fe4\",\n\t\"scope\": \"user_impersonation\",\n    \"startTime\": \"0001-01-01T00:00:00\",\n    \"expiryTime\": \"9000-01-01T00:00:00\"\n}"
                  }
            },
            {
            "$ref": "#/parameters/ApiVersionParameter"
            },
            {
                "$ref": "#/parameters/tenantIDInPath"
            }
          ],
          "responses" : {
            "201" : {
              "description" : "OK. The operation was successful.",
              "schema" : {
                "$ref" : "#/definitions/OAuth2"
              }
            }
          }
        }
      }
```
**And in definitions**:

```
    "OAuth2" : {
        "properties" : {
          "odata.type" : {
            "type" : "string",
            "description": "Microsoft.DirectoryServices.OAuth2PermissionGrant"
          },
          "clientId" : {
            "type" : "string",
            "description": "The objectId of the Service Principal associated with the app"
          },
          "consentType" : {
            "type" : "string",
            "description": "Typically set to AllPrincipals"
          },
          "principalId" : {
            "type" : "object",
            "description": "Set to null if AllPrincipals is set"
          },
          "resourceId" : {
            "type" : "string",
            "description" : "Service Principal Id of the resource you want to grant"
          },
          "scope" : {
            "type" : "string",
            "description": "Typically set to user_impersonation"
          },
          "startTime" : {
            "type" : "string",
            "description" : "Start time for TTL"
          },
          "expiryTime" : {
            "type" : "string",
            "description" : "Expiry time for TTL"
          }
        },
        "example" : {
          "odata.type" : "odata.type",
          "resourceId" : "resourceId",
          "clientId" : "clientId",
          "scope" : "scope",
          "expiryTime" : "expiryTime",
          "consentType" : "consentType",
          "principalId" : "{}",
          "startTime" : "startTime"
        }
      }
```

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

### PR information

- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
