### PR TITLE
add option to import images from public registries

### DIFF
--- a/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2017-10-01/containerregistry.json
+++ b/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2017-10-01/containerregistry.json
@@ -59,6 +59,9 @@
           },
           "ImportImageByManifestDigest": {
             "$ref": "./examples/ImportImageByManifestDigest.json"
+          },
+          "ImportImageFromPublicRegistry": {
+            "$ref": "./examples/ImportImageFromPublicRegistry.json"
           }
         },
         "x-ms-long-running-operation": true
@@ -1189,13 +1192,16 @@
     },
     "ImportSource": {
       "required": [
-        "resourceId",
         "sourceImage"
       ],
       "type": "object",
       "properties": {
         "resourceId": {
-          "description": "The resource identifier of the target Azure Container Registry.",
+          "description": "The resource identifier of the source Azure Container Registry.",
+          "type": "string"
+        },
+        "registryUri": {
+          "description": "The address of the source registry.",
           "type": "string"
         },
         "sourceImage": {

--- a/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2017-10-01/examples/ImportImageFromPublicRegistry.json
+++ b/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2017-10-01/examples/ImportImageFromPublicRegistry.json
@@ -1,0 +1,25 @@
+{
+    "parameters": {
+        "api-version": "2017-10-01",
+        "subscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resourceGroupName": "myResourceGroup",
+        "registryName": "myRegistry",
+        "parameters": {
+            "source": {
+                "registryUri": "registry.hub.docker.com",
+                "sourceImage":"library/hello-world"
+            },
+            "targetTags": [
+                "targetRepository:targetTag"
+            ],
+            "untaggedTargetRepositories": [
+                "targetRepository1"
+            ],
+            "mode": "Force"
+        }
+    },
+    "responses": {
+        "200": {},
+        "202": {}
+    }
+}


### PR DESCRIPTION
Allows users to import images from public registries instead of only Azure Container Registries.  Only one registry source can be specified.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
