### PR TITLE
typo: Fix Microsoft.Web/CommonDefinitions.json

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/CommonDefinitions.json
@@ -676,7 +676,7 @@
    "type": "object",
    "properties": {
     "unit": {
-     "description": "Units of measurement for the quota resourse.",
+     "description": "Units of measurement for the quota resource.",
      "type": "string"
     },
     "nextResetTime": {
@@ -1372,12 +1372,12 @@
     },
     "changeStep": {
      "format": "double",
-     "description": "In auto ramp up scenario this is the step to to add/remove from <code>ReroutePercentage</code> until it reaches \n<code>MinReroutePercentage</code> or <code>MaxReroutePercentage</code>. Site metrics are checked every N minutes specificed in <code>ChangeIntervalInMinutes</code>.\nCustom decision algorithm can be provided in TiPCallback site extension which URL can be specified in <code>ChangeDecisionCallbackUrl</code>.",
+     "description": "In auto ramp up scenario this is the step to add/remove from <code>ReroutePercentage</code> until it reaches \n<code>MinReroutePercentage</code> or <code>MaxReroutePercentage</code>. Site metrics are checked every N minutes specified in <code>ChangeIntervalInMinutes</code>.\nCustom decision algorithm can be provided in TiPCallback site extension which URL can be specified in <code>ChangeDecisionCallbackUrl</code>.",
      "type": "number"
     },
     "changeIntervalInMinutes": {
      "format": "int32",
-     "description": "Specifies interval in mimuntes to reevaluate ReroutePercentage.",
+     "description": "Specifies interval in minutes to reevaluate ReroutePercentage.",
      "type": "integer"
     },
     "minReroutePercentage": {
@@ -2311,7 +2311,7 @@
    }
   },
   "SlotSwapStatus": {
-   "description": "The status of the last successfull slot swap operation.",
+   "description": "The status of the last successful slot swap operation.",
    "type": "object",
    "properties": {
     "timestampUtc": {
@@ -2507,7 +2507,7 @@
    }
   },
   "User": {
-   "description": "User crendentials used for publishing activity.",
+   "description": "User credentials used for publishing activity.",
    "type": "object",
    "allOf": [
     {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/CommonDefinitions.json
@@ -1567,12 +1567,12 @@
         },
         "changeStep": {
           "format": "double",
-          "description": "In auto ramp up scenario this is the step to to add/remove from <code>ReroutePercentage</code> until it reaches \n<code>MinReroutePercentage</code> or <code>MaxReroutePercentage</code>. Site metrics are checked every N minutes specificed in <code>ChangeIntervalInMinutes</code>.\nCustom decision algorithm can be provided in TiPCallback site extension which URL can be specified in <code>ChangeDecisionCallbackUrl</code>.",
+          "description": "In auto ramp up scenario this is the step to add/remove from <code>ReroutePercentage</code> until it reaches \n<code>MinReroutePercentage</code> or <code>MaxReroutePercentage</code>. Site metrics are checked every N minutes specified in <code>ChangeIntervalInMinutes</code>.\nCustom decision algorithm can be provided in TiPCallback site extension which URL can be specified in <code>ChangeDecisionCallbackUrl</code>.",
           "type": "number"
         },
         "changeIntervalInMinutes": {
           "format": "int32",
-          "description": "Specifies interval in mimuntes to reevaluate ReroutePercentage.",
+          "description": "Specifies interval in minutes to reevaluate ReroutePercentage.",
           "type": "integer"
         },
         "minReroutePercentage": {
@@ -2554,7 +2554,7 @@
       }
     },
     "SlotSwapStatus": {
-      "description": "The status of the last successfull slot swap operation.",
+      "description": "The status of the last successful slot swap operation.",
       "type": "object",
       "properties": {
         "timestampUtc": {
@@ -2722,7 +2722,7 @@
       }
     },
     "User": {
-      "description": "User crendentials used for publishing activity.",
+      "description": "User credentials used for publishing activity.",
       "type": "object",
       "allOf": [
         {


### PR DESCRIPTION
- Double word "to"
- resourse -> resource
- mimuntes -> minutes
- specificed -> specified
- successfull -> successful
- crendentials -> credentials
