### PR TITLE
Bump node azure-servicefabric version to 2.0.1

### DIFF
--- a/specification/servicefabric/data-plane/readme.nodejs.md
+++ b/specification/servicefabric/data-plane/readme.nodejs.md
@@ -7,7 +7,7 @@ Please also specify `--node-sdks-folder=<path to root folder of your azure-sdk-f
 nodejs:
   azure-arm: false
   package-name: azure-servicefabric
-  package-version: 2.0.0
+  package-version: 2.0.1
   output-folder: $(node-sdks-folder)/lib/services/serviceFabric
   override-client-name: ServiceFabricClient
   generate-license-txt: true


### PR DESCRIPTION
This should resolve the issue where we generated an incorrect GitHub link.
