### PR TITLE
Oct10

### DIFF
--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/CheckNameAvailability.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/CheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "location": "eastus",
+    "parameters": {
+      "type": "Microsoft.SignalRService/SignalR",
+      "name": "my-signalr-service"
+    },
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nameAvailable": false,
+        "reason": "AlreadyExists",
+        "message": "The leaf is already used by other people"
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/CheckNameAvailability.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/CheckNameAvailability.json
@@ -5,7 +5,7 @@
       "type": "Microsoft.SignalRService/SignalR",
       "name": "my-signalr-service"
     },
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/CreateOrUpdate.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/CreateOrUpdate.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "parameters": {
+      "location": "eastus",
+      "tags": {
+        "key1": "value1"
+      },
+      "sku": {
+        "name": "Standard_S1",
+        "tier": "Standard",
+        "capacity": 1
+      },
+      "properties": {
+        "hostNamePrefix": null
+      }
+    },
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "sku": {
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "externalIP": "10.0.0.1",
+          "hostName": "myservice.service.signalr.net",
+          "publicPort": 5001,
+          "serverPort": 5002,
+          "version": "1.0-preview",
+          "hostNamePrefix": null
+        },
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+        "name": "mySignalRService",
+        "type": "Microsoft.SignalRService/SignalR"
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult..."
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/CreateOrUpdate.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/CreateOrUpdate.json
@@ -14,7 +14,7 @@
         "hostNamePrefix": null
       }
     },
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"
@@ -32,8 +32,8 @@
           "provisioningState": "Succeeded",
           "externalIP": "10.0.0.1",
           "hostName": "myservice.service.signalr.net",
-          "publicPort": 5001,
-          "serverPort": 5002,
+          "publicPort": 443,
+          "serverPort": 443,
           "version": "1.0-preview",
           "hostNamePrefix": null
         },

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Delete.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Delete.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Get.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Get.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sku": {
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "externalIP": "10.0.0.1",
+          "hostName": "myservice.service.signalr.net",
+          "publicPort": 5001,
+          "serverPort": 5002,
+          "version": "1.0-preview",
+          "hostNamePrefix": null
+        },
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+        "name": "mySignalRService",
+        "type": "Microsoft.SignalRService/SignalR"
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Get.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"
@@ -18,8 +18,8 @@
           "provisioningState": "Succeeded",
           "externalIP": "10.0.0.1",
           "hostName": "myservice.service.signalr.net",
-          "publicPort": 5001,
-          "serverPort": 5002,
+          "publicPort": 443,
+          "serverPort": 443,
           "version": "1.0-preview",
           "hostNamePrefix": null
         },

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListByResourceGroup.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListByResourceGroup.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "sku": {
+              "name": "Standard_S1",
+              "tier": "Standard",
+              "size": "S1",
+              "capacity": 1
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "externalIP": "10.0.0.1",
+              "hostName": "myservice.service.signalr.net",
+              "publicPort": 5001,
+              "serverPort": 5002,
+              "version": "1.0-preview",
+              "hostNamePrefix": null
+            },
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+            "name": "mySignalRService",
+            "type": "Microsoft.SignalRService/SignalR"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListByResourceGroup.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup"
   },
@@ -19,8 +19,8 @@
               "provisioningState": "Succeeded",
               "externalIP": "10.0.0.1",
               "hostName": "myservice.service.signalr.net",
-              "publicPort": 5001,
-              "serverPort": 5002,
+              "publicPort": 443,
+              "serverPort": 443,
               "version": "1.0-preview",
               "hostNamePrefix": null
             },

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListBySubscription.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListBySubscription.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "sku": {
+              "name": "Standard_S1",
+              "tier": "Standard",
+              "size": "S1",
+              "capacity": 1
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "externalIP": "10.0.0.1",
+              "hostName": "myservice.service.signalr.net",
+              "publicPort": 5001,
+              "serverPort": 5002,
+              "version": "1.0-preview",
+              "hostNamePrefix": null
+            },
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+            "name": "mySignalRService",
+            "type": "Microsoft.SignalRService/SignalR"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListBySubscription.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {
@@ -18,8 +18,8 @@
               "provisioningState": "Succeeded",
               "externalIP": "10.0.0.1",
               "hostName": "myservice.service.signalr.net",
-              "publicPort": 5001,
-              "serverPort": 5002,
+              "publicPort": 443,
+              "serverPort": 443,
               "version": "1.0-preview",
               "hostNamePrefix": null
             },

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListKeys.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "primaryAccessKey",
+        "secondaryKey": "secondaryAccessKey",
+        "primaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=primaryAccessKey;",
+        "secondaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=secondaryAccessKey;"
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListKeys.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"
@@ -10,8 +10,8 @@
       "body": {
         "primaryKey": "primaryAccessKey",
         "secondaryKey": "secondaryAccessKey",
-        "primaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=primaryAccessKey;",
-        "secondaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=secondaryAccessKey;"
+        "primaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=primaryAccessKey;Version=1.0",
+        "secondaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=secondaryAccessKey;Version=1.0"
       }
     }
   }

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListOperations.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListOperations.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2018-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.SignalRService/SignalR/read",
+            "display": {
+              "provider": "Microsoft.SignalRService",
+              "resource": "SignalR",
+              "operation": "Manage SignalR (read-only)",
+              "description": "View the SignalR's settings and configurations in the management portal or through API"
+            },
+            "properties": {}
+          }
+        ],
+        "nextLink": "providers/Microsoft.SignalRService?$skipToken={opaqueString}"
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListOperations.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListOperations.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-03-01-preview"
+    "api-version": "2018-10-01"
   },
   "responses": {
     "200": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListUsagesByLocation.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListUsagesByLocation.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "location": "eastus",
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SignalRService/locations/eastus/usages/Usage1",
+            "currentValue": 0,
+            "limit": 100,
+            "name": {
+              "value": "Usage1",
+              "localizedValue": "Usage1"
+            },
+            "unit": "Count"
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SignalRService/locations/eastus/usages/Usage2",
+            "currentValue": 0,
+            "limit": 100,
+            "name": {
+              "value": "Usage2",
+              "localizedValue": "Usage2"
+            },
+            "unit": "Count"
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToMoreResults..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListUsagesByLocation.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/ListUsagesByLocation.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "location": "eastus",
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/RegenerateKey.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/RegenerateKey.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "parameters": {
+      "keyType": "Primary"
+    },
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "primaryKey": "primaryAccessKey",
+        "secondaryKey": "secondaryAccessKey",
+        "primaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=primaryAccessKey;",
+        "secondaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=secondaryAccessKey;"
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/RegenerateKey.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/RegenerateKey.json
@@ -3,7 +3,7 @@
     "parameters": {
       "keyType": "Primary"
     },
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Update.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Update.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "parameters": {
+      "tags": {
+        "key1": "value1"
+      },
+      "sku": {
+        "name": "Standard_S1",
+        "tier": "Standard",
+        "capacity": 1
+      },
+      "properties": {
+        "hostNamePrefix": null
+      }
+    },
+    "api-version": "2018-03-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sku": {
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "externalIP": "10.0.0.1",
+          "hostName": "myservice.service.signalr.net",
+          "publicPort": 5001,
+          "serverPort": 5002,
+          "version": "1.0-preview",
+          "hostNamePrefix": null
+        },
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+        "name": "mySignalRService",
+        "type": "Microsoft.SignalRService/SignalR"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Update.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/examples/Update.json
@@ -13,7 +13,7 @@
         "hostNamePrefix": null
       }
     },
-    "api-version": "2018-03-01-preview",
+    "api-version": "2018-10-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"
@@ -31,8 +31,8 @@
           "provisioningState": "Succeeded",
           "externalIP": "10.0.0.1",
           "hostName": "myservice.service.signalr.net",
-          "publicPort": 5001,
-          "serverPort": 5002,
+          "publicPort": 443,
+          "serverPort": 443,
           "version": "1.0-preview",
           "hostNamePrefix": null
         },

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/signalr.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2018-03-01-preview",
+    "version": "2018-10-01",
     "title": "SignalRManagementClient",
     "description": "REST API for Azure SignalR Service"
   },
@@ -751,7 +751,7 @@
           "type": "string"
         },
         "tier": {
-          "description": "Optional tier of this particular SKU. `Basic` is deprecated, use `Standard` instead for Basic tier",
+          "description": "Optional tier of this particular SKU. `Basic` is deprecated, use `Standard` instead for Basic tier.",
           "enum": [
             "Free",
             "Basic",
@@ -962,8 +962,8 @@
           "type": "integer"
         },
         "name": {
-          "description": "Localizable String object containing the name and a localized value.",
-          "$ref": "#/definitions/SignalRUsageName"
+          "$ref": "#/definitions/SignalRUsageName",
+          "description": "Localizable String object containing the name and a localized value."
         },
         "unit": {
           "description": "Representing the units of the usage quota. Possible values are: Count, Bytes, Seconds, Percent, CountPerSecond, BytesPerSecond.",
@@ -994,7 +994,8 @@
       "required": true,
       "type": "string",
       "enum": [
-        "2018-03-01-preview"
+        "2018-03-01-preview",
+        "2018-10-01"
       ]
     },
     "SubscriptionIdParameter": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2018-10-01/signalr.json
@@ -1,0 +1,1042 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-03-01-preview",
+    "title": "SignalRManagementClient",
+    "description": "REST API for Azure SignalR Service"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/providers/Microsoft.SignalRService/operations": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Lists all of the available REST API operations of the Microsoft.SignalRService provider.",
+        "operationId": "Operations_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the list of operations.",
+            "schema": {
+              "$ref": "#/definitions/OperationList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "ListOperations": {
+            "$ref": "./examples/ListOperations.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/locations/{location}/checkNameAvailability": {
+      "post": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Checks that the SignalR name is valid and is not already in use.",
+        "operationId": "SignalR_CheckNameAvailability",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "path",
+            "description": "the region",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the operation.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/NameAvailabilityParameters"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the name availability.",
+            "schema": {
+              "$ref": "#/definitions/NameAvailability"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CheckNameAvailability": {
+            "$ref": "./examples/CheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/SignalR": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Handles requests to list all resources in a subscription.",
+        "operationId": "SignalR_ListBySubscription",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the list of SignalR services in the subscription.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResourceList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "ListBySubscription": {
+            "$ref": "./examples/ListBySubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Handles requests to list all resources in a resource group.",
+        "operationId": "SignalR_ListByResourceGroup",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the list of SignalR services in a resourceGroup.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResourceList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "ListByResourceGroup": {
+            "$ref": "./examples/ListByResourceGroup.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}/listKeys": {
+      "post": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Get the access keys of the SignalR resource.",
+        "operationId": "SignalR_ListKeys",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes SignalR service access keys.",
+            "schema": {
+              "$ref": "#/definitions/SignalRKeys"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListKeys": {
+            "$ref": "./examples/ListKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}/regenerateKey": {
+      "post": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Regenerate SignalR service access key. PrimaryKey and SecondaryKey cannot be regenerated at the same time.",
+        "operationId": "SignalR_RegenerateKey",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameter that describes the Regenerate Key Operation.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/RegenerateKeyParameters"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created and an async operation is excuting in background to make the new key to take effect. The response contains new keys and a Location header to query the async operation result.",
+            "schema": {
+              "$ref": "#/definitions/SignalRKeys"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "RegenerateKey": {
+            "$ref": "./examples/RegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Get the SignalR service and its properties.",
+        "operationId": "SignalR_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describe the corresponding SingalR service.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get": {
+            "$ref": "./examples/Get.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Create a new SignalR service and update an exiting SignalR service.",
+        "operationId": "SignalR_CreateOrUpdate",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for the create or update operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/SignalRCreateParameters"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created. The response describes the new service and contains a Location header to query the operation result.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          },
+          "202": {
+            "description": "Accepted. The response indicates the exiting SingalR service is now updating  and contains a Location header to query the operation result.."
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "CreateOrUpdate": {
+            "$ref": "./examples/CreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Operation to delete a SignalR service.",
+        "operationId": "SignalR_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted. The response indicates the delete operation is performed in the background."
+          },
+          "204": {
+            "description": "Success. The response indicates the resource is already deleted."
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Delete": {
+            "$ref": "./examples/Delete.json"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Operation to update an exiting SignalR service.",
+        "operationId": "SignalR_Update",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for the update operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/SignalRUpdateParameters"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes a SingalR service which is not up-to-date.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          },
+          "202": {
+            "description": "Accepted. The response indicates the exiting SingalR service is now updating  and contains a Location header to query the operation result.."
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Update": {
+            "$ref": "./examples/Update.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/locations/{location}/usages": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "List usage quotas for Azure SignalR service by location.",
+        "operationId": "Usages_List",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "path",
+            "description": "the location like \"eastus\"",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describe the usage quotas of a subscription in specified region.",
+            "schema": {
+              "$ref": "#/definitions/SignalRUsageList"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "ListUsagesByLocation": {
+            "$ref": "./examples/ListUsagesByLocation.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "OperationList": {
+      "description": "Result of the request to list REST API operations. It contains a list of operations.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of operations supported by the resource provider.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "nextLink": {
+          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+          "type": "string"
+        }
+      }
+    },
+    "Operation": {
+      "description": "REST API operation supported by SignalR resource provider.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the operation with format: {provider}/{resource}/{operation}",
+          "type": "string"
+        },
+        "display": {
+          "$ref": "#/definitions/OperationDisplay",
+          "description": "The object that describes the operation."
+        },
+        "origin": {
+          "description": "Optional. The intended executor of the operation; governs the display of the operation in the RBAC UX and the audit logs UX.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/OperationProperties",
+          "description": "Extra properties for the operation.",
+          "x-ms-client-flatten": false
+        }
+      }
+    },
+    "OperationDisplay": {
+      "description": "The object that describes a operation.",
+      "type": "object",
+      "properties": {
+        "provider": {
+          "description": "Friendly name of the resource provider",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Resource type on which the operation is performed.",
+          "type": "string"
+        },
+        "operation": {
+          "description": "The localized friendly name for the operation.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The localized friendly description for the operation",
+          "type": "string"
+        }
+      }
+    },
+    "OperationProperties": {
+      "description": "Extra Operation properties.",
+      "type": "object",
+      "properties": {
+        "serviceSpecification": {
+          "$ref": "#/definitions/ServiceSpecification",
+          "description": "The service specifications."
+        }
+      }
+    },
+    "ServiceSpecification": {
+      "description": "An object that describes a specification.",
+      "type": "object",
+      "properties": {
+        "metricSpecifications": {
+          "description": "Specifications of the Metrics for Azure Monitoring.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MetricSpecification"
+          }
+        }
+      }
+    },
+    "MetricSpecification": {
+      "description": "Specifications of the Metrics for Azure Monitoring.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the metric.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Localized friendly display name of the metric.",
+          "type": "string"
+        },
+        "displayDescription": {
+          "description": "Localized friendly description of the metric.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The unit that makes sense for the metric.",
+          "type": "string"
+        },
+        "aggregationType": {
+          "description": "Only provide one value for this field. Valid values: Average, Minimum, Maximum, Total, Count.",
+          "type": "string"
+        },
+        "fillGapWithZero": {
+          "description": "Optional. If set to true, then zero will be returned for time duration where no metric is emitted/published. \r\nEx. a metric that returns the number of times a particular error code was emitted. The error code may not appear \r\noften, instead of the RP publishing 0, Shoebox can auto fill in 0s for time periods where nothing was emitted.",
+          "type": "string"
+        },
+        "category": {
+          "description": "The name of the metric category that the metric belongs to. A metric can only belong to a single category.",
+          "type": "string"
+        },
+        "dimensions": {
+          "description": "The dimensions of the metrics.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Dimension"
+          }
+        }
+      }
+    },
+    "Dimension": {
+      "description": "Specifications of the Dimension of metrics.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The public facing name of the dimension.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Localized friendly display name of the dimension.",
+          "type": "string"
+        },
+        "internalName": {
+          "description": "Name of the dimension as it appears in MDM.",
+          "type": "string"
+        },
+        "toBeExportedForShoebox": {
+          "description": "A Boolean flag indicating whether this dimension should be included for the shoebox export scenario.",
+          "type": "boolean"
+        }
+      }
+    },
+    "NameAvailabilityParameters": {
+      "description": "Data POST-ed to the nameAvailability action",
+      "required": [
+        "type",
+        "name"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The resource type. Should be always \"Microsoft.SignalRService/SignalR\".",
+          "type": "string"
+        },
+        "name": {
+          "description": "The SignalR service name to validate. e.g.\"my-signalR-name-here\"",
+          "type": "string"
+        }
+      }
+    },
+    "NameAvailability": {
+      "description": "Result of the request to check name availability. It contains a flag and possible reason of failure.",
+      "type": "object",
+      "properties": {
+        "nameAvailable": {
+          "description": "Indicates whether the name is available or not.",
+          "type": "boolean"
+        },
+        "reason": {
+          "description": "The reason of the availability. Required if name is not available.",
+          "type": "string"
+        },
+        "message": {
+          "description": "The message of the operation.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRResourceList": {
+      "description": "Object that includes an array of SignalR services and a possible link for next set.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of SignalR services",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SignalRResource"
+          }
+        },
+        "nextLink": {
+          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRResource": {
+      "description": "A class represent a SignalR service resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResource"
+        }
+      ],
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/ResourceSku",
+          "description": "SKU of the service."
+        },
+        "properties": {
+          "$ref": "#/definitions/SignalRProperties",
+          "description": "The properties of the service.",
+          "x-ms-client-flatten": true
+        },
+        "id": {
+          "description": "Fully qualified resource Id for the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "The name of the resouce.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "The type of the service - e.g. \"Microsoft.SignalRService/SignalR\"",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "TrackedResource": {
+      "description": "The resource model definition for a ARM tracked top level resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "location": {
+          "description": "The GEO location of the SignalR service. e.g. West US | East US | North Central US | South Central US.",
+          "type": "string",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "description": "Tags of the service which is a list of key value pairs that describe the resource.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create",
+            "update"
+          ]
+        }
+      }
+    },
+    "Resource": {
+      "description": "The core properties of ARM resources.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Fully qualified resource Id for the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "The name of the resouce.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "The type of the service - e.g. \"Microsoft.SignalRService/SignalR\"",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ResourceSku": {
+      "description": "The billing information of the resource.(e.g. basic vs. standard)",
+      "required": [
+        "name"
+      ],
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the SKU. This is typically a letter + number code, such as A0 or P3.  Required (if sku is specified)",
+          "type": "string"
+        },
+        "tier": {
+          "description": "Optional tier of this particular SKU. `Basic` is deprecated, use `Standard` instead for Basic tier",
+          "enum": [
+            "Free",
+            "Basic",
+            "Standard",
+            "Premium"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SignalRSkuTier",
+            "modelAsString": true
+          }
+        },
+        "size": {
+          "description": "Optional, string. When the name field is the combination of tier and some other value, this would be the standalone code.",
+          "type": "string"
+        },
+        "family": {
+          "description": "Optional, string. If the service has different generations of hardware, for the same SKU, then that can be captured here.",
+          "type": "string"
+        },
+        "capacity": {
+          "format": "int32",
+          "description": "Optional, integer. If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not \r\npossible for the resource this may be omitted.",
+          "type": "integer"
+        }
+      }
+    },
+    "SignalRProperties": {
+      "description": "A class that describes the properties of the SignalR service that should contain more read-only properties than AzSignalR.Models.SignalRCreateOrUpdateProperties",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalRCreateOrUpdateProperties"
+        }
+      ],
+      "properties": {
+        "provisioningState": {
+          "description": "Provisioning state of the resource.",
+          "enum": [
+            "Unknown",
+            "Succeeded",
+            "Failed",
+            "Canceled",
+            "Running",
+            "Creating",
+            "Updating",
+            "Deleting",
+            "Moving"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "ProvisioningState",
+            "modelAsString": true
+          }
+        },
+        "externalIP": {
+          "description": "The publicly accessible IP of the SignalR service.",
+          "type": "string",
+          "readOnly": true
+        },
+        "hostName": {
+          "description": "FQDN of the SignalR service instance. Format: xxx.service.signalr.net",
+          "type": "string",
+          "readOnly": true
+        },
+        "publicPort": {
+          "format": "int32",
+          "description": "The publicly accessibly port of the SignalR service which is designed for browser/client side usage.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "serverPort": {
+          "format": "int32",
+          "description": "The publicly accessibly port of the SignalR service which is designed for customer server side usage.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "version": {
+          "description": "Version of the SignalR resource. Probably you need the same or higher version of client SDKs.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRCreateOrUpdateProperties": {
+      "description": "Settings used to provision or configure the resource.",
+      "type": "object",
+      "properties": {
+        "hostNamePrefix": {
+          "description": "Prefix for the hostName of the SignalR service. Retained for future use.\r\nThe hostname will be of format: &lt;hostNamePrefix&gt;.service.signalr.net.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRKeys": {
+      "description": "A class represents the access keys of SignalR service.",
+      "type": "object",
+      "properties": {
+        "primaryKey": {
+          "description": "The primary access key.",
+          "type": "string"
+        },
+        "secondaryKey": {
+          "description": "The secondary access key.",
+          "type": "string"
+        },
+        "primaryConnectionString": {
+          "description": "SignalR connection string constructed via the primaryKey",
+          "type": "string"
+        },
+        "secondaryConnectionString": {
+          "description": "SignalR connection string constructed via the secondaryKey",
+          "type": "string"
+        }
+      }
+    },
+    "RegenerateKeyParameters": {
+      "description": "Parameters describes the request to regenerate access keys",
+      "type": "object",
+      "properties": {
+        "keyType": {
+          "description": "The keyType to regenerate. Must be either 'primary' or 'secondary'(case-insensitive).",
+          "enum": [
+            "Primary",
+            "Secondary"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "KeyType",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "SignalRCreateParameters": {
+      "description": "Parameters for SignalR service create/update operation.\r\n\r\nKeep the same schema as AzSignalR.Models.SignalRResource",
+      "required": [
+        "location"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalRUpdateParameters"
+        }
+      ],
+      "properties": {
+        "location": {
+          "description": "Azure GEO region: e.g. West US | East US | North Central US | South Central US | West Europe | North Europe | East Asia | Southeast Asia | etc. \r\nThe geo region of a resource never changes after it is created.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRUpdateParameters": {
+      "description": "Parameters for SignalR service update operation",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "description": "A list of key value pairs that describe the resource.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "sku": {
+          "$ref": "#/definitions/ResourceSku",
+          "description": "The billing information of the resource.(e.g. basic vs. standard)"
+        },
+        "properties": {
+          "$ref": "#/definitions/SignalRCreateOrUpdateProperties",
+          "description": "Settings used to provision or configure the resource",
+          "x-ms-client-flatten": false
+        }
+      }
+    },
+    "SignalRUsageList": {
+      "description": "Object that includes an array of SignalR resource usages and a possible link for next set.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of SignalR usages",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SignalRUsage"
+          }
+        },
+        "nextLink": {
+          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRUsage": {
+      "description": "Object that describes a specific usage of SignalR resources.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Fully qualified ARM resource id",
+          "type": "string"
+        },
+        "currentValue": {
+          "format": "int64",
+          "description": "Current value for the usage quota.",
+          "type": "integer"
+        },
+        "limit": {
+          "format": "int64",
+          "description": "The maximum permitted value for the usage quota. If there is no limit, this value will be -1.",
+          "type": "integer"
+        },
+        "name": {
+          "description": "Localizable String object containing the name and a localized value.",
+          "$ref": "#/definitions/SignalRUsageName"
+        },
+        "unit": {
+          "description": "Representing the units of the usage quota. Possible values are: Count, Bytes, Seconds, Percent, CountPerSecond, BytesPerSecond.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRUsageName": {
+      "description": "Localizable String object containing the name and a localized value.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The indentifier of the usage.",
+          "type": "string"
+        },
+        "localizedValue": {
+          "description": "Localized name of the usage.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "Client Api Version.",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "2018-03-01-preview"
+      ]
+    },
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Gets subscription Id which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+      "required": true,
+      "type": "string"
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "SignalRServiceName": {
+      "name": "resourceName",
+      "in": "path",
+      "description": "The name of the SignalR resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      },
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow"
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ]
+}

--- a/specification/signalr/resource-manager/readme.go.md
+++ b/specification/signalr/resource-manager/readme.go.md
@@ -14,6 +14,7 @@ go:
 ``` yaml $(go) && $(multiapi)
 batch:
   - tag: package-2018-03-01-preview
+  - tag: package-2018-10-01
 ```
 
 ### Tag: package-2018-03-01-preview and go
@@ -23,4 +24,13 @@ Please also specify `--go-sdk-folder=<path to the root directory of your azure-s
 
 ``` yaml $(tag) == 'package-2018-03-01-preview' && $(go)
 output-folder: $(go-sdk-folder)/services/preview/$(namespace)/mgmt/2018-03-01-preview/$(namespace)
+```
+
+### Tag: package-2018-10-01 and go
+
+These settings apply only when `--tag=package-2018-10-01 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2018-10-01' && $(go)
+output-folder: $(go-sdk-folder)/services/$(namespace)/mgmt/package-2018-10-01/$(namespace)
 ```

--- a/specification/signalr/resource-manager/readme.md
+++ b/specification/signalr/resource-manager/readme.md
@@ -26,9 +26,17 @@ These are the global settings for the SignalR API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2018-03-01-preview
+tag: package-2018-10-01
 ```
 
+### Tag: package-2018-10-01
+
+These settings apply only when `--tag=package-2018-10-01` is specified on the command line.
+
+``` yaml $(tag) == 'package-2018-10-01'
+input-file:
+- Microsoft.SignalRService/stable/2018-10-01/signalr.json
+```
 
 ### Tag: package-2018-03-01-preview
 
@@ -112,6 +120,20 @@ output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-signalr
 ``` yaml $(java) && $(multiapi)
 batch:
   - tag: package-2018-03-01-preview
+  - tag: package-2018-10-01
+```
+
+### Tag: package-2018-10-01 and java
+
+These settings apply only when `--tag=package-2018-10-01 --java` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+``` yaml $(tag) == 'package-2018-10-01' && $(java) && $(multiapi)
+java:
+  namespace: com.microsoft.azure.management.signalr.v2018_10_01
+  output-folder: $(azure-libraries-for-java-folder)/signalr/resource-manager/v2018_10_01
+regenerate-manager: true
+generate-interface: true
 ```
 
 ### Tag: package-2018-03-01-preview and java

--- a/specification/signalr/resource-manager/readme.ruby.md
+++ b/specification/signalr/resource-manager/readme.ruby.md
@@ -13,6 +13,17 @@ azure-arm: true
 ``` yaml $(ruby) && $(multiapi)
 batch:
   - tag: package-2018-03-01-preview
+  - tag: package-2018-10-01
+```
+
+### Tag: package-2018-10-01 and ruby
+
+These settings apply only when `--tag=package-2018-10-01 --ruby` is specified on the command line.
+Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
+
+``` yaml $(tag) == 'package-2018-10-01' && $(ruby)
+namespace: "Azure::Signalr::Mgmt::V2018_10_01"
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_signalr/lib
 ```
 
 ### Tag: package-2018-03-01-preview and ruby


### PR DESCRIPTION
Azure SignalR Service is adding a new api-version `2018-10-01` since we already went GA.  However there is no new API comparing to the spec for `2018-03-01-preview`. We only changed the version in readme files, spec and examples.

Two commits included. Ther first one copied the files from `2018-03-01-preview`. And the second added a api-version.

Quality control:
All validations documented at https://github.com/Azure/adx-documentation-pr/wiki/Azure-Swagger-Tools passed.
