### PR TITLE
Revert "Model ContainerNic refs under ContainerNicConfig as sub resources"

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkProfile.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkProfile.json
@@ -447,7 +447,7 @@
         "containerNetworkInterfaces": {
           "type": "array",
           "items": {
-            "$ref": "./network.json#/definitions/SubResource"
+            "$ref": "#/definitions/ContainerNetworkInterface"
           },
           "description": "A list of container network interfaces created from this container network interface configuration."
         },


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#4459

Targeted in incorrect folder, submitting PR to revert this