### PR TITLE
return more perperties of SignalR resource

### DIFF
--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
@@ -34,6 +34,7 @@
           "hostName": "myservice.service.signalr.net",
           "publicPort": 5001,
           "serverPort": 5002,
+          "version": "1.0-preview",
           "hostNamePrefix": null
         },
         "location": "eastus",

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/Get.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/Get.json
@@ -9,9 +9,9 @@
     "200": {
       "body": {
         "sku": {
-          "name": "Basic_DS2",
-          "tier": "Basic",
-          "size": "DS2",
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
           "capacity": 1
         },
         "properties": {
@@ -20,6 +20,7 @@
           "hostName": "myservice.service.signalr.net",
           "publicPort": 5001,
           "serverPort": 5002,
+          "version": "1.0-preview",
           "hostNamePrefix": null
         },
         "location": "eastus",

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListByResourceGroup.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListByResourceGroup.json
@@ -10,9 +10,9 @@
         "value": [
           {
             "sku": {
-              "name": "Basic_DS2",
-              "tier": "Basic",
-              "size": "DS2",
+              "name": "Standard_S1",
+              "tier": "Standard",
+              "size": "S1",
               "capacity": 1
             },
             "properties": {
@@ -21,6 +21,7 @@
               "hostName": "myservice.service.signalr.net",
               "publicPort": 5001,
               "serverPort": 5002,
+              "version": "1.0-preview",
               "hostNamePrefix": null
             },
             "location": "eastus",

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListBySubscription.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListBySubscription.json
@@ -9,9 +9,9 @@
         "value": [
           {
             "sku": {
-              "name": "Basic_DS2",
-              "tier": "Basic",
-              "size": "DS2",
+              "name": "Standard_S1",
+              "tier": "Standard",
+              "size": "S1",
               "capacity": 1
             },
             "properties": {
@@ -20,6 +20,7 @@
               "hostName": "myservice.service.signalr.net",
               "publicPort": 5001,
               "serverPort": 5002,
+              "version": "1.0-preview",
               "hostNamePrefix": null
             },
             "location": "eastus",

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListKeys.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/ListKeys.json
@@ -9,7 +9,9 @@
     "200": {
       "body": {
         "primaryKey": "primaryAccessKey",
-        "secondaryKey": "secondaryAccessKey"
+        "secondaryKey": "secondaryAccessKey",
+        "primaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=primaryAccessKey;",
+        "secondaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=secondaryAccessKey;"
       }
     }
   }

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/RegenerateKey.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/RegenerateKey.json
@@ -12,7 +12,9 @@
     "201": {
       "body": {
         "primaryKey": "primaryAccessKey",
-        "secondaryKey": "secondaryAccessKey"
+        "secondaryKey": "secondaryAccessKey",
+        "primaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=primaryAccessKey;",
+        "secondaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=secondaryAccessKey;"
       },
       "headers": {
         "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult..."

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/Update.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/Update.json
@@ -5,8 +5,8 @@
         "key1": "value1"
       },
       "sku": {
-        "name": "Basic_DS2",
-        "tier": "Basic",
+        "name": "Standard_S1",
+        "tier": "Standard",
         "capacity": 1
       },
       "properties": {
@@ -22,9 +22,9 @@
     "200": {
       "body": {
         "sku": {
-          "name": "Basic_DS2",
-          "tier": "Basic",
-          "size": "DS2",
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
           "capacity": 1
         },
         "properties": {
@@ -33,6 +33,7 @@
           "hostName": "myservice.service.signalr.net",
           "publicPort": 5001,
           "serverPort": 5002,
+          "version": "1.0-preview",
           "hostNamePrefix": null
         },
         "location": "eastus",

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
@@ -566,6 +566,35 @@
               "category": {
                   "description": "The name of the metric category that the metric belongs to. A metric can only belong to a single category.",
                   "type": "string"
+              },
+              "dimensions": {
+                  "description": "The dimensions of the metrics.",
+                  "type": "array",
+                  "items": {
+                      "$ref": "#/definitions/Dimension"
+                  }
+              }
+          }
+      },
+      "Dimension": {
+          "description": "Specifications of the Dimension of metrics.",
+          "type": "object",
+          "properties": {
+              "name": {
+                  "description": "The public facing name of the dimension.",
+                  "type": "string"
+              },
+              "displayName": {
+                  "description": "Localized friendly display name of the dimension.",
+                  "type": "string"
+              },
+              "internalName": {
+                  "description": "Name of the dimension as it appears in MDM.",
+                  "type": "string"
+              },
+              "toBeExportedForShoebox": {
+                  "description": "A Boolean flag indicating whether this dimension should be included for the shoebox export scenario.",
+                  "type": "boolean"
               }
           }
       },
@@ -800,6 +829,10 @@
                   "description": "The publicly accessibly port of the SignalR service which is designed for customer server side usage.",
                   "type": "integer",
                   "readOnly": true
+              },
+              "version": {
+                  "description": "Version of the SignalR resource. Probably you need the same or higher version of client SDKs.",
+                  "type": "string"
               }
           }
       },
@@ -823,6 +856,14 @@
               },
               "secondaryKey": {
                   "description": "The secondary access key.",
+                  "type": "string"
+              },
+              "primaryConnectionString": {
+                  "description": "SignalR connection string constructed via the primaryKey",
+                  "type": "string"
+              },
+              "secondaryConnectionString": {
+                  "description": "SignalR connection string constructed via the secondaryKey",
                   "type": "string"
               }
           }


### PR DESCRIPTION
more properties are return in SignalR service apis:
- add `version` to SignalR resource
- add connection strings to SignalR resource ListKeys api
- return dimension for metrics in Action Metadata API.

Tests and validations following https://github.com/Azure/adx-documentation-pr/wiki/Azure-Swagger-Tools passed.