### PR TITLE
Fix type-o in adhybridhealthservice model

### DIFF
--- a/specification/adhybridhealthservice/resource-manager/Microsoft.ADHybridHealthService/stable/2014-01-01/ADHybridHealthService.json
+++ b/specification/adhybridhealthservice/resource-manager/Microsoft.ADHybridHealthService/stable/2014-01-01/ADHybridHealthService.json
@@ -4587,7 +4587,7 @@
           "description": "The AAD side user principal name.",
           "type": "string"
         },
-        "aadDistringuishedName": {
+        "aadDistinguishedName": {
           "description": "The AAD side distinguished name for the object.",
           "type": "string"
         },

--- a/specification/adhybridhealthservice/resource-manager/readme.go.md
+++ b/specification/adhybridhealthservice/resource-manager/readme.go.md
@@ -1,0 +1,26 @@
+## Go
+
+These settings apply only when `--go` is specified on the command line.
+
+``` yaml $(go)
+go:
+  license-header: MICROSOFT_APACHE_NO_VERSION
+  namespace: adhybridhealthservice
+  clear-output-folder: true
+```
+
+### Go multi-api
+
+``` yaml $(go) && $(multiapi)
+batch:
+  - tag: package-2014-01
+```
+
+### Tag: package-2014-01 and go
+
+These settings apply only when `--tag=package-2014-01 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2014-01' && $(go)
+output-folder: $(go-sdk-folder)/services/adhybridhealthservice/mgmt/2014-01-01/adhybridhealthservice
+```

--- a/specification/adhybridhealthservice/resource-manager/readme.md
+++ b/specification/adhybridhealthservice/resource-manager/readme.md
@@ -88,31 +88,7 @@ python:
 
 ## Go
 
-These settings apply only when `--go` is specified on the command line.
-
-``` yaml $(go)
-go:
-  license-header: MICROSOFT_APACHE_NO_VERSION
-  namespace: adhybridhealthservice
-  clear-output-folder: true
-```
-
-### Go multi-api
-
-``` yaml $(go) && $(multiapi)
-batch:
-  - tag: package-2014-01
-```
-
-### Tag: package-2014-01 and go
-
-These settings apply only when `--tag=package-2014-01 --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag) == 'package-2014-01' && $(go)
-output-folder: $(go-sdk-folder)/services/adhybridhealthservice/mgmt/2014-01-01/adhybridhealthservice
-```
-
+See configuration in [readme.go.md](./readme.go.md)
 
 ## Java
 


### PR DESCRIPTION
Move Go SDK config to its own config file

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
