### PR TITLE
chore: Convert Travis matrix to jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,87 +3,97 @@ node_js:
   - '8'
 services:
   - docker
-env:
-  matrix:
-    - MODE=branchStrategy
-    - MODE=syntax CHECK_NAME="Syntax Validator"
-    - MODE=python CHECK_NAME="SDK Generation - Python"
-    - MODE=node CHECK_NAME="SDK Generation - Node"
-    - MODE=typescript CHECK_NAME="SDK Generation - TypeScript"
-    - MODE=ruby CHECK_NAME="SDK Generation - Ruby"
-    - MODE=java CHECK_NAME="SDK Generation - Java"
-    - MODE=go CHECK_NAME="SDK Generation - Go"
-    - MODE=semantic PR_ONLY=true CHECK_NAME="Semantic Validator"
-    - MODE=semantic PR_ONLY=false
-    - MODE=model PR_ONLY=true CHECK_NAME="Model Validator"
-    - MODE=BreakingChange PR_ONLY=true CHECK_NAME="Breaking Changes"
-    - MODE=lintdiff PR_ONLY=true CHECK_NAME="Linter Diff"
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: MODE=node CHECK_NAME="SDK Generation - Node"
-    - env: MODE=typescript CHECK_NAME="SDK Generation - TypeScript"
-    - env: MODE=ruby CHECK_NAME="SDK Generation - Ruby"
-    - env: MODE=java CHECK_NAME="SDK Generation - Java"
-    - env: MODE=go CHECK_NAME="SDK Generation - Go"
-    - env: MODE=semantic PR_ONLY=false
-    - env: MODE=model PR_ONLY=true CHECK_NAME="Model Validator"
-    - env: MODE=BreakingChange PR_ONLY=true CHECK_NAME="Breaking Changes"
 install: true
-script:
-  - >-
-    if [[ $MODE == 'python' ]]; then
-      travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-python -v
-    fi
-  - >-
-    if [[ $MODE == 'node' ]]; then
-      travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-node -v
-    fi
-  - >-
-    if [[ $MODE == 'typescript' ]]; then
-      travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-js -v
-    fi
-  - >-
-    if [[ $MODE == 'ruby' ]]; then
-      travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-ruby -v
-    fi
-  - >-
-    if [[ $MODE == 'go' ]]; then
-      travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-go -o latest -v
-    fi
-  - >-
-    if [[ $MODE == 'java' ]]; then
-      travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-java -v
-    fi
-  - >-
-    if [[ $MODE == 'branchStrategy' ]]; then
-      # Check to ensure CI is not executing for a PR against the master branch in the private repository
-      ! [[ $TRAVIS_PULL_REQUEST != 'false' && $TRAVIS_REPO_SLUG == 'Azure/azure-rest-api-specs-pr' && $TRAVIS_BRANCH == 'master' ]]
-    fi
-  - >-
-    if [[ $MODE == 'syntax' ]]; then
-      npm install
-      npm test -- test/syntax.js
-    fi
-  - >-
-    if [[ $MODE == 'semantic' ]]; then
-      npm install
-      node scripts/semanticValidation.js
-    fi
-  - >-
-    if [[ $MODE == 'model' ]]; then
-      npm install
-      node scripts/modelValidation.js
-    fi
-  - >-
-    if [[ $MODE == 'BreakingChange' ]]; then
-      scripts/install-dotnet.sh
-      npm install
-      node -- scripts/breaking-change.js
-    fi
-  - >-
-    if [[ $MODE == 'lintdiff' ]]; then
-      scripts/install-dotnet.sh
-      npm install
-      node scripts/momentOfTruth.js && node scripts/momentOfTruthPostProcessing.js
-    fi
+stages:
+  - Gate
+  - Test
+jobs:
+  allow_failures:
+    - stage: Test
+      name: Model Validator
+      install: npm install
+      script: node scripts/modelValidation.js
+      env:
+        - PR_ONLY=true
+    - stage: Test
+      name: Semantic Validator All files
+      install: npm install
+      script: node scripts/semanticValidation.js
+      env:
+        - PR_ONLY=false
+    - stage: Test
+      name: Node
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-node -v
+    - stage: Test
+      name: Typescript
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-js -v
+    - stage: Test
+      name: Ruby
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-ruby -v
+    - stage: Test
+      name: Go
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-go -o latest -v
+    - stage: Test
+      name: Java
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-java -v
+  include:
+    - stage: Gate
+      name: Branch Strategy
+      script: false
+      if: branch = master AND repo = Azure/azure-rest-api-specs-pr AND type = pull_request
+    - stage: Test
+      name: Semantic Validator PR files
+      install: npm install
+      script: node scripts/semanticValidation.js
+      env:
+        - PR_ONLY=true
+    - stage: Test
+      name: Linter Diff
+      install:
+        - scripts/install-dotnet.sh
+        - npm install
+      script: node scripts/momentOfTruth.js && node scripts/momentOfTruthPostProcessing.js
+      env:
+        - PR_ONLY=true
+    - stage: Test
+      name: Syntax Validator
+      install: npm install
+      script: npm test -- test/syntax.js
+    - stage: Test
+      name: Python
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-python -v
+    - stage: Test
+      name: Semantic Validator All files
+      install: npm install
+      script: node scripts/semanticValidation.js
+      env:
+        - PR_ONLY=false
+    - stage: Test
+      name: Breaking Changes
+      install:
+        - scripts/install-dotnet.sh
+        - npm install
+      script: node -- scripts/breaking-change.js
+      env:
+        - PR_ONLY=true
+    - stage: Test
+      name: Model Validator
+      install: npm install
+      script: node scripts/modelValidation.js
+      env:
+        - PR_ONLY=true
+    - stage: Test
+      name: Node
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-node -v
+    - stage: Test
+      name: Typescript
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-js -v
+    - stage: Test
+      name: Ruby
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-ruby -v
+    - stage: Test
+      name: Go
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-go -o latest -v
+    - stage: Test
+      name: Java
+      script: travis_wait 30 scripts/swagger-to-sdk.sh Azure/azure-sdk-for-java -v


### PR DESCRIPTION
Was trying to figure out what the build was doing, so I converted it to the newer Stage syntax https://docs.travis-ci.com/user/build-stages/
This will actually slightly slow it down with the current split of stages. It would run as fast if only the "Gate" is separated out. The benefit I see with the SDK generation being separated out is that the PRs aren't created if there are problems with the PR.
Don't think I entirely understood the PR_ONLY flag, but jobs can be filtered out in the stages format by adding `if: type = pull_request` https://docs.travis-ci.com/user/conditions-v1