### PR TITLE
fixing invalid location in examples

### DIFF
--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerCreate.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerCreate.json
@@ -5,7 +5,7 @@
     "api-version": "2017-04-30-preview",
     "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
     "parameters": {
-      "location": "OneBox",
+      "location": "eastus",
       "properties": {
         "administratorLogin": "cloudsa",
         "administratorLoginPassword": "password",
@@ -29,7 +29,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforMySQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "name": "MYSQLS3M100",
           "tier": "Basic",
@@ -52,7 +52,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforMySQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "name": "MYSQLS3M100",
           "tier": "Basic",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerGet.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerGet.json
@@ -11,7 +11,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforMySQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "name": "MYSQLS3M100",
           "tier": "Basic",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerList.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerList.json
@@ -11,7 +11,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
             "name": "testserver",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "MYSQLS3M100",
               "tier": "Basic",
@@ -32,7 +32,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/serv1",
             "name": "serv1",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "MYSQLS3M100",
               "tier": "Basic",
@@ -53,7 +53,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup2/providers/Microsoft.DBforMySQL/servers/serv2",
             "name": "serv2",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "MYSQLS3M100",
               "tier": "Basic",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerListByResourceGroup.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerListByResourceGroup.json
@@ -12,7 +12,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/serv1",
             "name": "serv1",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "MYSQLS3M100",
               "tier": "Basic",
@@ -33,7 +33,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
             "name": "testserver",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "MYSQLS3M100",
               "tier": "Basic",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerUpdate.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-04-30-preview/examples/ServerUpdate.json
@@ -17,7 +17,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforMySQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "name": "MYSQLS3M100",
           "tier": "Basic",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerCreate.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerCreate.json
@@ -5,7 +5,7 @@
     "api-version": "2017-12-01-preview",
     "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
     "parameters": {
-      "location": "OneBox",
+      "location": "eastus",
       "properties": {
         "administratorLogin": "cloudsa",
         "administratorLoginPassword": "password",
@@ -34,7 +34,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforMySQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "capacity": 2,
           "family": "Gen4",
@@ -64,7 +64,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforMySQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "capacity": 2,
           "family": "Gen4",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerGet.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerGet.json
@@ -11,7 +11,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforMySQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "tags": {
           "elasticServer": "1"
         },

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerList.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerList.json
@@ -11,7 +11,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
             "name": "testserver",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },
@@ -39,7 +39,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver1",
             "name": "testserver1",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },
@@ -67,7 +67,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver2",
             "name": "testserver2",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerListByResourceGroup.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerListByResourceGroup.json
@@ -12,7 +12,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
             "name": "testserver",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },
@@ -40,7 +40,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver1",
             "name": "testserver1",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },
@@ -68,7 +68,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver2",
             "name": "testserver2",
             "type": "Microsoft.DBforMySQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerUpdate.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/examples/ServerUpdate.json
@@ -17,7 +17,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforMySQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforMySQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "capacity": 2,
           "family": "Gen4",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerCreate.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerCreate.json
@@ -5,7 +5,7 @@
     "api-version": "2017-04-30-preview",
     "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
     "parameters": {
-      "location": "OneBox",
+      "location": "eastus",
       "properties": {
         "administratorLogin": "cloudsa",
         "administratorLoginPassword": "password",
@@ -29,7 +29,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforPostgreSQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "name": "PGSQLB100",
           "tier": "Basic",
@@ -52,7 +52,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforPostgreSQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "name": "PGSQLB100",
           "tier": "Basic",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerGet.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerGet.json
@@ -11,7 +11,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforPostgreSQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "name": "PGSQLB100",
           "tier": "Basic",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerList.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerList.json
@@ -11,7 +11,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
             "name": "testserver",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "PGSQLB100",
               "tier": "Basic",
@@ -32,7 +32,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/serv1",
             "name": "serv1",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "PGSQLB100",
               "tier": "Basic",
@@ -53,7 +53,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup2/providers/Microsoft.DBforPostgreSQL/servers/serv2",
             "name": "serv2",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "PGSQLB100",
               "tier": "Basic",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerListByResourceGroup.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerListByResourceGroup.json
@@ -12,7 +12,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/serv1",
             "name": "serv1",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "PGSQLB100",
               "tier": "Basic",
@@ -33,7 +33,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
             "name": "testserver",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "sku": {
               "name": "PGSQLB100",
               "tier": "Basic",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerUpdate.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-04-30-preview/examples/ServerUpdate.json
@@ -17,7 +17,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforPostgreSQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "name": "PGSQLB100",
           "tier": "Basic",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerCreate.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerCreate.json
@@ -5,7 +5,7 @@
     "api-version": "2017-12-01-preview",
     "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
     "parameters": {
-      "location": "OneBox",
+      "location": "eastus",
       "properties": {
         "administratorLogin": "cloudsa",
         "administratorLoginPassword": "password",
@@ -34,7 +34,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforPostgreSQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "capacity": 2,
           "family": "Gen4",
@@ -64,7 +64,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforPostgreSQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "capacity": 2,
           "family": "Gen4",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerGet.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerGet.json
@@ -11,7 +11,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforPostgreSQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "tags": {
           "elasticServer": "1"
         },

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerList.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerList.json
@@ -11,7 +11,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
             "name": "testserver",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },
@@ -39,7 +39,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver1",
             "name": "testserver1",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },
@@ -67,7 +67,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver2",
             "name": "testserver2",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerListByResourceGroup.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerListByResourceGroup.json
@@ -12,7 +12,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
             "name": "testserver",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },
@@ -40,7 +40,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver1",
             "name": "testserver1",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },
@@ -68,7 +68,7 @@
             "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver2",
             "name": "testserver2",
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "location": "onebox",
+            "location": "eastus",
             "tags": {
               "elasticServer": "1"
             },

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerUpdate.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerUpdate.json
@@ -17,7 +17,7 @@
         "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/servers/testserver",
         "name": "testserver",
         "type": "Microsoft.DBforPostgreSQL/servers",
-        "location": "onebox",
+        "location": "eastus",
         "sku": {
           "capacity": 2,
           "family": "Gen4",


### PR DESCRIPTION
OneBox is not a valid location, replaced with proper location.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
