### PR TITLE
typo: Fix AppServiceCertificateOrders.json

### DIFF
--- a/specification/web/resource-manager/Microsoft.CertificateRegistration/stable/2015-08-01/AppServiceCertificateOrders.json
+++ b/specification/web/resource-manager/Microsoft.CertificateRegistration/stable/2015-08-01/AppServiceCertificateOrders.json
@@ -164,7 +164,7 @@
           {
             "name": "certificateDistinguishedName",
             "in": "body",
-            "description": "Distinguished name to to use for the certificate order.",
+            "description": "Distinguished name to use for the certificate order.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/AppServiceCertificateOrder"
@@ -220,7 +220,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Succesfully deleted certificate order."
+            "description": "Successfully deleted certificate order."
           },
           "204": {
             "description": "Certificate order does not exist."
@@ -248,7 +248,7 @@
           {
             "name": "certificateDistinguishedName",
             "in": "body",
-            "description": "Distinguished name to to use for the certificate order.",
+            "description": "Distinguished name to use for the certificate order.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/AppServiceCertificateOrderPatchResource"
@@ -449,7 +449,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Succesfully deleted certificate."
+            "description": "Successfully deleted certificate."
           },
           "204": {
             "description": "Certificate does not exist."
@@ -1072,7 +1072,7 @@
       }
     },
     "AppServiceCertificateOrderCollection": {
-      "description": "Collection of certitificate orders.",
+      "description": "Collection of certificate orders.",
       "required": [
         "value"
       ],

--- a/specification/web/resource-manager/Microsoft.CertificateRegistration/stable/2018-02-01/AppServiceCertificateOrders.json
+++ b/specification/web/resource-manager/Microsoft.CertificateRegistration/stable/2018-02-01/AppServiceCertificateOrders.json
@@ -182,7 +182,7 @@
           {
             "name": "certificateDistinguishedName",
             "in": "body",
-            "description": "Distinguished name to to use for the certificate order.",
+            "description": "Distinguished name to use for the certificate order.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/AppServiceCertificateOrder"
@@ -244,7 +244,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Succesfully deleted certificate order."
+            "description": "Successfully deleted certificate order."
           },
           "204": {
             "description": "Certificate order does not exist."
@@ -272,7 +272,7 @@
           {
             "name": "certificateDistinguishedName",
             "in": "body",
-            "description": "Distinguished name to to use for the certificate order.",
+            "description": "Distinguished name to use for the certificate order.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/AppServiceCertificateOrderPatchResource"
@@ -497,7 +497,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Succesfully deleted certificate."
+            "description": "Successfully deleted certificate."
           },
           "204": {
             "description": "Certificate does not exist."
@@ -1144,7 +1144,7 @@
       }
     },
     "AppServiceCertificateOrderCollection": {
-      "description": "Collection of certitificate orders.",
+      "description": "Collection of certificate orders.",
       "required": [
         "value"
       ],


### PR DESCRIPTION
- Double word "to"
- Successully -> Successfully
- certitificate -> certificate

These exist in the previous version but I guessed that the previous versions aren't patched. If that's not the case, I'll submit that too
