### PR TITLE
Move Ruby SDK config to its own config file

### DIFF
--- a/specification/databox/resource-manager/readme.md
+++ b/specification/databox/resource-manager/readme.md
@@ -105,30 +105,7 @@ python:
 
 ## Ruby
 
-These settings apply only when `--ruby` is specified on the command line.
-
-``` yaml
-package-name: azure_mgmt_databox
-package-version: "0.0.1"
-azure-arm: true
-```
-
-### Ruby multi-api
-
-``` yaml $(ruby) && $(multiapi)
-batch:
-  - tag: package-2018-01
-```
-
-### Tag: package-2018-01 and ruby
-
-These settings apply only when `--tag=package-2018-01 --ruby` is specified on the command line.
-Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
-
-``` yaml $(tag) == 'package-2018-01' && $(ruby)
-namespace: "Azure::Compute::Mgmt::V2018_01_01"
-output-folder: $(ruby-sdks-folder)/management/azure_mgmt_databox/lib
-```
+See configuration in [readme.ruby.md](./readme.ruby.md)
 
 ## Go
 

--- a/specification/databox/resource-manager/readme.ruby.md
+++ b/specification/databox/resource-manager/readme.ruby.md
@@ -1,0 +1,26 @@
+## Ruby
+
+These settings apply only when `--ruby` is specified on the command line.
+
+``` yaml $(ruby)
+package-name: azure_mgmt_databox
+package-version: "0.0.1"
+azure-arm: true
+```
+
+### Ruby multi-api
+
+``` yaml $(ruby) && $(multiapi)
+batch:
+  - tag: package-2018-01
+```
+
+### Tag: package-2018-01 and ruby
+
+These settings apply only when `--tag=package-2018-01 --ruby` is specified on the command line.
+Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
+
+``` yaml $(tag) == 'package-2018-01' && $(ruby)
+namespace: "Azure::Compute::Mgmt::V2018_01_01"
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_databox/lib
+```


### PR DESCRIPTION
The package-name variable for Ruby was colliding with the Go build.
Moved the Ruby config to its own file to avoid the collision.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
