### PR TITLE
typo: Fix network/resource-manager/Microsoft.Network/network

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/preview/2015-05-01-preview/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/preview/2015-05-01-preview/network.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "NetworkResourceProviderClient",
-    "description": "The Windows Azure Network management API provides a RESTful set of web services that interact with Windows Azure Networks service to manage your network resrources. The API has entities that capture the relationship between an end user and the Windows Azure Networks service.",
+    "description": "The Windows Azure Network management API provides a RESTful set of web services that interact with Windows Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Windows Azure Networks service.",
     "version": "2015-05-01-preview"
   },
   "host": "management.azure.com",
@@ -42,7 +42,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_Delete",
-        "description": "The delete applicationgateway operation deletes the specified applicationgateway.",
+        "description": "The delete application gateway operation deletes the specified application gateway.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -56,7 +56,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the applicationgateway."
+            "description": "The name of the application gateway."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -83,7 +83,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_Get",
-        "description": "The Get applicationgateway operation retreives information about the specified applicationgateway.",
+        "description": "The Get application gateway operation retrieves information about the specified application gateway.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -97,7 +97,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the applicationgateway."
+            "description": "The name of the application gateway."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -175,7 +175,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_List",
-        "description": "The List ApplicationGateway opertion retrieves all the applicationgateways in a resource group.",
+        "description": "The List ApplicationGateway operation retrieves all the application gateways in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -210,7 +210,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_ListAll",
-        "description": "The List applicationgateway opertion retrieves all the applicationgateways in a subscription.",
+        "description": "The List application gateway operation retrieves all the application gateways in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -238,7 +238,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_Start",
-        "description": "The Start ApplicationGateway operation starts application gatewayin the specified resource group through Network resource provider.",
+        "description": "The Start ApplicationGateway operation starts application gateway in the specified resource group through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -275,7 +275,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_Stop",
-        "description": "The STOP ApplicationGateway operation stops application gatewayin the specified resource group through Network resource provider.",
+        "description": "The STOP ApplicationGateway operation stops application gateway in the specified resource group through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -356,7 +356,7 @@
           "ExpressRouteCircuits"
         ],
         "operationId": "ExpressRouteCircuits_Get",
-        "description": "The Get ExpressRouteCircuit operation retreives information about the specified ExpressRouteCircuit.",
+        "description": "The Get ExpressRouteCircuit operation retrieves information about the specified ExpressRouteCircuit.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -448,7 +448,7 @@
           "ExpressRouteCircuits"
         ],
         "operationId": "ExpressRouteCircuits_ListArpTable",
-        "description": "The ListArpTable from ExpressRouteCircuit opertion retrieves the currently advertised arp table associated with the ExpressRouteCircuits in a resource group.",
+        "description": "The ListArpTable from ExpressRouteCircuit operation retrieves the currently advertised arp table associated with the ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -490,7 +490,7 @@
           "ExpressRouteCircuits"
         ],
         "operationId": "ExpressRouteCircuits_ListRoutesTable",
-        "description": "The ListRoutesTable from ExpressRouteCircuit opertion retrieves the currently advertised routes table associated with the ExpressRouteCircuits in a resource group.",
+        "description": "The ListRoutesTable from ExpressRouteCircuit operation retrieves the currently advertised routes table associated with the ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -532,7 +532,7 @@
           "ExpressRouteCircuits"
         ],
         "operationId": "ExpressRouteCircuits_ListStats",
-        "description": "The Liststats ExpressRouteCircuit opertion retrieves all the stats from a ExpressRouteCircuits in a resource group.",
+        "description": "The ListStats ExpressRouteCircuit operation retrieves all the stats from a ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -574,7 +574,7 @@
           "ExpressRouteCircuits"
         ],
         "operationId": "ExpressRouteCircuits_List",
-        "description": "The List ExpressRouteCircuit opertion retrieves all the ExpressRouteCircuits in a resource group.",
+        "description": "The List ExpressRouteCircuit operation retrieves all the ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -609,7 +609,7 @@
           "ExpressRouteCircuits"
         ],
         "operationId": "ExpressRouteCircuits_ListAll",
-        "description": "The List ExpressRouteCircuit opertion retrieves all the ExpressRouteCircuits in a subscription.",
+        "description": "The List ExpressRouteCircuit operation retrieves all the ExpressRouteCircuits in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -637,7 +637,7 @@
           "ExpressRouteServiceProviders"
         ],
         "operationId": "ExpressRouteServiceProviders_List",
-        "description": "The List ExpressRouteServiceProvider opertion retrieves all the available ExpressRouteServiceProviders.",
+        "description": "The List ExpressRouteServiceProvider operation retrieves all the available ExpressRouteServiceProviders.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -757,7 +757,7 @@
           "ExpressRouteCircuitPeerings"
         ],
         "operationId": "ExpressRouteCircuitPeerings_CreateOrUpdate",
-        "description": "The Put Pering operation creates/updates an peering in the specified ExpressRouteCircuits",
+        "description": "The Put Peering operation creates/updates an peering in the specified ExpressRouteCircuits",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -833,7 +833,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the curcuit."
+            "description": "The name of the circuit."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -902,7 +902,7 @@
           "LoadBalancers"
         ],
         "operationId": "LoadBalancers_Get",
-        "description": "The Get ntework interface operation retreives information about the specified network interface.",
+        "description": "The Get network interface operation retrieves information about the specified network interface.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -994,7 +994,7 @@
           "LoadBalancers"
         ],
         "operationId": "LoadBalancers_ListAll",
-        "description": "The List loadBalancer opertion retrieves all the loadbalancers in a subscription.",
+        "description": "The List loadBalancer operation retrieves all the load balancers in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1022,7 +1022,7 @@
           "LoadBalancers"
         ],
         "operationId": "LoadBalancers_List",
-        "description": "The List loadBalancer opertion retrieves all the loadbalancers in a resource group.",
+        "description": "The List loadBalancer operation retrieves all the load balancers in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1149,7 +1149,7 @@
           "LocalNetworkGateways"
         ],
         "operationId": "LocalNetworkGateways_Delete",
-        "description": "The Delete LocalNetworkGateway operation deletes the specifed local network Gateway through Network resource provider.",
+        "description": "The Delete LocalNetworkGateway operation deletes the specified local network Gateway through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1192,7 +1192,7 @@
           "LocalNetworkGateways"
         ],
         "operationId": "LocalNetworkGateways_List",
-        "description": "The List LocalNetworkGateways opertion retrieves all the local network gateways stored.",
+        "description": "The List LocalNetworkGateways operation retrieves all the local network gateways stored.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1227,7 +1227,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_Delete",
-        "description": "The delete netwokInterface operation deletes the specified netwokInterface.",
+        "description": "The delete networkInterface operation deletes the specified networkInterface.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1268,7 +1268,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_Get",
-        "description": "The Get ntework interface operation retreives information about the specified network interface.",
+        "description": "The Get network interface operation retrieves information about the specified network interface.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1451,7 +1451,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_GetVirtualMachineScaleSetNetworkInterface",
-        "description": "The Get ntework interface operation retreives information about the specified network interface in a virtual machine scale set.",
+        "description": "The Get network interface operation retrieves information about the specified network interface in a virtual machine scale set.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1504,7 +1504,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_ListAll",
-        "description": "The List networkInterfaces opertion retrieves all the networkInterfaces in a subscription.",
+        "description": "The List networkInterfaces operation retrieves all the networkInterfaces in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1532,7 +1532,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_List",
-        "description": "The List networkInterfaces opertion retrieves all the networkInterfaces in a resource group.",
+        "description": "The List networkInterfaces operation retrieves all the networkInterfaces in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1567,7 +1567,7 @@
           "RouteTables"
         ],
         "operationId": "RouteTables_Delete",
-        "description": "The Delete RouteTable operation deletes the specifed Route Table",
+        "description": "The Delete RouteTable operation deletes the specified Route Table",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1645,7 +1645,7 @@
           "RouteTables"
         ],
         "operationId": "RouteTables_CreateOrUpdate",
-        "description": "The Put RouteTable operation creates/updates a route tablein the specified resource group.",
+        "description": "The Put RouteTable operation creates/updates a route table in the specified resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1763,7 +1763,7 @@
           "NetworkSecurityGroups"
         ],
         "operationId": "NetworkSecurityGroups_Delete",
-        "description": "The Delete NetworkSecurityGroup operation deletes the specifed network security group",
+        "description": "The Delete NetworkSecurityGroup operation deletes the specified network security group",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1841,7 +1841,7 @@
           "NetworkSecurityGroups"
         ],
         "operationId": "NetworkSecurityGroups_CreateOrUpdate",
-        "description": "The Put NetworkSecurityGroup operation creates/updates a network security groupin the specified resource group.",
+        "description": "The Put NetworkSecurityGroup operation creates/updates a network security group in the specified resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2000,7 +2000,7 @@
           "PublicIpAddresses"
         ],
         "operationId": "PublicIpAddresses_Get",
-        "description": "The Get publicIpAddress operation retreives information about the specified pubicIpAddress",
+        "description": "The Get publicIpAddress operation retrieves information about the specified pubicIpAddress",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2092,7 +2092,7 @@
           "PublicIpAddresses"
         ],
         "operationId": "PublicIpAddresses_ListAll",
-        "description": "The List publicIpAddress opertion retrieves all the publicIpAddresses in a subscription.",
+        "description": "The List publicIpAddress operation retrieves all the publicIpAddresses in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2120,7 +2120,7 @@
           "PublicIpAddresses"
         ],
         "operationId": "PublicIpAddresses_List",
-        "description": "The List publicIpAddress opertion retrieves all the publicIpAddresses in a resource group.",
+        "description": "The List publicIpAddress operation retrieves all the publicIpAddresses in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2203,7 +2203,7 @@
           "Routes"
         ],
         "operationId": "Routes_Get",
-        "description": "The Get route operation retreives information about the specified route from the route table.",
+        "description": "The Get route operation retrieves information about the specified route from the route table.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2277,7 +2277,7 @@
             "schema": {
               "$ref": "#/definitions/Route"
             },
-            "description": "Parameters supplied to the create/update routeoperation"
+            "description": "Parameters supplied to the create/update route operation"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2309,7 +2309,7 @@
           "Routes"
         ],
         "operationId": "Routes_List",
-        "description": "The List network security rule opertion retrieves all the routes in a route table.",
+        "description": "The List network security rule operation retrieves all the routes in a route table.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2399,7 +2399,7 @@
           "SecurityRules"
         ],
         "operationId": "SecurityRules_Get",
-        "description": "The Get NetworkSecurityRule operation retreives information about the specified network security rule.",
+        "description": "The Get NetworkSecurityRule operation retrieves information about the specified network security rule.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2505,7 +2505,7 @@
           "SecurityRules"
         ],
         "operationId": "SecurityRules_List",
-        "description": "The List network security rule opertion retrieves all the security rules in a network security group.",
+        "description": "The List network security rule operation retrieves all the security rules in a network security group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2639,7 +2639,7 @@
           "ExpressRouteCircuitAuthorizations"
         ],
         "operationId": "ExpressRouteCircuitAuthorizations_CreateOrUpdate",
-        "description": "The Put Authorization operation creates/updates an authorization in thespecified ExpressRouteCircuits",
+        "description": "The Put Authorization operation creates/updates an authorization in the specified ExpressRouteCircuits",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2715,7 +2715,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the curcuit."
+            "description": "The name of the circuit."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2791,7 +2791,7 @@
           "Subnets"
         ],
         "operationId": "Subnets_Get",
-        "description": "The Get subnet operation retreives information about the specified subnet.",
+        "description": "The Get subnet operation retrieves information about the specified subnet.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2835,7 +2835,7 @@
           "Subnets"
         ],
         "operationId": "Subnets_CreateOrUpdate",
-        "description": "The Put Subnet operation creates/updates a subnet in thespecified virtual network",
+        "description": "The Put Subnet operation creates/updates a subnet in the specified virtual network",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2897,7 +2897,7 @@
           "Subnets"
         ],
         "operationId": "Subnets_List",
-        "description": "The List subnets opertion retrieves all the subnets in a virtual network.",
+        "description": "The List subnets operation retrieves all the subnets in a virtual network.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2989,7 +2989,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the virtual network gateway conenction."
+            "description": "The name of the virtual network gateway connection."
           },
           {
             "name": "parameters",
@@ -3067,7 +3067,7 @@
           "VirtualNetworkGatewayConnections"
         ],
         "operationId": "VirtualNetworkGatewayConnections_Delete",
-        "description": "The Delete VirtualNetworkGatewayConnection operation deletes the specifed virtual network Gateway connection through Network resource provider.",
+        "description": "The Delete VirtualNetworkGatewayConnection operation deletes the specified virtual network Gateway connection through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3170,7 +3170,7 @@
             "schema": {
               "$ref": "#/definitions/ConnectionSharedKey"
             },
-            "description": "Parameters supplied to the Begin Set Virtual Network Gateway conection Shared key operation throughNetwork resource provider."
+            "description": "Parameters supplied to the Begin Set Virtual Network Gateway connection Shared key operation through Network resource provider."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -3381,7 +3381,7 @@
           "VirtualNetworkGateways"
         ],
         "operationId": "VirtualNetworkGateways_Delete",
-        "description": "The Delete VirtualNetworkGateway operation deletes the specifed virtual network Gateway through Network resource provider.",
+        "description": "The Delete VirtualNetworkGateway operation deletes the specified virtual network Gateway through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3424,7 +3424,7 @@
           "VirtualNetworkGateways"
         ],
         "operationId": "VirtualNetworkGateways_List",
-        "description": "The List VirtualNetworkGateways opertion retrieves all the virtual network gateways stored.",
+        "description": "The List VirtualNetworkGateways operation retrieves all the virtual network gateways stored.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3459,7 +3459,7 @@
           "VirtualNetworkGateways"
         ],
         "operationId": "VirtualNetworkGateways_Reset",
-        "description": "The Reset VirtualNetworkGateway operation resets the primary of the virtual network gatewayin the specified resource group through Network resource provider.",
+        "description": "The Reset VirtualNetworkGateway operation resets the primary of the virtual network gateway in the specified resource group through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3511,7 +3511,7 @@
           "VirtualNetworks"
         ],
         "operationId": "VirtualNetworks_Delete",
-        "description": "The Delete VirtualNetwork operation deletes the specifed virtual network",
+        "description": "The Delete VirtualNetwork operation deletes the specified virtual network",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3777,7 +3777,7 @@
       "properties": {
         "subnet": {
           "$ref": "#/definitions/SubResource",
-          "description": "Gets or sets the reference of the subnet resource.A subnet from where appliation gateway gets its private address "
+          "description": "Gets or sets the reference of the subnet resource.A subnet from where application gateway gets its private address "
         },
         "provisioningState": {
           "type": "string",
@@ -4403,7 +4403,7 @@
           "description": "Gets or Sets RoutingRegistryName of the config."
         }
       },
-      "description": "Specfies the peering config"
+      "description": "Specifies the peering config"
     },
     "ExpressRouteCircuitStats": {
       "properties": {
@@ -4484,7 +4484,7 @@
         },
         "microsoftPeeringConfig": {
           "$ref": "#/definitions/ExpressRouteCircuitPeeringConfig",
-          "description": "Gets or sets the mircosoft peering config"
+          "description": "Gets or sets the Microsoft peering config"
         },
         "stats": {
           "$ref": "#/definitions/ExpressRouteCircuitStats",
@@ -4832,7 +4832,7 @@
         },
         "subnet": {
           "$ref": "#/definitions/SubResource",
-          "description": "Gets or sets the reference of the subnet resource.A subnet from wher the load balancer gets its private frontend address "
+          "description": "Gets or sets the reference of the subnet resource.A subnet from where the load balancer gets its private frontend address "
         },
         "publicIPAddress": {
           "$ref": "#/definitions/SubResource",
@@ -4942,7 +4942,7 @@
           "$ref": "#/definitions/SubResource"
         }
       ],
-      "description": "Pool of backend IP addresseses"
+      "description": "Pool of backend IP addresses"
     },
     "LoadBalancingRulePropertiesFormat": {
       "properties": {
@@ -4991,12 +4991,12 @@
         "backendPort": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal compotnent on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
+          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal component on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
         },
         "idleTimeoutInMinutes": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This emlement is only used when the protocol is set to Tcp"
+          "description": "Gets or sets the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to Tcp"
         },
         "enableFloatingIP": {
           "type": "boolean",
@@ -5071,7 +5071,7 @@
         "numberOfProbes": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the number of probes where if no response, will result in stopping further traffic from being delivered to the endpoint. This values allows endponints to be taken out of rotation faster or slower than the typical times used in Azure. "
+          "description": "Gets or sets the number of probes where if no response, will result in stopping further traffic from being delivered to the endpoint. This values allows endpoints to be taken out of rotation faster or slower than the typical times used in Azure. "
         },
         "requestPath": {
           "type": "string",
@@ -5121,7 +5121,7 @@
         },
         "protocol": {
           "type": "string",
-          "description": "Gets or sets the transport potocol for the external endpoint. Possible values are Udp or Tcp",
+          "description": "Gets or sets the transport protocol for the external endpoint. Possible values are Udp or Tcp",
           "enum": [
             "Udp",
             "Tcp"
@@ -5134,17 +5134,17 @@
         "frontendPort": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the port for the external endpoint. You can spcify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
+          "description": "Gets or sets the port for the external endpoint. You can specify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
         },
         "backendPort": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal compotnent on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
+          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal component on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
         },
         "idleTimeoutInMinutes": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This emlement is only used when the protocol is set to Tcp"
+          "description": "Gets or sets the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to Tcp"
         },
         "enableFloatingIP": {
           "type": "boolean",
@@ -5192,7 +5192,7 @@
         },
         "protocol": {
           "type": "string",
-          "description": "Gets or sets the transport potocol for the external endpoint. Possible values are Udp or Tcp",
+          "description": "Gets or sets the transport protocol for the external endpoint. Possible values are Udp or Tcp",
           "enum": [
             "Udp",
             "Tcp"
@@ -5205,17 +5205,17 @@
         "frontendPortRangeStart": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the starting port range for the NAT pool. You can spcify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
+          "description": "Gets or sets the starting port range for the NAT pool. You can specify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
         },
         "frontendPortRangeEnd": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the ending port range for the NAT pool. You can spcify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
+          "description": "Gets or sets the ending port range for the NAT pool. You can specify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
         },
         "backendPort": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal compotnent on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
+          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal component on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
         },
         "provisioningState": {
           "type": "string",
@@ -5317,14 +5317,14 @@
           "items": {
             "$ref": "#/definitions/BackendAddressPool"
           },
-          "description": "Gets or sets Pools of backend IP addresseses"
+          "description": "Gets or sets Pools of backend IP addresses"
         },
         "loadBalancingRules": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/LoadBalancingRule"
           },
-          "description": "Gets or sets loadbalancing rules"
+          "description": "Gets or sets load balancing rules"
         },
         "probes": {
           "type": "array",
@@ -5557,7 +5557,7 @@
         },
         "internalFqdn": {
           "type": "string",
-          "description": "Gets or sets full IDNS name in the form, DnsName.VnetId.ZoneId.TopleveSuffix. This is set when the NIC is associated to a VM"
+          "description": "Gets or sets full IDNS name in the form, DnsName.VnetId.ZoneId.TopLevelSuffix. This is set when the NIC is associated to a VM"
         }
       },
       "description": "Dns Settings of a network interface"
@@ -5752,7 +5752,7 @@
           "description": "Gets the URL to get the next set of results."
         }
       },
-      "description": "Response for ListRouteTable Api servive call"
+      "description": "Response for ListRouteTable Api service call"
     },
     "SecurityRulePropertiesFormat": {
       "properties": {
@@ -5775,19 +5775,19 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "Gets or sets Source Port or Range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "Gets or sets Source Port or Range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "Gets or sets Destination Port or Range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "Gets or sets Destination Port or Range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "Gets or sets source address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "Gets or sets source address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "Gets or sets destination address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. "
+          "description": "Gets or sets destination address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. "
         },
         "access": {
           "type": "string",
@@ -5808,7 +5808,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "Gets or sets the direction of the rule.InBound or Outbound. The direction specifies if rule will be evaluated on incoming or outcoming traffic.",
+          "description": "Gets or sets the direction of the rule.InBound or Outbound. The direction specifies if rule will be evaluated on incoming or outgoing traffic.",
           "enum": [
             "Inbound",
             "Outbound"
@@ -5926,7 +5926,7 @@
           "description": "Gets the URL to get the next set of results."
         }
       },
-      "description": "Response for ListNetworkSecurityGroups Api servive call"
+      "description": "Response for ListNetworkSecurityGroups Api service call"
     },
     "PublicIpAddressDnsSettings": {
       "properties": {
@@ -5940,7 +5940,7 @@
         },
         "reverseFqdn": {
           "type": "string",
-          "description": "Gets or Sests the Reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN. "
+          "description": "Gets or Sets the Reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN. "
         }
       },
       "description": "Contains FQDN of the DNS record associated with the public IP address"
@@ -5974,7 +5974,7 @@
         "idleTimeoutInMinutes": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the Idletimeout of the public IP address"
+          "description": "Gets or sets the idle timeout of the public IP address"
         },
         "resourceGuid": {
           "type": "string",
@@ -6038,7 +6038,7 @@
           "description": "Gets the URL to get the next set of results."
         }
       },
-      "description": "Response for ListRoute Api servive call"
+      "description": "Response for ListRoute Api service call"
     },
     "SecurityRuleListResult": {
       "properties": {
@@ -6122,7 +6122,7 @@
           "$ref": "#/definitions/SubResource"
         }
       ],
-      "description": "Subnet in a VirtualNework resource"
+      "description": "Subnet in a VirtualNetwork resource"
     },
     "SubnetListResult": {
       "properties": {
@@ -6310,7 +6310,7 @@
           "description": "Gets or sets Provisioning state of the VirtualNetworkGateway resource Updating/Deleting/Failed"
         }
       },
-      "description": "VirtualNeworkGateay properties"
+      "description": "VirtualNetworkGateway properties"
     },
     "VirtualNetworkGateway": {
       "properties": {
@@ -6343,7 +6343,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type -Ipsec/Dedicated/VpnClient/Vnet2Vnet",
+          "description": "Gateway connection type IPsec/Dedicated/VpnClient/Vnet2Vnet",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -6362,7 +6362,7 @@
         },
         "sharedKey": {
           "type": "string",
-          "description": "The Ipsec share key."
+          "description": "The IPsec share key."
         },
         "connectionStatus": {
           "type": "string",
@@ -6401,7 +6401,7 @@
           "description": "Gets or sets Provisioning state of the VirtualNetworkGatewayConnection resource Updating/Deleting/Failed"
         }
       },
-      "description": "VirtualNeworkGatewayConnection properties"
+      "description": "VirtualNetworkGatewayConnection properties"
     },
     "VirtualNetworkGatewayConnection": {
       "properties": {
@@ -6428,7 +6428,7 @@
           "description": "The virtual network connection shared key value"
         }
       },
-      "description": "Response for GetConnectionSharedKey Api servive call"
+      "description": "Response for GetConnectionSharedKey Api service call"
     },
     "VirtualNetworkGatewayConnectionListResult": {
       "properties": {
@@ -6542,7 +6542,7 @@
           "description": "Gets the URL to get the next set of results."
         }
       },
-      "description": "Response for ListVirtualNetworks Api servive call"
+      "description": "Response for ListVirtualNetworks Api service call"
     },
     "DnsNameAvailabilityResult": {
       "properties": {
@@ -6551,7 +6551,7 @@
           "description": "Domain availability (True/False)"
         }
       },
-      "description": "Response for CheckDnsNameAvailability Api servive call"
+      "description": "Response for CheckDnsNameAvailability Api service call"
     },
     "ErrorDetails": {
       "properties": {
@@ -6607,7 +6607,7 @@
           "$ref": "#/definitions/Error"
         }
       },
-      "description": "The response body contains the status of the specified asynchronous operation, indicating whether it has succeeded, is inprogress, or has failed. Note that this status is distinct from the HTTP status code returned for the Get Operation Status operation itself. If the asynchronous operation succeeded, the response body includes the HTTP status code for the successful request. If the asynchronous operation failed, the response body includes the HTTP status code for the failed request and error information regarding the failure."
+      "description": "The response body contains the status of the specified asynchronous operation, indicating whether it has succeeded, is in progress, or has failed. Note that this status is distinct from the HTTP status code returned for the Get Operation Status operation itself. If the asynchronous operation succeeded, the response body includes the HTTP status code for the successful request. If the asynchronous operation failed, the response body includes the HTTP status code for the failed request and error information regarding the failure."
     },
     "Resource": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2015-06-15/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2015-06-15/loadBalancer.json
@@ -463,7 +463,7 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "A loag balancing rule for a load balancer."
+      "description": "A load balancing rule for a load balancer."
     },
     "ProbePropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2015-06-15/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2015-06-15/networkSecurityGroup.json
@@ -458,19 +458,19 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "access": {
           "type": "string",
@@ -491,7 +491,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2015-06-15/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2015-06-15/virtualNetworkGateway.json
@@ -592,7 +592,7 @@
             "schema": {
               "$ref": "#/definitions/ConnectionSharedKey"
             },
-            "description": "Parameters supplied to the Begin Set Virtual Network Gateway conection Shared key operation throughNetwork resource provider."
+            "description": "Parameters supplied to the Begin Set Virtual Network Gateway connection Shared key operation throughNetwork resource provider."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1123,7 +1123,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -1213,7 +1213,7 @@
           "description": "The virtual network connection shared key value"
         }
       },
-      "description": "Response for CheckConnectionSharedKey Api servive call"
+      "description": "Response for CheckConnectionSharedKey API service call"
     },
     "VirtualNetworkGatewayConnectionListResult": {
       "properties": {
@@ -1247,7 +1247,7 @@
           "description": "The virtual network connection shared key value"
         }
       },
-      "description": "Response for GetConnectionSharedKey Api servive call"
+      "description": "Response for GetConnectionSharedKey API service call"
     },
 	"LocalNetworkGatewayPropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2016-03-30/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2016-03-30/network.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "NetworkManagementClient",
-    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resrources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
     "version": "2016-03-30"
   },
   "host": "management.azure.com",
@@ -42,7 +42,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_Delete",
-        "description": "The delete applicationgateway operation deletes the specified applicationgateway.",
+        "description": "The delete application gateway operation deletes the specified application gateway.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -56,7 +56,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the applicationgateway."
+            "description": "The name of the application gateway."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -83,7 +83,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_Get",
-        "description": "The Get applicationgateway operation retreives information about the specified applicationgateway.",
+        "description": "The Get application gateway operation retrieves information about the specified application gateway.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -97,7 +97,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the applicationgateway."
+            "description": "The name of the application gateway."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -175,7 +175,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_List",
-        "description": "The List ApplicationGateway opertion retrieves all the applicationgateways in a resource group.",
+        "description": "The List ApplicationGateway operation retrieves all the application gateways in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -210,7 +210,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_ListAll",
-        "description": "The List applicationgateway opertion retrieves all the applicationgateways in a subscription.",
+        "description": "The List application gateway operation retrieves all the application gateways in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -238,7 +238,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_Start",
-        "description": "The Start ApplicationGateway operation starts application gatewayin the specified resource group through Network resource provider.",
+        "description": "The Start ApplicationGateway operation starts application gateway in the specified resource group through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -278,7 +278,7 @@
           "ApplicationGateways"
         ],
         "operationId": "ApplicationGateways_Stop",
-        "description": "The STOP ApplicationGateway operation stops application gatewayin the specified resource group through Network resource provider.",
+        "description": "The STOP ApplicationGateway operation stops application gateway in the specified resource group through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -410,7 +410,7 @@
           "ExpressRouteCircuitAuthorizations"
         ],
         "operationId": "ExpressRouteCircuitAuthorizations_CreateOrUpdate",
-        "description": "The Put Authorization operation creates/updates an authorization in thespecified ExpressRouteCircuits",
+        "description": "The Put Authorization operation creates/updates an authorization in the specified ExpressRouteCircuits",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -486,7 +486,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the curcuit."
+            "description": "The name of the circuit."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -606,7 +606,7 @@
           "ExpressRouteCircuitPeerings"
         ],
         "operationId": "ExpressRouteCircuitPeerings_CreateOrUpdate",
-        "description": "The Put Pering operation creates/updates an peering in the specified ExpressRouteCircuits",
+        "description": "The Put Peering operation creates/updates an peering in the specified ExpressRouteCircuits",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -682,7 +682,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the curcuit."
+            "description": "The name of the circuit."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -751,7 +751,7 @@
           "ExpressRouteCircuits"
         ],
         "operationId": "ExpressRouteCircuits_Get",
-        "description": "The Get ExpressRouteCircuit operation retreives information about the specified ExpressRouteCircuit.",
+        "description": "The Get ExpressRouteCircuit operation retrieves information about the specified ExpressRouteCircuit.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -843,7 +843,7 @@
           "ExpressRouteCircuitArpTable"
         ],
         "operationId": "ExpressRouteCircuits_ListArpTable",
-        "description": "The ListArpTable from ExpressRouteCircuit opertion retrieves the currently advertised arp table associated with the ExpressRouteCircuits in a resource group.",
+        "description": "The ListArpTable from ExpressRouteCircuit operation retrieves the currently advertised arp table associated with the ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -900,7 +900,7 @@
           "ExpressRouteCircuitRoutesTable"
         ],
         "operationId": "ExpressRouteCircuits_ListRoutesTable",
-        "description": "The ListRoutesTable from ExpressRouteCircuit opertion retrieves the currently advertised routes table associated with the ExpressRouteCircuits in a resource group.",
+        "description": "The ListRoutesTable from ExpressRouteCircuit operation retrieves the currently advertised routes table associated with the ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -957,7 +957,7 @@
           "ExpressRouteCircuitRoutesTableSummary"
         ],
         "operationId": "ExpressRouteCircuits_ListRoutesTableSummary",
-        "description": "The ListRoutesTable from ExpressRouteCircuit opertion retrieves the currently advertised routes table associated with the ExpressRouteCircuits in a resource group.",
+        "description": "The ListRoutesTable from ExpressRouteCircuit operation retrieves the currently advertised routes table associated with the ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1014,7 +1014,7 @@
           "ExpressRouteCircuitStats"
         ],
         "operationId": "ExpressRouteCircuits_GetStats",
-        "description": "The Liststats ExpressRouteCircuit opertion retrieves all the stats from a ExpressRouteCircuits in a resource group.",
+        "description": "The GetStats ExpressRouteCircuit operation retrieves all the stats from a ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1053,7 +1053,7 @@
           "ExpressRouteCircuitStats"
         ],
         "operationId": "ExpressRouteCircuits_GetPeeringStats",
-        "description": "The Liststats ExpressRouteCircuit opertion retrieves all the stats from a ExpressRouteCircuits in a resource group.",
+        "description": "The GetPeeringStats ExpressRouteCircuit operation retrieves all the stats from a ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1099,7 +1099,7 @@
           "ExpressRouteCircuits"
         ],
         "operationId": "ExpressRouteCircuits_List",
-        "description": "The List ExpressRouteCircuit opertion retrieves all the ExpressRouteCircuits in a resource group.",
+        "description": "The List ExpressRouteCircuit operation retrieves all the ExpressRouteCircuits in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1134,7 +1134,7 @@
           "ExpressRouteCircuits"
         ],
         "operationId": "ExpressRouteCircuits_ListAll",
-        "description": "The List ExpressRouteCircuit opertion retrieves all the ExpressRouteCircuits in a subscription.",
+        "description": "The List ExpressRouteCircuit operation retrieves all the ExpressRouteCircuits in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1162,7 +1162,7 @@
           "ExpressRouteServiceProviders"
         ],
         "operationId": "ExpressRouteServiceProviders_List",
-        "description": "The List ExpressRouteServiceProvider opertion retrieves all the available ExpressRouteServiceProviders.",
+        "description": "The List ExpressRouteServiceProvider operation retrieves all the available ExpressRouteServiceProviders.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1231,7 +1231,7 @@
           "LoadBalancers"
         ],
         "operationId": "LoadBalancers_Get",
-        "description": "The Get ntework interface operation retreives information about the specified network interface.",
+        "description": "The Get network interface operation retrieves information about the specified network interface.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1330,7 +1330,7 @@
           "LoadBalancers"
         ],
         "operationId": "LoadBalancers_ListAll",
-        "description": "The List loadBalancer opertion retrieves all the loadbalancers in a subscription.",
+        "description": "The List loadBalancer operation retrieves all the load balancers in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1358,7 +1358,7 @@
           "LoadBalancers"
         ],
         "operationId": "LoadBalancers_List",
-        "description": "The List loadBalancer opertion retrieves all the loadbalancers in a resource group.",
+        "description": "The List loadBalancer operation retrieves all the load balancers in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1483,7 +1483,7 @@
           "LocalNetworkGateways"
         ],
         "operationId": "LocalNetworkGateways_Delete",
-        "description": "The Delete LocalNetworkGateway operation deletes the specifed local network Gateway through Network resource provider.",
+        "description": "The Delete LocalNetworkGateway operation deletes the specified local network Gateway through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1526,7 +1526,7 @@
           "LocalNetworkGateways"
         ],
         "operationId": "LocalNetworkGateways_List",
-        "description": "The List LocalNetworkGateways opertion retrieves all the local network gateways stored.",
+        "description": "The List LocalNetworkGateways operation retrieves all the local network gateways stored.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1561,7 +1561,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_Delete",
-        "description": "The delete netwokInterface operation deletes the specified netwokInterface.",
+        "description": "The delete networkInterface operation deletes the specified networkInterface.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1602,7 +1602,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_Get",
-        "description": "The Get ntework interface operation retreives information about the specified network interface.",
+        "description": "The Get network interface operation retrieves information about the specified network interface.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1792,7 +1792,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_GetVirtualMachineScaleSetNetworkInterface",
-        "description": "The Get ntework interface operation retreives information about the specified network interface in a virtual machine scale set.",
+        "description": "The Get network interface operation retrieves information about the specified network interface in a virtual machine scale set.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1852,7 +1852,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_ListAll",
-        "description": "The List networkInterfaces opertion retrieves all the networkInterfaces in a subscription.",
+        "description": "The List networkInterfaces operation retrieves all the networkInterfaces in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1880,7 +1880,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_List",
-        "description": "The List networkInterfaces opertion retrieves all the networkInterfaces in a resource group.",
+        "description": "The List networkInterfaces operation retrieves all the networkInterfaces in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1915,7 +1915,7 @@
           "NetworkSecurityGroups"
         ],
         "operationId": "NetworkSecurityGroups_Delete",
-        "description": "The Delete NetworkSecurityGroup operation deletes the specifed network security group",
+        "description": "The Delete NetworkSecurityGroup operation deletes the specified network security group",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2000,7 +2000,7 @@
           "NetworkSecurityGroups"
         ],
         "operationId": "NetworkSecurityGroups_CreateOrUpdate",
-        "description": "The Put NetworkSecurityGroup operation creates/updates a network security groupin the specified resource group.",
+        "description": "The Put NetworkSecurityGroup operation creates/updates a network security group in the specified resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2159,7 +2159,7 @@
           "PublicIPAddresses"
         ],
         "operationId": "PublicIPAddresses_Get",
-        "description": "The Get publicIpAddress operation retreives information about the specified pubicIpAddress",
+        "description": "The Get publicIpAddress operation retrieves information about the specified pubicIpAddress",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2258,7 +2258,7 @@
           "PublicIPAddresses"
         ],
         "operationId": "PublicIPAddresses_ListAll",
-        "description": "The List publicIpAddress opertion retrieves all the publicIpAddresses in a subscription.",
+        "description": "The List publicIpAddress operation retrieves all the publicIpAddresses in a subscription.",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2286,7 +2286,7 @@
           "PublicIPAddresses"
         ],
         "operationId": "PublicIPAddresses_List",
-        "description": "The List publicIpAddress opertion retrieves all the publicIpAddresses in a resource group.",
+        "description": "The List publicIpAddress operation retrieves all the publicIpAddresses in a resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2321,7 +2321,7 @@
           "RouteTables"
         ],
         "operationId": "RouteTables_Delete",
-        "description": "The Delete RouteTable operation deletes the specifed Route Table",
+        "description": "The Delete RouteTable operation deletes the specified Route Table",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2406,7 +2406,7 @@
           "RouteTables"
         ],
         "operationId": "RouteTables_CreateOrUpdate",
-        "description": "The Put RouteTable operation creates/updates a route tablein the specified resource group.",
+        "description": "The Put RouteTable operation creates/updates a route table in the specified resource group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2572,7 +2572,7 @@
           "Routes"
         ],
         "operationId": "Routes_Get",
-        "description": "The Get route operation retreives information about the specified route from the route table.",
+        "description": "The Get route operation retrieves information about the specified route from the route table.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2646,7 +2646,7 @@
             "schema": {
               "$ref": "#/definitions/Route"
             },
-            "description": "Parameters supplied to the create/update routeoperation"
+            "description": "Parameters supplied to the create/update route operation"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2678,7 +2678,7 @@
           "Routes"
         ],
         "operationId": "Routes_List",
-        "description": "The List network security rule opertion retrieves all the routes in a route table.",
+        "description": "The List network security rule operation retrieves all the routes in a route table.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2768,7 +2768,7 @@
           "SecurityRules"
         ],
         "operationId": "SecurityRules_Get",
-        "description": "The Get NetworkSecurityRule operation retreives information about the specified network security rule.",
+        "description": "The Get NetworkSecurityRule operation retrieves information about the specified network security rule.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2874,7 +2874,7 @@
           "SecurityRules"
         ],
         "operationId": "SecurityRules_List",
-        "description": "The List network security rule opertion retrieves all the security rules in a network security group.",
+        "description": "The List network security rule operation retrieves all the security rules in a network security group.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -2964,7 +2964,7 @@
           "Subnets"
         ],
         "operationId": "Subnets_Get",
-        "description": "The Get subnet operation retreives information about the specified subnet.",
+        "description": "The Get subnet operation retrieves information about the specified subnet.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3015,7 +3015,7 @@
           "Subnets"
         ],
         "operationId": "Subnets_CreateOrUpdate",
-        "description": "The Put Subnet operation creates/updates a subnet in thespecified virtual network",
+        "description": "The Put Subnet operation creates/updates a subnet in the specified virtual network",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3077,7 +3077,7 @@
           "Subnets"
         ],
         "operationId": "Subnets_List",
-        "description": "The List subnets opertion retrieves all the subnets in a virtual network.",
+        "description": "The List subnets operation retrieves all the subnets in a virtual network.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3169,7 +3169,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the virtual network gateway conenction."
+            "description": "The name of the virtual network gateway connection."
           },
           {
             "name": "parameters",
@@ -3245,7 +3245,7 @@
           "VirtualNetworkGatewayConnections"
         ],
         "operationId": "VirtualNetworkGatewayConnections_Delete",
-        "description": "The Delete VirtualNetworkGatewayConnection operation deletes the specifed virtual network Gateway connection through Network resource provider.",
+        "description": "The Delete VirtualNetworkGatewayConnection operation deletes the specified virtual network Gateway connection through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3437,7 +3437,7 @@
             "schema": {
               "$ref": "#/definitions/ConnectionSharedKey"
             },
-            "description": "Parameters supplied to the Begin Set Virtual Network Gateway conection Shared key operation throughNetwork resource provider."
+            "description": "Parameters supplied to the Begin Set Virtual Network Gateway connection Shared key operation through Network resource provider."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -3559,7 +3559,7 @@
           "VirtualNetworkGateways"
         ],
         "operationId": "VirtualNetworkGateways_Delete",
-        "description": "The Delete VirtualNetworkGateway operation deletes the specifed virtual network Gateway through Network resource provider.",
+        "description": "The Delete VirtualNetworkGateway operation deletes the specified virtual network Gateway through Network resource provider.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3602,7 +3602,7 @@
           "VirtualNetworkGateways"
         ],
         "operationId": "VirtualNetworkGateways_List",
-        "description": "The List VirtualNetworkGateways opertion retrieves all the virtual network gateways stored.",
+        "description": "The List VirtualNetworkGateways operation retrieves all the virtual network gateways stored.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -3737,7 +3737,7 @@
           "VirtualNetworks"
         ],
         "operationId": "VirtualNetworks_Delete",
-        "description": "The Delete VirtualNetwork operation deletes the specifed virtual network",
+        "description": "The Delete VirtualNetwork operation deletes the specified virtual network",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -4010,7 +4010,7 @@
       "properties": {
         "subnet": {
           "$ref": "#/definitions/SubResource",
-          "description": "Gets or sets the reference of the subnet resource.A subnet from where appliation gateway gets its private address "
+          "description": "Gets or sets the reference of the subnet resource.A subnet from where application gateway gets its private address "
         },
         "provisioningState": {
           "type": "string",
@@ -4629,7 +4629,7 @@
         },
         "resourceGuid": {
           "type": "string",
-          "description": "Gets or sets resource guid property of the ApplicationGateway resource"
+          "description": "Gets or sets resource GUID property of the ApplicationGateway resource"
         },
         "provisioningState": {
           "type": "string",
@@ -4813,7 +4813,7 @@
           "description": "Gets or Sets RoutingRegistryName of the config."
         }
       },
-      "description": "Specfies the peering config"
+      "description": "Specifies the peering config"
     },
     "ExpressRouteCircuitStats": {
       "properties": {
@@ -4904,7 +4904,7 @@
         },
         "microsoftPeeringConfig": {
           "$ref": "#/definitions/ExpressRouteCircuitPeeringConfig",
-          "description": "Gets or sets the mircosoft peering config"
+          "description": "Gets or sets the Microsoft peering config"
         },
         "stats": {
           "$ref": "#/definitions/ExpressRouteCircuitStats",
@@ -5426,7 +5426,7 @@
           "$ref": "#/definitions/SubResource"
         }
       ],
-      "description": "Pool of backend IP addresseses"
+      "description": "Pool of backend IP addresses"
     },
     "LoadBalancingRulePropertiesFormat": {
       "properties": {
@@ -5475,12 +5475,12 @@
         "backendPort": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal compotnent on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
+          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal component on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
         },
         "idleTimeoutInMinutes": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This emlement is only used when the protocol is set to Tcp"
+          "description": "Gets or sets the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to Tcp"
         },
         "enableFloatingIP": {
           "type": "boolean",
@@ -5553,7 +5553,7 @@
         "numberOfProbes": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the number of probes where if no response, will result in stopping further traffic from being delivered to the endpoint. This values allows endponints to be taken out of rotation faster or slower than the typical times used in Azure. "
+          "description": "Gets or sets the number of probes where if no response, will result in stopping further traffic from being delivered to the endpoint. This values allows endpoints to be taken out of rotation faster or slower than the typical times used in Azure. "
         },
         "requestPath": {
           "type": "string",
@@ -5603,7 +5603,7 @@
         },
         "protocol": {
           "type": "string",
-          "description": "Gets or sets the transport potocol for the external endpoint. Possible values are Udp or Tcp",
+          "description": "Gets or sets the transport protocol for the external endpoint. Possible values are Udp or Tcp",
           "enum": [
             "Udp",
             "Tcp"
@@ -5616,17 +5616,17 @@
         "frontendPort": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the port for the external endpoint. You can spcify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
+          "description": "Gets or sets the port for the external endpoint. You can specify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
         },
         "backendPort": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal compotnent on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
+          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal component on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
         },
         "idleTimeoutInMinutes": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This emlement is only used when the protocol is set to Tcp"
+          "description": "Gets or sets the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to Tcp"
         },
         "enableFloatingIP": {
           "type": "boolean",
@@ -5669,7 +5669,7 @@
         },
         "protocol": {
           "type": "string",
-          "description": "Gets or sets the transport potocol for the external endpoint. Possible values are Udp or Tcp",
+          "description": "Gets or sets the transport protocol for the external endpoint. Possible values are Udp or Tcp",
           "enum": [
             "Udp",
             "Tcp"
@@ -5682,17 +5682,17 @@
         "frontendPortRangeStart": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the starting port range for the NAT pool. You can spcify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
+          "description": "Gets or sets the starting port range for the NAT pool. You can specify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
         },
         "frontendPortRangeEnd": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the ending port range for the NAT pool. You can spcify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
+          "description": "Gets or sets the ending port range for the NAT pool. You can specify any port number you choose, but the port numbers specified for each role in the service must be unique. Possible values range between 1 and 65535, inclusive"
         },
         "backendPort": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal compotnent on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
+          "description": "Gets or sets a port used for internal connections on the endpoint. The localPort attribute maps the eternal port of the endpoint to an internal port on a role. This is useful in scenarios where a role must communicate to an internal component on a port that is different from the one that is exposed externally. If not specified, the value of localPort is the same as the port attribute. Set the value of localPort to '*' to automatically assign an unallocated port that is discoverable using the runtime API"
         },
         "provisioningState": {
           "type": "string",
@@ -5793,14 +5793,14 @@
           "items": {
             "$ref": "#/definitions/BackendAddressPool"
           },
-          "description": "Gets or sets Pools of backend IP addresseses"
+          "description": "Gets or sets Pools of backend IP addresses"
         },
         "loadBalancingRules": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/LoadBalancingRule"
           },
-          "description": "Gets or sets loadbalancing rules"
+          "description": "Gets or sets load balancing rules"
         },
         "probes": {
           "type": "array",
@@ -5832,7 +5832,7 @@
         },
         "resourceGuid": {
           "type": "string",
-          "description": "Gets or sets resource guid property of the Load balancer resource"
+          "description": "Gets or sets resource GUID property of the Load balancer resource"
         },
         "provisioningState": {
           "type": "string",
@@ -5921,7 +5921,7 @@
         },
         "resourceGuid": {
           "type": "string",
-          "description": "Gets or sets resource guid property of the LocalNetworkGateway resource"
+          "description": "Gets or sets resource GUID property of the LocalNetworkGateway resource"
         },
         "provisioningState": {
           "type": "string",
@@ -6074,7 +6074,7 @@
         },
         "internalFqdn": {
           "type": "string",
-          "description": "Gets or sets the internal fqdn."
+          "description": "Gets or sets the internal FQDN."
         },
         "internalDomainNameSuffix": {
           "type": "string",
@@ -6118,7 +6118,7 @@
         },
         "resourceGuid": {
           "type": "string",
-          "description": "Gets or sets resource guid property of the network interface resource"
+          "description": "Gets or sets resource GUID property of the network interface resource"
         },
         "provisioningState": {
           "type": "string",
@@ -6182,19 +6182,19 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "Gets or sets Source Port or Range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "Gets or sets Source Port or Range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "Gets or sets Destination Port or Range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "Gets or sets Destination Port or Range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "Gets or sets source address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "Gets or sets source address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "Gets or sets destination address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. "
+          "description": "Gets or sets destination address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. "
         },
         "access": {
           "type": "string",
@@ -6215,7 +6215,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "Gets or sets the direction of the rule.InBound or Outbound. The direction specifies if rule will be evaluated on incoming or outcoming traffic.",
+          "description": "Gets or sets the direction of the rule.InBound or Outbound. The direction specifies if rule will be evaluated on incoming or outgoing traffic.",
           "enum": [
             "Inbound",
             "Outbound"
@@ -6292,7 +6292,7 @@
         },
         "resourceGuid": {
           "type": "string",
-          "description": "Gets or sets resource guid property of the network security group resource"
+          "description": "Gets or sets resource GUID property of the network security group resource"
         },
         "provisioningState": {
           "type": "string",
@@ -6333,7 +6333,7 @@
           "description": "Gets the URL to get the next set of results."
         }
       },
-      "description": "Response for ListNetworkSecurityGroups Api servive call"
+      "description": "Response for ListNetworkSecurityGroups Api service call"
     },
     "PublicIPAddressDnsSettings": {
       "properties": {
@@ -6347,7 +6347,7 @@
         },
         "reverseFqdn": {
           "type": "string",
-          "description": "Gets or Sests the Reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN. "
+          "description": "Gets or Sets the Reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN. "
         }
       },
       "description": "Contains FQDN of the DNS record associated with the public IP address"
@@ -6391,11 +6391,11 @@
         "idleTimeoutInMinutes": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the Idletimeout of the public IP address"
+          "description": "Gets or sets the idle timeout of the public IP address"
         },
         "resourceGuid": {
           "type": "string",
-          "description": "Gets or sets resource guid property of the PublicIP resource"
+          "description": "Gets or sets resource GUID property of the PublicIP resource"
         },
         "provisioningState": {
           "type": "string",
@@ -6550,7 +6550,7 @@
           "description": "Gets the URL to get the next set of results."
         }
       },
-      "description": "Response for ListRouteTable Api servive call"
+      "description": "Response for ListRouteTable Api service call"
     },
     "RouteListResult": {
       "properties": {
@@ -6566,7 +6566,7 @@
           "description": "Gets the URL to get the next set of results."
         }
       },
-      "description": "Response for ListRoute Api servive call"
+      "description": "Response for ListRoute Api service call"
     },
     "SecurityRuleListResult": {
       "properties": {
@@ -6686,7 +6686,7 @@
           "$ref": "#/definitions/SubResource"
         }
       ],
-      "description": "Subnet in a VirtualNework resource"
+      "description": "Subnet in a VirtualNetwork resource"
     },
     "SubnetListResult": {
       "properties": {
@@ -6875,14 +6875,14 @@
         },
         "resourceGuid": {
           "type": "string",
-          "description": "Gets or sets resource guid property of the VirtualNetworkGateway resource"
+          "description": "Gets or sets resource GUID property of the VirtualNetworkGateway resource"
         },
         "provisioningState": {
           "type": "string",
           "description": "Gets or sets Provisioning state of the VirtualNetworkGateway resource Updating/Deleting/Failed"
         }
       },
-      "description": "VirtualNeworkGateay properties"
+      "description": "VirtualNetworkGateway properties"
     },
     "VirtualNetworkGateway": {
       "properties": {
@@ -6995,7 +6995,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type -Ipsec/Dedicated/VpnClient/Vnet2Vnet",
+          "description": "Gateway connection type IPsec/Dedicated/VpnClient/Vnet2Vnet",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -7014,7 +7014,7 @@
         },
         "sharedKey": {
           "type": "string",
-          "description": "The Ipsec share key."
+          "description": "The IPsec share key."
         },
         "connectionStatus": {
           "type": "string",
@@ -7050,14 +7050,14 @@
         },
         "resourceGuid": {
           "type": "string",
-          "description": "Gets or sets resource guid property of the VirtualNetworkGatewayConnection resource"
+          "description": "Gets or sets resource GUID property of the VirtualNetworkGatewayConnection resource"
         },
         "provisioningState": {
           "type": "string",
           "description": "Gets or sets Provisioning state of the VirtualNetworkGatewayConnection resource Updating/Deleting/Failed"
         }
       },
-      "description": "VirtualNeworkGatewayConnection properties"
+      "description": "VirtualNetworkGatewayConnection properties"
     },
     "VirtualNetworkGatewayConnection": {
       "properties": {
@@ -7154,7 +7154,7 @@
           "description": "The virtual network connection shared key value"
         }
       },
-      "description": "Response for CheckConnectionSharedKey Api servive call"
+      "description": "Response for CheckConnectionSharedKey Api service call"
     },
     "VirtualNetworkGatewayConnectionListResult": {
       "properties": {
@@ -7188,7 +7188,7 @@
           "description": "The virtual network connection shared key value"
         }
       },
-      "description": "Response for GetConnectionSharedKey Api servive call"
+      "description": "Response for GetConnectionSharedKey Api service call"
     },
     "VirtualNetworkGatewayListResult": {
       "properties": {
@@ -7237,7 +7237,7 @@
         },
         "resourceGuid": {
           "type": "string",
-          "description": "Gets or sets resource guid property of the VirtualNetwork resource"
+          "description": "Gets or sets resource GUID property of the VirtualNetwork resource"
         },
         "provisioningState": {
           "type": "string",
@@ -7277,7 +7277,7 @@
           "description": "Gets the URL to get the next set of results."
         }
       },
-      "description": "Response for ListVirtualNetworks Api servive call"
+      "description": "Response for ListVirtualNetworks Api service call"
     },
     "DnsNameAvailabilityResult": {
       "properties": {
@@ -7286,7 +7286,7 @@
           "description": "Domain availability (True/False)"
         }
       },
-      "description": "Response for CheckDnsNameAvailability Api servive call"
+      "description": "Response for CheckDnsNameAvailability Api service call"
     },
     "ErrorDetails": {
       "properties": {
@@ -7342,7 +7342,7 @@
           "$ref": "#/definitions/Error"
         }
       },
-      "description": "The response body contains the status of the specified asynchronous operation, indicating whether it has succeeded, is inprogress, or has failed. Note that this status is distinct from the HTTP status code returned for the Get Operation Status operation itself. If the asynchronous operation succeeded, the response body includes the HTTP status code for the successful request. If the asynchronous operation failed, the response body includes the HTTP status code for the failed request and error information regarding the failure."
+      "description": "The response body contains the status of the specified asynchronous operation, indicating whether it has succeeded, is in progress, or has failed. Note that this status is distinct from the HTTP status code returned for the Get Operation Status operation itself. If the asynchronous operation succeeded, the response body includes the HTTP status code for the successful request. If the asynchronous operation failed, the response body includes the HTTP status code for the failed request and error information regarding the failure."
     },
     "Resource": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2016-06-01/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2016-06-01/network.json
@@ -1561,7 +1561,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_Delete",
-        "description": "The delete netwokInterface operation deletes the specified netwokInterface.",
+        "description": "The delete networkInterface operation deletes the specified networkInterface.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -1915,7 +1915,7 @@
           "NetworkInterfaces"
         ],
         "operationId": "NetworkInterfaces_GetEffectiveRouteTable",
-        "description": "The get effective routetable operation retrieves all the route tables applied on a networkInterface.",
+        "description": "Retrieves all the route tables applied on a networkInterface.",
         "parameters": [
           {
             "name": "resourceGroupName",
@@ -5303,7 +5303,7 @@
         },
         "microsoftPeeringConfig": {
           "$ref": "#/definitions/ExpressRouteCircuitPeeringConfig",
-          "description": "Gets or sets the mircosoft peering config"
+          "description": "Gets or sets the Microsoft peering config"
         },
         "stats": {
           "$ref": "#/definitions/ExpressRouteCircuitStats",
@@ -6602,19 +6602,19 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "Gets or sets Source Port or Range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "Gets or sets Source Port or Range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "Gets or sets Destination Port or Range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "Gets or sets Destination Port or Range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "Gets or sets source address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "Gets or sets source address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "Gets or sets destination address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. "
+          "description": "Gets or sets destination address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. "
         },
         "access": {
           "type": "string",
@@ -6635,7 +6635,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "Gets or sets the direction of the rule.InBound or Outbound. The direction specifies if rule will be evaluated on incoming or outcoming traffic.",
+          "description": "Gets or sets the direction of the rule.InBound or Outbound. The direction specifies if rule will be evaluated on incoming or outgoing traffic.",
           "enum": [
             "Inbound",
             "Outbound"
@@ -6943,7 +6943,7 @@
         "idleTimeoutInMinutes": {
           "type": "integer",
           "format": "int32",
-          "description": "Gets or sets the Idletimeout of the public IP address"
+          "description": "Gets or sets the idle timeout of the public IP address"
         },
         "resourceGuid": {
           "type": "string",
@@ -7409,7 +7409,7 @@
           "$ref": "#/definitions/SubResource"
         }
       ],
-      "description": "Subnet in a VirtualNework resource"
+      "description": "Subnet in a VirtualNetwork resource"
     },
     "VirtualNetworkPeering": {
       "properties": {
@@ -7431,7 +7431,7 @@
           "$ref": "#/definitions/SubResource"
         }
       ],
-      "description": "Peerings in a VirtualNework resource"
+      "description": "Peerings in a VirtualNetwork resource"
     },
     "SubnetListResult": {
       "properties": {
@@ -7762,7 +7762,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type -Ipsec/Dedicated/VpnClient/Vnet2Vnet",
+          "description": "Gateway connection type IPsec/Dedicated/VpnClient/Vnet2Vnet",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -7781,7 +7781,7 @@
         },
         "sharedKey": {
           "type": "string",
-          "description": "The Ipsec share key."
+          "description": "The IPsec share key."
         },
         "connectionStatus": {
           "type": "string",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2016-09-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2016-09-01/loadBalancer.json
@@ -469,7 +469,7 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "A loag balancing rule for a load balancer."
+      "description": "A load balancing rule for a load balancer."
     },
     "ProbePropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2016-09-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2016-09-01/networkSecurityGroup.json
@@ -458,19 +458,19 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "access": {
           "type": "string",
@@ -491,7 +491,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2016-09-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2016-09-01/virtualNetworkGateway.json
@@ -226,8 +226,8 @@
             "type": "string",
             "description": "The name of the virtual network gateway."
           },
-          { 
-            "name": "gatewayVip",		
+          {
+            "name": "gatewayVip",
             "in": "query",
             "required": false,
             "type": "string",
@@ -577,7 +577,7 @@
         },
         "x-ms-long-running-operation": true
       }
-    },    
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey": {
       "put": {
         "tags": [
@@ -668,7 +668,7 @@
             }
           }
         }
-      }	  
+      }
     },
 	"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections": {
       "get": {
@@ -1421,19 +1421,19 @@
           }
         },
         "ingressBytesTransferred": {
-          "readOnly": true,		
+          "readOnly": true,
           "type": "integer",
           "format": "int64",
           "description": "The Ingress Bytes Transferred in this connection"
         },
         "egressBytesTransferred": {
-          "readOnly": true,		
+          "readOnly": true,
           "type": "integer",
           "format": "int64",
           "description": "The Egress Bytes Transferred in this connection"
-        },		
+        },
         "lastConnectionEstablishedUtcTime": {
-          "readOnly": true,		
+          "readOnly": true,
           "type": "string",
           "description": "The time at which connection was established in Utc format."
         }
@@ -1457,7 +1457,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -1597,7 +1597,7 @@
       },
       "required": [
         "value"
-      ],	  
+      ],
       "description": "Response for GetConnectionSharedKey API service call"
     },
 	"LocalNetworkGatewayPropertiesFormat": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2016-12-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2016-12-01/networkSecurityGroup.json
@@ -458,19 +458,19 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "access": {
           "type": "string",
@@ -491,7 +491,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2016-12-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2016-12-01/virtualNetworkGateway.json
@@ -226,8 +226,8 @@
             "type": "string",
             "description": "The name of the virtual network gateway."
           },
-          { 
-            "name": "gatewayVip",		
+          {
+            "name": "gatewayVip",
             "in": "query",
             "required": false,
             "type": "string",
@@ -577,7 +577,7 @@
         },
         "x-ms-long-running-operation": true
       }
-    },    
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey": {
       "put": {
         "tags": [
@@ -668,7 +668,7 @@
             }
           }
         }
-      }	  
+      }
     },
 	"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections": {
       "get": {
@@ -1408,19 +1408,19 @@
           }
         },
         "ingressBytesTransferred": {
-          "readOnly": true,		
+          "readOnly": true,
           "type": "integer",
           "format": "int64",
           "description": "The Ingress Bytes Transferred in this connection"
         },
         "egressBytesTransferred": {
-          "readOnly": true,		
+          "readOnly": true,
           "type": "integer",
           "format": "int64",
           "description": "The Egress Bytes Transferred in this connection"
-        },		
+        },
         "lastConnectionEstablishedUtcTime": {
-          "readOnly": true,		
+          "readOnly": true,
           "type": "string",
           "description": "The time at which connection was established in Utc format."
         }
@@ -1444,7 +1444,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -1584,7 +1584,7 @@
       },
       "required": [
         "value"
-      ],	  
+      ],
       "description": "Response for GetConnectionSharedKey API service call"
     },
 	"LocalNetworkGatewayPropertiesFormat": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-03-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-03-01/networkSecurityGroup.json
@@ -458,19 +458,19 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "access": {
           "type": "string",
@@ -491,7 +491,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-03-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-03-01/virtualNetworkGateway.json
@@ -226,8 +226,8 @@
             "type": "string",
             "description": "The name of the virtual network gateway."
           },
-          { 
-            "name": "gatewayVip",		
+          {
+            "name": "gatewayVip",
             "in": "query",
             "required": false,
             "type": "string",
@@ -577,7 +577,7 @@
         },
         "x-ms-long-running-operation": true
       }
-    },    
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey": {
       "put": {
         "tags": [
@@ -668,7 +668,7 @@
             }
           }
         }
-      }	  
+      }
     },
 	"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections": {
       "get": {
@@ -1420,19 +1420,19 @@
           }
         },
         "ingressBytesTransferred": {
-          "readOnly": true,		
+          "readOnly": true,
           "type": "integer",
           "format": "int64",
           "description": "The Ingress Bytes Transferred in this connection"
         },
         "egressBytesTransferred": {
-          "readOnly": true,		
+          "readOnly": true,
           "type": "integer",
           "format": "int64",
           "description": "The Egress Bytes Transferred in this connection"
-        },		
+        },
         "lastConnectionEstablishedUtcTime": {
-          "readOnly": true,		
+          "readOnly": true,
           "type": "string",
           "description": "The time at which connection was established in Utc format."
         }
@@ -1456,7 +1456,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -1608,7 +1608,7 @@
       },
       "required": [
         "value"
-      ],	  
+      ],
       "description": "Response for GetConnectionSharedKey API service call"
     },
     "IpsecPolicy": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/networkInterface.json
@@ -825,14 +825,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -847,14 +847,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/networkSecurityGroup.json
@@ -604,15 +604,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -623,7 +623,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -667,7 +667,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/virtualNetworkGateway.json
@@ -1605,7 +1605,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -1983,7 +1983,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/networkInterface.json
@@ -805,14 +805,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -827,14 +827,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/networkSecurityGroup.json
@@ -580,15 +580,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -599,7 +599,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -643,7 +643,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/virtualNetworkGateway.json
@@ -1649,7 +1649,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2027,7 +2027,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/networkInterface.json
@@ -862,14 +862,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -884,14 +884,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/networkSecurityGroup.json
@@ -630,15 +630,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -656,7 +656,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -707,7 +707,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/virtualNetworkGateway.json
@@ -1887,7 +1887,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2265,7 +2265,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/networkInterface.json
@@ -862,14 +862,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -884,14 +884,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/networkSecurityGroup.json
@@ -630,15 +630,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -656,7 +656,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -707,7 +707,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/networkWatcher.json
@@ -2729,7 +2729,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -2901,7 +2901,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/virtualNetworkGateway.json
@@ -1887,7 +1887,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2265,7 +2265,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/networkInterface.json
@@ -862,14 +862,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -884,14 +884,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/networkSecurityGroup.json
@@ -630,15 +630,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -656,7 +656,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -707,7 +707,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/networkWatcher.json
@@ -2810,7 +2810,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -2982,7 +2982,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/virtualNetworkGateway.json
@@ -1887,7 +1887,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2265,7 +2265,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/applicationGateway.json
@@ -1750,7 +1750,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size for WAF."
+          "description": "Maximum request body size for WAF."
         }
       },
       "required": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkInterface.json
@@ -862,14 +862,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -884,14 +884,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkSecurityGroup.json
@@ -630,15 +630,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -656,7 +656,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -707,7 +707,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/networkWatcher.json
@@ -2889,7 +2889,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -3061,7 +3061,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/virtualNetworkGateway.json
@@ -1887,7 +1887,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2265,7 +2265,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/applicationGateway.json
@@ -489,8 +489,8 @@
         ],
         "operationId": "ApplicationGateways_ListAvailableSslOptions",
         "x-ms-examples": {
-          "Get Available Ssl Options": { 
-            "$ref": "./examples/ApplicationGatewayAvailableSslOptionsGet.json" 
+          "Get Available Ssl Options": {
+            "$ref": "./examples/ApplicationGatewayAvailableSslOptionsGet.json"
           }
         },
         "description": "Lists available Ssl options for configuring Ssl policy.",
@@ -1738,19 +1738,19 @@
             "$ref": "#/definitions/ApplicationGatewayFirewallDisabledRuleGroup"
           },
           "description": "The disabled rule groups."
-        }, 
-        "requestBodyCheck": { 
-          "type": "boolean", 
-          "description": "Whether allow WAF to check request Body." 
-        }, 
-        "maxRequestBodySize": { 
-          "type": "integer", 
-          "format": "int32", 
-          "maximum": 128, 
-          "exclusiveMaximum": false, 
-          "minimum": 8, 
-          "exclusiveMinimum": false, 
-          "description": "Maxium request body size for WAF."
+        },
+        "requestBodyCheck": {
+          "type": "boolean",
+          "description": "Whether allow WAF to check request Body."
+        },
+        "maxRequestBodySize": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 128,
+          "exclusiveMaximum": false,
+          "minimum": 8,
+          "exclusiveMinimum": false,
+          "description": "Maximum request body size for WAF."
         }
       },
       "required": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/expressRouteCrossConnection.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/expressRouteCrossConnection.json
@@ -53,7 +53,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }
@@ -93,7 +93,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/networkInterface.json
@@ -862,14 +862,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -884,14 +884,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/networkSecurityGroup.json
@@ -630,15 +630,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -656,7 +656,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -707,7 +707,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/networkWatcher.json
@@ -2797,7 +2797,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -2982,7 +2982,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/virtualNetworkGateway.json
@@ -754,7 +754,7 @@
             "description": "Accepted and the operation will complete asynchronously."
           },
           "200": {
-            "description": "Request successful. The operation sets the specificed vpnclient ipsec parameters for P2S client of the virtual network gateway.",
+            "description": "Request successful. The operation sets the specified vpnclient ipsec parameters for P2S client of the virtual network gateway.",
             "schema": {
               "$ref": "#/definitions/VpnClientIPsecParameters"
             }
@@ -1717,7 +1717,7 @@
             "$ref": "#/definitions/IpsecPolicy"
           },
           "description": "VpnClientIpsecPolicies for virtual network gateway P2S client."
-        },		
+        },
         "radiusServerAddress": {
           "type": "string",
           "description": "The radius server address property of the VirtualNetworkGateway resource for vpn client connection."
@@ -2058,7 +2058,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2325,7 +2325,7 @@
             "ECP384",
             "PFS24",
             "PFS14",
-            "PFSMM"		
+            "PFSMM"
           ],
           "x-ms-enum": {
             "name": "PfsGroup",
@@ -2474,7 +2474,7 @@
         "pfsGroup"
       ],
       "description": "An IPSec parameters for a virtual network gateway P2S connection."
-    },	
+    },
     "LocalNetworkGatewayPropertiesFormat": {
       "properties": {
         "localNetworkAddressSpace": {
@@ -2572,7 +2572,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/applicationGateway.json
@@ -1769,7 +1769,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size for WAF."
+          "description": "Maximum request body size for WAF."
         }
       },
       "required": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/azureFirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/azureFirewall.json
@@ -1,273 +1,273 @@
-{  
+{
    "swagger":"2.0",
-   "info":{  
+   "info":{
       "title":"NetworkManagementClient",
       "description":"The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
       "version":"2018-04-01"
    },
    "host":"management.azure.com",
-   "schemes":[  
+   "schemes":[
       "https"
    ],
-   "consumes":[  
+   "consumes":[
       "application/json"
    ],
-   "produces":[  
+   "produces":[
       "application/json"
    ],
-   "security":[  
-      {  
-         "azure_auth":[  
+   "security":[
+      {
+         "azure_auth":[
             "user_impersonation"
          ]
       }
    ],
-   "securityDefinitions":{  
-      "azure_auth":{  
+   "securityDefinitions":{
+      "azure_auth":{
          "type":"oauth2",
          "authorizationUrl":"https://login.microsoftonline.com/common/oauth2/authorize",
          "flow":"implicit",
          "description":"Azure Active Directory OAuth2 Flow",
-         "scopes":{  
+         "scopes":{
             "user_impersonation":"impersonate your user account"
          }
       }
    },
-   "paths":{  
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{  
-         "delete":{  
-            "tags":[  
+   "paths":{
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{
+         "delete":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Delete",
             "description":"Deletes the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "202":{  
+            "responses":{
+               "202":{
                   "description":"Accepted and the operation will complete asynchronously."
                },
-               "204":{  
+               "204":{
                   "description":"Request successful. Resource with the specified name does not exist"
                },
-               "200":{  
+               "200":{
                   "description":"Delete successful."
                }
             },
-            "x-ms-examples":{  
-               "Delete Azure Firewall":{  
+            "x-ms-examples":{
+               "Delete Azure Firewall":{
                   "$ref":"./examples/AzureFirewallDelete.json"
                }
             },
             "x-ms-long-running-operation":true
          },
-         "get":{  
-            "tags":[  
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Get",
             "description":"Gets the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Request successful. The operation returns a AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Get Azure Firewall":{  
+            "x-ms-examples":{
+               "Get Azure Firewall":{
                   "$ref":"./examples/AzureFirewallGet.json"
                }
             }
          },
-         "put":{  
-            "tags":[  
+         "put":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_CreateOrUpdate",
             "description":"Creates or updates the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "name":"parameters",
                   "in":"body",
                   "required":true,
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   },
                   "description":"Parameters supplied to the create or update Azure Firewall operation."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "201":{  
+            "responses":{
+               "201":{
                   "description":"Create successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                },
-               "200":{  
+               "200":{
                   "description":"Update successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Create Azure Firewall":{  
+            "x-ms-examples":{
+               "Create Azure Firewall":{
                   "$ref":"./examples/AzureFirewallPut.json"
                }
             },
             "x-ms-long-running-operation":true
          }
       },
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_List",
             "description":"Lists all Azure Firewalls in a resource group.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given resource group":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given resource group":{
                   "$ref":"./examples/AzureFirewallListByResourceGroup.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       },
-      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_ListAll",
             "description":"Gets all the Azure Firewalls in a subscription.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given subscription":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given subscription":{
                   "$ref":"./examples/AzureFirewallListBySubscription.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       }
    },
-   "definitions":{  
-      "AzureFirewallIPConfigurationPropertiesFormat":{  
-         "properties":{  
+   "definitions":{
+      "AzureFirewallIPConfigurationPropertiesFormat":{
+         "properties":{
 			"privateIPAddress": {
 			  "type": "string",
 			  "description": "The Firewall Internal Load Balancer IP to be used as the next hop in User Defined Routes."
 			},
-            "subnet":{  
+            "subnet":{
                "$ref":"./network.json#/definitions/SubResource",
                "description":"Reference of the subnet resource. This resource must be named 'AzureFirewallSubnet'."
             },
-			"internalPublicIpAddress":{  
+			"internalPublicIpAddress":{
                "$ref":"./network.json#/definitions/SubResource",
                "description":"Reference of the PublicIP resource. This field is a mandatory input."
             },
@@ -275,103 +275,103 @@
 			  "$ref": "./network.json#/definitions/SubResource",
 			  "description": "Reference of the PublicIP resource. This field is populated in the output."
 			},
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of IP configuration of an Azure Firewall."
       },
-      "AzureFirewallIPConfiguration":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallIPConfiguration":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallIPConfigurationPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "description":"A unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"IP configuration of an Azure Firewall."
       },
-      "AzureFirewallPropertiesFormat":{  
-         "properties":{  
-            "applicationRuleCollections":{  
+      "AzureFirewallPropertiesFormat":{
+         "properties":{
+            "applicationRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleCollection"
                },
                "description":"Collection of application rule collections used by a Azure Firewall."
             },
-            "networkRuleCollections":{  
+            "networkRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleCollection"
                },
                "description":"Collection of network rule collections used by a Azure Firewall."
             },
-            "ipConfigurations":{  
+            "ipConfigurations":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallIPConfiguration"
                },
                "description":"IP configuration of the Azure Firewall resource."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the Azure Firewall."
       },
-      "AzureFirewall":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewall":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallPropertiesFormat"
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/Resource"
             }
          ],
          "description":"Azure Firewall resource"
       },
-      "AzureFirewallListResult":{  
-         "properties":{  
-            "value":{  
+      "AzureFirewallListResult":{
+         "properties":{
+            "value":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewall"
                },
                "description":"List of a Azure Firewalls in a resource group."
             },
-            "nextLink":{  
+            "nextLink":{
                "type":"string",
                "description":"URL to get the next set of results."
             }
          },
          "description":"Response for ListAzureFirewalls API service call."
       },
-      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -380,54 +380,54 @@
                "exclusiveMinimum":false,
                "description":"Priority of the application rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRule"
                },
                "description":"Collection of rules used by a application rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the application rule collection."
       },
-      "AzureFirewallApplicationRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallApplicationRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallApplicationRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Application rule collection resource"
       },
-      "AzureFirewallApplicationRuleProtocol":{  
-         "properties":{  
-            "protocolType":{  
+      "AzureFirewallApplicationRuleProtocol":{
+         "properties":{
+            "protocolType":{
                "description":"Protocol type",
                "$ref":"#/definitions/AzureFirewallApplicationRuleProtocolType"
             },
-            "port":{  
+            "port":{
                "type":"integer",
                "format":"int32",
                "maximum":64000,
@@ -439,43 +439,43 @@
          },
          "description":"Properties of the application rule protocol."
       },
-      "AzureFirewallApplicationRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallApplicationRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the application rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-			"sourceAddresses":{  
+			"sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleProtocol"
                },
                "description":"Array of ApplicationRuleProtocols."
             },
-            "targetUrls":{  
+            "targetUrls":{
                "type":"array",
                "description":"List of URLs for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
          },
          "description":"Properties of an application rule."
       },
-      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -484,146 +484,146 @@
                "exclusiveMinimum":false,
                "description":"Priority of the network rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRule"
                },
                "description":"Collection of rules used by a network rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the network rule collection."
       },
-      "AzureFirewallNetworkRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallNetworkRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallNetworkRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Network rule collection resource"
       },
-      "AzureFirewallNetworkRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallNetworkRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the network rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleProtocol"
                },
                "description":"Array of AzureFirewallNetworkRuleProtocols."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationAddresses":{  
+            "destinationAddresses":{
                "type":"array",
                "description":"List of destination IP addresses.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationPorts":{  
+            "destinationPorts":{
                "type":"array",
                "description":"List of destination ports.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
          },
          "description":"Properties of the network rule."
       },
-      "AzureFirewallRCAction":{  
-         "properties":{  
-            "type":{  
+      "AzureFirewallRCAction":{
+         "properties":{
+            "type":{
                "description":"The type of action.",
                "$ref":"#/definitions/AzureFirewallRCActionType"
             }
          },
          "description":"Properties of the AzureFirewallRCAction."
       },
-      "AzureFirewallRCActionType":{  
+      "AzureFirewallRCActionType":{
          "type":"string",
          "description":"The action type of a rule collection",
-         "enum":[  
+         "enum":[
             "Allow",
             "Deny"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallRCActionType",
             "modelAsString":true
          }
       },
-      "ProvisioningState":{  
+      "ProvisioningState":{
          "type":"string",
          "readOnly":true,
-         "description":"The current provisisoning state.",
-         "enum":[  
+         "description":"The current provisioning state.",
+         "enum":[
             "Succeeded",
             "Updating",
             "Deleting",
             "Failed"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"ProvisioningState",
             "modelAsString":true
          }
       },
-      "AzureFirewallNetworkRuleProtocol":{  
+      "AzureFirewallNetworkRuleProtocol":{
          "type":"string",
          "description":"The protocol of a Network Rule resource",
-         "enum":[  
+         "enum":[
             "TCP",
             "UDP",
             "Any",
-			"ICMP"
+            "ICMP"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallNetworkRuleProtocol",
             "modelAsString":true
          }
       },
-      "AzureFirewallApplicationRuleProtocolType":{  
+      "AzureFirewallApplicationRuleProtocolType":{
          "type":"string",
          "description":"The protocol type of a Application Rule resource",
-         "enum":[  
+         "enum":[
             "Http",
             "Https"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallApplicationRuleProtocolType",
             "modelAsString":true
          }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/expressRouteCrossConnection.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/expressRouteCrossConnection.json
@@ -51,7 +51,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }
@@ -91,7 +91,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/networkInterface.json
@@ -860,14 +860,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -882,14 +882,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/networkSecurityGroup.json
@@ -628,15 +628,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -654,7 +654,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -705,7 +705,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/networkWatcher.json
@@ -2916,7 +2916,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -3101,7 +3101,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/virtualNetworkGateway.json
@@ -752,7 +752,7 @@
             "description": "Accepted and the operation will complete asynchronously."
           },
           "200": {
-            "description": "Request successful. The operation sets the specificed vpnclient ipsec parameters for P2S client of the virtual network gateway.",
+            "description": "Request successful. The operation sets the specified vpnclient ipsec parameters for P2S client of the virtual network gateway.",
             "schema": {
               "$ref": "#/definitions/VpnClientIPsecParameters"
             }
@@ -803,8 +803,8 @@
         },
         "x-ms-long-running-operation": true,
         "x-ms-examples": {
-          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" } 
-        }               
+          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" }
+        }
 
       }
     },
@@ -1723,7 +1723,7 @@
             "$ref": "#/definitions/IpsecPolicy"
           },
           "description": "VpnClientIpsecPolicies for virtual network gateway P2S client."
-        },		
+        },
         "radiusServerAddress": {
           "type": "string",
           "description": "The radius server address property of the VirtualNetworkGateway resource for vpn client connection."
@@ -2076,7 +2076,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2348,7 +2348,7 @@
             "ECP384",
             "PFS24",
             "PFS14",
-            "PFSMM"		
+            "PFSMM"
           ],
           "x-ms-enum": {
             "name": "PfsGroup",
@@ -2497,7 +2497,7 @@
         "pfsGroup"
       ],
       "description": "An IPSec parameters for a virtual network gateway P2S connection."
-    },	
+    },
     "LocalNetworkGatewayPropertiesFormat": {
       "properties": {
         "localNetworkAddressSpace": {
@@ -2595,7 +2595,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/virtualWan.json
@@ -328,7 +328,7 @@
         "x-ms-examples": {
           "VpnSiteGet": { "$ref": "./examples/VpnSiteGet.json" }
         },
-        "description": "Retrieves the details of a VPNsite.",
+        "description": "Retrieves the details of a VPN site.",
         "parameters": [
           {
             "$ref": "./network.json#/parameters/SubscriptionIdParameter"
@@ -2039,7 +2039,7 @@
     "ProvisioningState": {
       "type": "string",
       "readOnly": true,
-      "description": "The current provisisoning state.",
+      "description": "The current provisioning state.",
       "enum": [
         "Succeeded",
         "Updating",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/applicationGateway.json
@@ -1769,7 +1769,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size for WAF."
+          "description": "Maximum request body size for WAF."
         }
       },
       "required": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/azureFirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/azureFirewall.json
@@ -1,273 +1,273 @@
-{  
+{
    "swagger":"2.0",
-   "info":{  
+   "info":{
       "title":"NetworkManagementClient",
       "description":"The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
       "version": "2018-06-01"
    },
    "host":"management.azure.com",
-   "schemes":[  
+   "schemes":[
       "https"
    ],
-   "consumes":[  
+   "consumes":[
       "application/json"
    ],
-   "produces":[  
+   "produces":[
       "application/json"
    ],
-   "security":[  
-      {  
-         "azure_auth":[  
+   "security":[
+      {
+         "azure_auth":[
             "user_impersonation"
          ]
       }
    ],
-   "securityDefinitions":{  
-      "azure_auth":{  
+   "securityDefinitions":{
+      "azure_auth":{
          "type":"oauth2",
          "authorizationUrl":"https://login.microsoftonline.com/common/oauth2/authorize",
          "flow":"implicit",
          "description":"Azure Active Directory OAuth2 Flow",
-         "scopes":{  
+         "scopes":{
             "user_impersonation":"impersonate your user account"
          }
       }
    },
-   "paths":{  
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{  
-         "delete":{  
-            "tags":[  
+   "paths":{
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{
+         "delete":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Delete",
             "description":"Deletes the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "202":{  
+            "responses":{
+               "202":{
                   "description":"Accepted and the operation will complete asynchronously."
                },
-               "204":{  
+               "204":{
                   "description":"Request successful. Resource with the specified name does not exist"
                },
-               "200":{  
+               "200":{
                   "description":"Delete successful."
                }
             },
-            "x-ms-examples":{  
-               "Delete Azure Firewall":{  
+            "x-ms-examples":{
+               "Delete Azure Firewall":{
                   "$ref":"./examples/AzureFirewallDelete.json"
                }
             },
             "x-ms-long-running-operation":true
          },
-         "get":{  
-            "tags":[  
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Get",
             "description":"Gets the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Request successful. The operation returns a AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Get Azure Firewall":{  
+            "x-ms-examples":{
+               "Get Azure Firewall":{
                   "$ref":"./examples/AzureFirewallGet.json"
                }
             }
          },
-         "put":{  
-            "tags":[  
+         "put":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_CreateOrUpdate",
             "description":"Creates or updates the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "name":"parameters",
                   "in":"body",
                   "required":true,
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   },
                   "description":"Parameters supplied to the create or update Azure Firewall operation."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "201":{  
+            "responses":{
+               "201":{
                   "description":"Create successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                },
-               "200":{  
+               "200":{
                   "description":"Update successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Create Azure Firewall":{  
+            "x-ms-examples":{
+               "Create Azure Firewall":{
                   "$ref":"./examples/AzureFirewallPut.json"
                }
             },
             "x-ms-long-running-operation":true
          }
       },
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_List",
             "description":"Lists all Azure Firewalls in a resource group.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given resource group":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given resource group":{
                   "$ref":"./examples/AzureFirewallListByResourceGroup.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       },
-      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_ListAll",
             "description":"Gets all the Azure Firewalls in a subscription.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given subscription":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given subscription":{
                   "$ref":"./examples/AzureFirewallListBySubscription.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       }
    },
-   "definitions":{  
-      "AzureFirewallIPConfigurationPropertiesFormat":{  
-         "properties":{  
+   "definitions":{
+      "AzureFirewallIPConfigurationPropertiesFormat":{
+         "properties":{
 			"privateIPAddress": {
 			  "type": "string",
 			  "description": "The Firewall Internal Load Balancer IP to be used as the next hop in User Defined Routes."
 			},
-            "subnet":{  
+            "subnet":{
                "$ref":"./network.json#/definitions/SubResource",
                "description":"Reference of the subnet resource. This resource must be named 'AzureFirewallSubnet'."
             },
-			"internalPublicIpAddress":{  
+			"internalPublicIpAddress":{
                "$ref":"./network.json#/definitions/SubResource",
                "description":"Reference of the PublicIP resource. This field is a mandatory input."
             },
@@ -275,103 +275,103 @@
 			  "$ref": "./network.json#/definitions/SubResource",
 			  "description": "Reference of the PublicIP resource. This field is populated in the output."
 			},
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of IP configuration of an Azure Firewall."
       },
-      "AzureFirewallIPConfiguration":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallIPConfiguration":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallIPConfigurationPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "description":"A unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"IP configuration of an Azure Firewall."
       },
-      "AzureFirewallPropertiesFormat":{  
-         "properties":{  
-            "applicationRuleCollections":{  
+      "AzureFirewallPropertiesFormat":{
+         "properties":{
+            "applicationRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleCollection"
                },
                "description":"Collection of application rule collections used by a Azure Firewall."
             },
-            "networkRuleCollections":{  
+            "networkRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleCollection"
                },
                "description":"Collection of network rule collections used by a Azure Firewall."
             },
-            "ipConfigurations":{  
+            "ipConfigurations":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallIPConfiguration"
                },
                "description":"IP configuration of the Azure Firewall resource."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the Azure Firewall."
       },
-      "AzureFirewall":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewall":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallPropertiesFormat"
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/Resource"
             }
          ],
          "description":"Azure Firewall resource"
       },
-      "AzureFirewallListResult":{  
-         "properties":{  
-            "value":{  
+      "AzureFirewallListResult":{
+         "properties":{
+            "value":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewall"
                },
                "description":"List of a Azure Firewalls in a resource group."
             },
-            "nextLink":{  
+            "nextLink":{
                "type":"string",
                "description":"URL to get the next set of results."
             }
          },
          "description":"Response for ListAzureFirewalls API service call."
       },
-      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -380,54 +380,54 @@
                "exclusiveMinimum":false,
                "description":"Priority of the application rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRule"
                },
                "description":"Collection of rules used by a application rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the application rule collection."
       },
-      "AzureFirewallApplicationRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallApplicationRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallApplicationRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Application rule collection resource"
       },
-      "AzureFirewallApplicationRuleProtocol":{  
-         "properties":{  
-            "protocolType":{  
+      "AzureFirewallApplicationRuleProtocol":{
+         "properties":{
+            "protocolType":{
                "description":"Protocol type",
                "$ref":"#/definitions/AzureFirewallApplicationRuleProtocolType"
             },
-            "port":{  
+            "port":{
                "type":"integer",
                "format":"int32",
                "maximum":64000,
@@ -439,43 +439,43 @@
          },
          "description":"Properties of the application rule protocol."
       },
-      "AzureFirewallApplicationRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallApplicationRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the application rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-			"sourceAddresses":{  
+			"sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleProtocol"
                },
                "description":"Array of ApplicationRuleProtocols."
             },
-            "targetUrls":{  
+            "targetUrls":{
                "type":"array",
                "description":"List of URLs for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
          },
          "description":"Properties of an application rule."
       },
-      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -484,146 +484,146 @@
                "exclusiveMinimum":false,
                "description":"Priority of the network rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRule"
                },
                "description":"Collection of rules used by a network rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the network rule collection."
       },
-      "AzureFirewallNetworkRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallNetworkRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallNetworkRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Network rule collection resource"
       },
-      "AzureFirewallNetworkRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallNetworkRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the network rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleProtocol"
                },
                "description":"Array of AzureFirewallNetworkRuleProtocols."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationAddresses":{  
+            "destinationAddresses":{
                "type":"array",
                "description":"List of destination IP addresses.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationPorts":{  
+            "destinationPorts":{
                "type":"array",
                "description":"List of destination ports.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
          },
          "description":"Properties of the network rule."
       },
-      "AzureFirewallRCAction":{  
-         "properties":{  
-            "type":{  
+      "AzureFirewallRCAction":{
+         "properties":{
+            "type":{
                "description":"The type of action.",
                "$ref":"#/definitions/AzureFirewallRCActionType"
             }
          },
          "description":"Properties of the AzureFirewallRCAction."
       },
-      "AzureFirewallRCActionType":{  
+      "AzureFirewallRCActionType":{
          "type":"string",
          "description":"The action type of a rule collection",
-         "enum":[  
+         "enum":[
             "Allow",
             "Deny"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallRCActionType",
             "modelAsString":true
          }
       },
-      "ProvisioningState":{  
+      "ProvisioningState":{
          "type":"string",
          "readOnly":true,
-         "description":"The current provisisoning state.",
-         "enum":[  
+         "description":"The current provisioning state.",
+         "enum":[
             "Succeeded",
             "Updating",
             "Deleting",
             "Failed"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"ProvisioningState",
             "modelAsString":true
          }
       },
-      "AzureFirewallNetworkRuleProtocol":{  
+      "AzureFirewallNetworkRuleProtocol":{
          "type":"string",
          "description":"The protocol of a Network Rule resource",
-         "enum":[  
+         "enum":[
             "TCP",
             "UDP",
             "Any",
 			"ICMP"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallNetworkRuleProtocol",
             "modelAsString":true
          }
       },
-      "AzureFirewallApplicationRuleProtocolType":{  
+      "AzureFirewallApplicationRuleProtocolType":{
          "type":"string",
          "description":"The protocol type of a Application Rule resource",
-         "enum":[  
+         "enum":[
             "Http",
             "Https"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallApplicationRuleProtocolType",
             "modelAsString":true
          }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/expressRouteCrossConnection.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/expressRouteCrossConnection.json
@@ -51,7 +51,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }
@@ -91,7 +91,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/networkInterface.json
@@ -860,14 +860,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -882,14 +882,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/networkSecurityGroup.json
@@ -628,15 +628,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -654,7 +654,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -705,7 +705,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/networkWatcher.json
@@ -1785,8 +1785,8 @@
         ],
         "operationId": "NetworkWatchers_GetNetworkConfigurationDiagnostic",
         "x-ms-long-running-operation": true,
-        "x-ms-long-running-operation-options": { 
-          "final-state-via": "location" 
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
         },
         "description": "Get network configuration diagnostic.",
         "parameters": [
@@ -1822,7 +1822,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns the result of network condifuration diagnostic.",
+            "description": "Request successful. The operation returns the result of network configuration diagnostic.",
             "schema": {
               "$ref": "#/definitions/NetworkConfigurationDiagnosticResponse"
             }
@@ -3172,7 +3172,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -3357,7 +3357,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {
@@ -3484,7 +3484,7 @@
         },
         "destinationPort": {
           "type": "string",
-          "description": "Traffice destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
+          "description": "Traffic destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualNetworkGateway.json
@@ -795,7 +795,7 @@
             "description": "Accepted and the operation will complete asynchronously."
           },
           "200": {
-            "description": "Request successful. The operation sets the specificed vpnclient ipsec parameters for P2S client of the virtual network gateway.",
+            "description": "Request successful. The operation sets the specified vpnclient ipsec parameters for P2S client of the virtual network gateway.",
             "schema": {
               "$ref": "#/definitions/VpnClientIPsecParameters"
             }
@@ -846,8 +846,8 @@
         },
         "x-ms-long-running-operation": true,
         "x-ms-examples": {
-          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" } 
-        }               
+          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" }
+        }
 
       }
     },
@@ -1766,7 +1766,7 @@
             "$ref": "#/definitions/IpsecPolicy"
           },
           "description": "VpnClientIpsecPolicies for virtual network gateway P2S client."
-        },		
+        },
         "radiusServerAddress": {
           "type": "string",
           "description": "The radius server address property of the VirtualNetworkGateway resource for vpn client connection."
@@ -2119,7 +2119,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2391,7 +2391,7 @@
             "ECP384",
             "PFS24",
             "PFS14",
-            "PFSMM"		
+            "PFSMM"
           ],
           "x-ms-enum": {
             "name": "PfsGroup",
@@ -2540,7 +2540,7 @@
         "pfsGroup"
       ],
       "description": "An IPSec parameters for a virtual network gateway P2S connection."
-    },	
+    },
     "LocalNetworkGatewayPropertiesFormat": {
       "properties": {
         "localNetworkAddressSpace": {
@@ -2638,7 +2638,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/virtualWan.json
@@ -328,7 +328,7 @@
         "x-ms-examples": {
           "VpnSiteGet": { "$ref": "./examples/VpnSiteGet.json" }
         },
-        "description": "Retrieves the details of a VPNsite.",
+        "description": "Retrieves the details of a VPN site.",
         "parameters": [
           {
             "$ref": "./network.json#/parameters/SubscriptionIdParameter"
@@ -2039,7 +2039,7 @@
     "ProvisioningState": {
       "type": "string",
       "readOnly": true,
-      "description": "The current provisisoning state.",
+      "description": "The current provisioning state.",
       "enum": [
         "Succeeded",
         "Updating",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/applicationGateway.json
@@ -1769,7 +1769,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size for WAF."
+          "description": "Maximum request body size for WAF."
         }
       },
       "required": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/azureFirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/azureFirewall.json
@@ -1,273 +1,273 @@
-{  
+{
    "swagger":"2.0",
-   "info":{  
+   "info":{
       "title":"NetworkManagementClient",
       "description":"The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
       "version": "2018-07-01"
    },
    "host":"management.azure.com",
-   "schemes":[  
+   "schemes":[
       "https"
    ],
-   "consumes":[  
+   "consumes":[
       "application/json"
    ],
-   "produces":[  
+   "produces":[
       "application/json"
    ],
-   "security":[  
-      {  
-         "azure_auth":[  
+   "security":[
+      {
+         "azure_auth":[
             "user_impersonation"
          ]
       }
    ],
-   "securityDefinitions":{  
-      "azure_auth":{  
+   "securityDefinitions":{
+      "azure_auth":{
          "type":"oauth2",
          "authorizationUrl":"https://login.microsoftonline.com/common/oauth2/authorize",
          "flow":"implicit",
          "description":"Azure Active Directory OAuth2 Flow",
-         "scopes":{  
+         "scopes":{
             "user_impersonation":"impersonate your user account"
          }
       }
    },
-   "paths":{  
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{  
-         "delete":{  
-            "tags":[  
+   "paths":{
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{
+         "delete":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Delete",
             "description":"Deletes the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "202":{  
+            "responses":{
+               "202":{
                   "description":"Accepted and the operation will complete asynchronously."
                },
-               "204":{  
+               "204":{
                   "description":"Request successful. Resource with the specified name does not exist"
                },
-               "200":{  
+               "200":{
                   "description":"Delete successful."
                }
             },
-            "x-ms-examples":{  
-               "Delete Azure Firewall":{  
+            "x-ms-examples":{
+               "Delete Azure Firewall":{
                   "$ref":"./examples/AzureFirewallDelete.json"
                }
             },
             "x-ms-long-running-operation":true
          },
-         "get":{  
-            "tags":[  
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Get",
             "description":"Gets the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Request successful. The operation returns a AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Get Azure Firewall":{  
+            "x-ms-examples":{
+               "Get Azure Firewall":{
                   "$ref":"./examples/AzureFirewallGet.json"
                }
             }
          },
-         "put":{  
-            "tags":[  
+         "put":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_CreateOrUpdate",
             "description":"Creates or updates the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "name":"parameters",
                   "in":"body",
                   "required":true,
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   },
                   "description":"Parameters supplied to the create or update Azure Firewall operation."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "201":{  
+            "responses":{
+               "201":{
                   "description":"Create successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                },
-               "200":{  
+               "200":{
                   "description":"Update successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Create Azure Firewall":{  
+            "x-ms-examples":{
+               "Create Azure Firewall":{
                   "$ref":"./examples/AzureFirewallPut.json"
                }
             },
             "x-ms-long-running-operation":true
          }
       },
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_List",
             "description":"Lists all Azure Firewalls in a resource group.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given resource group":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given resource group":{
                   "$ref":"./examples/AzureFirewallListByResourceGroup.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       },
-      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_ListAll",
             "description":"Gets all the Azure Firewalls in a subscription.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given subscription":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given subscription":{
                   "$ref":"./examples/AzureFirewallListBySubscription.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       }
    },
-   "definitions":{  
-      "AzureFirewallIPConfigurationPropertiesFormat":{  
-         "properties":{  
+   "definitions":{
+      "AzureFirewallIPConfigurationPropertiesFormat":{
+         "properties":{
 			"privateIPAddress": {
 			  "type": "string",
 			  "description": "The Firewall Internal Load Balancer IP to be used as the next hop in User Defined Routes."
 			},
-            "subnet":{  
+            "subnet":{
                "$ref":"./network.json#/definitions/SubResource",
                "description":"Reference of the subnet resource. This resource must be named 'AzureFirewallSubnet'."
             },
-			"internalPublicIpAddress":{  
+			"internalPublicIpAddress":{
                "$ref":"./network.json#/definitions/SubResource",
                "description":"Reference of the PublicIP resource. This field is a mandatory input."
             },
@@ -275,103 +275,103 @@
 			  "$ref": "./network.json#/definitions/SubResource",
 			  "description": "Reference of the PublicIP resource. This field is populated in the output."
 			},
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of IP configuration of an Azure Firewall."
       },
-      "AzureFirewallIPConfiguration":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallIPConfiguration":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallIPConfigurationPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "description":"A unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"IP configuration of an Azure Firewall."
       },
-      "AzureFirewallPropertiesFormat":{  
-         "properties":{  
-            "applicationRuleCollections":{  
+      "AzureFirewallPropertiesFormat":{
+         "properties":{
+            "applicationRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleCollection"
                },
                "description":"Collection of application rule collections used by a Azure Firewall."
             },
-            "networkRuleCollections":{  
+            "networkRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleCollection"
                },
                "description":"Collection of network rule collections used by a Azure Firewall."
             },
-            "ipConfigurations":{  
+            "ipConfigurations":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallIPConfiguration"
                },
                "description":"IP configuration of the Azure Firewall resource."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the Azure Firewall."
       },
-      "AzureFirewall":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewall":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallPropertiesFormat"
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/Resource"
             }
          ],
          "description":"Azure Firewall resource"
       },
-      "AzureFirewallListResult":{  
-         "properties":{  
-            "value":{  
+      "AzureFirewallListResult":{
+         "properties":{
+            "value":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewall"
                },
                "description":"List of a Azure Firewalls in a resource group."
             },
-            "nextLink":{  
+            "nextLink":{
                "type":"string",
                "description":"URL to get the next set of results."
             }
          },
          "description":"Response for ListAzureFirewalls API service call."
       },
-      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -380,54 +380,54 @@
                "exclusiveMinimum":false,
                "description":"Priority of the application rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRule"
                },
                "description":"Collection of rules used by a application rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the application rule collection."
       },
-      "AzureFirewallApplicationRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallApplicationRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallApplicationRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Application rule collection resource"
       },
-      "AzureFirewallApplicationRuleProtocol":{  
-         "properties":{  
-            "protocolType":{  
+      "AzureFirewallApplicationRuleProtocol":{
+         "properties":{
+            "protocolType":{
                "description":"Protocol type",
                "$ref":"#/definitions/AzureFirewallApplicationRuleProtocolType"
             },
-            "port":{  
+            "port":{
                "type":"integer",
                "format":"int32",
                "maximum":64000,
@@ -439,43 +439,43 @@
          },
          "description":"Properties of the application rule protocol."
       },
-      "AzureFirewallApplicationRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallApplicationRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the application rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-			"sourceAddresses":{  
+			"sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleProtocol"
                },
                "description":"Array of ApplicationRuleProtocols."
             },
-            "targetUrls":{  
+            "targetUrls":{
                "type":"array",
                "description":"List of URLs for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
          },
          "description":"Properties of an application rule."
       },
-      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -484,146 +484,146 @@
                "exclusiveMinimum":false,
                "description":"Priority of the network rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRule"
                },
                "description":"Collection of rules used by a network rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the network rule collection."
       },
-      "AzureFirewallNetworkRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallNetworkRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallNetworkRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Network rule collection resource"
       },
-      "AzureFirewallNetworkRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallNetworkRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the network rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleProtocol"
                },
                "description":"Array of AzureFirewallNetworkRuleProtocols."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationAddresses":{  
+            "destinationAddresses":{
                "type":"array",
                "description":"List of destination IP addresses.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationPorts":{  
+            "destinationPorts":{
                "type":"array",
                "description":"List of destination ports.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
          },
          "description":"Properties of the network rule."
       },
-      "AzureFirewallRCAction":{  
-         "properties":{  
-            "type":{  
+      "AzureFirewallRCAction":{
+         "properties":{
+            "type":{
                "description":"The type of action.",
                "$ref":"#/definitions/AzureFirewallRCActionType"
             }
          },
          "description":"Properties of the AzureFirewallRCAction."
       },
-      "AzureFirewallRCActionType":{  
+      "AzureFirewallRCActionType":{
          "type":"string",
          "description":"The action type of a rule collection",
-         "enum":[  
+         "enum":[
             "Allow",
             "Deny"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallRCActionType",
             "modelAsString":true
          }
       },
-      "ProvisioningState":{  
+      "ProvisioningState":{
          "type":"string",
          "readOnly":true,
-         "description":"The current provisisoning state.",
-         "enum":[  
+         "description":"The current provisioning state.",
+         "enum":[
             "Succeeded",
             "Updating",
             "Deleting",
             "Failed"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"ProvisioningState",
             "modelAsString":true
          }
       },
-      "AzureFirewallNetworkRuleProtocol":{  
+      "AzureFirewallNetworkRuleProtocol":{
          "type":"string",
          "description":"The protocol of a Network Rule resource",
-         "enum":[  
+         "enum":[
             "TCP",
             "UDP",
             "Any",
 			"ICMP"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallNetworkRuleProtocol",
             "modelAsString":true
          }
       },
-      "AzureFirewallApplicationRuleProtocolType":{  
+      "AzureFirewallApplicationRuleProtocolType":{
          "type":"string",
          "description":"The protocol type of a Application Rule resource",
-         "enum":[  
+         "enum":[
             "Http",
             "Https"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallApplicationRuleProtocolType",
             "modelAsString":true
          }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/expressRouteCrossConnection.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/expressRouteCrossConnection.json
@@ -51,7 +51,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }
@@ -91,7 +91,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/networkInterface.json
@@ -860,14 +860,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -882,14 +882,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/networkSecurityGroup.json
@@ -628,15 +628,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -654,7 +654,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -705,7 +705,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/networkWatcher.json
@@ -1785,8 +1785,8 @@
         ],
         "operationId": "NetworkWatchers_GetNetworkConfigurationDiagnostic",
         "x-ms-long-running-operation": true,
-        "x-ms-long-running-operation-options": { 
-          "final-state-via": "location" 
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
         },
         "description": "Get network configuration diagnostic.",
         "parameters": [
@@ -1822,7 +1822,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns the result of network condifuration diagnostic.",
+            "description": "Request successful. The operation returns the result of network configuration diagnostic.",
             "schema": {
               "$ref": "#/definitions/NetworkConfigurationDiagnosticResponse"
             }
@@ -3172,7 +3172,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -3357,7 +3357,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {
@@ -3484,7 +3484,7 @@
         },
         "destinationPort": {
           "type": "string",
-          "description": "Traffice destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
+          "description": "Traffic destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/publicIpPrefix.json
@@ -98,7 +98,7 @@
               "in": "path",
               "required": true,
               "type": "string",
-              "description": "The name of the PublicIPPrefx."
+              "description": "The name of the Public IP Prefix."
             },
             {
               "$ref": "./network.json#/parameters/ApiVersionParameter"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/serviceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/serviceEndpointPolicy.json
@@ -75,7 +75,7 @@
           }
         },
         "x-ms-examples": {
-          "Delete service endpoint Policys": { "$ref": "./examples/ServiceEndpointPolicyDelete.json" }
+          "Delete service endpoint Policy": { "$ref": "./examples/ServiceEndpointPolicyDelete.json" }
         },
         "x-ms-long-running-operation": true
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/virtualNetworkGateway.json
@@ -752,7 +752,7 @@
             "description": "Accepted and the operation will complete asynchronously."
           },
           "200": {
-            "description": "Request successful. The operation sets the specificed vpnclient ipsec parameters for P2S client of the virtual network gateway.",
+            "description": "Request successful. The operation sets the specified vpnclient ipsec parameters for P2S client of the virtual network gateway.",
             "schema": {
               "$ref": "#/definitions/VpnClientIPsecParameters"
             }
@@ -803,8 +803,8 @@
         },
         "x-ms-long-running-operation": true,
         "x-ms-examples": {
-          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" } 
-        }               
+          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" }
+        }
 
       }
     },
@@ -1723,7 +1723,7 @@
             "$ref": "#/definitions/IpsecPolicy"
           },
           "description": "VpnClientIpsecPolicies for virtual network gateway P2S client."
-        },		
+        },
         "radiusServerAddress": {
           "type": "string",
           "description": "The radius server address property of the VirtualNetworkGateway resource for vpn client connection."
@@ -2076,7 +2076,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2352,7 +2352,7 @@
             "ECP384",
             "PFS24",
             "PFS14",
-            "PFSMM"		
+            "PFSMM"
           ],
           "x-ms-enum": {
             "name": "PfsGroup",
@@ -2501,7 +2501,7 @@
         "pfsGroup"
       ],
       "description": "An IPSec parameters for a virtual network gateway P2S connection."
-    },	
+    },
     "LocalNetworkGatewayPropertiesFormat": {
       "properties": {
         "localNetworkAddressSpace": {
@@ -2599,7 +2599,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/virtualWan.json
@@ -328,7 +328,7 @@
         "x-ms-examples": {
           "VpnSiteGet": { "$ref": "./examples/VpnSiteGet.json" }
         },
-        "description": "Retrieves the details of a VPNsite.",
+        "description": "Retrieves the details of a VPN site.",
         "parameters": [
           {
             "$ref": "./network.json#/parameters/SubscriptionIdParameter"
@@ -2039,7 +2039,7 @@
     "ProvisioningState": {
       "type": "string",
       "readOnly": true,
-      "description": "The current provisisoning state.",
+      "description": "The current provisioning state.",
       "enum": [
         "Succeeded",
         "Updating",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/applicationGateway.json
@@ -1840,7 +1840,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size for WAF."
+          "description": "Maximum request body size for WAF."
         },
         "maxRequestBodySizeInKb": {
           "type": "integer",
@@ -1849,7 +1849,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size in Kb for WAF."
+          "description": "Maximum request body size in Kb for WAF."
         },
         "fileUploadLimitInMb": {
           "type": "integer",
@@ -1858,7 +1858,7 @@
           "exclusiveMaximum": false,
           "minimum": 0,
           "exclusiveMinimum": false,
-          "description": "Maxium file upload size in Mb for WAF."
+          "description": "Maximum file upload size in Mb for WAF."
         },
         "exclusions": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/azureFirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/azureFirewall.json
@@ -1,264 +1,264 @@
-{  
+{
    "swagger":"2.0",
-   "info":{  
+   "info":{
       "title":"NetworkManagementClient",
       "description":"The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
       "version": "2018-08-01"
    },
    "host":"management.azure.com",
-   "schemes":[  
+   "schemes":[
       "https"
    ],
-   "consumes":[  
+   "consumes":[
       "application/json"
    ],
-   "produces":[  
+   "produces":[
       "application/json"
    ],
-   "security":[  
-      {  
-         "azure_auth":[  
+   "security":[
+      {
+         "azure_auth":[
             "user_impersonation"
          ]
       }
    ],
-   "securityDefinitions":{  
-      "azure_auth":{  
+   "securityDefinitions":{
+      "azure_auth":{
          "type":"oauth2",
          "authorizationUrl":"https://login.microsoftonline.com/common/oauth2/authorize",
          "flow":"implicit",
          "description":"Azure Active Directory OAuth2 Flow",
-         "scopes":{  
+         "scopes":{
             "user_impersonation":"impersonate your user account"
          }
       }
    },
-   "paths":{  
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{  
-         "delete":{  
-            "tags":[  
+   "paths":{
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{
+         "delete":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Delete",
             "description":"Deletes the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "202":{  
+            "responses":{
+               "202":{
                   "description":"Accepted and the operation will complete asynchronously."
                },
-               "204":{  
+               "204":{
                   "description":"Request successful. Resource with the specified name does not exist"
                },
-               "200":{  
+               "200":{
                   "description":"Delete successful."
                }
             },
-            "x-ms-examples":{  
-               "Delete Azure Firewall":{  
+            "x-ms-examples":{
+               "Delete Azure Firewall":{
                   "$ref":"./examples/AzureFirewallDelete.json"
                }
             },
             "x-ms-long-running-operation":true
          },
-         "get":{  
-            "tags":[  
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Get",
             "description":"Gets the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Request successful. The operation returns an AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Get Azure Firewall":{  
+            "x-ms-examples":{
+               "Get Azure Firewall":{
                   "$ref":"./examples/AzureFirewallGet.json"
                }
             }
          },
-         "put":{  
-            "tags":[  
+         "put":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_CreateOrUpdate",
             "description":"Creates or updates the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "name":"parameters",
                   "in":"body",
                   "required":true,
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   },
                   "description":"Parameters supplied to the create or update Azure Firewall operation."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "201":{  
+            "responses":{
+               "201":{
                   "description":"Create successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                },
-               "200":{  
+               "200":{
                   "description":"Update successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Create Azure Firewall":{  
+            "x-ms-examples":{
+               "Create Azure Firewall":{
                   "$ref":"./examples/AzureFirewallPut.json"
                }
             },
             "x-ms-long-running-operation":true
          }
       },
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_List",
             "description":"Lists all Azure Firewalls in a resource group.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given resource group":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given resource group":{
                   "$ref":"./examples/AzureFirewallListByResourceGroup.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       },
-      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_ListAll",
             "description":"Gets all the Azure Firewalls in a subscription.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given subscription":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given subscription":{
                   "$ref":"./examples/AzureFirewallListBySubscription.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       }
    },
-   "definitions":{  
-      "AzureFirewallIPConfigurationPropertiesFormat":{  
-         "properties":{  
+   "definitions":{
+      "AzureFirewallIPConfigurationPropertiesFormat":{
+         "properties":{
             "privateIPAddress": {
               "type": "string",
               "description": "The Firewall Internal Load Balancer IP to be used as the next hop in User Defined Routes."
@@ -271,111 +271,111 @@
                "$ref": "./network.json#/definitions/SubResource",
                "description": "Reference of the PublicIP resource. This field is a mandatory input if subnet is not null."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of IP configuration of an Azure Firewall."
       },
-      "AzureFirewallIPConfiguration":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallIPConfiguration":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallIPConfigurationPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly": true,
                "description":"A unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"IP configuration of an Azure Firewall."
       },
-      "AzureFirewallPropertiesFormat":{  
-         "properties":{  
-            "applicationRuleCollections":{  
+      "AzureFirewallPropertiesFormat":{
+         "properties":{
+            "applicationRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleCollection"
                },
                "description":"Collection of application rule collections used by Azure Firewall."
             },
-            "natRuleCollections":{  
+            "natRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNatRuleCollection"
                },
                "description":"Collection of NAT rule collections used by Azure Firewall."
             },
-            "networkRuleCollections":{  
+            "networkRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleCollection"
                },
                "description":"Collection of network rule collections used by Azure Firewall."
             },
-            "ipConfigurations":{  
+            "ipConfigurations":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallIPConfiguration"
                },
                "description":"IP configuration of the Azure Firewall resource."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the Azure Firewall."
       },
-      "AzureFirewall":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewall":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallPropertiesFormat"
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/Resource"
             }
          ],
          "description":"Azure Firewall resource"
       },
-      "AzureFirewallListResult":{  
-         "properties":{  
-            "value":{  
+      "AzureFirewallListResult":{
+         "properties":{
+            "value":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewall"
                },
                "description":"List of Azure Firewalls in a resource group."
             },
-            "nextLink":{  
+            "nextLink":{
                "type":"string",
                "description":"URL to get the next set of results."
             }
          },
          "description":"Response for ListAzureFirewalls API service call."
       },
-      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -384,54 +384,54 @@
                "exclusiveMinimum":false,
                "description":"Priority of the application rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRule"
                },
                "description":"Collection of rules used by a application rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the application rule collection."
       },
-      "AzureFirewallApplicationRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallApplicationRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallApplicationRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Application rule collection resource"
       },
-      "AzureFirewallApplicationRuleProtocol":{  
-         "properties":{  
-            "protocolType":{  
+      "AzureFirewallApplicationRuleProtocol":{
+         "properties":{
+            "protocolType":{
                "description":"Protocol type",
                "$ref":"#/definitions/AzureFirewallApplicationRuleProtocolType"
             },
-            "port":{  
+            "port":{
                "type":"integer",
                "format":"int32",
                "maximum":64000,
@@ -443,41 +443,41 @@
          },
          "description":"Properties of the application rule protocol."
       },
-      "AzureFirewallApplicationRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallApplicationRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the application rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleProtocol"
                },
                "description":"Array of ApplicationRuleProtocols."
             },
-            "targetFqdns":{  
+            "targetFqdns":{
                "type":"array",
                "description":"List of FQDNs for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
             "fqdnTags":{
                "type":"array",
                "description":"List of FQDN Tags for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
@@ -485,8 +485,8 @@
          "description":"Properties of an application rule."
       },
       "AzureFirewallNatRuleCollectionProperties": {
-         "properties":{  
-            "priority":{  
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -495,120 +495,120 @@
                "exclusiveMinimum":false,
                "description":"Priority of the NAT rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallNatRCAction",
                "description":"The action type of a NAT rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNatRule"
                },
                "description":"Collection of rules used by a NAT rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the NAT rule collection."
       },
-      "AzureFirewallNatRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallNatRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallNatRuleCollectionProperties"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"NAT rule collection resource"
       },
-      "AzureFirewallNatRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallNatRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the NAT rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationAddresses":{  
+            "destinationAddresses":{
                "type":"array",
                "description":"List of destination IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationPorts":{  
+            "destinationPorts":{
                "type":"array",
                "description":"List of destination ports.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleProtocol"
                },
                "description":"Array of AzureFirewallNetworkRuleProtocols applicable to this NAT rule."
             },
-            "translatedAddress":{  
+            "translatedAddress":{
                "type":"string",
                "description":"The translated address for this NAT rule."
             },
-            "translatedPort":{  
+            "translatedPort":{
                "type":"string",
                "description":"The translated port for this NAT rule."
             }
          },
          "description":"Properties of a NAT rule."
       },
-      "AzureFirewallNatRCAction":{  
-         "properties":{  
-            "type":{  
+      "AzureFirewallNatRCAction":{
+         "properties":{
+            "type":{
                "description":"The type of action.",
                "$ref":"#/definitions/AzureFirewallNatRCActionType"
             }
          },
          "description":"AzureFirewall NAT Rule Collection Action."
       },
-      "AzureFirewallNatRCActionType":{  
+      "AzureFirewallNatRCActionType":{
          "type":"string",
          "description":"The action type of a NAT rule collection",
-         "enum":[  
+         "enum":[
             "Snat",
             "Dnat"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallNatRCActionType",
             "modelAsString":true
          }
       },
-      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -617,146 +617,146 @@
                "exclusiveMinimum":false,
                "description":"Priority of the network rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRule"
                },
                "description":"Collection of rules used by a network rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the network rule collection."
       },
-      "AzureFirewallNetworkRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallNetworkRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallNetworkRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Network rule collection resource"
       },
-      "AzureFirewallNetworkRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallNetworkRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the network rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleProtocol"
                },
                "description":"Array of AzureFirewallNetworkRuleProtocols."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationAddresses":{  
+            "destinationAddresses":{
                "type":"array",
                "description":"List of destination IP addresses.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationPorts":{  
+            "destinationPorts":{
                "type":"array",
                "description":"List of destination ports.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
          },
          "description":"Properties of the network rule."
       },
-      "AzureFirewallRCAction":{  
-         "properties":{  
-            "type":{  
+      "AzureFirewallRCAction":{
+         "properties":{
+            "type":{
                "description":"The type of action.",
                "$ref":"#/definitions/AzureFirewallRCActionType"
             }
          },
          "description":"Properties of the AzureFirewallRCAction."
       },
-      "AzureFirewallRCActionType":{  
+      "AzureFirewallRCActionType":{
          "type":"string",
          "description":"The action type of a rule collection",
-         "enum":[  
+         "enum":[
             "Allow",
             "Deny"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallRCActionType",
             "modelAsString":true
          }
       },
-      "ProvisioningState":{  
+      "ProvisioningState":{
          "type":"string",
          "readOnly":true,
-         "description":"The current provisisoning state.",
-         "enum":[  
+         "description":"The current provisioning state.",
+         "enum":[
             "Succeeded",
             "Updating",
             "Deleting",
             "Failed"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"ProvisioningState",
             "modelAsString":true
          }
       },
-      "AzureFirewallNetworkRuleProtocol":{  
+      "AzureFirewallNetworkRuleProtocol":{
          "type":"string",
          "description":"The protocol of a Network Rule resource",
-         "enum":[  
+         "enum":[
             "TCP",
             "UDP",
             "Any",
             "ICMP"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallNetworkRuleProtocol",
             "modelAsString":true
          }
       },
-      "AzureFirewallApplicationRuleProtocolType":{  
+      "AzureFirewallApplicationRuleProtocolType":{
          "type":"string",
          "description":"The protocol type of a Application Rule resource",
-         "enum":[  
+         "enum":[
             "Http",
             "Https"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallApplicationRuleProtocolType",
             "modelAsString":true
          }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/InterfaceEndpointCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/InterfaceEndpointCreate.json
@@ -24,7 +24,7 @@
         "location" : "eastus",
         "properties" : {
           "fqdn": "uniqueIdentifier.fqdn.windows.net",
-          "provisioningState": "Succeded",
+          "provisioningState": "Succeeded",
           "owner": "User",
           "endpointService": {
             "id": "/subscriptions/subId/resourceGroups/rg1/providers/Microsoft.Provider/resourceType/resourceName"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkInterfaceTapConfigurationCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkInterfaceTapConfigurationCreate.json
@@ -24,7 +24,7 @@
             "virtualNetworkTap": {
                 "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworkTaps/testvtap"
             },
-            "provisioningState": "Succeded"
+            "provisioningState": "Succeeded"
         }
       }
     },
@@ -38,7 +38,7 @@
             "virtualNetworkTap": {
                 "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworkTaps/testvtap"
             },
-            "provisioningState": "Succeded"
+            "provisioningState": "Succeeded"
         }      
       }
     }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkInterfaceTapConfigurationGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkInterfaceTapConfigurationGet.json
@@ -18,7 +18,7 @@
             "virtualNetworkTap": {
                 "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworkTaps/testvtap"
             },
-            "provisioningState": "Succeded"
+            "provisioningState": "Succeeded"
         }
        }
      }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkInterfaceTapConfigurationList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkInterfaceTapConfigurationList.json
@@ -18,7 +18,7 @@
                 "virtualNetworkTap": {
                 "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworkTaps/testvtap"
                 },
-                "provisioningState": "Succeded"
+                "provisioningState": "Succeeded"
             }
          }
         ]

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapCreate.json
@@ -26,7 +26,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {
@@ -48,7 +48,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapGet.json
@@ -18,7 +18,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapList.json
@@ -19,7 +19,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {
@@ -39,7 +39,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
              {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapListAll.json
@@ -18,7 +18,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {
@@ -38,7 +38,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
              {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkTapUpdateTags.json
@@ -26,7 +26,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "networkInterfaceTapConfigurations": [
                 {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface2/tapConfigurations/testtapConfiguration"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/expressRouteCrossConnection.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/expressRouteCrossConnection.json
@@ -51,7 +51,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }
@@ -91,7 +91,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/expressRoutePort.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/expressRoutePort.json
@@ -40,7 +40,7 @@
                     "ExpressRoutePortsLocations"
                 ],
                 "operationId": "ExpressRoutePortsLocations_List",
-                "description": "Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retriving a specific peering location.",
+                "description": "Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retrieving a specific peering location.",
                 "parameters": [
                     {
                         "$ref": "./network.json#/parameters/SubscriptionIdParameter"
@@ -670,7 +670,7 @@
                 "etherType": {
                     "readOnly": true,
                     "type": "string",
-                    "description": "Ethertype of the physical port."
+                    "description": "Ether type of the physical port."
                 },
                 "allocationDate": {
                     "readOnly": true,

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkInterface.json
@@ -580,7 +580,7 @@
             "description": "Delete successful."
           }
         },
-        "x-ms-examples": 
+        "x-ms-examples":
         {
           "Delete tap configuration": { "$ref": "./examples/NetworkInterfaceTapConfigurationDelete.json" }
         },
@@ -629,7 +629,7 @@
             }
           }
         },
-        "x-ms-examples": 
+        "x-ms-examples":
         {
           "Get Network Interface Tap Configurations": { "$ref": "./examples/NetworkInterfaceTapConfigurationGet.json" }
         }
@@ -692,7 +692,7 @@
             }
           }
         },
-        "x-ms-examples": 
+        "x-ms-examples":
         {
           "Create Network Interface Tap Configurations": { "$ref": "./examples/NetworkInterfaceTapConfigurationCreate.json" }
         },
@@ -776,7 +776,7 @@
     },
     "NetworkInterfaceTapConfigurationPropertiesFormat": {
       "properties": {
-        "virtualNetworkTap": {         
+        "virtualNetworkTap": {
             "$ref": "./virtualNetworkTap.json#/definitions/VirtualNetworkTap",
             "description": "The reference of the Virtual Network Tap resource."
           },
@@ -1158,14 +1158,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -1180,14 +1180,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkProfile.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkProfile.json
@@ -100,7 +100,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the PublicIPPrefx."
+            "description": "The name of the Public IP Prefix."
           },
           {
             "$ref": "./network.json#/parameters/ApiVersionParameter"
@@ -268,7 +268,7 @@
           }
         },
         "x-ms-examples": {
-          "List all network profilees": {
+          "List all network profiles": {
             "$ref": "./examples/NetworkProfileListAll.json"
           }
         },
@@ -308,7 +308,7 @@
           }
         },
         "x-ms-examples": {
-          "List resource group network profilees": {
+          "List resource group network profiles": {
             "$ref": "./examples/NetworkProfileList.json"
           }
         },
@@ -391,7 +391,7 @@
         },
         "container": {
           "$ref": "#/definitions/Container",
-          "description": "Reference to the conatinaer to which this container network interface is attached."
+          "description": "Reference to the container to which this container network interface is attached."
         },
         "ipConfigurations": {
           "type": "array",
@@ -485,13 +485,13 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Container network interface configruation child resource."
+      "description": "Container network interface configuration child resource."
     },
     "IPConfigurationProfilePropertiesFormat": {
       "properties": {
         "subnet": {
           "$ref": "./virtualNetwork.json#/definitions/Subnet",
-          "description": "The reference of the subnet resource to create a contatainer network interface ip configruation."
+          "description": "The reference of the subnet resource to create a container network interface ip configuration."
         },
         "provisioningState": {
           "readOnly": true,
@@ -499,7 +499,7 @@
           "description": "The provisioning state of the resource."
         }
       },
-      "description": "IP configruation profile properties."
+      "description": "IP configuration profile properties."
     },
     "IPConfigurationProfile": {
       "properties": {
@@ -555,7 +555,7 @@
           "$ref": "#/definitions/ContainerNetworkInterfaceIpConfigurationPropertiesFormat",
           "description": "Properties of the container network interface IP configuration."
         },
-        "name": {   
+        "name": {
           "type": "string",
           "description": "The name of the resource. This name can be used to access the resource."
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkSecurityGroup.json
@@ -628,15 +628,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -654,7 +654,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -705,7 +705,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/networkWatcher.json
@@ -1785,8 +1785,8 @@
         ],
         "operationId": "NetworkWatchers_GetNetworkConfigurationDiagnostic",
         "x-ms-long-running-operation": true,
-        "x-ms-long-running-operation-options": { 
-          "final-state-via": "location" 
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
         },
         "description": "Get network configuration diagnostic.",
         "parameters": [
@@ -1822,7 +1822,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns the result of network condifuration diagnostic.",
+            "description": "Request successful. The operation returns the result of network configuration diagnostic.",
             "schema": {
               "$ref": "#/definitions/NetworkConfigurationDiagnosticResponse"
             }
@@ -3172,7 +3172,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -3357,7 +3357,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {
@@ -3440,7 +3440,7 @@
           "description": "The ID of the target resource to perform network configuration diagnostic. Valid options are VM, NetworkInterface, VMSS/NetworkInterface and Application Gateway."
         },
         "verbosityLevel": {
-          "type": "string",          
+          "type": "string",
           "enum": [
             "Normal",
             "Minimum",
@@ -3497,7 +3497,7 @@
         },
         "destinationPort": {
           "type": "string",
-          "description": "Traffice destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
+          "description": "Traffic destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/publicIpPrefix.json
@@ -98,7 +98,7 @@
               "in": "path",
               "required": true,
               "type": "string",
-              "description": "The name of the PublicIPPrefx."
+              "description": "The name of the Public IP Prefix."
             },
             {
               "$ref": "./network.json#/parameters/ApiVersionParameter"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/serviceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/serviceEndpointPolicy.json
@@ -75,7 +75,7 @@
           }
         },
         "x-ms-examples": {
-          "Delete service endpoint Policys": { "$ref": "./examples/ServiceEndpointPolicyDelete.json" }
+          "Delete service endpoint Policy": { "$ref": "./examples/ServiceEndpointPolicyDelete.json" }
         },
         "x-ms-long-running-operation": true
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/virtualNetworkGateway.json
@@ -795,7 +795,7 @@
             "description": "Accepted and the operation will complete asynchronously."
           },
           "200": {
-            "description": "Request successful. The operation sets the specificed vpnclient ipsec parameters for P2S client of the virtual network gateway.",
+            "description": "Request successful. The operation sets the specified vpnclient ipsec parameters for P2S client of the virtual network gateway.",
             "schema": {
               "$ref": "#/definitions/VpnClientIPsecParameters"
             }
@@ -846,8 +846,8 @@
         },
         "x-ms-long-running-operation": true,
         "x-ms-examples": {
-          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" } 
-        }               
+          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" }
+        }
 
       }
     },
@@ -1766,7 +1766,7 @@
             "$ref": "#/definitions/IpsecPolicy"
           },
           "description": "VpnClientIpsecPolicies for virtual network gateway P2S client."
-        },		
+        },
         "radiusServerAddress": {
           "type": "string",
           "description": "The radius server address property of the VirtualNetworkGateway resource for vpn client connection."
@@ -2119,7 +2119,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",
@@ -2399,7 +2399,7 @@
             "ECP384",
             "PFS24",
             "PFS14",
-            "PFSMM"		
+            "PFSMM"
           ],
           "x-ms-enum": {
             "name": "PfsGroup",
@@ -2560,7 +2560,7 @@
         "pfsGroup"
       ],
       "description": "An IPSec parameters for a virtual network gateway P2S connection."
-    },	
+    },
     "LocalNetworkGatewayPropertiesFormat": {
       "properties": {
         "localNetworkAddressSpace": {
@@ -2658,7 +2658,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/virtualWan.json
@@ -342,7 +342,7 @@
             "$ref": "./examples/VpnSiteGet.json"
           }
         },
-        "description": "Retrieves the details of a VPNsite.",
+        "description": "Retrieves the details of a VPN site.",
         "parameters": [
           {
             "$ref": "./network.json#/parameters/SubscriptionIdParameter"
@@ -2252,7 +2252,7 @@
         },
         "x-ms-long-running-operation": true
       }
-    }	
+    }
   },
   "definitions": {
     "VirtualWanProperties": {
@@ -2298,7 +2298,7 @@
           "items": {
             "$ref": "#/definitions/P2SVpnServerConfiguration"
           }
-        },		
+        },
         "provisioningState": {
           "description": "The provisioning state of the resource.",
           "$ref": "#/definitions/ProvisioningState"
@@ -2448,7 +2448,7 @@
         "p2SVpnGateway": {
           "$ref": "./network.json#/definitions/SubResource",
           "description": "The P2SVpnGateway associated with this VirtualHub"
-        },		
+        },
         "expressRouteGateway": {
           "$ref": "./network.json#/definitions/SubResource",
           "description": "The expressRouteGateway associated with this VirtualHub"
@@ -2836,7 +2836,7 @@
     "ProvisioningState": {
       "type": "string",
       "readOnly": true,
-      "description": "The current provisisoning state.",
+      "description": "The current provisioning state.",
       "enum": [
         "Succeeded",
         "Updating",
@@ -2996,8 +2996,8 @@
         "publicCertData"
       ],
       "description": "Properties of Radius Server root certificate of P2SVpnServerConfiguration."
-    },	
-	"P2SVpnServerConfigRadiusServerRootCertificate": {
+    },
+    "P2SVpnServerConfigRadiusServerRootCertificate": {
       "properties": {
         "properties": {
           "x-ms-client-flatten": true,
@@ -3096,13 +3096,13 @@
         }
       ],
       "description": "Radius client root certificate of P2SVpnServerConfiguration."
-    },	
-	"P2SVpnServerConfigurationProperties": {
+    },
+    "P2SVpnServerConfigurationProperties": {
       "properties": {
         "name": {
           "type": "string",
-          "description": "The name of the P2SVpnServerConfiguration that is unique within a VirtualWan in a resource group. This name can be used to access the resource along with Paren VirtualWan resource name."
-        },	  
+          "description": "The name of the P2SVpnServerConfiguration that is unique within a VirtualWan in a resource group. This name can be used to access the resource along with Parent VirtualWan resource name."
+        },
         "vpnProtocols": {
           "type": "array",
           "items": {
@@ -3160,7 +3160,7 @@
         },
         "radiusServerSecret": {
           "type": "string",
-          "description": "The radius secret property of the P2SVpnServerConfiguration resource for for point to site client connection."
+          "description": "The radius secret property of the P2SVpnServerConfiguration resource for point to site client connection."
         },
         "provisioningState": {
           "readOnly": true,
@@ -3219,7 +3219,7 @@
           "description": "URL to get the next set of operation list results if there are any."
         }
       }
-    },	
+    },
     "VpnClientConnectionHealth": {
       "properties": {
         "totalIngressBytesTransferred": {
@@ -3239,7 +3239,7 @@
           "format": "int32",
           "description": "The total of p2s vpn clients connected at this time to this P2SVpnGateway."
         },
-		"allocatedIpAddresses": {
+        "allocatedIpAddresses": {
           "type": "array",
           "items": {
             "type": "string"
@@ -3248,8 +3248,8 @@
         }
       },
       "description": "VpnClientConnectionHealth properties"
-    },    
-	"P2SVpnGatewayProperties": {
+    },
+    "P2SVpnGatewayProperties": {
       "properties": {
         "virtualHub": {
           "$ref": "./network.json#/definitions/SubResource",
@@ -3274,8 +3274,8 @@
         },
         "vpnClientConnectionHealth": {
           "readOnly": true,
-		  "$ref": "#/definitions/VpnClientConnectionHealth",
-		  "description": "All P2S vpnclients' connection health status."
+          "$ref": "#/definitions/VpnClientConnectionHealth",
+          "description": "All P2S VPN clients' connection health status."
         }
       },
       "description": "Parameters for P2SVpnGateway"
@@ -3301,7 +3301,7 @@
         }
       ],
       "description": "P2SVpnGateway Resource."
-    },	
+    },
     "ListP2SVpnGatewaysResult": {
       "description": "Result of the request to list P2SVpnGateways. It contains a list of P2SVpnGateways and a URL nextLink to get the next set of results.",
       "properties": {
@@ -3343,6 +3343,6 @@
         }
       },
       "description": "Vpn Profile Response for package generation"
-    }	
+    }
   }
 }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/applicationGateway.json
@@ -1953,7 +1953,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size for WAF."
+          "description": "Maximum request body size for WAF."
         },
         "maxRequestBodySizeInKb": {
           "type": "integer",
@@ -1962,7 +1962,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size in Kb for WAF."
+          "description": "Maximum request body size in Kb for WAF."
         },
         "fileUploadLimitInMb": {
           "type": "integer",
@@ -1971,7 +1971,7 @@
           "exclusiveMaximum": false,
           "minimum": 0,
           "exclusiveMinimum": false,
-          "description": "Maxium file upload size in Mb for WAF."
+          "description": "Maximum file upload size in Mb for WAF."
         },
         "exclusions": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/azureFirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/azureFirewall.json
@@ -1,264 +1,264 @@
-{  
+{
    "swagger":"2.0",
-   "info":{  
+   "info":{
       "title":"NetworkManagementClient",
       "description":"The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
       "version": "2018-10-01"
    },
    "host":"management.azure.com",
-   "schemes":[  
+   "schemes":[
       "https"
    ],
-   "consumes":[  
+   "consumes":[
       "application/json"
    ],
-   "produces":[  
+   "produces":[
       "application/json"
    ],
-   "security":[  
-      {  
-         "azure_auth":[  
+   "security":[
+      {
+         "azure_auth":[
             "user_impersonation"
          ]
       }
    ],
-   "securityDefinitions":{  
-      "azure_auth":{  
+   "securityDefinitions":{
+      "azure_auth":{
          "type":"oauth2",
          "authorizationUrl":"https://login.microsoftonline.com/common/oauth2/authorize",
          "flow":"implicit",
          "description":"Azure Active Directory OAuth2 Flow",
-         "scopes":{  
+         "scopes":{
             "user_impersonation":"impersonate your user account"
          }
       }
    },
-   "paths":{  
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{  
-         "delete":{  
-            "tags":[  
+   "paths":{
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{
+         "delete":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Delete",
             "description":"Deletes the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "202":{  
+            "responses":{
+               "202":{
                   "description":"Accepted and the operation will complete asynchronously."
                },
-               "204":{  
+               "204":{
                   "description":"Request successful. Resource with the specified name does not exist"
                },
-               "200":{  
+               "200":{
                   "description":"Delete successful."
                }
             },
-            "x-ms-examples":{  
-               "Delete Azure Firewall":{  
+            "x-ms-examples":{
+               "Delete Azure Firewall":{
                   "$ref":"./examples/AzureFirewallDelete.json"
                }
             },
             "x-ms-long-running-operation":true
          },
-         "get":{  
-            "tags":[  
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Get",
             "description":"Gets the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Request successful. The operation returns an AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Get Azure Firewall":{  
+            "x-ms-examples":{
+               "Get Azure Firewall":{
                   "$ref":"./examples/AzureFirewallGet.json"
                }
             }
          },
-         "put":{  
-            "tags":[  
+         "put":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_CreateOrUpdate",
             "description":"Creates or updates the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "name":"parameters",
                   "in":"body",
                   "required":true,
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   },
                   "description":"Parameters supplied to the create or update Azure Firewall operation."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "201":{  
+            "responses":{
+               "201":{
                   "description":"Create successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                },
-               "200":{  
+               "200":{
                   "description":"Update successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Create Azure Firewall":{  
+            "x-ms-examples":{
+               "Create Azure Firewall":{
                   "$ref":"./examples/AzureFirewallPut.json"
                }
             },
             "x-ms-long-running-operation":true
          }
       },
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_List",
             "description":"Lists all Azure Firewalls in a resource group.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given resource group":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given resource group":{
                   "$ref":"./examples/AzureFirewallListByResourceGroup.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       },
-      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_ListAll",
             "description":"Gets all the Azure Firewalls in a subscription.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given subscription":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given subscription":{
                   "$ref":"./examples/AzureFirewallListBySubscription.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       }
    },
-   "definitions":{  
-      "AzureFirewallIPConfigurationPropertiesFormat":{  
-         "properties":{  
+   "definitions":{
+      "AzureFirewallIPConfigurationPropertiesFormat":{
+         "properties":{
             "privateIPAddress": {
                "type": "string",
                "readOnly": true,
@@ -272,111 +272,111 @@
                "$ref": "./network.json#/definitions/SubResource",
                "description": "Reference of the PublicIP resource. This field is a mandatory input if subnet is not null."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of IP configuration of an Azure Firewall."
       },
-      "AzureFirewallIPConfiguration":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallIPConfiguration":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallIPConfigurationPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly": true,
                "description":"A unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"IP configuration of an Azure Firewall."
       },
-      "AzureFirewallPropertiesFormat":{  
-         "properties":{  
-            "applicationRuleCollections":{  
+      "AzureFirewallPropertiesFormat":{
+         "properties":{
+            "applicationRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleCollection"
                },
                "description":"Collection of application rule collections used by Azure Firewall."
             },
-            "natRuleCollections":{  
+            "natRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNatRuleCollection"
                },
                "description":"Collection of NAT rule collections used by Azure Firewall."
             },
-            "networkRuleCollections":{  
+            "networkRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleCollection"
                },
                "description":"Collection of network rule collections used by Azure Firewall."
             },
-            "ipConfigurations":{  
+            "ipConfigurations":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallIPConfiguration"
                },
                "description":"IP configuration of the Azure Firewall resource."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the Azure Firewall."
       },
-      "AzureFirewall":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewall":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallPropertiesFormat"
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/Resource"
             }
          ],
          "description":"Azure Firewall resource"
       },
-      "AzureFirewallListResult":{  
-         "properties":{  
-            "value":{  
+      "AzureFirewallListResult":{
+         "properties":{
+            "value":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewall"
                },
                "description":"List of Azure Firewalls in a resource group."
             },
-            "nextLink":{  
+            "nextLink":{
                "type":"string",
                "description":"URL to get the next set of results."
             }
          },
          "description":"Response for ListAzureFirewalls API service call."
       },
-      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -385,54 +385,54 @@
                "exclusiveMinimum":false,
                "description":"Priority of the application rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRule"
                },
                "description":"Collection of rules used by a application rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the application rule collection."
       },
-      "AzureFirewallApplicationRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallApplicationRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallApplicationRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Application rule collection resource"
       },
-      "AzureFirewallApplicationRuleProtocol":{  
-         "properties":{  
-            "protocolType":{  
+      "AzureFirewallApplicationRuleProtocol":{
+         "properties":{
+            "protocolType":{
                "description":"Protocol type",
                "$ref":"#/definitions/AzureFirewallApplicationRuleProtocolType"
             },
-            "port":{  
+            "port":{
                "type":"integer",
                "format":"int32",
                "maximum":64000,
@@ -444,41 +444,41 @@
          },
          "description":"Properties of the application rule protocol."
       },
-      "AzureFirewallApplicationRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallApplicationRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the application rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleProtocol"
                },
                "description":"Array of ApplicationRuleProtocols."
             },
-            "targetFqdns":{  
+            "targetFqdns":{
                "type":"array",
                "description":"List of FQDNs for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
             "fqdnTags":{
                "type":"array",
                "description":"List of FQDN Tags for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
@@ -486,8 +486,8 @@
          "description":"Properties of an application rule."
       },
       "AzureFirewallNatRuleCollectionProperties": {
-         "properties":{  
-            "priority":{  
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -496,120 +496,120 @@
                "exclusiveMinimum":false,
                "description":"Priority of the NAT rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallNatRCAction",
                "description":"The action type of a NAT rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNatRule"
                },
                "description":"Collection of rules used by a NAT rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the NAT rule collection."
       },
-      "AzureFirewallNatRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallNatRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallNatRuleCollectionProperties"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"NAT rule collection resource"
       },
-      "AzureFirewallNatRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallNatRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the NAT rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationAddresses":{  
+            "destinationAddresses":{
                "type":"array",
                "description":"List of destination IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationPorts":{  
+            "destinationPorts":{
                "type":"array",
                "description":"List of destination ports.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleProtocol"
                },
                "description":"Array of AzureFirewallNetworkRuleProtocols applicable to this NAT rule."
             },
-            "translatedAddress":{  
+            "translatedAddress":{
                "type":"string",
                "description":"The translated address for this NAT rule."
             },
-            "translatedPort":{  
+            "translatedPort":{
                "type":"string",
                "description":"The translated port for this NAT rule."
             }
          },
          "description":"Properties of a NAT rule."
       },
-      "AzureFirewallNatRCAction":{  
-         "properties":{  
-            "type":{  
+      "AzureFirewallNatRCAction":{
+         "properties":{
+            "type":{
                "description":"The type of action.",
                "$ref":"#/definitions/AzureFirewallNatRCActionType"
             }
          },
          "description":"AzureFirewall NAT Rule Collection Action."
       },
-      "AzureFirewallNatRCActionType":{  
+      "AzureFirewallNatRCActionType":{
          "type":"string",
          "description":"The action type of a NAT rule collection",
-         "enum":[  
+         "enum":[
             "Snat",
             "Dnat"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallNatRCActionType",
             "modelAsString":true
          }
       },
-      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -618,146 +618,146 @@
                "exclusiveMinimum":false,
                "description":"Priority of the network rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRule"
                },
                "description":"Collection of rules used by a network rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the network rule collection."
       },
-      "AzureFirewallNetworkRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallNetworkRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallNetworkRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Network rule collection resource"
       },
-      "AzureFirewallNetworkRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallNetworkRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the network rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleProtocol"
                },
                "description":"Array of AzureFirewallNetworkRuleProtocols."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationAddresses":{  
+            "destinationAddresses":{
                "type":"array",
                "description":"List of destination IP addresses.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationPorts":{  
+            "destinationPorts":{
                "type":"array",
                "description":"List of destination ports.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
          },
          "description":"Properties of the network rule."
       },
-      "AzureFirewallRCAction":{  
-         "properties":{  
-            "type":{  
+      "AzureFirewallRCAction":{
+         "properties":{
+            "type":{
                "description":"The type of action.",
                "$ref":"#/definitions/AzureFirewallRCActionType"
             }
          },
          "description":"Properties of the AzureFirewallRCAction."
       },
-      "AzureFirewallRCActionType":{  
+      "AzureFirewallRCActionType":{
          "type":"string",
          "description":"The action type of a rule collection",
-         "enum":[  
+         "enum":[
             "Allow",
             "Deny"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallRCActionType",
             "modelAsString":true
          }
       },
-      "ProvisioningState":{  
+      "ProvisioningState":{
          "type":"string",
          "readOnly":true,
-         "description":"The current provisisoning state.",
-         "enum":[  
+         "description":"The current provisioning state.",
+         "enum":[
             "Succeeded",
             "Updating",
             "Deleting",
             "Failed"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"ProvisioningState",
             "modelAsString":true
          }
       },
-      "AzureFirewallNetworkRuleProtocol":{  
+      "AzureFirewallNetworkRuleProtocol":{
          "type":"string",
          "description":"The protocol of a Network Rule resource",
-         "enum":[  
+         "enum":[
             "TCP",
             "UDP",
             "Any",
             "ICMP"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallNetworkRuleProtocol",
             "modelAsString":true
          }
       },
-      "AzureFirewallApplicationRuleProtocolType":{  
+      "AzureFirewallApplicationRuleProtocolType":{
          "type":"string",
          "description":"The protocol type of a Application Rule resource",
-         "enum":[  
+         "enum":[
             "Http",
             "Https"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallApplicationRuleProtocolType",
             "modelAsString":true
          }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/InterfaceEndpointCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/InterfaceEndpointCreate.json
@@ -24,7 +24,7 @@
         "location" : "eastus",
         "properties" : {
           "fqdn": "uniqueIdentifier.fqdn.windows.net",
-          "provisioningState": "Succeded",
+          "provisioningState": "Succeeded",
           "owner": "User",
           "endpointService": {
             "id": "/subscriptions/subId/resourceGroups/rg1/providers/Microsoft.Provider/resourceType/resourceName"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkInterfaceTapConfigurationCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkInterfaceTapConfigurationCreate.json
@@ -24,7 +24,7 @@
             "virtualNetworkTap": {
                 "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworkTaps/testvtap"
             },
-            "provisioningState": "Succeded"
+            "provisioningState": "Succeeded"
         }
       }
     },
@@ -38,7 +38,7 @@
             "virtualNetworkTap": {
                 "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworkTaps/testvtap"
             },
-            "provisioningState": "Succeded"
+            "provisioningState": "Succeeded"
         }      
       }
     }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkInterfaceTapConfigurationGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkInterfaceTapConfigurationGet.json
@@ -18,7 +18,7 @@
             "virtualNetworkTap": {
                 "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworkTaps/testvtap"
             },
-            "provisioningState": "Succeded"
+            "provisioningState": "Succeeded"
         }
        }
      }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkInterfaceTapConfigurationList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkInterfaceTapConfigurationList.json
@@ -18,7 +18,7 @@
                 "virtualNetworkTap": {
                 "id": "/subscriptions/subid/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworkTaps/testvtap"
                 },
-                "provisioningState": "Succeded"
+                "provisioningState": "Succeeded"
             }
          }
         ]

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapCreate.json
@@ -26,7 +26,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {
@@ -48,7 +48,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapGet.json
@@ -18,7 +18,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapList.json
@@ -19,7 +19,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {
@@ -39,7 +39,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
              {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapListAll.json
@@ -18,7 +18,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
                 {
@@ -38,7 +38,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "resourceGuid": "6A7C139D-8B8D-499B-B7CB-4F3F02A8A44F",
             "networkInterfaceTapConfigurations": [
              {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkTapUpdateTags.json
@@ -26,7 +26,7 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface/ipConfigurations/testIPConfig1"
             },
             "destinationPort": 4789,
-            "provisioningState": "Succeded",
+            "provisioningState": "Succeeded",
             "networkInterfaceTapConfigurations": [
                 {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/testNetworkInterface2/tapConfigurations/testtapConfiguration"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/expressRouteCircuit.json
@@ -83,7 +83,7 @@
         },
         "x-ms-long-running-operation": true,
         "x-ms-examples": {
-          "Delete ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationDelete.json" } 
+          "Delete ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationDelete.json" }
         }
       },
       "get": {
@@ -130,7 +130,7 @@
           }
         },
         "x-ms-examples": {
-          "Get ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationGet.json" } 
+          "Get ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationGet.json" }
         }
       },
       "put": {
@@ -192,8 +192,8 @@
           }
         },
         "x-ms-long-running-operation": true,
-        "x-ms-examples": { 
-          "Create ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationCreate.json" } 
+        "x-ms-examples": {
+          "Create ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationCreate.json" }
         }
       }
     },
@@ -237,8 +237,8 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         },
-        "x-ms-examples": { 
-          "List ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationList.json" } 
+        "x-ms-examples": {
+          "List ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationList.json" }
         }
       }
     },
@@ -505,7 +505,7 @@
           }
         },
         "x-ms-examples": {
-          "Delete ExpressRouteCircuit": { "$ref": "./examples/ExpressRouteCircuitConnectionDelete.json" } 
+          "Delete ExpressRouteCircuit": { "$ref": "./examples/ExpressRouteCircuitConnectionDelete.json" }
         },
         "x-ms-long-running-operation": true
       },
@@ -607,7 +607,7 @@
             "schema": {
               "$ref": "#/definitions/ExpressRouteCircuitConnection"
             },
-            "description": "Parameters supplied to the create or update express route circuit circuit connection operation."
+            "description": "Parameters supplied to the create or update express route circuit connection operation."
           },
           {
             "$ref": "./network.json#/parameters/ApiVersionParameter"
@@ -685,8 +685,8 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         },
-        "x-ms-examples": { 
-          "List ExpressRouteCircuit Connection": { "$ref": "./examples/ExpressRouteCircuitConnectionList.json" } 
+        "x-ms-examples": {
+          "List ExpressRouteCircuit Connection": { "$ref": "./examples/ExpressRouteCircuitConnectionList.json" }
         }
       }
     },
@@ -1220,7 +1220,7 @@
           "nextLinkName": "nextLink"
         },
         "x-ms-examples": {
-          "List ExpressRouteCircuits in a subscription": { "$ref": "./examples/ExpressRouteCircuitListBySubscription.json" } 
+          "List ExpressRouteCircuits in a subscription": { "$ref": "./examples/ExpressRouteCircuitListBySubscription.json" }
         }
       }
     },
@@ -1241,7 +1241,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns a list of ExpressRouteServiceProdiver resources.",
+            "description": "Request successful. The operation returns a list of ExpressRouteServiceProvider resources.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteServiceProviderListResult"
             }
@@ -1334,7 +1334,7 @@
           "items": {
             "type": "string"
           },
-          "description": "The communities of bgp peering. Spepcified for microsoft peering"
+          "description": "The communities of bgp peering. Specified for microsoft peering"
         },
         "advertisedPublicPrefixesState": {
           "type": "string",
@@ -1612,7 +1612,7 @@
         "provisioningState": {
           "type": "string",
           "readOnly": true,
-          "description": "Provisioning state of the circuit connection resource. Possible values are: 'Succeded', 'Updating', 'Deleting', and 'Failed'."
+          "description": "Provisioning state of the circuit connection resource. Possible values are: 'Succeeded', 'Updating', 'Deleting', and 'Failed'."
         }
       }
     },
@@ -1782,7 +1782,7 @@
         "allowGlobalReach": {
           "type": "boolean",
           "description": "Flag to enable Global Reach on the circuit."
-        }        
+        }
       },
       "description": "Properties of ExpressRouteCircuit."
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/expressRouteCrossConnection.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/expressRouteCrossConnection.json
@@ -51,7 +51,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }
@@ -91,7 +91,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/expressRoutePort.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/expressRoutePort.json
@@ -40,7 +40,7 @@
                     "ExpressRoutePortsLocations"
                 ],
                 "operationId": "ExpressRoutePortsLocations_List",
-                "description": "Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retriving a specific peering location.",
+                "description": "Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retrieving a specific peering location.",
                 "parameters": [
                     {
                         "$ref": "./network.json#/parameters/SubscriptionIdParameter"
@@ -516,7 +516,7 @@
                 {
                     "$ref": "./network.json#/definitions/Resource"
                 }
-            ] 
+            ]
         },
         "ExpressRoutePortsLocationListResult": {
             "title": "ExpressRoutePorts Location List Result",
@@ -670,7 +670,7 @@
                 "etherType": {
                     "readOnly": true,
                     "type": "string",
-                    "description": "Ethertype of the physical port."
+                    "description": "Ether type of the physical port."
                 },
                 "allocationDate": {
                     "readOnly": true,

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkInterface.json
@@ -580,7 +580,7 @@
             "description": "Delete successful."
           }
         },
-        "x-ms-examples": 
+        "x-ms-examples":
         {
           "Delete tap configuration": { "$ref": "./examples/NetworkInterfaceTapConfigurationDelete.json" }
         },
@@ -629,7 +629,7 @@
             }
           }
         },
-        "x-ms-examples": 
+        "x-ms-examples":
         {
           "Get Network Interface Tap Configurations": { "$ref": "./examples/NetworkInterfaceTapConfigurationGet.json" }
         }
@@ -692,7 +692,7 @@
             }
           }
         },
-        "x-ms-examples": 
+        "x-ms-examples":
         {
           "Create Network Interface Tap Configurations": { "$ref": "./examples/NetworkInterfaceTapConfigurationCreate.json" }
         },
@@ -776,7 +776,7 @@
     },
     "NetworkInterfaceTapConfigurationPropertiesFormat": {
       "properties": {
-        "virtualNetworkTap": {         
+        "virtualNetworkTap": {
             "$ref": "./virtualNetworkTap.json#/definitions/VirtualNetworkTap",
             "description": "The reference of the Virtual Network Tap resource."
           },
@@ -1158,14 +1158,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -1180,14 +1180,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkProfile.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkProfile.json
@@ -100,7 +100,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the PublicIPPrefx."
+            "description": "The name of the Public IP Prefix."
           },
           {
             "$ref": "./network.json#/parameters/ApiVersionParameter"
@@ -268,7 +268,7 @@
           }
         },
         "x-ms-examples": {
-          "List all network profilees": {
+          "List all network profiles": {
             "$ref": "./examples/NetworkProfileListAll.json"
           }
         },
@@ -308,7 +308,7 @@
           }
         },
         "x-ms-examples": {
-          "List resource group network profilees": {
+          "List resource group network profiles": {
             "$ref": "./examples/NetworkProfileList.json"
           }
         },
@@ -391,7 +391,7 @@
         },
         "container": {
           "$ref": "#/definitions/Container",
-          "description": "Reference to the conatinaer to which this container network interface is attached."
+          "description": "Reference to the container to which this container network interface is attached."
         },
         "ipConfigurations": {
           "type": "array",
@@ -485,13 +485,13 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Container network interface configruation child resource."
+      "description": "Container network interface configuration child resource."
     },
     "IPConfigurationProfilePropertiesFormat": {
       "properties": {
         "subnet": {
           "$ref": "./virtualNetwork.json#/definitions/Subnet",
-          "description": "The reference of the subnet resource to create a contatainer network interface ip configruation."
+          "description": "The reference of the subnet resource to create a container network interface ip configuration."
         },
         "provisioningState": {
           "readOnly": true,
@@ -499,7 +499,7 @@
           "description": "The provisioning state of the resource."
         }
       },
-      "description": "IP configruation profile properties."
+      "description": "IP configuration profile properties."
     },
     "IPConfigurationProfile": {
       "properties": {
@@ -555,7 +555,7 @@
           "$ref": "#/definitions/ContainerNetworkInterfaceIpConfigurationPropertiesFormat",
           "description": "Properties of the container network interface IP configuration."
         },
-        "name": {   
+        "name": {
           "type": "string",
           "description": "The name of the resource. This name can be used to access the resource."
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkSecurityGroup.json
@@ -628,15 +628,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -654,7 +654,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -705,7 +705,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/networkWatcher.json
@@ -1785,8 +1785,8 @@
         ],
         "operationId": "NetworkWatchers_GetNetworkConfigurationDiagnostic",
         "x-ms-long-running-operation": true,
-        "x-ms-long-running-operation-options": { 
-          "final-state-via": "location" 
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
         },
         "description": "Get network configuration diagnostic.",
         "parameters": [
@@ -1822,7 +1822,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns the result of network condifuration diagnostic.",
+            "description": "Request successful. The operation returns the result of network configuration diagnostic.",
             "schema": {
               "$ref": "#/definitions/NetworkConfigurationDiagnosticResponse"
             }
@@ -3200,7 +3200,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -3385,7 +3385,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {
@@ -3468,7 +3468,7 @@
           "description": "The ID of the target resource to perform network configuration diagnostic. Valid options are VM, NetworkInterface, VMSS/NetworkInterface and Application Gateway."
         },
         "verbosityLevel": {
-          "type": "string",          
+          "type": "string",
           "enum": [
             "Normal",
             "Minimum",
@@ -3525,7 +3525,7 @@
         },
         "destinationPort": {
           "type": "string",
-          "description": "Traffice destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
+          "description": "Traffic destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/publicIpPrefix.json
@@ -98,7 +98,7 @@
               "in": "path",
               "required": true,
               "type": "string",
-              "description": "The name of the PublicIPPrefx."
+              "description": "The name of the Public IP Prefix."
             },
             {
               "$ref": "./network.json#/parameters/ApiVersionParameter"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/serviceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/serviceEndpointPolicy.json
@@ -75,7 +75,7 @@
           }
         },
         "x-ms-examples": {
-          "Delete service endpoint Policys": { "$ref": "./examples/ServiceEndpointPolicyDelete.json" }
+          "Delete service endpoint Policy": { "$ref": "./examples/ServiceEndpointPolicyDelete.json" }
         },
         "x-ms-long-running-operation": true
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/virtualNetworkGateway.json
@@ -795,7 +795,7 @@
             "description": "Accepted and the operation will complete asynchronously."
           },
           "200": {
-            "description": "Request successful. The operation sets the specificed vpnclient ipsec parameters for P2S client of the virtual network gateway.",
+            "description": "Request successful. The operation sets the specified vpnclient ipsec parameters for P2S client of the virtual network gateway.",
             "schema": {
               "$ref": "#/definitions/VpnClientIPsecParameters"
             }
@@ -846,8 +846,8 @@
         },
         "x-ms-long-running-operation": true,
         "x-ms-examples": {
-          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" } 
-        }               
+          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" }
+        }
 
       }
     },
@@ -1766,7 +1766,7 @@
             "$ref": "#/definitions/IpsecPolicy"
           },
           "description": "VpnClientIpsecPolicies for virtual network gateway P2S client."
-        },		
+        },
         "radiusServerAddress": {
           "type": "string",
           "description": "The radius server address property of the VirtualNetworkGateway resource for vpn client connection."
@@ -2399,7 +2399,7 @@
             "ECP384",
             "PFS24",
             "PFS14",
-            "PFSMM"		
+            "PFSMM"
           ],
           "x-ms-enum": {
             "name": "PfsGroup",
@@ -2560,7 +2560,7 @@
         "pfsGroup"
       ],
       "description": "An IPSec parameters for a virtual network gateway P2S connection."
-    },	
+    },
     "LocalNetworkGatewayPropertiesFormat": {
       "properties": {
         "localNetworkAddressSpace": {
@@ -2658,7 +2658,7 @@
         },
         "connectionType": {
           "type": "string",
-          "description": "Gateway connection type. Possible values are: 'Ipsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
+          "description": "Gateway connection type. Possible values are: 'IPsec','Vnet2Vnet','ExpressRoute', and 'VPNClient.",
           "enum": [
             "IPsec",
             "Vnet2Vnet",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/virtualWan.json
@@ -342,7 +342,7 @@
             "$ref": "./examples/VpnSiteGet.json"
           }
         },
-        "description": "Retrieves the details of a VPNsite.",
+        "description": "Retrieves the details of a VPN site.",
         "parameters": [
           {
             "$ref": "./network.json#/parameters/SubscriptionIdParameter"
@@ -2252,7 +2252,7 @@
         },
         "x-ms-long-running-operation": true
       }
-    }	
+    }
   },
   "definitions": {
     "VirtualWanProperties": {
@@ -2298,7 +2298,7 @@
           "items": {
             "$ref": "#/definitions/P2SVpnServerConfiguration"
           }
-        },		
+        },
         "provisioningState": {
           "description": "The provisioning state of the resource.",
           "$ref": "#/definitions/ProvisioningState"
@@ -2448,7 +2448,7 @@
         "p2SVpnGateway": {
           "$ref": "./network.json#/definitions/SubResource",
           "description": "The P2SVpnGateway associated with this VirtualHub"
-        },		
+        },
         "expressRouteGateway": {
           "$ref": "./network.json#/definitions/SubResource",
           "description": "The expressRouteGateway associated with this VirtualHub"
@@ -2836,7 +2836,7 @@
     "ProvisioningState": {
       "type": "string",
       "readOnly": true,
-      "description": "The current provisisoning state.",
+      "description": "The current provisioning state.",
       "enum": [
         "Succeeded",
         "Updating",
@@ -2996,7 +2996,7 @@
         "publicCertData"
       ],
       "description": "Properties of Radius Server root certificate of P2SVpnServerConfiguration."
-    },	
+    },
 	"P2SVpnServerConfigRadiusServerRootCertificate": {
       "properties": {
         "properties": {
@@ -3096,13 +3096,13 @@
         }
       ],
       "description": "Radius client root certificate of P2SVpnServerConfiguration."
-    },	
+    },
 	"P2SVpnServerConfigurationProperties": {
       "properties": {
         "name": {
           "type": "string",
-          "description": "The name of the P2SVpnServerConfiguration that is unique within a VirtualWan in a resource group. This name can be used to access the resource along with Paren VirtualWan resource name."
-        },	  
+          "description": "The name of the P2SVpnServerConfiguration that is unique within a VirtualWan in a resource group. This name can be used to access the resource along with Parent VirtualWan resource name."
+        },
         "vpnProtocols": {
           "type": "array",
           "items": {
@@ -3160,7 +3160,7 @@
         },
         "radiusServerSecret": {
           "type": "string",
-          "description": "The radius secret property of the P2SVpnServerConfiguration resource for for point to site client connection."
+          "description": "The radius secret property of the P2SVpnServerConfiguration resource for point to site client connection."
         },
         "provisioningState": {
           "readOnly": true,
@@ -3219,7 +3219,7 @@
           "description": "URL to get the next set of operation list results if there are any."
         }
       }
-    },	
+    },
     "VpnClientConnectionHealth": {
       "properties": {
         "totalIngressBytesTransferred": {
@@ -3248,7 +3248,7 @@
         }
       },
       "description": "VpnClientConnectionHealth properties"
-    },    
+    },
 	"P2SVpnGatewayProperties": {
       "properties": {
         "virtualHub": {
@@ -3275,7 +3275,7 @@
         "vpnClientConnectionHealth": {
           "readOnly": true,
 		  "$ref": "#/definitions/VpnClientConnectionHealth",
-		  "description": "All P2S vpnclients' connection health status."
+		  "description": "All P2S VPN clients' connection health status."
         }
       },
       "description": "Parameters for P2SVpnGateway"
@@ -3301,7 +3301,7 @@
         }
       ],
       "description": "P2SVpnGateway Resource."
-    },	
+    },
     "ListP2SVpnGatewaysResult": {
       "description": "Result of the request to list P2SVpnGateways. It contains a list of P2SVpnGateways and a URL nextLink to get the next set of results.",
       "properties": {
@@ -3343,6 +3343,6 @@
         }
       },
       "description": "Vpn Profile Response for package generation"
-    }	
+    }
   }
 }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/applicationGateway.json
@@ -1953,7 +1953,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size for WAF."
+          "description": "Maximum request body size for WAF."
         },
         "maxRequestBodySizeInKb": {
           "type": "integer",
@@ -1962,7 +1962,7 @@
           "exclusiveMaximum": false,
           "minimum": 8,
           "exclusiveMinimum": false,
-          "description": "Maxium request body size in Kb for WAF."
+          "description": "Maximum request body size in Kb for WAF."
         },
         "fileUploadLimitInMb": {
           "type": "integer",
@@ -1971,7 +1971,7 @@
           "exclusiveMaximum": false,
           "minimum": 0,
           "exclusiveMinimum": false,
-          "description": "Maxium file upload size in Mb for WAF."
+          "description": "Maximum file upload size in Mb for WAF."
         },
         "exclusions": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/azureFirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/azureFirewall.json
@@ -1,264 +1,264 @@
-{  
+{
    "swagger":"2.0",
-   "info":{  
+   "info":{
       "title":"NetworkManagementClient",
       "description":"The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
       "version": "2018-11-01"
    },
    "host":"management.azure.com",
-   "schemes":[  
+   "schemes":[
       "https"
    ],
-   "consumes":[  
+   "consumes":[
       "application/json"
    ],
-   "produces":[  
+   "produces":[
       "application/json"
    ],
-   "security":[  
-      {  
-         "azure_auth":[  
+   "security":[
+      {
+         "azure_auth":[
             "user_impersonation"
          ]
       }
    ],
-   "securityDefinitions":{  
-      "azure_auth":{  
+   "securityDefinitions":{
+      "azure_auth":{
          "type":"oauth2",
          "authorizationUrl":"https://login.microsoftonline.com/common/oauth2/authorize",
          "flow":"implicit",
          "description":"Azure Active Directory OAuth2 Flow",
-         "scopes":{  
+         "scopes":{
             "user_impersonation":"impersonate your user account"
          }
       }
    },
-   "paths":{  
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{  
-         "delete":{  
-            "tags":[  
+   "paths":{
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}":{
+         "delete":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Delete",
             "description":"Deletes the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "202":{  
+            "responses":{
+               "202":{
                   "description":"Accepted and the operation will complete asynchronously."
                },
-               "204":{  
+               "204":{
                   "description":"Request successful. Resource with the specified name does not exist"
                },
-               "200":{  
+               "200":{
                   "description":"Delete successful."
                }
             },
-            "x-ms-examples":{  
-               "Delete Azure Firewall":{  
+            "x-ms-examples":{
+               "Delete Azure Firewall":{
                   "$ref":"./examples/AzureFirewallDelete.json"
                }
             },
             "x-ms-long-running-operation":true
          },
-         "get":{  
-            "tags":[  
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_Get",
             "description":"Gets the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Request successful. The operation returns an AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Get Azure Firewall":{  
+            "x-ms-examples":{
+               "Get Azure Firewall":{
                   "$ref":"./examples/AzureFirewallGet.json"
                }
             }
          },
-         "put":{  
-            "tags":[  
+         "put":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_CreateOrUpdate",
             "description":"Creates or updates the specified Azure Firewall.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "name":"azureFirewallName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the Azure Firewall."
                },
-               {  
+               {
                   "name":"parameters",
                   "in":"body",
                   "required":true,
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   },
                   "description":"Parameters supplied to the create or update Azure Firewall operation."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "201":{  
+            "responses":{
+               "201":{
                   "description":"Create successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                },
-               "200":{  
+               "200":{
                   "description":"Update successful. The operation returns the resulting AzureFirewall resource.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewall"
                   }
                }
             },
-            "x-ms-examples":{  
-               "Create Azure Firewall":{  
+            "x-ms-examples":{
+               "Create Azure Firewall":{
                   "$ref":"./examples/AzureFirewallPut.json"
                }
             },
             "x-ms-long-running-operation":true
          }
       },
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_List",
             "description":"Lists all Azure Firewalls in a resource group.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "name":"resourceGroupName",
                   "in":"path",
                   "required":true,
                   "type":"string",
                   "description":"The name of the resource group."
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given resource group":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given resource group":{
                   "$ref":"./examples/AzureFirewallListByResourceGroup.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       },
-      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{  
-         "get":{  
-            "tags":[  
+      "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls":{
+         "get":{
+            "tags":[
                "AzureFirewalls"
             ],
             "operationId":"AzureFirewalls_ListAll",
             "description":"Gets all the Azure Firewalls in a subscription.",
-            "parameters":[  
-               {  
+            "parameters":[
+               {
                   "$ref":"./network.json#/parameters/ApiVersionParameter"
                },
-               {  
+               {
                   "$ref":"./network.json#/parameters/SubscriptionIdParameter"
                }
             ],
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"Success. The operation returns a list of AzureFirewall resources.",
-                  "schema":{  
+                  "schema":{
                      "$ref":"#/definitions/AzureFirewallListResult"
                   }
                }
             },
-            "x-ms-examples":{  
-               "List all Azure Firewalls for a given subscription":{  
+            "x-ms-examples":{
+               "List all Azure Firewalls for a given subscription":{
                   "$ref":"./examples/AzureFirewallListBySubscription.json"
                }
             },
-            "x-ms-pageable":{  
+            "x-ms-pageable":{
                "nextLinkName":"nextLink"
             }
          }
       }
    },
-   "definitions":{  
-      "AzureFirewallIPConfigurationPropertiesFormat":{  
-         "properties":{  
+   "definitions":{
+      "AzureFirewallIPConfigurationPropertiesFormat":{
+         "properties":{
             "privateIPAddress": {
                "type": "string",
                "readOnly": true,
@@ -272,111 +272,111 @@
                "$ref": "./network.json#/definitions/SubResource",
                "description": "Reference of the PublicIP resource. This field is a mandatory input if subnet is not null."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of IP configuration of an Azure Firewall."
       },
-      "AzureFirewallIPConfiguration":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallIPConfiguration":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallIPConfigurationPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly": true,
                "description":"A unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"IP configuration of an Azure Firewall."
       },
-      "AzureFirewallPropertiesFormat":{  
-         "properties":{  
-            "applicationRuleCollections":{  
+      "AzureFirewallPropertiesFormat":{
+         "properties":{
+            "applicationRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleCollection"
                },
                "description":"Collection of application rule collections used by Azure Firewall."
             },
-            "natRuleCollections":{  
+            "natRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNatRuleCollection"
                },
                "description":"Collection of NAT rule collections used by Azure Firewall."
             },
-            "networkRuleCollections":{  
+            "networkRuleCollections":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleCollection"
                },
                "description":"Collection of network rule collections used by Azure Firewall."
             },
-            "ipConfigurations":{  
+            "ipConfigurations":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallIPConfiguration"
                },
                "description":"IP configuration of the Azure Firewall resource."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the Azure Firewall."
       },
-      "AzureFirewall":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewall":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallPropertiesFormat"
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/Resource"
             }
          ],
          "description":"Azure Firewall resource"
       },
-      "AzureFirewallListResult":{  
-         "properties":{  
-            "value":{  
+      "AzureFirewallListResult":{
+         "properties":{
+            "value":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewall"
                },
                "description":"List of Azure Firewalls in a resource group."
             },
-            "nextLink":{  
+            "nextLink":{
                "type":"string",
                "description":"URL to get the next set of results."
             }
          },
          "description":"Response for ListAzureFirewalls API service call."
       },
-      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallApplicationRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -385,54 +385,54 @@
                "exclusiveMinimum":false,
                "description":"Priority of the application rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRule"
                },
                "description":"Collection of rules used by a application rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the application rule collection."
       },
-      "AzureFirewallApplicationRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallApplicationRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallApplicationRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Application rule collection resource"
       },
-      "AzureFirewallApplicationRuleProtocol":{  
-         "properties":{  
-            "protocolType":{  
+      "AzureFirewallApplicationRuleProtocol":{
+         "properties":{
+            "protocolType":{
                "description":"Protocol type",
                "$ref":"#/definitions/AzureFirewallApplicationRuleProtocolType"
             },
-            "port":{  
+            "port":{
                "type":"integer",
                "format":"int32",
                "maximum":64000,
@@ -444,41 +444,41 @@
          },
          "description":"Properties of the application rule protocol."
       },
-      "AzureFirewallApplicationRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallApplicationRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the application rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallApplicationRuleProtocol"
                },
                "description":"Array of ApplicationRuleProtocols."
             },
-            "targetFqdns":{  
+            "targetFqdns":{
                "type":"array",
                "description":"List of FQDNs for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
             "fqdnTags":{
                "type":"array",
                "description":"List of FQDN Tags for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
@@ -486,8 +486,8 @@
          "description":"Properties of an application rule."
       },
       "AzureFirewallNatRuleCollectionProperties": {
-         "properties":{  
-            "priority":{  
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -496,120 +496,120 @@
                "exclusiveMinimum":false,
                "description":"Priority of the NAT rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallNatRCAction",
                "description":"The action type of a NAT rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNatRule"
                },
                "description":"Collection of rules used by a NAT rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the NAT rule collection."
       },
-      "AzureFirewallNatRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallNatRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallNatRuleCollectionProperties"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"NAT rule collection resource"
       },
-      "AzureFirewallNatRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallNatRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the NAT rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationAddresses":{  
+            "destinationAddresses":{
                "type":"array",
                "description":"List of destination IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationPorts":{  
+            "destinationPorts":{
                "type":"array",
                "description":"List of destination ports.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleProtocol"
                },
                "description":"Array of AzureFirewallNetworkRuleProtocols applicable to this NAT rule."
             },
-            "translatedAddress":{  
+            "translatedAddress":{
                "type":"string",
                "description":"The translated address for this NAT rule."
             },
-            "translatedPort":{  
+            "translatedPort":{
                "type":"string",
                "description":"The translated port for this NAT rule."
             }
          },
          "description":"Properties of a NAT rule."
       },
-      "AzureFirewallNatRCAction":{  
-         "properties":{  
-            "type":{  
+      "AzureFirewallNatRCAction":{
+         "properties":{
+            "type":{
                "description":"The type of action.",
                "$ref":"#/definitions/AzureFirewallNatRCActionType"
             }
          },
          "description":"AzureFirewall NAT Rule Collection Action."
       },
-      "AzureFirewallNatRCActionType":{  
+      "AzureFirewallNatRCActionType":{
          "type":"string",
          "description":"The action type of a NAT rule collection",
-         "enum":[  
+         "enum":[
             "Snat",
             "Dnat"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallNatRCActionType",
             "modelAsString":true
          }
       },
-      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{  
-         "properties":{  
-            "priority":{  
+      "AzureFirewallNetworkRuleCollectionPropertiesFormat":{
+         "properties":{
+            "priority":{
                "type":"integer",
                "format":"int32",
                "maximum":65000,
@@ -618,146 +618,146 @@
                "exclusiveMinimum":false,
                "description":"Priority of the network rule collection resource."
             },
-            "action":{  
+            "action":{
                "$ref":"#/definitions/AzureFirewallRCAction",
                "description":"The action type of a rule collection"
             },
-            "rules":{  
+            "rules":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRule"
                },
                "description":"Collection of rules used by a network rule collection."
             },
-            "provisioningState":{  
+            "provisioningState":{
                "description":"The provisioning state of the resource.",
                "$ref":"#/definitions/ProvisioningState"
             }
          },
          "description":"Properties of the network rule collection."
       },
-      "AzureFirewallNetworkRuleCollection":{  
-         "properties":{  
-            "properties":{  
+      "AzureFirewallNetworkRuleCollection":{
+         "properties":{
+            "properties":{
                "x-ms-client-flatten":true,
                "$ref":"#/definitions/AzureFirewallNetworkRuleCollectionPropertiesFormat"
             },
-            "name":{  
+            "name":{
                "type":"string",
                "description":"Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
             },
-            "etag":{  
+            "etag":{
                "type":"string",
                "readOnly":true,
                "description":"Gets a unique read-only string that changes whenever the resource is updated."
             }
          },
-         "allOf":[  
-            {  
+         "allOf":[
+            {
                "$ref":"./network.json#/definitions/SubResource"
             }
          ],
          "description":"Network rule collection resource"
       },
-      "AzureFirewallNetworkRule":{  
-         "properties":{  
-            "name":{  
+      "AzureFirewallNetworkRule":{
+         "properties":{
+            "name":{
                "type":"string",
                "description":"Name of the network rule."
             },
-            "description":{  
+            "description":{
                "type":"string",
                "description":"Description of the rule."
             },
-            "protocols":{  
+            "protocols":{
                "type":"array",
-               "items":{  
+               "items":{
                   "$ref":"#/definitions/AzureFirewallNetworkRuleProtocol"
                },
                "description":"Array of AzureFirewallNetworkRuleProtocols."
             },
-            "sourceAddresses":{  
+            "sourceAddresses":{
                "type":"array",
                "description":"List of source IP addresses for this rule.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationAddresses":{  
+            "destinationAddresses":{
                "type":"array",
                "description":"List of destination IP addresses.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             },
-            "destinationPorts":{  
+            "destinationPorts":{
                "type":"array",
                "description":"List of destination ports.",
-               "items":{  
+               "items":{
                   "type":"string"
                }
             }
          },
          "description":"Properties of the network rule."
       },
-      "AzureFirewallRCAction":{  
-         "properties":{  
-            "type":{  
+      "AzureFirewallRCAction":{
+         "properties":{
+            "type":{
                "description":"The type of action.",
                "$ref":"#/definitions/AzureFirewallRCActionType"
             }
          },
          "description":"Properties of the AzureFirewallRCAction."
       },
-      "AzureFirewallRCActionType":{  
+      "AzureFirewallRCActionType":{
          "type":"string",
          "description":"The action type of a rule collection",
-         "enum":[  
+         "enum":[
             "Allow",
             "Deny"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallRCActionType",
             "modelAsString":true
          }
       },
-      "ProvisioningState":{  
+      "ProvisioningState":{
          "type":"string",
          "readOnly":true,
-         "description":"The current provisisoning state.",
-         "enum":[  
+         "description":"The current provisioning state.",
+         "enum":[
             "Succeeded",
             "Updating",
             "Deleting",
             "Failed"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"ProvisioningState",
             "modelAsString":true
          }
       },
-      "AzureFirewallNetworkRuleProtocol":{  
+      "AzureFirewallNetworkRuleProtocol":{
          "type":"string",
          "description":"The protocol of a Network Rule resource",
-         "enum":[  
+         "enum":[
             "TCP",
             "UDP",
             "Any",
             "ICMP"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallNetworkRuleProtocol",
             "modelAsString":true
          }
       },
-      "AzureFirewallApplicationRuleProtocolType":{  
+      "AzureFirewallApplicationRuleProtocolType":{
          "type":"string",
          "description":"The protocol type of a Application Rule resource",
-         "enum":[  
+         "enum":[
             "Http",
             "Https"
          ],
-         "x-ms-enum":{  
+         "x-ms-enum":{
             "name":"AzureFirewallApplicationRuleProtocolType",
             "modelAsString":true
          }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/expressRouteCircuit.json
@@ -83,7 +83,7 @@
         },
         "x-ms-long-running-operation": true,
         "x-ms-examples": {
-          "Delete ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationDelete.json" } 
+          "Delete ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationDelete.json" }
         }
       },
       "get": {
@@ -130,7 +130,7 @@
           }
         },
         "x-ms-examples": {
-          "Get ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationGet.json" } 
+          "Get ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationGet.json" }
         }
       },
       "put": {
@@ -192,8 +192,8 @@
           }
         },
         "x-ms-long-running-operation": true,
-        "x-ms-examples": { 
-          "Create ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationCreate.json" } 
+        "x-ms-examples": {
+          "Create ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationCreate.json" }
         }
       }
     },
@@ -237,8 +237,8 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         },
-        "x-ms-examples": { 
-          "List ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationList.json" } 
+        "x-ms-examples": {
+          "List ExpressRouteCircuit Authorization": { "$ref": "./examples/ExpressRouteCircuitAuthorizationList.json" }
         }
       }
     },
@@ -505,7 +505,7 @@
           }
         },
         "x-ms-examples": {
-          "Delete ExpressRouteCircuit": { "$ref": "./examples/ExpressRouteCircuitConnectionDelete.json" } 
+          "Delete ExpressRouteCircuit": { "$ref": "./examples/ExpressRouteCircuitConnectionDelete.json" }
         },
         "x-ms-long-running-operation": true
       },
@@ -607,7 +607,7 @@
             "schema": {
               "$ref": "#/definitions/ExpressRouteCircuitConnection"
             },
-            "description": "Parameters supplied to the create or update express route circuit circuit connection operation."
+            "description": "Parameters supplied to the create or update express route circuit connection operation."
           },
           {
             "$ref": "./network.json#/parameters/ApiVersionParameter"
@@ -685,8 +685,8 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         },
-        "x-ms-examples": { 
-          "List ExpressRouteCircuit Connection": { "$ref": "./examples/ExpressRouteCircuitConnectionList.json" } 
+        "x-ms-examples": {
+          "List ExpressRouteCircuit Connection": { "$ref": "./examples/ExpressRouteCircuitConnectionList.json" }
         }
       }
     },
@@ -1220,7 +1220,7 @@
           "nextLinkName": "nextLink"
         },
         "x-ms-examples": {
-          "List ExpressRouteCircuits in a subscription": { "$ref": "./examples/ExpressRouteCircuitListBySubscription.json" } 
+          "List ExpressRouteCircuits in a subscription": { "$ref": "./examples/ExpressRouteCircuitListBySubscription.json" }
         }
       }
     },
@@ -1241,7 +1241,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns a list of ExpressRouteServiceProdiver resources.",
+            "description": "Request successful. The operation returns a list of ExpressRouteServiceProvider resources.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteServiceProviderListResult"
             }
@@ -1334,7 +1334,7 @@
           "items": {
             "type": "string"
           },
-          "description": "The communities of bgp peering. Spepcified for microsoft peering"
+          "description": "The communities of bgp peering. Specified for microsoft peering"
         },
         "advertisedPublicPrefixesState": {
           "type": "string",
@@ -1612,7 +1612,7 @@
         "provisioningState": {
           "type": "string",
           "readOnly": true,
-          "description": "Provisioning state of the circuit connection resource. Possible values are: 'Succeded', 'Updating', 'Deleting', and 'Failed'."
+          "description": "Provisioning state of the circuit connection resource. Possible values are: 'Succeeded', 'Updating', 'Deleting', and 'Failed'."
         }
       }
     },
@@ -1782,7 +1782,7 @@
         "allowGlobalReach": {
           "type": "boolean",
           "description": "Flag to enable Global Reach on the circuit."
-        }        
+        }
       },
       "description": "Properties of ExpressRouteCircuit."
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/expressRouteCrossConnection.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/expressRouteCrossConnection.json
@@ -51,7 +51,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful. The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }
@@ -91,7 +91,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no crossconnection resources an empty list is returned.",
+            "description": "Request successful.The operation returns a list of ExpressRouteCrossConnection resources. If there are no cross connection resources an empty list is returned.",
             "schema": {
               "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
             }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/expressRoutePort.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/expressRoutePort.json
@@ -40,7 +40,7 @@
                     "ExpressRoutePortsLocations"
                 ],
                 "operationId": "ExpressRoutePortsLocations_List",
-                "description": "Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retriving a specific peering location.",
+                "description": "Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retrieving a specific peering location.",
                 "parameters": [
                     {
                         "$ref": "./network.json#/parameters/SubscriptionIdParameter"
@@ -516,7 +516,7 @@
                 {
                     "$ref": "./network.json#/definitions/Resource"
                 }
-            ] 
+            ]
         },
         "ExpressRoutePortsLocationListResult": {
             "title": "ExpressRoutePorts Location List Result",
@@ -670,7 +670,7 @@
                 "etherType": {
                     "readOnly": true,
                     "type": "string",
-                    "description": "Ethertype of the physical port."
+                    "description": "Ether type of the physical port."
                 },
                 "allocationDate": {
                     "readOnly": true,

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/networkInterface.json
@@ -580,7 +580,7 @@
             "description": "Delete successful."
           }
         },
-        "x-ms-examples": 
+        "x-ms-examples":
         {
           "Delete tap configuration": { "$ref": "./examples/NetworkInterfaceTapConfigurationDelete.json" }
         },
@@ -629,7 +629,7 @@
             }
           }
         },
-        "x-ms-examples": 
+        "x-ms-examples":
         {
           "Get Network Interface Tap Configurations": { "$ref": "./examples/NetworkInterfaceTapConfigurationGet.json" }
         }
@@ -692,7 +692,7 @@
             }
           }
         },
-        "x-ms-examples": 
+        "x-ms-examples":
         {
           "Create Network Interface Tap Configurations": { "$ref": "./examples/NetworkInterfaceTapConfigurationCreate.json" }
         },
@@ -776,7 +776,7 @@
     },
     "NetworkInterfaceTapConfigurationPropertiesFormat": {
       "properties": {
-        "virtualNetworkTap": {         
+        "virtualNetworkTap": {
             "$ref": "./virtualNetworkTap.json#/definitions/VirtualNetworkTap",
             "description": "The reference of the Virtual Network Tap resource."
           },
@@ -1158,14 +1158,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "destinationPortRanges": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as seperator (e.g. 100-400), or an asterix (*)"
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*)"
         },
         "sourceAddressPrefix": {
           "type": "string",
@@ -1180,14 +1180,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "destinationAddressPrefixes" : {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AureLoadBalancer, Internet), System Tags, and the asterix (*)."
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*)."
         },
         "expandedSourceAddressPrefix": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/networkProfile.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/networkProfile.json
@@ -100,7 +100,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the PublicIPPrefx."
+            "description": "The name of the PublicIPPrefix."
           },
           {
             "$ref": "./network.json#/parameters/ApiVersionParameter"
@@ -268,7 +268,7 @@
           }
         },
         "x-ms-examples": {
-          "List all network profilees": {
+          "List all network profiles": {
             "$ref": "./examples/NetworkProfileListAll.json"
           }
         },
@@ -308,7 +308,7 @@
           }
         },
         "x-ms-examples": {
-          "List resource group network profilees": {
+          "List resource group network profiles": {
             "$ref": "./examples/NetworkProfileList.json"
           }
         },
@@ -391,7 +391,7 @@
         },
         "container": {
           "$ref": "#/definitions/Container",
-          "description": "Reference to the conatinaer to which this container network interface is attached."
+          "description": "Reference to the container to which this container network interface is attached."
         },
         "ipConfigurations": {
           "type": "array",
@@ -485,13 +485,13 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Container network interface configruation child resource."
+      "description": "Container network interface configuration child resource."
     },
     "IPConfigurationProfilePropertiesFormat": {
       "properties": {
         "subnet": {
           "$ref": "./virtualNetwork.json#/definitions/Subnet",
-          "description": "The reference of the subnet resource to create a contatainer network interface ip configruation."
+          "description": "The reference of the subnet resource to create a container network interface ip configuration."
         },
         "provisioningState": {
           "readOnly": true,
@@ -499,7 +499,7 @@
           "description": "The provisioning state of the resource."
         }
       },
-      "description": "IP configruation profile properties."
+      "description": "IP configuration profile properties."
     },
     "IPConfigurationProfile": {
       "properties": {
@@ -555,7 +555,7 @@
           "$ref": "#/definitions/ContainerNetworkInterfaceIpConfigurationPropertiesFormat",
           "description": "Properties of the container network interface IP configuration."
         },
-        "name": {   
+        "name": {
           "type": "string",
           "description": "The name of the resource. This name can be used to access the resource."
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/networkSecurityGroup.json
@@ -628,15 +628,15 @@
         },
         "sourcePortRange": {
           "type": "string",
-          "description": "The source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisks '*' can also be used to match all ports."
         },
         "destinationPortRange": {
           "type": "string",
-          "description": "The destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports."
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisks '*' can also be used to match all ports."
         },
         "sourceAddressPrefix": {
           "type": "string",
-          "description": "The CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
+          "description": "The CIDR or source IP range. Asterisks '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from. "
         },
         "sourceAddressPrefixes": {
           "type": "array",
@@ -654,7 +654,7 @@
         },
         "destinationAddressPrefix": {
           "type": "string",
-          "description": "The destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisks '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
         },
         "destinationAddressPrefixes": {
           "type": "array",
@@ -705,7 +705,7 @@
         },
         "direction": {
           "type": "string",
-          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outcoming traffic. Possible values are: 'Inbound' and 'Outbound'.",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. Possible values are: 'Inbound' and 'Outbound'.",
           "enum": [
             "Inbound",
             "Outbound"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/networkWatcher.json
@@ -1785,8 +1785,8 @@
         ],
         "operationId": "NetworkWatchers_GetNetworkConfigurationDiagnostic",
         "x-ms-long-running-operation": true,
-        "x-ms-long-running-operation-options": { 
-          "final-state-via": "location" 
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
         },
         "description": "Get network configuration diagnostic.",
         "parameters": [
@@ -1822,7 +1822,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Request successful. The operation returns the result of network condifuration diagnostic.",
+            "description": "Request successful. The operation returns the result of network configuration diagnostic.",
             "schema": {
               "$ref": "#/definitions/NetworkConfigurationDiagnosticResponse"
             }
@@ -3200,7 +3200,7 @@
       "properties": {
         "location": {
           "type": "string",
-          "description": "Connection monitor location."         
+          "description": "Connection monitor location."
         },
         "tags": {
           "type": "object",
@@ -3385,7 +3385,7 @@
           "description": "Information about connection states."
         }
       },
-      "description": "List of connection states snaphots."
+      "description": "List of connection states snapshots."
     },
     "ConnectionStateSnapshot": {
       "properties": {
@@ -3468,7 +3468,7 @@
           "description": "The ID of the target resource to perform network configuration diagnostic. Valid options are VM, NetworkInterface, VMSS/NetworkInterface and Application Gateway."
         },
         "verbosityLevel": {
-          "type": "string",          
+          "type": "string",
           "enum": [
             "Normal",
             "Minimum",
@@ -3525,7 +3525,7 @@
         },
         "destinationPort": {
           "type": "string",
-          "description": "Traffice destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
+          "description": "Traffic destination port. Accepted values are '*', port (for example, 3389) and port range (for example, 80-100)."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/publicIpPrefix.json
@@ -98,7 +98,7 @@
               "in": "path",
               "required": true,
               "type": "string",
-              "description": "The name of the PublicIPPrefx."
+              "description": "The name of the PublicIPPrefix."
             },
             {
               "$ref": "./network.json#/parameters/ApiVersionParameter"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/serviceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/serviceEndpointPolicy.json
@@ -75,7 +75,7 @@
           }
         },
         "x-ms-examples": {
-          "Delete service endpoint Policys": { "$ref": "./examples/ServiceEndpointPolicyDelete.json" }
+          "Delete service endpoint Policies": { "$ref": "./examples/ServiceEndpointPolicyDelete.json" }
         },
         "x-ms-long-running-operation": true
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/virtualNetworkGateway.json
@@ -795,7 +795,7 @@
             "description": "Accepted and the operation will complete asynchronously."
           },
           "200": {
-            "description": "Request successful. The operation sets the specificed vpnclient ipsec parameters for P2S client of the virtual network gateway.",
+            "description": "Request successful. The operation sets the specified vpnclient ipsec parameters for P2S client of the virtual network gateway.",
             "schema": {
               "$ref": "#/definitions/VpnClientIPsecParameters"
             }
@@ -846,8 +846,8 @@
         },
         "x-ms-long-running-operation": true,
         "x-ms-examples": {
-          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" } 
-        }               
+          "Get VirtualNetworkGateway VpnClientIpsecParameters": { "$ref": "./examples/VirtualNetworkGatewayGetVpnClientIpsecParameters.json" }
+        }
 
       }
     },
@@ -1766,7 +1766,7 @@
             "$ref": "#/definitions/IpsecPolicy"
           },
           "description": "VpnClientIpsecPolicies for virtual network gateway P2S client."
-        },		
+        },
         "radiusServerAddress": {
           "type": "string",
           "description": "The radius server address property of the VirtualNetworkGateway resource for vpn client connection."
@@ -2399,7 +2399,7 @@
             "ECP384",
             "PFS24",
             "PFS14",
-            "PFSMM"		
+            "PFSMM"
           ],
           "x-ms-enum": {
             "name": "PfsGroup",
@@ -2560,7 +2560,7 @@
         "pfsGroup"
       ],
       "description": "An IPSec parameters for a virtual network gateway P2S connection."
-    },	
+    },
     "LocalNetworkGatewayPropertiesFormat": {
       "properties": {
         "localNetworkAddressSpace": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/virtualWan.json
@@ -342,7 +342,7 @@
             "$ref": "./examples/VpnSiteGet.json"
           }
         },
-        "description": "Retrieves the details of a VPNsite.",
+        "description": "Retrieves the details of a VPN site.",
         "parameters": [
           {
             "$ref": "./network.json#/parameters/SubscriptionIdParameter"
@@ -2252,7 +2252,7 @@
         },
         "x-ms-long-running-operation": true
       }
-    }	
+    }
   },
   "definitions": {
     "VirtualWanProperties": {
@@ -2298,7 +2298,7 @@
           "items": {
             "$ref": "#/definitions/P2SVpnServerConfiguration"
           }
-        },		
+        },
         "provisioningState": {
           "description": "The provisioning state of the resource.",
           "$ref": "#/definitions/ProvisioningState"
@@ -2448,7 +2448,7 @@
         "p2SVpnGateway": {
           "$ref": "./network.json#/definitions/SubResource",
           "description": "The P2SVpnGateway associated with this VirtualHub"
-        },		
+        },
         "expressRouteGateway": {
           "$ref": "./network.json#/definitions/SubResource",
           "description": "The expressRouteGateway associated with this VirtualHub"
@@ -2836,7 +2836,7 @@
     "ProvisioningState": {
       "type": "string",
       "readOnly": true,
-      "description": "The current provisisoning state.",
+      "description": "The current provisioning state.",
       "enum": [
         "Succeeded",
         "Updating",
@@ -2996,7 +2996,7 @@
         "publicCertData"
       ],
       "description": "Properties of Radius Server root certificate of P2SVpnServerConfiguration."
-    },	
+    },
 	"P2SVpnServerConfigRadiusServerRootCertificate": {
       "properties": {
         "properties": {
@@ -3096,13 +3096,13 @@
         }
       ],
       "description": "Radius client root certificate of P2SVpnServerConfiguration."
-    },	
+    },
 	"P2SVpnServerConfigurationProperties": {
       "properties": {
         "name": {
           "type": "string",
           "description": "The name of the P2SVpnServerConfiguration that is unique within a VirtualWan in a resource group. This name can be used to access the resource along with Paren VirtualWan resource name."
-        },	  
+        },
         "vpnProtocols": {
           "type": "array",
           "items": {
@@ -3160,7 +3160,7 @@
         },
         "radiusServerSecret": {
           "type": "string",
-          "description": "The radius secret property of the P2SVpnServerConfiguration resource for for point to site client connection."
+          "description": "The radius secret property of the P2SVpnServerConfiguration resource for point to site client connection."
         },
         "provisioningState": {
           "readOnly": true,
@@ -3219,7 +3219,7 @@
           "description": "URL to get the next set of operation list results if there are any."
         }
       }
-    },	
+    },
     "VpnClientConnectionHealth": {
       "properties": {
         "totalIngressBytesTransferred": {
@@ -3248,7 +3248,7 @@
         }
       },
       "description": "VpnClientConnectionHealth properties"
-    },    
+    },
 	"P2SVpnGatewayProperties": {
       "properties": {
         "virtualHub": {
@@ -3275,7 +3275,7 @@
         "vpnClientConnectionHealth": {
           "readOnly": true,
 		  "$ref": "#/definitions/VpnClientConnectionHealth",
-		  "description": "All P2S vpnclients' connection health status."
+		  "description": "All P2S VPN clients' connection health status."
         }
       },
       "description": "Parameters for P2SVpnGateway"
@@ -3301,7 +3301,7 @@
         }
       ],
       "description": "P2SVpnGateway Resource."
-    },	
+    },
     "ListP2SVpnGatewaysResult": {
       "description": "Result of the request to list P2SVpnGateways. It contains a list of P2SVpnGateways and a URL nextLink to get the next set of results.",
       "properties": {
@@ -3343,6 +3343,6 @@
         }
       },
       "description": "Vpn Profile Response for package generation"
-    }	
+    }
   }
 }


### PR DESCRIPTION
- resrources -> resources
- retreive -> retrieve
- opertion -> operation
- Various stuck together words
- Pering -> Peering
- curcuit -> circuit
- Various "network" typo variations
- specifed -> specified
- conenction -> connection
- appliation -> application
- mircosoft -> Microsoft
- wher -> where
- addresseses -> addresses
- compotnent -> component
- emlement -> element
- endponints -> endpoints
- potocol -> protocol
- servive -> service
- outcoming -> outgoing
- Sests -> Sets
- Gateay -> Gateway

Sorry this got a little noisy, but should all be non-breaking docs fixes