### PR TITLE
EventGrid: README.md changes: Updated default tag for global settings and updates to multi-api settings.

### DIFF
--- a/specification/eventgrid/resource-manager/readme.md
+++ b/specification/eventgrid/resource-manager/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the Azure EventGrid API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2018-09-preview
+tag: package-2018-05-preview
 ```
 
 
@@ -159,20 +159,10 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
-  - tag: package-2018-09-preview
   - tag: package-2018-05-preview
   - tag: package-2018-01
   - tag: package-2017-09-preview
   - tag: package-2017-06-preview
-```
-
-### Tag: package-2018-09-preview and go
-
-These settings apply only when `--tag=package-2018-09-preview --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag) == 'package-2018-09-preview' && $(go)
-output-folder: $(go-sdk-folder)/services/preview/eventgrid/mgmt/2018-09-15-preview/eventgrid
 ```
 
 ### Tag: package-2018-05-preview and go
@@ -230,22 +220,8 @@ output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-eventgrid
 
 ``` yaml $(java) && $(multiapi)
 batch:
-  - tag: package-2018-09-preview
   - tag: package-2018-05-preview
   - tag: package-2018-01
-```
-
-### Tag: package-2018-09-preview and java
-
-These settings apply only when `--tag=package-2018-09-preview --java` is specified on the command line.
-Please also specify `--azure-libraries-for-java=<path to the root directory of your azure-sdk-for-java clone>`.
-
-``` yaml $(tag) == 'package-2018-09-preview' && $(java) && $(multiapi)
-java:
-  namespace: com.microsoft.azure.management.eventgrid.v2018_09_15_preview
-  output-folder: $(azure-libraries-for-java-folder)/eventgrid/resource-manager/v2018_09_15_preview
-regenerate-manager: true
-generate-interface: true
 ```
 
 ### Tag: package-2018-05-preview and java

--- a/specification/eventgrid/resource-manager/readme.ruby.md
+++ b/specification/eventgrid/resource-manager/readme.ruby.md
@@ -12,23 +12,11 @@ azure-arm: true
 
 ``` yaml $(ruby) && $(multiapi)
 batch:
-  - tag: package-2018-09-preview
   - tag: package-2018-05-preview
   - tag: package-2018-01
   - tag: package-2017-09-preview
   - tag: package-2017-06-preview
 ```
-
-### Tag: package-2018-09-preview and ruby
-
-These settings apply only when `--tag=package-2018-09-preview --ruby` is specified on the command line.
-Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
-
-``` yaml $(tag) == 'package-2018-09-preview' && $(ruby)
-namespace: "Azure::EventGrid::Mgmt::V2018_09_15_preview"
-output-folder: $(ruby-sdks-folder)/management/azure_mgmt_event_grid/lib
-```
-
 
 ### Tag: package-2018-05-preview and ruby
 


### PR DESCRIPTION
This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

EventGrid: README.md changes: Updated default tag for global settings and updates to multi-api settings. Will re-enable 2018-09 tag once the service bits corresponding to this API version are deployed in all regions.

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [X] If applicable, the PR references the bug/issue that it fixes.
- [X] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [X] My spec meets the review criteria:
  - [X] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [X] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
