### PR TITLE
Fix Usages' validation to allow display names like "West US"

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/UsageListSpacedLocation.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/UsageListSpacedLocation.json
@@ -1,0 +1,335 @@
+{
+  "parameters": {
+    "location": "West US",
+    "api-version": "2018-07-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "currentValue": 12.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/VirtualNetworks",
+            "limit": 50.0,
+            "name": {
+              "localizedValue": "Virtual Networks",
+              "value": "VirtualNetworks"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 1.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/StaticPublicIPAddresses",
+            "limit": 20.0,
+            "name": {
+              "localizedValue": "Static Public IP Addresses",
+              "value": "StaticPublicIPAddresses"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 3.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/NetworkSecurityGroups",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Network Security Groups",
+              "value": "NetworkSecurityGroups"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 12.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/PublicIPAddresses",
+            "limit": 60.0,
+            "name": {
+              "localizedValue": "Public IP Addresses",
+              "value": "PublicIPAddresses"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/PublicIpPrefixes",
+            "limit": 2147483647.0,
+            "name": {
+              "localizedValue": "Public Ip Prefixes",
+              "value": "PublicIpPrefixes"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 2.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/NetworkInterfaces",
+            "limit": 24000.0,
+            "name": {
+              "localizedValue": "Network Interfaces",
+              "value": "NetworkInterfaces"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/LoadBalancers",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Load Balancers",
+              "value": "LoadBalancers"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 3.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/ApplicationGateways",
+            "limit": 50.0,
+            "name": {
+              "localizedValue": "Application Gateways",
+              "value": "ApplicationGateways"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 5.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/RouteTables",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Route Tables",
+              "value": "RouteTables"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/RouteFilters",
+            "limit": 1000.0,
+            "name": {
+              "localizedValue": "Route Filters",
+              "value": "RouteFilters"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/NetworkWatchers",
+            "limit": 1.0,
+            "name": {
+              "localizedValue": "Network Watchers",
+              "value": "NetworkWatchers"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/PacketCaptures",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Packet Captures",
+              "value": "PacketCaptures"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/ApplicationSecurityGroups",
+            "limit": 500.0,
+            "name": {
+              "localizedValue": "Application Security Groups.",
+              "value": "ApplicationSecurityGroups"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/DdosProtectionPlans",
+            "limit": 1.0,
+            "name": {
+              "localizedValue": "DDoS Protection Plans.",
+              "value": "DdosProtectionPlans"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/ServiceEndpointPolicies",
+            "limit": 200.0,
+            "name": {
+              "localizedValue": "Service Endpoint Policies",
+              "value": "ServiceEndpointPolicies"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/NetworkIntentPolicies",
+            "limit": 200.0,
+            "name": {
+              "localizedValue": "Network Intent Policies",
+              "value": "NetworkIntentPolicies"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/DnsServersPerVirtualNetwork",
+            "limit": 9.0,
+            "name": {
+              "localizedValue": "DNS servers per Virtual Network",
+              "value": "DnsServersPerVirtualNetwork"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/SubnetsPerVirtualNetwork",
+            "limit": 1000.0,
+            "name": {
+              "localizedValue": "Subnets per Virtual Network",
+              "value": "SubnetsPerVirtualNetwork"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/IPConfigurationsPerVirtualNetwork",
+            "limit": 16384.0,
+            "name": {
+              "localizedValue": "IP Configurations per Virtual Network",
+              "value": "IPConfigurationsPerVirtualNetwork"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/PeeringsPerVirtualNetwork",
+            "limit": 50.0,
+            "name": {
+              "localizedValue": "Peerings per Virtual Network",
+              "value": "PeeringsPerVirtualNetwork"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/SecurityRulesPerNetworkSecurityGroup",
+            "limit": 1000.0,
+            "name": {
+              "localizedValue": "Security rules per Network Security Group",
+              "value": "SecurityRulesPerNetworkSecurityGroup"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/SecurityRulesPerNetworkIntentPolicy",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Security rules per Network Intent Policy",
+              "value": "SecurityRulesPerNetworkIntentPolicy"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/RoutesPerNetworkIntentPolicy",
+            "limit": 100.0,
+            "name": {
+              "localizedValue": "Routes per Network Intent Policy",
+              "value": "RoutesPerNetworkIntentPolicy"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/SecurityRuleAddressesOrPortsPerNetworkSecurityGroup",
+            "limit": 2000.0,
+            "name": {
+              "localizedValue": "Security rules addresses or ports per Network Security Group",
+              "value": "SecurityRuleAddressesOrPortsPerNetworkSecurityGroup"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/InboundRulesPerLoadBalancer",
+            "limit": 150.0,
+            "name": {
+              "localizedValue": "Inbound Rules per Load Balancer",
+              "value": "InboundRulesPerLoadBalancer"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/FrontendIPConfigurationPerLoadBalancer",
+            "limit": 10.0,
+            "name": {
+              "localizedValue": "Frontend IP Configurations per Load Balancer",
+              "value": "FrontendIPConfigurationPerLoadBalancer"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/OutboundRulesPerLoadBalancer",
+            "limit": 5.0,
+            "name": {
+              "localizedValue": "Outbound Rules per Load Balancer",
+              "value": "OutboundRulesPerLoadBalancer"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/RoutesPerRouteTable",
+            "limit": 400.0,
+            "name": {
+              "localizedValue": "Routes per Route Table",
+              "value": "RoutesPerRouteTable"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/SecondaryIPConfigurationsPerNetworkInterface",
+            "limit": 256.0,
+            "name": {
+              "localizedValue": "Secondary IP Configurations per Network Interface",
+              "value": "SecondaryIPConfigurationsPerNetworkInterface"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/InboundRulesPerNetworkInterface",
+            "limit": 500.0,
+            "name": {
+              "localizedValue": "Inbound rules per Network Interface",
+              "value": "InboundRulesPerNetworkInterface"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/RouteFilterRulesPerRouteFilter",
+            "limit": 1.0,
+            "name": {
+              "localizedValue": "Route filter rules per Route Filter",
+              "value": "RouteFilterRulesPerRouteFilter"
+            },
+            "unit": "Count"
+          },
+          {
+            "currentValue": 0.0,
+            "id": "/subscriptions/subid/providers/Microsoft.Network/locations/West US/usages/RouteFiltersPerExpressRouteBgpPeering",
+            "limit": 1.0,
+            "name": {
+              "localizedValue": "Route filters per Express route BGP Peering",
+              "value": "RouteFiltersPerExpressRouteBgpPeering"
+            },
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/usage.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/usage.json
@@ -48,7 +48,7 @@
             "required": true,
             "type": "string",
             "description": "The location where resource usage is queried.",
-            "pattern": "^[-\\w\\._]+$"
+            "pattern": "^[-\\w\\._ ]+$"
           },
           {
             "$ref": "./network.json#/parameters/ApiVersionParameter"
@@ -66,7 +66,8 @@
           }
         },
         "x-ms-examples": {
-          "List usages": { "$ref": "./examples/UsageList.json" }
+          "List usages": { "$ref": "./examples/UsageList.json" },
+          "List usages spaced location": { "$ref": "./examples/UsageListSpacedLocation.json" }
         },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"


### PR DESCRIPTION
This fix was previously merged but somehow got lost between branches https://github.com/Azure/azure-rest-api-specs/pull/1811
Fixes https://github.com/Azure/azure-rest-api-specs/issues/3581

Allow spaces in `location` in `Usages_List`

---

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
