### PR TITLE
Microsoft.ResourceGraph - Promote additionalProperties to a dictionary

### DIFF
--- a/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/preview/2018-09-01-preview/resourcegraph.json
+++ b/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/preview/2018-09-01-preview/resourcegraph.json
@@ -454,11 +454,10 @@
         "message": {
           "type": "string",
           "description": "A human readable error message."
-        },
-        "additionalProperties": {
-          "type": "object",
-          "description": "Additional custom properties."
         }
+      },
+      "additionalProperties": {
+        "type": "object"
       },
       "required": [
         "code",


### PR DESCRIPTION
Building on top of #3716. 

Current spec generates AdditionalProperties as object, it would be more convenient to have a Dictionary<string, object> instead.

This is not a breaking change as the RP backend is not live yet.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
