### PR TITLE
Add maximum chunk size to data lake store docs.

### DIFF
--- a/specification/datalake-store/data-plane/Microsoft.DataLakeStore/preview/2015-10-01-preview/filesystem.json
+++ b/specification/datalake-store/data-plane/Microsoft.DataLakeStore/preview/2015-10-01-preview/filesystem.json
@@ -286,7 +286,7 @@
           "FileSystem"
         ],
         "operationId": "FileSystem_Concat",
-        "description": "Concatenates the list of source files into the destination file, removing all source files upon success.",
+        "description": "Concatenates the list of source files into the destination file, removing all source files upon success.  This operation has been deprecated, please use operation FileSystem_MsConcat instead.",
         "parameters": [
           {
             "name": "destinationPath",
@@ -331,7 +331,8 @@
               "$ref": "#/definitions/AdlsError"
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/webhdfs/v1/{msConcatDestinationPath}?op=MSCONCAT": {

--- a/specification/datalake-store/data-plane/Microsoft.DataLakeStore/preview/2015-10-01-preview/filesystem.json
+++ b/specification/datalake-store/data-plane/Microsoft.DataLakeStore/preview/2015-10-01-preview/filesystem.json
@@ -64,7 +64,7 @@
               "format": "file"
             },
             "required": true,
-            "description": "The file contents to include when appending to the file."
+            "description": "The file contents to include when appending to the file.  The maximum content size is 4MB.  For content larger than 4MB you must append the content in 4MB chunks."
           },
           {
             "name": "appendMode",
@@ -647,7 +647,7 @@
               "format": "file"
             },
             "required": true,
-            "description": "The file contents to include when appending to the file."
+            "description": "The file contents to include when appending to the file.  The maximum content size is 4MB.  For content larger than 4MB you must append the content in 4MB chunks."
           },
           {
             "name": "offset",
@@ -719,7 +719,7 @@
               "format": "file"
             },
             "required": false,
-            "description": "The file contents to include when creating the file. This parameter is optional, resulting in an empty file if not specified."
+            "description": "The file contents to include when creating the file. This parameter is optional, resulting in an empty file if not specified.  The maximum content size is 4MB.  For content larger than 4MB you must append the content in 4MB chunks."
           },
           {
             "name": "overwrite",

--- a/specification/datalake-store/data-plane/Microsoft.DataLakeStore/preview/2015-10-01-preview/filesystem.json
+++ b/specification/datalake-store/data-plane/Microsoft.DataLakeStore/preview/2015-10-01-preview/filesystem.json
@@ -277,8 +277,10 @@
           }
         }
       }
-    },
-    "/webhdfs/v1/{destinationPath}": {
+    }
+  },
+  "x-ms-paths": {
+    "/webhdfs/v1/{destinationPath}?op=CONCAT": {
       "post": {
         "tags": [
           "FileSystem"
@@ -332,7 +334,7 @@
         }
       }
     },
-    "/webhdfs/v1/{msConcatDestinationPath}": {
+    "/webhdfs/v1/{msConcatDestinationPath}?op=MSCONCAT": {
       "post": {
         "tags": [
           "FileSystem"
@@ -395,7 +397,7 @@
         }
       }
     },
-    "/webhdfs/v1/{listFilePath}": {
+    "/webhdfs/v1/{listFilePath}?op=MSLISTSTATUS": {
       "get": {
         "tags": [
           "FileSystem"
@@ -463,7 +465,7 @@
         }
       }
     },
-    "/webhdfs/va/{getContentSummaryFilePath}": {
+    "/webhdfs/va/{getContentSummaryFilePath}?op=GETCONTENTSUMMARY": {
       "get": {
         "tags": [
           "FileSystem"
@@ -509,7 +511,7 @@
         }
       }
     },
-    "/webhdfs/v1/{getFilePath}": {
+    "/webhdfs/v1/{getFilePath}?op=MSGETFILESTATUS": {
       "get": {
         "tags": [
           "FileSystem"
@@ -555,7 +557,7 @@
         }
       }
     },
-    "/webhdfs/v1/{flushFilePath}": {
+    "/webhdfs/v1/{flushFilePath}?op=APPEND;append=true;flush=true": {
       "post": {
         "tags": [
           "FileSystem"
@@ -621,7 +623,7 @@
         }
       }
     },
-    "/webhdfs/v1/{directFilePath}": {
+    "/webhdfs/v1/{directFilePath}?op=APPEND": {
       "post": {
         "tags": [
           "FileSystem"
@@ -834,7 +836,7 @@
         }
       }
     },
-    "/webhdfs/v1/{setAclFilePath}": {
+    "/webhdfs/v1/{setAclFilePath}?op=SETACL": {
       "put": {
         "tags": [
           "FileSystem"
@@ -884,7 +886,7 @@
         }
       }
     },
-    "/webhdfs/v1/{modifyAclFilePath}": {
+    "/webhdfs/v1/{modifyAclFilePath}?op=MODIFYACLENTRIES": {
       "put": {
         "tags": [
           "FileSystem"
@@ -934,7 +936,7 @@
         }
       }
     },
-    "/webhdfs/v1/{removeAclFilePath}": {
+    "/webhdfs/v1/{removeAclFilePath}?op=REMOVEACLENTRIES": {
       "put": {
         "tags": [
           "FileSystem"
@@ -984,7 +986,7 @@
         }
       }
     },
-    "/webhdfs/v1/{defaultAclFilePath}": {
+    "/webhdfs/v1/{defaultAclFilePath}?op=REMOVEDEFAULTACL": {
       "put": {
         "tags": [
           "FileSystem"
@@ -1027,7 +1029,7 @@
         }
       }
     },
-    "/webhdfs/v1/{aclFilePath}": {
+    "/webhdfs/v1/{aclFilePath}?op=REMOVEACL": {
       "put": {
         "tags": [
           "FileSystem"
@@ -1114,7 +1116,7 @@
         }
       }
     },
-    "/webhdfs/v1/{filePath}": {
+    "/webhdfs/v1/{filePath}?op=DELETE": {
       "delete": {
         "tags": [
           "FileSystem"
@@ -1167,7 +1169,7 @@
         }
       }
     },
-    "/webhdfs/v1/{renameFilePath}": {
+    "/webhdfs/v1/{renameFilePath}?op=RENAME": {
       "put": {
         "tags": [
           "FileSystem"
@@ -1220,7 +1222,7 @@
         }
       }
     },
-    "/webhdfs/v1/{setOwnerFilePath}": {
+    "/webhdfs/v1/{setOwnerFilePath}?op=SETOWNER": {
       "put": {
         "tags": [
           "FileSystem"
@@ -1277,7 +1279,7 @@
         }
       }
     },
-    "/webhdfs/v1/{setPermissionFilePath}": {
+    "/webhdfs/v1/{setPermissionFilePath}?op=SETPERMISSION": {
       "put": {
         "tags": [
           "FileSystem"

--- a/specification/datalake-store/data-plane/Microsoft.DataLakeStore/stable/2016-11-01/filesystem.json
+++ b/specification/datalake-store/data-plane/Microsoft.DataLakeStore/stable/2016-11-01/filesystem.json
@@ -130,7 +130,7 @@
               "format": "file"
             },
             "required": true,
-            "description": "The file contents to include when appending to the file."
+            "description": "The file contents to include when appending to the file.  The maximum content size is 4MB.  For content larger than 4MB you must append the content in 4MB chunks."
           },
           {
             "name": "appendMode",
@@ -743,7 +743,7 @@
               "format": "file"
             },
             "required": true,
-            "description": "The file contents to include when appending to the file."
+            "description": "The file contents to include when appending to the file.  The maximum content size is 4MB.  For content larger than 4MB you must append the content in 4MB chunks."
           },
           {
             "name": "offset",
@@ -854,7 +854,7 @@
               "format": "file"
             },
             "required": false,
-            "description": "The file contents to include when creating the file. This parameter is optional, resulting in an empty file if not specified."
+            "description": "The file contents to include when creating the file. This parameter is optional, resulting in an empty file if not specified.  The maximum content size is 4MB.  For content larger than 4MB you must append the content in 4MB chunks."
           },
           {
             "name": "overwrite",


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
