### PR TITLE
Remove readonly attribute from identities collection in users

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/apimusers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/apimusers.json
@@ -822,7 +822,6 @@
           "description": "Optional note about a user set by the administrator."
         },
         "identities": {
-          "readOnly": true,
           "type": "array",
           "items": {
             "$ref": "#/definitions/UserIdentityContract"

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/apimusers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/apimusers.json
@@ -822,7 +822,6 @@
           "description": "Optional note about a user set by the administrator."
         },
         "identities": {
-          "readOnly": true,
           "type": "array",
           "items": {
             "$ref": "#/definitions/UserIdentityContract"


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>

Related to BUG : https://github.com/Azure/azure-sdk-for-node/issues/3857
This property was not readonly in 2018-01-01 iteration of api-version and above

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
