### PR TITLE
Bug fix for readonly property

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-01-01/apimdeployment.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-01-01/apimdeployment.json
@@ -741,8 +741,7 @@
         },
         "certificate": {
           "$ref": "#/definitions/CertificateInformation",
-          "description": "Certificate information.",
-          "readOnly": true
+          "description": "Certificate information."
         }
       },
       "required": [

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/apimdeployment.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/apimdeployment.json
@@ -741,8 +741,7 @@
         },
         "certificate": {
           "$ref": "#/definitions/CertificateInformation",
-          "description": "Certificate information.",
-          "readOnly": true
+          "description": "Certificate information."
         }
       },
       "required": [


### PR DESCRIPTION
The CertificateInformation is not a readonly property on the service side. Fixing the bug, so that clients can be updated.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
