### PR TITLE
Rename Post to Grants

### DIFF
--- a/specification/graphrbac/data-plane/stable/1.6/graphrbac.json
+++ b/specification/graphrbac/data-plane/stable/1.6/graphrbac.json
@@ -346,7 +346,7 @@
           }
         }
       }
-    },    
+    },
     "/{tenantID}/applications/{applicationObjectId}/keyCredentials": {
       "get": {
         "tags": [
@@ -831,7 +831,7 @@
             }
           }
         }
-      }      
+      }
     },
     "/{tenantID}/groups/{objectId}/getMemberGroups": {
       "post": {
@@ -1628,13 +1628,13 @@
       },
       "post" : {
        "tags": [
-         "OAuth2Permissions_post"
+         "OAuth2Permissions_Grants"
        ],
         "consumes" : [ "application/json" ],
         "operationId": "OAuth2_Post",
         "description": "Grants OAuth2 permissions for the relevant resource Ids of an app.",
         "produces" : [ "application/json" ],
-        "parameters" : [ 
+        "parameters" : [
           {
           "in" : "body",
           "name" : "body",
@@ -2227,7 +2227,7 @@
         {
           "$ref": "#/definitions/DirectoryObject"
         }
-      ],            
+      ],
       "properties": {
         "appId": {
           "type": "string",
@@ -2305,7 +2305,7 @@
         "type": "object"
       },
       "description": "Request parameters for adding a owner to an application."
-    },    
+    },
     "KeyCredentialListResult": {
       "type": "object",
       "properties": {
@@ -2550,7 +2550,7 @@
         {
           "$ref": "#/definitions/DirectoryObject"
         }
-      ],            
+      ],
       "properties": {
         "displayName": {
           "type": "string",
@@ -2689,7 +2689,7 @@
           "$ref": "#/definitions/DirectoryObject"
         }
       ],
-      "type": "object",     
+      "type": "object",
       "properties": {
         "displayName": {
           "type": "string",
@@ -2890,7 +2890,7 @@
             "name": "UserType",
             "modelAsString": true
           }
-        },        
+        },
         "accountEnabled": {
           "type": "boolean",
           "description": "Whether the account is enabled."

--- a/specification/graphrbac/data-plane/stable/1.6/graphrbac.json
+++ b/specification/graphrbac/data-plane/stable/1.6/graphrbac.json
@@ -1628,7 +1628,7 @@
       },
       "post" : {
        "tags": [
-         "OAuth2Permissions_Grants"
+         "OAuth2Permissions_Grant"
        ],
         "consumes" : [ "application/json" ],
         "operationId": "OAuth2_Post",


### PR DESCRIPTION
@shanepeckham Our naming convention should not use HTTP verbs as part of operation ID, but be more meaningfull. This PR renames "post" to "grants", this will make SDK looks like:
> client.oauth2_permissions.grants()

which is very better user friendly. I do believe your CLI PR is not merged yet, so I think it's the right time to do that now. I discussed this with your initial reviewer @marstr and he agreed on that.

@yugangw-msft FYI