### PR TITLE
fix check name availabilty method for botservice

### DIFF
--- a/specification/botservice/resource-manager/Microsoft.BotService/preview/2018-07-12/botservice.json
+++ b/specification/botservice/resource-manager/Microsoft.BotService/preview/2018-07-12/botservice.json
@@ -611,14 +611,14 @@
       }
     },
     "/providers/Microsoft.BotService/checkNameAvailability": {
-      "get": {
+      "post": {
         "tags": [
           "Bot"
         ],
         "description": "Check whether a bot name is available.",
         "operationId": "Bots_GetCheckNameAvailability",
         "x-ms-examples": {
-          "List Bots by Subscription": {
+          "check Name Availability": {
             "$ref": "./examples/CheckNameAvailability.json"
           }
         },

--- a/specification/botservice/resource-manager/Microsoft.BotService/preview/2018-07-12/examples/CheckNameAvailability.json
+++ b/specification/botservice/resource-manager/Microsoft.BotService/preview/2018-07-12/examples/CheckNameAvailability.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2017-01-01",
+    "api-version": "2018-07-12",
     "parameters": {
       "name": "testbotname",
       "type": "string"

--- a/specification/botservice/resource-manager/readme.python.md
+++ b/specification/botservice/resource-manager/readme.python.md
@@ -12,7 +12,7 @@ python:
   payload-flattening-threshold: 2
   namespace: azure.mgmt.botservice
   package-name: azure-mgmt-botservice
-  package-version: 0.1.0
+  package-version: 0.2.0
   clear-output-folder: true
 ```
 ``` yaml $(python) && $(python-mode) == 'update'


### PR DESCRIPTION
This is not a breaking change , just that the swagger is wrong - 
the checknameavaialbility tenant level method is modelled as a GET. however, on generating a python sdk for this swagger, i get the error : "a get method cannot have a request body"
So i am changing this to be a POST instead. This method is not in use currently either on the portal or azure cli. the python sdk method is broken with the above exception.