### PR TITLE
[AKS] note that only one agent pool is currently supported

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
@@ -319,7 +319,7 @@
             "$ref": "./examples/ManagedClustersListClusterCredentialResult.json"
           }
         }
-      } 
+      }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}": {
       "get": {
@@ -1162,7 +1162,7 @@
           "items": {
             "$ref": "#/definitions/ManagedClusterAgentPoolProfile"
           },
-          "description": "Properties of the agent pool."
+          "description": "Properties of the agent pool. Currently only one agent pool can exist."
         },
         "linuxProfile": {
           "$ref": "#/definitions/ContainerServiceLinuxProfile",
@@ -1412,7 +1412,7 @@
           "description": "Base64-encoded Kubernetes configuration file."
         }
       },
-      "description": "The credential result response." 
+      "description": "The credential result response."
     }
   },
   "parameters": {


### PR DESCRIPTION
Clarify that AKS supports a single agent pool currently. Thanks to @WebSpider for suggesting this.

Closes Azure/azure-sdk-for-python#3256.

cc: @lmazuel

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
