### PR TITLE
Suppression rule for Microsoft.Resources

### DIFF
--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -300,6 +300,14 @@ directive:
     where: $.definitions.GenericResource.properties
     reason: managedBy is a top level property
   - suppress: BodyTopLevelProperties
+    from: resources.json
+    where: $.definitions.TagDetails.properties
+    reason: TagDetails is a top level property
+  - suppress: BodyTopLevelProperties
+    from: resources.json
+    where: $.definitions.TagValue.properties
+    reason: TagValue is a top level property
+  - suppress: BodyTopLevelProperties
     from: managedapplications.json
     where: $.definitions.Appliance.properties
     reason: managedBy is a top level property


### PR DESCRIPTION
Suppression rule for Microsoft.Resources

Properties in  TagDetails and TagValue are the top level. The error "(BodyTopLevelProperties/R3006/ARMViolation): Top level properties should be one of name, type, id, location, properties, tags, plan, sku, etag, managedBy, identity, zones. Model definition 'TagValue' has extra properties ['tagValue,count']" should not happen.

The same definition is in stable\2018-02-01\resources.json