### PR TITLE
Microsot.Network/virtualnetworkgateways Reset VPN Client Shared Key

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkGatewayResetVpnClientSharedKey.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkGatewayResetVpnClientSharedKey.json
@@ -1,0 +1,12 @@
+{
+    "parameters": {
+        "api-version": "2018-06-01",
+        "subscriptionId": "subid",
+        "resourceGroupName": "rg1",
+        "virtualNetworkGatewayName" : "vpngw"
+    },
+    "responses" : {
+        "202" : { },
+        "200" : { }
+    }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualNetworkGateway.json
@@ -393,7 +393,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation reset the vpn client shared key of the virtual network gateway.",
+            "description": "Request successful. The operation reset the vpn client shared key of the virtual network gateway."
           },
           "202": {
             "description": "Accepted and the operation will complete asynchronously"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualNetworkGateway.json
@@ -362,6 +362,49 @@
         "x-ms-long-running-operation": true
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/resetvpnclientsharedkey": {
+      "post": {
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "operationId": "VirtualNetworkGateways_Resetvpnclientsharedkey",
+        "description": "Resets the VPN client shared key of the virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network gateway."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation reset the vpn client shared key of the virtual network gateway.",
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously"
+          }
+        },
+        "x-ms-examples": {
+          "ResetVpnClientSharedKey": { "$ref": "./examples/VirtualNetworkGatewayResetVpnClientSharedKey.json" }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnclientpackage": {
       "post": {
         "tags": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualNetworkGateway.json
@@ -367,7 +367,7 @@
         "tags": [
           "VirtualNetworkGateways"
         ],
-        "operationId": "VirtualNetworkGateways_Resetvpnclientsharedkey",
+        "operationId": "VirtualNetworkGateways_ResetVpnClientSharedKey",
         "description": "Resets the VPN client shared key of the virtual network gateway in the specified resource group.",
         "parameters": [
           {


### PR DESCRIPTION
Added a reset VPN Client shared key operation (POST) on virtual network gateway resource.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
