### PR TITLE
Port fix from PR 4459 to 2018-10-01

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkProfile.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkProfile.json
@@ -447,7 +447,7 @@
         "containerNetworkInterfaces": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ContainerNetworkInterface"
+            "$ref": "./network.json#/definitions/SubResource"
           },
           "description": "A list of container network interfaces created from this container network interface configuration."
         },


### PR DESCRIPTION
Copied https://github.com/Azure/azure-rest-api-specs/pull/4459 changes to newer API version

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
