### PR TITLE
Fix ref/allOf in same object to fix doc generation

### DIFF
--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2018-04-19/definitions/MigrateSqlServerSqlDbTask.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2018-04-19/definitions/MigrateSqlServerSqlDbTask.json
@@ -376,23 +376,90 @@
       "x-ms-discriminator-value": "MigrationValidationOutput",
       "type": "object",
       "description": "Validation result for Sql Server to Azure Sql DB migration.",
-      "$ref": "./MigrationValidation.json#/definitions/MigrationValidationResult",
       "allOf": [
         {
           "$ref": "#/definitions/MigrateSqlServerSqlDbTaskOutput"
         }
-      ]
+       ],
+      "properties": {
+        "migrationId": {
+          "type": "string",
+          "description": "Migration Identifier",
+          "readOnly": true
+        },
+        "summaryResults": {
+          "type": "object",
+          "description": "Validation summary results for each database",
+          "additionalProperties": {
+            "$ref": "./MigrationValidation.json#/definitions/MigrationValidationDatabaseSummaryResult"
+          }
+        },
+        "status": {
+          "$ref": "./MigrationValidation.json#/definitions/ValidationStatus",
+          "description": "Current status of validation at the migration level. Status from the database validation result status will be aggregated here.",
+          "readOnly": true
+        }
+      }
     },
     "MigrateSqlServerSqlDbTaskOutputDatabaseLevelValidationResult": {
       "x-ms-discriminator-value": "MigrationDatabaseLevelValidationOutput",
       "type": "object",
       "description": "Database validation result for Sql Server to Azure Sql DB migration.",
-      "$ref": "./MigrationValidation.json#/definitions/MigrationValidationDatabaseLevelResult",
       "allOf": [
         {
           "$ref": "#/definitions/MigrateSqlServerSqlDbTaskOutput"
         }
-      ]
+      ],
+      "properties": {
+        "migrationId": {
+          "type": "string",
+          "description": "Migration Identifier",
+          "readOnly": true
+        },
+        "sourceDatabaseName": {
+          "type": "string",
+          "description": "Name of the source database",
+          "readOnly": true
+        },
+        "targetDatabaseName": {
+          "type": "string",
+          "description": "Name of the target database",
+          "readOnly": true
+        },
+        "startedOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Validation start time",
+          "readOnly": true
+        },
+        "endedOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Validation end time",
+          "readOnly": true
+        },
+        "dataIntegrityValidationResult": {
+          "description": "Provides data integrity validation result between the source and target tables that are migrated.",
+          "$ref": "./MigrationValidation.json#/definitions/DataIntegrityValidationResult",
+          "readOnly": true
+        },
+        "schemaValidationResult": {
+          "description": "Provides schema comparison result between source and target database",
+          "$ref": "./MigrationValidation.json#/definitions/SchemaComparisonValidationResult",
+          "readOnly": true
+        },
+
+        "queryAnalysisValidationResult": {
+          "description": "Results of some of the query execution result between source and target database",
+          "$ref": "./MigrationValidation.json#/definitions/QueryAnalysisValidationResult",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "./MigrationValidation.json#/definitions/ValidationStatus",
+          "description": "Current status of validation at the database level",
+          "readOnly": true
+        }
+      }
     }
   }
 }

--- a/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2018-04-19/definitions/MigrationValidation.json
+++ b/specification/datamigration/resource-manager/Microsoft.DataMigration/stable/2018-04-19/definitions/MigrationValidation.json
@@ -51,34 +51,6 @@
         }
       }
     },
-    "MigrationValidationResult": {
-      "type": "object",
-      "description": "Migration Validation Result",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Migration validation result identifier",
-          "readOnly": true
-        },
-        "migrationId": {
-          "type": "string",
-          "description": "Migration Identifier",
-          "readOnly": true
-        },
-        "summaryResults": {
-          "type": "object",
-          "description": "Validation summary results for each database",
-          "additionalProperties": {
-            "$ref": "#/definitions/MigrationValidationDatabaseSummaryResult"
-          }
-        },
-        "status": {
-          "$ref": "#/definitions/ValidationStatus",
-          "description": "Current status of validation at the migration level. Status from the database validation result status will be aggregated here.",
-          "readOnly": true
-        }
-      }
-    },
     "MigrationValidationDatabaseSummaryResult": {
       "type": "object",
       "description": "Migration Validation Database level summary result",
@@ -114,65 +86,6 @@
           "type": "string",
           "format": "date-time",
           "description": "Validation end time",
-          "readOnly": true
-        },
-        "status": {
-          "$ref": "#/definitions/ValidationStatus",
-          "description": "Current status of validation at the database level",
-          "readOnly": true
-        }
-      }
-    },
-    "MigrationValidationDatabaseLevelResult": {
-      "type": "object",
-      "description": "Database level validation results",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Result identifier",
-          "readOnly": true
-        },
-        "migrationId": {
-          "type": "string",
-          "description": "Migration Identifier",
-          "readOnly": true
-        },
-        "sourceDatabaseName": {
-          "type": "string",
-          "description": "Name of the source database",
-          "readOnly": true
-        },
-        "targetDatabaseName": {
-          "type": "string",
-          "description": "Name of the target database",
-          "readOnly": true
-        },
-        "startedOn": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Validation start time",
-          "readOnly": true
-        },
-        "endedOn": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Validation end time",
-          "readOnly": true
-        },
-        "dataIntegrityValidationResult": {
-          "description": "Provides data integrity validation result between the source and target tables that are migrated.",
-          "$ref": "#/definitions/DataIntegrityValidationResult",
-          "readOnly": true
-        },
-        "schemaValidationResult": {
-          "description": "Provides schema comparison result between source and target database",
-          "$ref": "#/definitions/SchemaComparisonValidationResult",
-          "readOnly": true
-        },
-
-        "queryAnalysisValidationResult": {
-          "description": "Results of some of the query execution result between source and target database",
-          "$ref": "#/definitions/QueryAnalysisValidationResult",
           "readOnly": true
         },
         "status": {


### PR DESCRIPTION
Fix ref/allOf in same object. This was found by doc team.
Docs cannot be generated for the swagger because of this issue.
This does not change the api, just changes the hierarchy of internal objects.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
