### PR TITLE
Adds canFailover boolean flag under storage account's GeoReplicationS…

### DIFF
--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2018-07-01/examples/StorageAccountGetProperties.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2018-07-01/examples/StorageAccountGetProperties.json
@@ -16,7 +16,8 @@
         "properties": {
           "geoReplicationStats": {
             "status": "Live",
-            "lastSyncTime": "2018-10-30T00:25:34Z"
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "canFailover": true
           },
           "isHnsEnabled": true,
           "azureFilesAadIntegration": true,

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2018-07-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2018-07-01/storage.json
@@ -1335,6 +1335,11 @@
           "type": "string",
           "format": "date-time",
           "description": "All primary writes preceding this UTC date/time value are guaranteed to be available for read operations. Primary writes following this point in time may or may not be available for reads. Element may be default value if value of LastSyncTime is not available, this can happen if secondary is offline or we are in bootstrap."
+        },
+        "canFailover": {
+          "readOnly": true,
+          "type": "boolean",
+          "description": "A boolean flag which indicates whether or not account failover is supported for the account."
         }
       },
       "description": "Statistics related to replication for storage account's Blob, Table, Queue and File services. It is only available when geo-redundant replication is enabled for the storage account."


### PR DESCRIPTION
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
