### PR TITLE
[HDInsight] Added additional parameters for security profile

### DIFF
--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2015-03-01-preview/cluster.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2015-03-01-preview/cluster.json
@@ -446,6 +446,14 @@
                         "type": "string"
                     },
                     "description": "Optional. The Distinguished Names for cluster user groups"
+                },
+                "aaddsResourceId": {
+                    "type": "string",
+                    "description": "The resource ID of the user's Azure Active Directory Domain Service."
+                },
+                "msiResourceId": {
+                    "type": "string",
+                    "description": "User assigned identity that has permissions to read and create cluster-related artifacts in the user's AADDS."
                 }
             }
         },

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2018-06-01-preview/cluster.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2018-06-01-preview/cluster.json
@@ -446,6 +446,14 @@
                         "type": "string"
                     },
                     "description": "Optional. The Distinguished Names for cluster user groups"
+                },
+                "aaddsResourceId": {
+                    "type": "string",
+                    "description": "The resource ID of the user's Azure Active Directory Domain Service."
+                },
+                "msiResourceId": {
+                    "type": "string",
+                    "description": "User assigned identity that has permissions to read and create cluster-related artifacts in the user's AADDS."
                 }
             }
         },


### PR DESCRIPTION
Note: this API change has not yet been deployed RP-side. I am opening this pull request beforehand to get this API change approved.

We are adding optional parameters to the cluster resource, but we do not expect this to be a breaking change, as this is not modifiable after the initial PUT.

-----

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
