### PR TITLE
Microsoft.Logic - Don't make ResourceReference id readonly

### DIFF
--- a/specification/logic/resource-manager/Microsoft.Logic/preview/2018-07-01-preview/logic.json
+++ b/specification/logic/resource-manager/Microsoft.Logic/preview/2018-07-01-preview/logic.json
@@ -5169,7 +5169,6 @@
       "properties": {
         "id": {
           "type": "string",
-          "readOnly": true,
           "description": "The resource id."
         },
         "name": {


### PR DESCRIPTION
Don't make ResourceReference id readonly, it's causing a bug in the SDK where an Logic Apps with integration accounts can't be saved

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
