### PR TITLE
Model ContainerNic refs under ContainerNicConfig as sub resources

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkProfile.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkProfile.json
@@ -447,7 +447,7 @@
         "containerNetworkInterfaces": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ContainerNetworkInterface"
+            "$ref": "./network.json#/definitions/SubResource"
           },
           "description": "A list of container network interfaces created from this container network interface configuration."
         },


### PR DESCRIPTION
Modelling container nic children on container nic configs as resource ids only to fix a circular reference issue.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
