### PR TITLE
Remove serverAppSecret which is not required for AKS cluster updates

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
@@ -1321,8 +1321,7 @@
       },
       "required": [
         "clientAppID",
-        "serverAppID",
-        "serverAppSecret"
+        "serverAppID"
       ],
       "description": "AADProfile specifies attributes for Azure Active Directory integration."
     },


### PR DESCRIPTION
Remove serverAppSecret which is not required for AKS cluster updates.

Without this, scale up AKS cluster would report error:

```
containerservice.ManagedClustersClient#CreateOrUpdate: Invalid input: autorest/validation: validation failed: parameter=parameters.ManagedClusterProperties.AadProfile.ServerAppSecret constraint=Null value=(*string)(nil) details: value can not be null; required parameter
```

Note: Go SDK should be also be updated after this.

cc @weinong @mboersma 