### PR TITLE
MetricAlert swagger fix

### DIFF
--- a/specification/monitor/resource-manager/microsoft.insights/stable/2018-03-01/metricAlert_API.json
+++ b/specification/monitor/resource-manager/microsoft.insights/stable/2018-03-01/metricAlert_API.json
@@ -561,7 +561,7 @@
             "LessThanOrEqual"
           ],
           "x-ms-enum": {
-            "name": "MetricCriteriaOperator",
+            "name": "MetricAlertRuleCondition",
             "modelAsString": true
           },
           "description": "the criteria operator."
@@ -575,7 +575,7 @@
             "Total"
           ],
           "x-ms-enum": {
-            "name": "MetricCriteriaAggregationType",
+            "name": "MetricAlertRuleAggregationTime",
             "modelAsString": true
           },
           "description": "the criteria time aggregation types."

--- a/specification/monitor/resource-manager/microsoft.insights/stable/2018-03-01/metricAlert_API.json
+++ b/specification/monitor/resource-manager/microsoft.insights/stable/2018-03-01/metricAlert_API.json
@@ -551,6 +551,7 @@
           "description": "Namespace of the metric."
         },
         "operator": {
+          "type": "string",
           "enum": [
             "Equals",
             "NotEquals",
@@ -560,12 +561,13 @@
             "LessThanOrEqual"
           ],
           "x-ms-enum": {
-            "name": "Operator",
+            "name": "MetricCriteriaOperator",
             "modelAsString": true
           },
           "description": "the criteria operator."
         },
         "timeAggregation": {
+          "type": "string",
           "enum": [
             "Average",
             "Minimum",
@@ -573,7 +575,7 @@
             "Total"
           ],
           "x-ms-enum": {
-            "name": "AggregationType",
+            "name": "MetricCriteriaAggregationType",
             "modelAsString": true
           },
           "description": "the criteria time aggregation types."

--- a/specification/monitor/resource-manager/microsoft.insights/stable/2018-03-01/metricAlert_API.json
+++ b/specification/monitor/resource-manager/microsoft.insights/stable/2018-03-01/metricAlert_API.json
@@ -575,7 +575,7 @@
             "Total"
           ],
           "x-ms-enum": {
-            "name": "MetricAlertRuleAggregationTime",
+            "name": "MetricAlertRuleTimeAggregation",
             "modelAsString": true
           },
           "description": "the criteria time aggregation types."


### PR DESCRIPTION
Since enum types **were not** declared as type=string generation on C# and Java side (checked in Fluent code) was producing object types instead of Enums or ExpandableStringEnum. 