### PR TITLE
Add facet sortBy and filter to ResourceGraph swagger

### DIFF
--- a/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/preview/2018-09-01-preview/examples/ResourcesFacetQuery.json
+++ b/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/preview/2018-09-01-preview/examples/ResourcesFacetQuery.json
@@ -7,7 +7,7 @@
       "subscriptions": [
         "cfbbd179-59d2-4052-aa06-9270a38aa9d6"
       ],
-      "query": "where type =~ 'Microsoft.Compute/virtualMachines' | project id, name, location, properties.storageProfile.osDisk.osType | limit 5",
+      "query": "where type =~ 'Microsoft.Compute/virtualMachines' | project id, name, location, resourceGroup, properties.storageProfile.osDisk.osType | limit 5",
       "facets": [
         {
           "expression": "location",
@@ -27,6 +27,21 @@
           "expression": "nonExistingColumn",
           "options": {
             "sortOrder": "desc",
+            "$top": 3
+          }
+        },
+        {
+          "expression": "resourceGroup",
+          "options": {
+            "sortBy": "tolower(resourceGroup)",
+            "sortOrder": "asc",
+            "$top": 3
+          }
+        },
+        {
+          "expression": "resourceGroup",
+          "options": {
+            "filter": "resourceGroup contains 'test'",
             "$top": 3
           }
         }
@@ -54,39 +69,48 @@
               "type": "string"
             },
             {
+              "name": "resourceGroup",
+              "type": "string"
+            },
+            {
               "name": "properties_storageProfile_osDisk_osType",
               "type": "object"
             }
           ],
           "rows": [
             [
-              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/RG1/providers/Microsoft.Compute/virtualMachines/myTestVm",
+              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/B-TEST-RG/providers/Microsoft.Compute/virtualMachines/myTestVm",
               "myTestVm",
               "eastus",
+              "B-TEST-RG",
               "Windows"
             ],
             [
-              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/RG1/providers/Microsoft.Compute/virtualMachines/myTestAccountVm",
+              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/c-rg/providers/Microsoft.Compute/virtualMachines/myTestAccountVm",
               "myTestAccountVm",
               "westcentralus",
+              "c-rg",
               "Windows"
             ],
             [
-              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/RG1/providers/Microsoft.Compute/virtualMachines/yetanothertest",
+              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/I-RG/providers/Microsoft.Compute/virtualMachines/yetanothertest",
               "yetanothertest",
               "eastus",
+              "I-RG",
               "Linux"
             ],
             [
-              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/RG2/providers/Microsoft.Compute/virtualMachines/drafttest1bux4cv7a7q3aw",
+              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/x-test-rg/providers/Microsoft.Compute/virtualMachines/drafttest1bux4cv7a7q3aw",
               "drafttest1bux4cv7a7q3aw",
               "southcentralus",
+              "x-test-rg",
               "Linux"
             ],
             [
-              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/RG2/providers/Microsoft.Compute/virtualMachines/testvmntp25370",
+              "/subscriptions/cfbbd179-59d2-4052-aa06-9270a38aa9d6/resourceGroups/y-rg/providers/Microsoft.Compute/virtualMachines/testvmntp25370",
               "testvmntp25370",
               "eastus",
+              "y-rg",
               "Windows"
             ]
           ]
@@ -165,6 +189,66 @@
                 "message": "Invalid column names: [nonExistingColumn]."
               }
             ]
+          },
+          {
+            "expression": "resourceGroup",
+            "resultType": "FacetResult",
+            "totalRecords": 5,
+            "count": 3,
+            "data": {
+              "columns": [
+                {
+                  "name": "resourceGroup",
+                  "type": "string"
+                },
+                {
+                  "name": "count",
+                  "type": "integer"
+                }
+              ],
+              "rows": [
+                [
+                  "B-TEST-RG",
+                  1
+                ],
+                [
+                  "c-rg",
+                  1
+                ],
+                [
+                  "I-RG",
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "expression": "resourceGroup",
+            "resultType": "FacetResult",
+            "totalRecords": 2,
+            "count": 2,
+            "data": {
+              "columns": [
+                {
+                  "name": "resourceGroup",
+                  "type": "string"
+                },
+                {
+                  "name": "count",
+                  "type": "integer"
+                }
+              ],
+              "rows": [
+                [
+                  "B-TEST-RG",
+                  1
+                ],
+                [
+                  "x-test-rg",
+                  1
+                ]
+              ]
+            }
           }
         ]
       }

--- a/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/preview/2018-09-01-preview/resourcegraph.json
+++ b/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/preview/2018-09-01-preview/resourcegraph.json
@@ -193,8 +193,12 @@
     "FacetRequestOptions": {
       "description": "The options for facet evaluation",
       "properties": {
+        "sortBy": {
+          "description": "The column name or query expression to sort on. Defaults to count if not present.",
+          "type": "string"
+        },
         "sortOrder": {
-          "description": "The sorting order by the hit count",
+          "description": "The sorting order by the selected column (count by default).",
           "type": "string",
           "default": "desc",
           "enum": [
@@ -205,6 +209,10 @@
             "name": "FacetSortOrder",
             "modelAsString": false
           }
+        },
+        "filter": {
+          "description": "Specifies the filter condition for the 'where' clause which will be run on main query's result, just before the actual faceting.",
+          "type": "string"
         },
         "$top": {
           "description": "The maximum number of facet rows that should be returned.",

--- a/specification/resourcegraph/resource-manager/readme.python.md
+++ b/specification/resourcegraph/resource-manager/readme.python.md
@@ -12,7 +12,7 @@ python:
   payload-flattening-threshold: 2
   namespace: azure.mgmt.resourcegraph
   package-name: azure-mgmt-resourcegraph
-  package-version: 0.6.0
+  package-version: 0.7.0
   clear-output-folder: true
 ```
 ``` yaml $(python) && $(python-mode) == 'update'


### PR DESCRIPTION
Adding a couple of extra fields in a non-breaking manner.

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [x] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [x] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [x] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
