### PR TITLE
chore: Add vscode-docs-authoring suggestion

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "vscode-docs-authoring"
+    ]
+}


### PR DESCRIPTION
VS Code now supports suggesting extensions for when you open a repo https://code.visualstudio.com/docs/editor/extension-gallery#_recommended-extensions
https://github.com/Microsoft/vscode-docs-authoring is the bundle recommended authoring MS docs and includes things like spellchecking and Markdown linting. This is mostly how I've been picking up issues in the swagger files