### PR TITLE
Change MariaDB example from Gen4 server to Gen5 server

### DIFF
--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/PerformanceTiersListByLocation.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/PerformanceTiersListByLocation.json
@@ -14,22 +14,22 @@
               {
                 "edition": "Basic",
                 "vCore": 1,
-                "hardwareGeneration": "Gen4",
+                "hardwareGeneration": "Gen5",
                 "minStorageMB": 5120,
                 "maxStorageMB": 1048576,
                 "minBackupRetentionDays": 7,
                 "maxBackupRetentionDays": 35,
-                "id": "B_Gen4_1"
+                "id": "B_Gen5_1"
               },
               {
                 "edition": "Basic",
                 "vCore": 2,
-                "hardwareGeneration": "Gen4",
+                "hardwareGeneration": "Gen5",
                 "minStorageMB": 5120,
                 "maxStorageMB": 1048576,
                 "minBackupRetentionDays": 7,
                 "maxBackupRetentionDays": 35,
-                "id": "B_Gen4_2"
+                "id": "B_Gen5_2"
               }
             ]
           },
@@ -39,52 +39,52 @@
               {
                 "edition": "GeneralPurpose",
                 "vCore": 2,
-                "hardwareGeneration": "Gen4",
+                "hardwareGeneration": "Gen5",
                 "minStorageMB": 5120,
                 "maxStorageMB": 2097152,
                 "minBackupRetentionDays": 7,
                 "maxBackupRetentionDays": 35,
-                "id": "GP_Gen4_2"
+                "id": "GP_Gen5_2"
               },
               {
                 "edition": "GeneralPurpose",
                 "vCore": 4,
-                "hardwareGeneration": "Gen4",
+                "hardwareGeneration": "Gen5",
                 "minStorageMB": 5120,
                 "maxStorageMB": 2097152,
                 "minBackupRetentionDays": 7,
                 "maxBackupRetentionDays": 35,
-                "id": "GP_Gen4_4"
+                "id": "GP_Gen5_4"
               },
               {
                 "edition": "GeneralPurpose",
                 "vCore": 8,
-                "hardwareGeneration": "Gen4",
+                "hardwareGeneration": "Gen5",
                 "minStorageMB": 5120,
                 "maxStorageMB": 2097152,
                 "minBackupRetentionDays": 7,
                 "maxBackupRetentionDays": 35,
-                "id": "GP_Gen4_8"
+                "id": "GP_Gen5_8"
               },
               {
                 "edition": "GeneralPurpose",
                 "vCore": 16,
-                "hardwareGeneration": "Gen4",
+                "hardwareGeneration": "Gen5",
                 "minStorageMB": 5120,
                 "maxStorageMB": 2097152,
                 "minBackupRetentionDays": 7,
                 "maxBackupRetentionDays": 35,
-                "id": "GP_Gen4_16"
+                "id": "GP_Gen5_16"
               },
               {
                 "edition": "GeneralPurpose",
                 "vCore": 32,
-                "hardwareGeneration": "Gen4",
+                "hardwareGeneration": "Gen5",
                 "minStorageMB": 5120,
                 "maxStorageMB": 2097152,
                 "minBackupRetentionDays": 7,
                 "maxBackupRetentionDays": 35,
-                "id": "GP_Gen4_32"
+                "id": "GP_Gen5_32"
               }
             ]
           }

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerCreate.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerCreate.json
@@ -18,10 +18,10 @@
         "createMode": "Default"
       },
       "sku": {
-        "name": "GP_Gen4_2",
+        "name": "GP_Gen5_2",
         "tier": "GeneralPurpose",
         "capacity": 2,
-        "family": "Gen4"
+        "family": "Gen5"
       },
       "tags": {
         "ElasticServer": "1"
@@ -32,9 +32,9 @@
     "201": {
       "body": {
         "sku": {
-          "name": "GP_Gen4_2",
+          "name": "GP_Gen5_2",
           "tier": "GeneralPurpose",
-          "family": "Gen4",
+          "family": "Gen5",
           "capacity": 2
         },
         "properties": {
@@ -66,9 +66,9 @@
         "type": "Microsoft.DBforMariaDB/servers",
         "location": "westus",
         "sku": {
-          "name": "GP_Gen4_2",
+          "name": "GP_Gen5_2",
           "tier": "GeneralPurpose",
-          "family": "Gen4",
+          "family": "Gen5",
           "capacity": 2
         },
         "tags": {

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerCreateGeoRestoreMode.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerCreateGeoRestoreMode.json
@@ -11,9 +11,9 @@
                 "sourceServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/SourceResourceGroup/providers/Microsoft.DBforMariaDB/servers/sourceserver"
             },
             "sku": {
-                "name": "GP_Gen4_2",
+                "name": "GP_Gen5_2",
                 "tier": "GeneralPurpose",
-                "family": "Gen4",
+                "family": "Gen5",
                 "capacity": 2
             },
             "tags": {
@@ -25,9 +25,9 @@
         "201": {
             "body": {
               "sku": {
-                "name": "GP_Gen4_2",
+                "name": "GP_Gen5_2",
                 "tier": "GeneralPurpose",
-                "family": "Gen4",
+                "family": "Gen5",
                 "capacity": 2
               },
               "properties": {
@@ -59,9 +59,9 @@
               "type": "Microsoft.DBforMariaDB/servers",
               "location": "westus",
               "sku": {
-                "name": "GP_Gen4_2",
+                "name": "GP_Gen5_2",
                 "tier": "GeneralPurpose",
-                "family": "Gen4",
+                "family": "Gen5",
                 "capacity": 2
               },
               "tags": {

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerCreatePointInTimeRestore.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerCreatePointInTimeRestore.json
@@ -12,9 +12,9 @@
                 "sourceServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/SourceResourceGroup/providers/Microsoft.DBforMariaDB/servers/sourceserver"
             },
             "sku": {
-                "name": "GP_Gen4_2",
+                "name": "GP_Gen5_2",
                 "tier": "GeneralPurpose",
-                "family": "Gen4",
+                "family": "Gen5",
                 "capacity": 2
             },
             "tags": {
@@ -26,9 +26,9 @@
         "201": {
             "body": {
               "sku": {
-                "name": "GP_Gen4_2",
+                "name": "GP_Gen5_2",
                 "tier": "GeneralPurpose",
-                "family": "Gen4",
+                "family": "Gen5",
                 "capacity": 2
               },
               "properties": {
@@ -60,9 +60,9 @@
               "type": "Microsoft.DBforMariaDB/servers",
               "location": "brazilsouth",
               "sku": {
-                "name": "GP_Gen4_2",
+                "name": "GP_Gen5_2",
                 "tier": "GeneralPurpose",
-                "family": "Gen4",
+                "family": "Gen5",
                 "capacity": 2
               },
               "tags": {

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerGet.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerGet.json
@@ -9,9 +9,9 @@
     "200": {
       "body": {
         "sku": {
-          "name": "GP_Gen4_2",
+          "name": "GP_Gen5_2",
           "tier": "GeneralPurpose",
-          "family": "Gen4",
+          "family": "Gen5",
           "capacity": 2
         },
         "properties": {

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerList.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerList.json
@@ -9,9 +9,9 @@
         "value": [
           {
             "sku": {
-              "name": "B_Gen4_2",
+              "name": "B_Gen5_2",
               "tier": "Basic",
-              "family": "Gen4",
+              "family": "Gen5",
               "capacity": 2
             },
             "properties": {
@@ -34,9 +34,9 @@
           },
           {
             "sku": {
-              "name": "GP_Gen4_2",
+              "name": "GP_Gen5_2",
               "tier": "GeneralPurpose",
-              "family": "Gen4",
+              "family": "Gen5",
               "capacity": 2
             },
             "properties": {
@@ -59,9 +59,9 @@
           },
           {
             "sku": {
-              "name": "GP_Gen4_4",
+              "name": "GP_Gen5_4",
               "tier": "GeneralPurpose",
-              "family": "Gen4",
+              "family": "Gen5",
               "capacity": 4
             },
             "properties": {

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerListByResourceGroup.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerListByResourceGroup.json
@@ -10,9 +10,9 @@
         "value": [
           {
             "sku": {
-              "name": "B_Gen4_1",
+              "name": "B_Gen5_1",
               "tier": "Basic",
-              "family": "Gen4",
+              "family": "Gen5",
               "capacity": 1
             },
             "properties": {
@@ -35,9 +35,9 @@
           },
           {
             "sku": {
-              "name": "GP_Gen4_2",
+              "name": "GP_Gen5_2",
               "tier": "GeneralPurpose",
-              "family": "Gen4",
+              "family": "Gen5",
               "capacity": 2
             },
             "properties": {

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerUpdate.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/examples/ServerUpdate.json
@@ -15,9 +15,9 @@
     "200": {
       "body": {
         "sku": {
-          "name": "GP_Gen4_2",
+          "name": "GP_Gen5_2",
           "tier": "GeneralPurpose",
-          "family": "Gen4",
+          "family": "Gen5",
           "capacity": 2
         },
         "properties": {


### PR DESCRIPTION
MariaDB service does not support Gen4 server currently, so change its examples from Gen4 to Gen5.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
