### PR TITLE
Adding property to VirtualNetworkRule for Cosmos DB

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/cosmos-db.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/cosmos-db.json
@@ -1890,6 +1890,10 @@
         "id":{
           "type": "string",
           "description": "Resource ID of a subnet, for example: /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}."
+        },
+        "ignoreMissingVNetServiceEndpoint":{
+          "type": "boolean",
+          "description": "Create firewall rule before the virtual network has vnet service endpoint enabled."
         }
       }
     },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMax.json
@@ -14,7 +14,8 @@
         "isVirtualNetworkFilterEnabled": true,
         "virtualNetworkRules": [
           {
-            "id": "/subscriptions/subId/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
+            "id": "/subscriptions/subId/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1",
+            "ignoreMissingVNetServiceEndpoint": false
           }
         ],
         "locations": [

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMulti.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMulti.json
@@ -15,7 +15,8 @@
         "enableMultipleWriteLocations": true,
         "virtualNetworkRules": [
           {
-            "id": "/subscriptions/subId/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
+            "id": "/subscriptions/subId/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1",
+            "ignoreMissingVNetServiceEndpoint": false
           }
         ],
         "locations": [


### PR DESCRIPTION
Adding property ignoreMissingVNetServiceEndpoint to VirtualNetworkRule object in Cosmos DB swagger.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
