### PR TITLE
[Cognitive Services] Fix metadata types for Content Moderator.

### DIFF
--- a/specification/cognitiveservices/data-plane/ContentModerator/stable/v1.0/ContentModerator.json
+++ b/specification/cognitiveservices/data-plane/ContentModerator/stable/v1.0/ContentModerator.json
@@ -2915,18 +2915,7 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          },
-          "properties": {
-            "Key One": {
-              "description": "Optional Key value pair to describe your list.",
-              "type": "string"
-            },
-            "Key Two": {
-              "description": "Optional Key value pair to describe your list.",
-              "type": "string"
-            }
           }
-
         }
       }
     },
@@ -2950,16 +2939,6 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          },
-          "properties": {
-            "Key One": {
-              "description": "Optional Key value pair to describe your list.",
-              "type": "string"
-            },
-            "Key Two": {
-              "description": "Optional Key value pair to describe your list.",
-              "type": "string"
-            }
           }
         }
       }
@@ -2992,15 +2971,8 @@
           "type": "array",
           "items": {
             "type": "object",
-            "properties": {
-              "Key One": {
-                "description": "Key parameter to describe advanced info.",
-                "type": "string"
-              },
-              "Key Two": {
-                "description": "Key parameter to describe advanced info.",
-                "type": "string"
-              }
+            "additionalProperties": {
+              "type": "string"
             }
           }
         },
@@ -3710,18 +3682,9 @@
           "Metadata": {
             "description": "Metadata of the list.",
             "type": "object",
-
-            "properties": {
-              "Key One": {
-                "description": "Optional key value pair to describe your list.",
-                "type": "string"
-              },
-              "Key Two": {
-                "description": "Optional key value pair to describe your list.",
-                "type": "string"
-              }
+            "additionalProperties": {
+              "type": "string"
             }
-
           }
         }
 


### PR DESCRIPTION
Metadata should be a dictionary. The swagger was written in a wrong way.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
