### PR TITLE
Resource Health RP changes for new resource type /events and /impacte…

### DIFF
--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/ResourceHealth.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/ResourceHealth.json
@@ -511,7 +511,7 @@
               "description": "Recommended actions of event.",
               "properties": {
                 "groupId": {
-                  "type": "string",
+                  "type": "integer",
                   "description": "Recommended action group Id for the service health event."
                 },
                 "title": {
@@ -873,7 +873,7 @@
               "description": "Timestamp for when the health was last checked. ",
               "format": "date-time"
             },
-            "recentlyResolvedState": {
+            "recentlyResolved": {
               "type": "object",
               "description": "An annotation describing a change in the availabilityState to Available from Unavailable with a reasonType of type Unplanned",
               "properties": {

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/ResourceHealth.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/ResourceHealth.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2018-01-01",
+    "version": "2018-07-01-preview",
     "title": "Microsoft.ResourceHealth",
     "description": "The Resource Health Client."
   },
@@ -69,6 +69,53 @@
         "x-ms-examples": {
           "ListEventsBySubscriptionId": {
             "$ref": "./examples/Events_ListBySubscriptionId.json"
+          }
+        }
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.ResourceHealth/events": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "operationId": "Events_ListBySingleResource",
+        "description": "Lists current service health events for given resource.",
+        "parameters": [
+          {
+            "name": "resourceUri",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The fully qualified ID of the resource, including the resource name and resource type. Currently the API support not nested and one nesting level resource types : /subscriptions/{subscriptionId}/resourceGroups/{resource-group-name}/providers/{resource-provider-name}/{resource-type}/{resource-name} and /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resource-provider-name}/{parentResourceType}/{parentResourceName}/{resourceType}/{resourceName}",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/FilterParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of current service health events for given resource",
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "ListEventsBySingleResource": {
+            "$ref": "./examples/Events_ListBySingleResource.json"
           }
         }
       }

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/ResourceHealth.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/ResourceHealth.json
@@ -1,0 +1,919 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-01-01",
+    "title": "Microsoft.ResourceHealth",
+    "description": "The Resource Health Client."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ResourceHealth/events": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "operationId": "Events_ListBySubscriptionId",
+        "description": "Lists current service health events in the subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/FilterParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of current service health events in the subscription",
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "ListEventsBySubscriptionId": {
+            "$ref": "./examples/Events_ListBySubscriptionId.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ResourceHealth/impactedResources": {
+      "get": {
+        "tags": [
+          "ImpactedResources"
+        ],
+        "operationId": "ImpactedResources_ListBySubscriptionId",
+        "description": "Lists the current availability status for impacted resources in the subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/FilterParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of current availability status for impacted resources in the subscription",
+            "schema": {
+              "$ref": "#/definitions/impactedResourceListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "ListHealthBySubscriptionId": {
+            "$ref": "./examples/ImpactedResources_ListBySubscriptionId.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ResourceHealth/availabilityStatuses": {
+      "get": {
+        "tags": [
+          "AvailabilityStatuses"
+        ],
+        "operationId": "AvailabilityStatuses_ListBySubscriptionId",
+        "description": "Lists the current availability status for all the resources in the subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/FilterParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ExpandParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of current availability status for all the resources in the subscription",
+            "schema": {
+              "$ref": "#/definitions/availabilityStatusListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "ListHealthBySubscriptionId": {
+            "$ref": "./examples/AvailabilityStatuses_ListBySubscriptionId.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ResourceHealth/availabilityStatuses": {
+      "get": {
+        "tags": [
+          "AvailabilityStatuses"
+        ],
+        "operationId": "AvailabilityStatuses_ListByResourceGroup",
+        "description": "Lists the current availability status for all the resources in the resource group.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/FilterParameter"
+          },
+          {
+            "$ref": "#/parameters/ExpandParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of current availability status for all the resources in the resource group",
+            "schema": {
+              "$ref": "#/definitions/availabilityStatusListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "ListByResourceGroup": {
+            "$ref": "./examples/AvailabilityStatuses_ListByResourceGroup.json"
+          }
+        }
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.ResourceHealth/availabilityStatuses/current": {
+      "get": {
+        "tags": [
+          "AvailabilityStatuses"
+        ],
+        "operationId": "AvailabilityStatuses_GetByResource",
+        "description": "Gets current availability status for a single resource",
+        "parameters": [
+          {
+            "name": "resourceUri",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The fully qualified ID of the resource, including the resource name and resource type. Currently the API support not nested and one nesting level resource types : /subscriptions/{subscriptionId}/resourceGroups/{resource-group-name}/providers/{resource-provider-name}/{resource-type}/{resource-name} and /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resource-provider-name}/{parentResourceType}/{parentResourceName}/{resourceType}/{resourceName}",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/FilterParameter"
+          },
+          {
+            "$ref": "#/parameters/ExpandParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The current availability status for a single resource",
+            "schema": {
+              "$ref": "#/definitions/availabilityStatus"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetCurrentHealthByResource": {
+            "$ref": "./examples/AvailabilityStatus_GetByResource.json"
+          }
+        }
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.ResourceHealth/availabilityStatuses": {
+      "get": {
+        "tags": [
+          "AvailabilityStatuses"
+        ],
+        "operationId": "AvailabilityStatuses_List",
+        "description": "Lists all historical availability transitions and impacting events for a single resource.",
+        "parameters": [
+          {
+            "name": "resourceUri",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The fully qualified ID of the resource, including the resource name and resource type. Currently the API support not nested and one nesting level resource types : /subscriptions/{subscriptionId}/resourceGroups/{resource-group-name}/providers/{resource-provider-name}/{resource-type}/{resource-name} and /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resource-provider-name}/{parentResourceType}/{parentResourceName}/{resourceType}/{resourceName}",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/FilterParameter"
+          },
+          {
+            "$ref": "#/parameters/ExpandParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of historical availability statuses for a single resource",
+            "schema": {
+              "$ref": "#/definitions/availabilityStatusListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "GetHealthHistoryByResource": {
+            "$ref": "./examples/Availabilitystatuses_List.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.ResourceHealth/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "operationId": "Operations_List",
+        "description": "Lists available operations for the resourcehealth resource provider",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of available operations for the resourcehealth resource provider",
+            "schema": {
+              "$ref": "#/definitions/operationListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "events": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/event"
+          },
+          "description": "The list of event."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URI to fetch the next page of events. Call ListNext() with this URI to fetch the next page of events."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "description": "The List events operation response."
+    },
+    "event": {
+      "type": "object",
+      "description": "Service health event",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "type": "object",
+          "description": "Properties of event.",
+          "properties": {
+            "eventType": {
+              "type": "string",
+              "description": "Type of event.",
+              "enum": [
+                "ServiceIssue",
+                "PlannedMaintenance",
+                "HealthAdvisory",
+                "RCA"
+              ],
+              "x-ms-enum": {
+                "name": "EventTypeValues",
+                "modelAsString": true
+              }
+            },
+            "eventSource": {
+              "type": "string",
+              "description": "Source of event.",
+              "enum": [
+                "ResourceHealth",
+                "ServiceHealth"
+              ],
+              "x-ms-enum": {
+                "name": "EventSourceValues",
+                "modelAsString": true
+              }
+            },
+            "status": {
+              "type": "string",
+              "description": "Current status of event.",
+              "enum": [
+                "Active",
+                "Resolved"
+              ],
+              "x-ms-enum": {
+                "name": "EventStatusValues",
+                "modelAsString": true
+              }
+            },
+            "title": {
+              "type": "string",
+              "description": "Title text of event."
+            },
+            "summary": {
+              "type": "string",
+              "description": "Summary text of event."
+            },
+            "reason": {
+              "type": "string",
+              "description": "Downtime reason of event."
+            },
+            "impactStartTime": {
+              "type": "string",
+              "description": "It provides the Timestamp for when the health impacting event started.",
+              "format": "date-time"
+            },
+            "impactMitigationTime": {
+              "type": "string",
+              "description": "It provides the Timestamp for when the health impacting event resolved.",
+              "format": "date-time"
+            },
+            "impact": {
+              "type": "array",
+              "description": "List services impacted by the service health event.",
+              "items": {
+                "$ref": "#/definitions/impact"
+              }
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "impact": {
+      "description": "Azure service impacted by the service health event.",
+      "properties": {
+        "impactedService": {
+          "type": "string",
+          "description": "Impacted service name.",
+          "enum": [
+            "Virtual Machines",
+            "SQL Database"
+          ],
+          "x-ms-enum": {
+            "name": "Services",
+            "modelAsString": true
+          }
+        },
+        "impactedRegions": {
+          "type": "array",
+          "description": "List regions impacted by the service health event.",
+          "items": {
+            "$ref": "#/definitions/impactedServiceRegion"
+          }
+        }
+      }
+    },
+    "impactedServiceRegion": {
+      "description": "Azure region impacted by the service health event.",
+      "properties": {
+        "impactedRegion": {
+          "type": "string",
+          "description": "Impacted region name."
+        },
+        "status": {
+          "type": "string",
+          "description": "Current status of event in the region.",
+          "enum": [
+            "Active",
+            "Resolved"
+          ],
+          "x-ms-enum": {
+            "name": "EventStatusValues",
+            "modelAsString": true
+          }
+        },
+        "impactedSubscriptions": {
+          "type": "array",
+          "description": "List subscription impacted by the service health event.",
+          "items": {
+            "type": "string",
+            "description": "Subscription impacted by the service health event."
+          }
+        },
+        "impactedResourcesCount": {
+          "type": "integer",
+          "description": "Total Azure resources impacted by the service health event."
+        },
+        "lastUpdateTime": {
+          "type": "string",
+          "description": "It provides the Timestamp for when the last update for the service health event.",
+          "format": "date-time"
+        }
+      }
+    },
+    "impactedResourceListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/impactedResourceStatus"
+          },
+          "description": "The list of impactedResourceStatus."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URI to fetch the next page of impactedResourceStatus."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "description": "The List impactedResourceStatus operation response."
+    },
+    "impactedResourceStatus": {
+      "type": "object",
+      "description": "impactedResource with health status",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "type": "object",
+          "description": "Properties of impacted resource status.",
+          "properties": {
+            "availabilityState": {
+              "type": "string",
+              "description": "Impacted resource status of the resource.",
+              "enum": [
+                "Available",
+                "Unavailable",
+                "Degraded",
+                "Unknown"
+              ],
+              "x-ms-enum": {
+                "name": "AvailabilityStateValues",
+                "modelAsString": true
+              }
+            },
+            "title": {
+              "type": "string",
+              "description": "Title description of the impacted resource status."
+            },
+            "summary": {
+              "type": "string",
+              "description": "Summary description of the impacted resource status."
+            },
+            "reasonType": {
+              "type": "string",
+              "description": "When the resource's availabilityState is Unavailable, it describes where the health impacting event was originated.",
+              "enum": [
+                "Unplanned",
+                "Planned",
+                "UserInitiated"
+              ],
+              "x-ms-enum": {
+                "name": "ReasonTypeValues",
+                "modelAsString": true
+              }
+            },
+            "occuredTime": {
+              "type": "string",
+              "description": "Timestamp for when last change in health status occurred.",
+              "format": "date-time"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "availabilityStatusListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/availabilityStatus"
+          },
+          "description": "The list of availabilityStatuses."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URI to fetch the next page of availabilityStatuses. Call ListNext() with this URI to fetch the next page of availabilityStatuses."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "description": "The List availabilityStatus operation response."
+    },
+    "availabilityStatus": {
+      "type": "object",
+      "description": "availabilityStatus of a resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Azure Resource Manager Identity for the availabilityStatuses resource."
+        },
+        "name": {
+          "type": "string",
+          "description": "current."
+        },
+        "type": {
+          "type": "string",
+          "description": "Microsoft.ResourceHealth/AvailabilityStatuses."
+        },
+        "location": {
+          "type": "string",
+          "description": "Azure Resource Manager geo location of the resource."
+        },
+        "properties": {
+          "type": "object",
+          "description": "Properties of availability state.",
+          "properties": {
+            "availabilityState": {
+              "type": "string",
+              "description": "Availability status of the resource. When it is null, this availabilityStatus object represents an availability impacting event",
+              "enum": [
+                "Available",
+                "Unavailable",
+                "Degraded",
+                "Unknown"
+              ],
+              "x-ms-enum": {
+                "name": "AvailabilityStateValues",
+                "modelAsString": true
+              }
+            },
+            "summary": {
+              "type": "string",
+              "description": "Summary description of the availability status."
+            },
+            "detailedStatus": {
+              "type": "string",
+              "description": "Details of the availability status."
+            },
+            "reasonType": {
+              "type": "string",
+              "description": "When the resource's availabilityState is Unavailable, it describes where the health impacting event was originated. Examples are planned, unplanned, user initiated or an outage etc."
+            },
+            "rootCauseAttributionTime": {
+              "type": "string",
+              "description": "When the resource's availabilityState is Unavailable, it provides the Timestamp for when the health impacting event was received.",
+              "format": "date-time"
+            },
+            "healthEventType": {
+              "type": "string",
+              "description": "In case of an availability impacting event, it describes when the health impacting event was originated. Examples are Lifecycle, Downtime, Fault Analysis etc."
+            },
+            "healthEventCause": {
+              "type": "string",
+              "description": "In case of an availability impacting event, it describes where the health impacting event was originated. Examples are PlatformInitiated, UserInitiated etc."
+            },
+            "healthEventCategory": {
+              "type": "string",
+              "description": "In case of an availability impacting event, it describes the category of a PlatformInitiated health impacting event. Examples are Planned, Unplanned etc."
+            },
+            "healthEventId": {
+              "type": "string",
+              "description": "It is a unique Id that identifies the event"
+            },
+            "resolutionETA": {
+              "type": "string",
+              "description": "When the resource's availabilityState is Unavailable and the reasonType is not User Initiated, it provides the date and time for when the issue is expected to be resolved.",
+              "format": "date-time"
+            },
+            "occuredTime": {
+              "type": "string",
+              "description": "Timestamp for when last change in health status occurred.",
+              "format": "date-time"
+            },
+            "reasonChronicity": {
+              "type": "string",
+              "description": "Chronicity of the availability transition.",
+              "enum": [
+                "Transient",
+                "Persistent"
+              ],
+              "x-ms-enum": {
+                "name": "reasonChronicityTypes",
+                "modelAsString": true
+              }
+            },
+            "reportedTime": {
+              "type": "string",
+              "description": "Timestamp for when the health was last checked. ",
+              "format": "date-time"
+            },
+            "recentlyResolvedState": {
+              "type": "object",
+              "description": "An annotation describing a change in the availabilityState to Available from Unavailable with a reasonType of type Unplanned",
+              "properties": {
+                "unavailableOccurredTime": {
+                  "type": "string",
+                  "description": "Timestamp for when the availabilityState changed to Unavailable",
+                  "format": "date-time"
+                },
+                "resolvedTime": {
+                  "type": "string",
+                  "description": "Timestamp when the availabilityState changes to Available.",
+                  "format": "date-time"
+                },
+                "unavailabilitySummary": {
+                  "type": "string",
+                  "description": "Brief description of cause of the resource becoming unavailable."
+                }
+              }
+            },
+            "recommendedActions": {
+              "type": "array",
+              "description": "Lists actions the user can take based on the current availabilityState of the resource.",
+              "items": {
+                "$ref": "#/definitions/recommendedAction"
+              }
+            },
+            "serviceImpactingEvents": {
+              "type": "array",
+              "description": "Lists the service impacting events that may be affecting the health of the resource.",
+              "items": {
+                "$ref": "#/definitions/serviceImpactingEvent"
+              }
+            }
+          }
+        }
+      }
+    },
+    "recommendedAction": {
+      "description": "Lists actions the user can take based on the current availabilityState of the resource.",
+      "properties": {
+        "action": {
+          "type": "string",
+          "description": "Recommended action."
+        },
+        "actionUrl": {
+          "type": "string",
+          "description": "Link to the action"
+        },
+        "actionUrlText": {
+          "type": "string",
+          "description": "Substring of action, it describes which text should host the action url."
+        }
+      }
+    },
+    "serviceImpactingEvent": {
+      "description": "Lists the service impacting events that may be affecting the health of the resource.",
+      "properties": {
+        "eventStartTime": {
+          "type": "string",
+          "description": "Timestamp for when the event started.",
+          "format": "date-time"
+        },
+        "eventStatusLastModifiedTime": {
+          "type": "string",
+          "description": "Timestamp for when event was submitted/detected.",
+          "format": "date-time"
+        },
+        "correlationId": {
+          "type": "string",
+          "description": "Correlation id for the event"
+        },
+        "status": {
+          "type": "object",
+          "description": "Status of the service impacting event.",
+          "properties": {
+            "value": {
+              "type": "string",
+              "description": "Current status of the event"
+            }
+          }
+        },
+        "incidentProperties": {
+          "type": "object",
+          "description": "Properties of the service impacting event.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Title of the incident."
+            },
+            "service": {
+              "type": "string",
+              "description": "Service impacted by the event."
+            },
+            "region": {
+              "type": "string",
+              "description": "Region impacted by the event."
+            },
+            "incidentType": {
+              "type": "string",
+              "description": "Type of Event."
+            }
+          }
+        }
+      }
+    },
+    "operationListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/operation"
+          },
+          "description": "List of operations available in the resourcehealth resource provider."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "description": "Lists the operations response."
+    },
+    "operation": {
+      "description": "Operation available in the resourcehealth resource provider.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the operation."
+        },
+        "display": {
+          "type": "object",
+          "description": "Properties of the operation.",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "Provider name."
+            },
+            "resource": {
+              "type": "string",
+              "description": "Resource name."
+            },
+            "operation": {
+              "type": "string",
+              "description": "Operation."
+            },
+            "description": {
+              "type": "string",
+              "description": "Description of the operation."
+            }
+          }
+        }
+      }
+    },
+    "ErrorResponse": {
+      "description": "Error details.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The error code.",
+          "type": "string",
+          "readOnly": true
+        },
+        "message": {
+          "description": "The error message.",
+          "type": "string",
+          "readOnly": true
+        },
+        "details": {
+          "description": "The error details.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    },
+    "ResourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the resource group.",
+      "x-ms-parameter-location": "method"
+    },
+    "FilterParameter": {
+      "name": "$filter",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "The filter to apply on the operation. For more information please see https://docs.microsoft.com/en-us/rest/api/apimanagement/apis?redirectedfrom=MSDN",
+      "x-ms-parameter-location": "method"
+    },
+    "ExpandParameter": {
+      "name": "$expand",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "Setting $expand=recommendedactions in url query expands the recommendedactions in the response.",
+      "x-ms-parameter-location": "method"
+    },
+    "EventIdParameter": {
+      "name": "eventId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "EventId for the Service health event"
+    }
+  }
+}

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/ResourceHealth.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/ResourceHealth.json
@@ -409,9 +409,38 @@
               "type": "string",
               "description": "Summary text of event."
             },
-            "reason": {
+            "header": {
               "type": "string",
-              "description": "Downtime reason of event."
+              "description": "Header text of event."
+            },
+            "level": {
+              "type": "string",
+              "description": "Level of event.",
+              "enum": [
+                "Critical",
+                "Warning"
+              ],
+              "x-ms-enum": {
+                "name": "LevelValues",
+                "modelAsString": true
+              }
+            },
+            "article": {
+              "type": "object",
+              "description": "Article of event.",
+              "properties": {
+                "articleContent": {
+                  "type": "string",
+                  "description": "Article content of event."
+                }
+              }
+            },
+            "links": {
+              "type": "array",
+              "description": "Useful links of event.",
+              "items": {
+                "$ref": "#/definitions/link"
+              }
             },
             "impactStartTime": {
               "type": "string",
@@ -429,6 +458,39 @@
               "items": {
                 "$ref": "#/definitions/impact"
               }
+            },
+            "recommendedActions": {
+              "type": "object",
+              "description": "Recommended actions of event.",
+              "properties": {
+                "groupId": {
+                  "type": "string",
+                  "description": "Recommended action group Id for the service health event."
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Recommended action title for the service health event."
+                },
+                "actions": {
+                  "type": "array",
+                  "description": "Recommended actions for the service health event.",
+                  "items": {
+                    "type": "string",
+                    "description": "Recommended action for the service health event."
+                  }
+                },
+                "localeCode": {
+                  "type": "string",
+                  "description": "Recommended action locale for the service health event."
+                }
+              }
+            },
+            "faqs": {
+              "type": "array",
+              "description": "Frequently asked questions for the service health event.",
+              "items": {
+                "$ref": "#/definitions/faq"
+              }
             }
           }
         }
@@ -439,20 +501,72 @@
         }
       ]
     },
+    "link": {
+      "description": "Useful links for service health event.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of link.",
+          "enum": [
+            "Button",
+            "Hyperlink"
+          ],
+          "x-ms-enum": {
+            "name": "LinkTypeValues",
+            "modelAsString": true
+          }
+        },
+        "displayText": {
+          "type": "object",
+          "description": "Display text of link.",
+          "properties": {
+            "value": {
+              "type": "string",
+              "description": "Display text of link."
+            },
+            "localizedValue": {
+              "type": "string",
+              "description": "Localized display text of link."
+            }
+          }
+        },
+        "extensionName": {
+          "type": "string",
+          "description": "It provides the name of portal extension to produce link for given service health event."
+        },
+        "bladeName": {
+          "type": "string",
+          "description": "It provides the name of portal extension blade to produce link for given service health event."
+        },
+        "parameters": {
+          "type": "object",
+          "description": "It provides a map of parameter name and value for portal extension blade to produce lik for given service health event."
+        }
+      }
+    },
+    "faq": {
+      "description": "Frequently asked question for the service health event",
+      "properties": {
+        "question": {
+          "type": "string",
+          "description": "FAQ question for the service health event."
+        },
+        "answer": {
+          "type": "string",
+          "description": "FAQ answer for the service health event."
+        },
+        "localeCode": {
+          "type": "string",
+          "description": "FAQ locale for the service health event."
+        }
+      }
+    },
     "impact": {
       "description": "Azure service impacted by the service health event.",
       "properties": {
         "impactedService": {
           "type": "string",
-          "description": "Impacted service name.",
-          "enum": [
-            "Virtual Machines",
-            "SQL Database"
-          ],
-          "x-ms-enum": {
-            "name": "Services",
-            "modelAsString": true
-          }
+          "description": "Impacted service name."
         },
         "impactedRegions": {
           "type": "array",
@@ -490,13 +604,30 @@
             "description": "Subscription impacted by the service health event."
           }
         },
-        "impactedResourcesCount": {
-          "type": "integer",
-          "description": "Total Azure resources impacted by the service health event."
-        },
         "lastUpdateTime": {
           "type": "string",
           "description": "It provides the Timestamp for when the last update for the service health event.",
+          "format": "date-time"
+        },
+        "updates": {
+          "type": "array",
+          "description": "List of updates for given servie health event.",
+          "items": {
+            "$ref": "#/definitions/update"
+          }
+        }
+      }
+    },
+    "update": {
+      "description": "Update for service health event.",
+      "properties": {
+        "summary": {
+          "type": "string",
+          "description": "Summary text for the given update for the service health event."
+        },
+        "updateDateTime": {
+          "type": "string",
+          "description": "It provides the Timestamp for the given update for the service health event.",
           "format": "date-time"
         }
       }
@@ -837,7 +968,7 @@
             },
             "operation": {
               "type": "string",
-              "description": "Operation."
+              "description": "Operation name."
             },
             "description": {
               "type": "string",

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatus_GetByResource.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatus_GetByResource.json
@@ -1,0 +1,38 @@
+﻿{
+	"parameters": {
+		"resourceUri":"resourceUri",
+		"api-version": "2015-01-01",
+		"$expand": "recommendedactions"
+	},
+	"responses": {
+		"200": {
+			"body": {
+				"id": "/subscriptions/4abcdefgh-ijkl-mnop-qrstuvwxyz/resourceGroups/rhctestenv/providers/Microsoft.ClassicCompute/virtualMachines /rhctestenvV1PI/providers/Microsoft.ResourceHealth/availabilityStatuses/current",
+				"name": "current",
+				"type": "Microsoft.ResourceHealth/AvailabilityStatuses",
+				"location": "eastus",
+				"properties": {
+					"availabilityState": "Unavailable",
+					"summary": "We're sorry, we couldn't automatically recover your virtual machine",
+					"reasonType": "Unplanned",
+					"reasonChronicity": "Persistent",
+					"detailedStatus": "Disk problems are preventing us from automatically recovering your virtual machine",
+					"occuredTime": "2016-03-29T09:12:00Z",
+					"reportedTime": "2016-05-04T14:11:29.7598931Z",
+					"rootCauseAttributionTime": "2016-03-29T09:13:00Z",
+					"resolutionETA": "2016-03-29T09:37:00Z",
+					"RecommendedActions": [{
+						"Action": "To start this virtual machine, open the resource blade and click Start",
+						"ActionUrl": "<#ResourceBlade>",
+						"ActionUrlText": "resource blade"
+					},
+					{
+						"Action": "If you are experiencing problems you believe are caused by Azure, contact support",
+						"ActionUrl": "<#SupportCase>",
+						"ActionUrlText": "contact support"
+					}]
+				}
+			}
+		}
+	}
+}

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatus_GetByResource.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatus_GetByResource.json
@@ -21,15 +21,15 @@
 					"reportedTime": "2016-05-04T14:11:29.7598931Z",
 					"rootCauseAttributionTime": "2016-03-29T09:13:00Z",
 					"resolutionETA": "2016-03-29T09:37:00Z",
-					"RecommendedActions": [{
-						"Action": "To start this virtual machine, open the resource blade and click Start",
-						"ActionUrl": "<#ResourceBlade>",
-						"ActionUrlText": "resource blade"
+					"recommendedActions": [{
+						"action": "To start this virtual machine, open the resource blade and click Start",
+						"actionUrl": "<#ResourceBlade>",
+						"actionUrlText": "resource blade"
 					},
 					{
-						"Action": "If you are experiencing problems you believe are caused by Azure, contact support",
-						"ActionUrl": "<#SupportCase>",
-						"ActionUrlText": "contact support"
+						"action": "If you are experiencing problems you believe are caused by Azure, contact support",
+						"actionUrl": "<#SupportCase>",
+						"actionUrlText": "contact support"
 					}]
 				}
 			}

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListByResourceGroup.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListByResourceGroup.json
@@ -22,9 +22,9 @@
 						"occuredTime": "2016-03-29T09:12:00Z",
 						"reportedTime": "2016-05-04T14:11:29.7598931Z",
 						"recentlyResolved": {
-							"unavailableOccuredTime": "2017-02-28T00:48:00Z",
+							"unavailableOccurredTime": "2017-02-28T00:48:00Z",
 							"resolvedTime": "2017-02-28T00:49:00Z",
-							"unavailableSummary": "We are sorry your SQL database is unavailable"
+							"unavailabilitySummary": "We are sorry your SQL database is unavailable"
 						},
 						"recommendedActions": [{
 							"action": "To start this virtualmachine, open the resource blade and click Start",

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListByResourceGroup.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListByResourceGroup.json
@@ -1,0 +1,67 @@
+﻿{
+	"parameters": {
+		"subscriptionId": "subscriptionId",
+		"resourceGroupName": "resourceGroupName",
+		"api-version": "2015-01-01",
+		"$expand": "recommendedactions"
+	},
+	"responses": {
+		"200": {
+			"body": {
+				"value": [{
+					"id": "<resourceId>/providers/Microsoft.ResourceHealth/AvailabilityStatueses/current",
+					"name": "current",
+					"type": "Microsoft.ResourceHealth/AvailabilityStatuses",
+					"location": "eastus",
+					"properties": {
+						"availabilityState": "Available",
+						"summary": "Vm is available",
+						"reasonType": "Unplanned",
+						"reasonChronicity": "Persistent",
+						"detailedStatus": "We have not seen any issues with your virtual machine",
+						"occuredTime": "2016-03-29T09:12:00Z",
+						"reportedTime": "2016-05-04T14:11:29.7598931Z",
+						"RecentlyResolved": {
+							"UnavailableOccuredTime": "2017-02-28T00:48:00Z",
+							"ResolvedTime": "2017-02-28T00:49:00Z",
+							"UnavailableSummary": "We are sorry your SQL database is unavailable"
+						},
+						"RecommendedActions": [{
+							"Action": "To start this virtualmachine, open the resource blade and click Start",
+							"ActionUrl": "<#ResourceBlade>",
+							"ActionUrlText": "resourceblade"
+						}]
+					}
+				},
+				{
+					"id": "<resourceId>/providers/Microsoft.ResourceHealth/AvailabilityStatueses/current",
+					"name": "current",
+					"type": "Microsoft.ResourceHealth/AvailabilityStatuses",
+					"location": "eastus",
+					"properties": {
+						"availabilityState": "Unavailable",
+						"summary": "We are sorry, we couldn't automatically recovery our virtualmachine",
+						"reasonType": "Unplanned",
+						"reasonChronicity": "Persistent",
+						"detailedStatus": "Diskproblemsarepreventingusfromautomaticallyrecoveringyourvirtualmachine",
+						"occuredTime": "2016-03-29T09:12:00Z",
+						"reportedTime": "2016-05-04T14:11:29.7598931Z",
+						"rootCauseAttributionTime": "2016-03-29T09:13:00Z",
+						"resolutionETA": "2016-03-29T09:37:00Z",
+						"RecommendedActions": [{
+							"Action": "To start this virtualmachine, open the resource blade",
+							"ActionUrl": "<#ResourceBlade>",
+							"ActionUrlText": "resourceblade"
+						},
+						{
+							"Action": "If you are experiencing problems you believe are caused by Azure, contact support",
+							"ActionUrl": "<#SupportCase>",
+							"ActionUrlText": "contactsupport"
+						}]
+					}
+				}],
+				"nextLink": "{originalRequestUrl}?$skipToken={OpaquePageNumber}"
+			}
+		}
+	}
+}

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListByResourceGroup.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListByResourceGroup.json
@@ -22,14 +22,14 @@
 						"occuredTime": "2016-03-29T09:12:00Z",
 						"reportedTime": "2016-05-04T14:11:29.7598931Z",
 						"recentlyResolved": {
-							"UnavailableOccuredTime": "2017-02-28T00:48:00Z",
-							"ResolvedTime": "2017-02-28T00:49:00Z",
-							"UnavailableSummary": "We are sorry your SQL database is unavailable"
+							"unavailableOccuredTime": "2017-02-28T00:48:00Z",
+							"resolvedTime": "2017-02-28T00:49:00Z",
+							"unavailableSummary": "We are sorry your SQL database is unavailable"
 						},
 						"recommendedActions": [{
-							"Action": "To start this virtualmachine, open the resource blade and click Start",
-							"ActionUrl": "<#ResourceBlade>",
-							"ActionUrlText": "resourceblade"
+							"action": "To start this virtualmachine, open the resource blade and click Start",
+							"actionUrl": "<#ResourceBlade>",
+							"actionUrlText": "resourceblade"
 						}]
 					}
 				},
@@ -49,14 +49,14 @@
 						"rootCauseAttributionTime": "2016-03-29T09:13:00Z",
 						"resolutionETA": "2016-03-29T09:37:00Z",
 						"recommendedActions": [{
-							"Action": "To start this virtualmachine, open the resource blade",
-							"ActionUrl": "<#ResourceBlade>",
-							"ActionUrlText": "resourceblade"
+							"action": "To start this virtualmachine, open the resource blade",
+							"actionUrl": "<#ResourceBlade>",
+							"actionUrlText": "resourceblade"
 						},
 						{
-							"Action": "If you are experiencing problems you believe are caused by Azure, contact support",
-							"ActionUrl": "<#SupportCase>",
-							"ActionUrlText": "contactsupport"
+							"action": "If you are experiencing problems you believe are caused by Azure, contact support",
+							"actionUrl": "<#SupportCase>",
+							"actionUrlText": "contactsupport"
 						}]
 					}
 				}],

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListByResourceGroup.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListByResourceGroup.json
@@ -21,12 +21,12 @@
 						"detailedStatus": "We have not seen any issues with your virtual machine",
 						"occuredTime": "2016-03-29T09:12:00Z",
 						"reportedTime": "2016-05-04T14:11:29.7598931Z",
-						"RecentlyResolved": {
+						"recentlyResolved": {
 							"UnavailableOccuredTime": "2017-02-28T00:48:00Z",
 							"ResolvedTime": "2017-02-28T00:49:00Z",
 							"UnavailableSummary": "We are sorry your SQL database is unavailable"
 						},
-						"RecommendedActions": [{
+						"recommendedActions": [{
 							"Action": "To start this virtualmachine, open the resource blade and click Start",
 							"ActionUrl": "<#ResourceBlade>",
 							"ActionUrlText": "resourceblade"
@@ -48,7 +48,7 @@
 						"reportedTime": "2016-05-04T14:11:29.7598931Z",
 						"rootCauseAttributionTime": "2016-03-29T09:13:00Z",
 						"resolutionETA": "2016-03-29T09:37:00Z",
-						"RecommendedActions": [{
+						"recommendedActions": [{
 							"Action": "To start this virtualmachine, open the resource blade",
 							"ActionUrl": "<#ResourceBlade>",
 							"ActionUrlText": "resourceblade"

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListBySubscriptionId.json
@@ -20,12 +20,12 @@
 						"detailedStatus": "We have not seen any issues with your virtual machine",
 						"occuredTime": "2016-03-29T09:12:00Z",
 						"reportedTime": "2016-05-04T14:11:29.7598931Z",
-						"RecentlyResolved": {
+						"recentlyResolved": {
 							"UnavailableOccuredTime": "2017-02-28T00:48:00Z",
 							"ResolvedTime": "2017-02-28T00:49:00Z",
 							"UnavailableSummary": "We are sorry your SQL database is unavailable"
 						},
-						"RecommendedActions": [{
+						"recommendedActions": [{
 							"Action": "To start this virtualmachine, open the resource blade and click Start",
 							"ActionUrl": "<#ResourceBlade>",
 							"ActionUrlText": "resourceblade"

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListBySubscriptionId.json
@@ -21,14 +21,14 @@
 						"occuredTime": "2016-03-29T09:12:00Z",
 						"reportedTime": "2016-05-04T14:11:29.7598931Z",
 						"recentlyResolved": {
-							"UnavailableOccuredTime": "2017-02-28T00:48:00Z",
-							"ResolvedTime": "2017-02-28T00:49:00Z",
-							"UnavailableSummary": "We are sorry your SQL database is unavailable"
+							"unavailableOccuredTime": "2017-02-28T00:48:00Z",
+							"resolvedTime": "2017-02-28T00:49:00Z",
+							"unavailableSummary": "We are sorry your SQL database is unavailable"
 						},
 						"recommendedActions": [{
-							"Action": "To start this virtualmachine, open the resource blade and click Start",
-							"ActionUrl": "<#ResourceBlade>",
-							"ActionUrlText": "resourceblade"
+							"action": "To start this virtualmachine, open the resource blade and click Start",
+							"actionUrl": "<#ResourceBlade>",
+							"actionUrlText": "resourceblade"
 						}]
 					}
 				},
@@ -47,15 +47,15 @@
 						"reportedTime": "2016-05-04T14:11:29.7598931Z",
 						"rootCauseAttributionTime": "2016-03-29T09:13:00Z",
 						"resolutionETA": "2016-03-29T09:37:00Z",
-						"RecommendedActions": [{
-							"Action": "To start this virtualmachine, open the resource blade",
-							"ActionUrl": "<#ResourceBlade>",
-							"ActionUrlText": "resourceblade"
+						"recommendedActions": [{
+							"action": "To start this virtualmachine, open the resource blade",
+							"actionUrl": "<#ResourceBlade>",
+							"actionUrlText": "resourceblade"
 						},
 						{
-							"Action": "If you are experiencing problems you believe are caused by Azure, contact support",
-							"ActionUrl": "<#SupportCase>",
-							"ActionUrlText": "contactsupport"
+							"action": "If you are experiencing problems you believe are caused by Azure, contact support",
+							"actionUrl": "<#SupportCase>",
+							"actionUrlText": "contactsupport"
 						}]
 					}
 				}],

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListBySubscriptionId.json
@@ -1,0 +1,66 @@
+﻿{
+	"parameters": {
+		"subscriptionId": "subscriptionId",
+		"api-version": "2015-01-01",
+		"$expand": "recommendedactions"
+	},
+	"responses": {
+		"200": {
+			"body": {
+				"value": [{
+					"id": "<resourceId>/providers/Microsoft.ResourceHealth/AvailabilityStatueses/current",
+					"name": "current",
+					"type": "Microsoft.ResourceHealth/AvailabilityStatuses",
+					"location": "eastus",
+					"properties": {
+						"availabilityState": "Available",
+						"summary": "Vm is available",
+						"reasonType": "Unplanned",
+						"reasonChronicity": "Persistent",
+						"detailedStatus": "We have not seen any issues with your virtual machine",
+						"occuredTime": "2016-03-29T09:12:00Z",
+						"reportedTime": "2016-05-04T14:11:29.7598931Z",
+						"RecentlyResolved": {
+							"UnavailableOccuredTime": "2017-02-28T00:48:00Z",
+							"ResolvedTime": "2017-02-28T00:49:00Z",
+							"UnavailableSummary": "We are sorry your SQL database is unavailable"
+						},
+						"RecommendedActions": [{
+							"Action": "To start this virtualmachine, open the resource blade and click Start",
+							"ActionUrl": "<#ResourceBlade>",
+							"ActionUrlText": "resourceblade"
+						}]
+					}
+				},
+				{
+					"id": "<resourceId>/providers/Microsoft.ResourceHealth/AvailabilityStatueses/current",
+					"name": "current",
+					"type": "Microsoft.ResourceHealth/AvailabilityStatuses",
+					"location": "eastus",
+					"properties": {
+						"availabilityState": "Unavailable",
+						"summary": "We are sorry, we couldn't automatically recovery our virtualmachine",
+						"reasonType": "Unplanned",
+						"reasonChronicity": "Persistent",
+						"detailedStatus": "Diskproblemsarepreventingusfromautomaticallyrecoveringyourvirtualmachine",
+						"occuredTime": "2016-03-29T09:12:00Z",
+						"reportedTime": "2016-05-04T14:11:29.7598931Z",
+						"rootCauseAttributionTime": "2016-03-29T09:13:00Z",
+						"resolutionETA": "2016-03-29T09:37:00Z",
+						"RecommendedActions": [{
+							"Action": "To start this virtualmachine, open the resource blade",
+							"ActionUrl": "<#ResourceBlade>",
+							"ActionUrlText": "resourceblade"
+						},
+						{
+							"Action": "If you are experiencing problems you believe are caused by Azure, contact support",
+							"ActionUrl": "<#SupportCase>",
+							"ActionUrlText": "contactsupport"
+						}]
+					}
+				}],
+				"nextLink": "{originalRequestUrl}?$skipToken={OpaquePageNumber}"
+			}
+		}
+	}
+}

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/AvailabilityStatuses_ListBySubscriptionId.json
@@ -21,9 +21,9 @@
 						"occuredTime": "2016-03-29T09:12:00Z",
 						"reportedTime": "2016-05-04T14:11:29.7598931Z",
 						"recentlyResolved": {
-							"unavailableOccuredTime": "2017-02-28T00:48:00Z",
+							"unavailableOccurredTime": "2017-02-28T00:48:00Z",
 							"resolvedTime": "2017-02-28T00:49:00Z",
-							"unavailableSummary": "We are sorry your SQL database is unavailable"
+							"unavailabilitySummary": "We are sorry your SQL database is unavailable"
 						},
 						"recommendedActions": [{
 							"action": "To start this virtualmachine, open the resource blade and click Start",

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Availabilitystatuses_List.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Availabilitystatuses_List.json
@@ -1,0 +1,58 @@
+﻿{  
+   "parameters":{  
+      "resourceUri":"resourceUri",
+      "api-version":"2015-01-01"
+   },
+   "responses":{  
+      "200":{  
+         "body":{  
+            "value":[  
+               {  
+                  "id":"/subscriptions/4abcdefgh-ijkl-mnop-qrstuvwxyz/resourceGroups/rhctestenv/providers/Microsoft.ClassicCompute/virtualMachines/rhctes tenvV1PI/providers/Microsoft.ResourceHealth/availabilityStatuses/current",
+                  "name":"current",
+                  "type":"Microsoft.ResourceHealth/AvailabilityStatuses",
+                  "location":"eastus",
+                  "properties":{  
+                     "availabilityState":"Unavailable",
+                     "summary":"We're sorry, we couldn't automatically recover your virtual machine",
+                     "reasonType":"Unplanned",
+                     "reasonChronicity":"Persistent",
+                     "detailedStatus":"Disk problems are preventing us from automatically recovering your virtual machine",
+                     "occuredTime":"2016-03-29T09:12:00Z",
+                     "reportedTime":"2016-05-04T14:11:29.7598931Z",
+                     "rootCauseAttributionTime":"2016-03-29T09:13:00Z",
+                     "resolutionETA":"2016-03-29T09:37:00Z",
+                     "serviceImpactingEvents": [{  
+                        "eventStartTime":"2016-05-02T19:23:13.7115125Z",
+                        "eventStatusLastModifiedTime":"2016-05-02T19:27:04.9543491Z",
+                        "correlationId":"b56d0180-2d6c-4f7b-b750-c1eca681874c",
+                        "status":{  
+                           "value":"Resolved"
+                        },
+                        "incidentProperties":{  
+                           "title":"Virtual Machines - West Europe [West Europe]",
+                           "service":"Virtual Machines",
+                           "region":"East US",
+                           "incidentType":"outage"
+                        }
+                     }]
+                  }
+               },
+               {  
+                  "id":"/subscriptions/4abcdefgh-ijkl-mnop-qrstuvwxyz/resourceGroups/rhctestenv/providers/Microsoft.ClassicCompute/virtualMachines/rhctes tenvV1PI/providers/Microsoft.ResourceHealth/availabilityStatuses/2016-03-28+16%3a23%3a00Z",
+                  "name":"2016-03-28+16%3a23%3a00Z",
+                  "type":"Microsoft.ResourceHealth/AvailabilityStatuses",
+                  "location":"eastus",
+                  "properties":{  
+                     "availabilityState":"Available",
+                     "summary":"This virtual machine is running normally",
+                     "reasonChronicity":"Persistent",
+                     "detailedStatus":"There aren’t any known Azure platform problems affecting this virtual machine",
+                     "occuredTime":"2016-03-28T16:23:00Z"
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySingleResource.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySingleResource.json
@@ -1,8 +1,7 @@
 ﻿{
 	"parameters": {
-		"subscriptionId": "subscriptionId",
-		"api-version": "2018-07-01-preview",
-		"$filter": "service eq 'Virtual Machines' or region eq 'West US'"
+		"resourceUri": "/subscriptions/4abcdefgh-ijkl-mnop-qrstuvwxyz/resourceGroups/rhctestenv/providers/Microsoft.Compute/virtualMachines/rhctestenvV1PI",
+		"api-version": "2018-07-01-preview"
 	},
 	"responses": {
 		"200": {

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySingleResource.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySingleResource.json
@@ -1,6 +1,6 @@
 ﻿{
 	"parameters": {
-		"resourceUri": "/subscriptions/4abcdefgh-ijkl-mnop-qrstuvwxyz/resourceGroups/rhctestenv/providers/Microsoft.Compute/virtualMachines/rhctestenvV1PI",
+		"resourceUri": "subscriptions/4abcdefgh-ijkl-mnop-qrstuvwxyz/resourceGroups/rhctestenv/providers/Microsoft.Compute/virtualMachines/rhctestenvV1PI",
 		"api-version": "2018-07-01-preview"
 	},
 	"responses": {
@@ -50,7 +50,7 @@
 							],
 							"level": "Warning",
 							"impactStartTime": "2018-11-07T00:00:00Z",
-							"impactMitigationTime": "0001-01-01T00:00:00",
+							"impactMitigationTime": "2018-11-08T00:00:00Z",
 							"impact": [
 								{
 									"impactedService": "Virtual Machines",

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySubscriptionId.json
@@ -1,7 +1,7 @@
 ﻿{
 	"parameters": {
 		"subscriptionId": "subscriptionId",
-		"api-version": "2018-01-01",
+		"api-version": "2018-01-01-preview",
 		"$filter": "service eq 'Virtual Machines' or region eq 'West US'"
 	},
 	"responses": {
@@ -9,17 +9,49 @@
 			"body": {
 				"value": [
 					{
-						"id": "/providers/Microsoft.ResourceHealth/events/VIRTUALMACHINES-WESTUS-DTR1",
-						"name": "VIRTUALMACHINES-WESTUS-DTR1",
+						"id": "/providers/Microsoft.ResourceHealth/events/BC_1-FXZ",
+						"name": "BC_1-FXZ",
 						"type": "/providers/Microsoft.ResourceHealth/events",
 						"properties": {
 							"eventType": "ServiceIssue",
 							"eventSource": "ResourceHealth",
 							"status": "Active",
-							"title": "Unavailable",
-							"summary": "Your virtual machine is unavailable",
-							"reason": "DTR1",
-							"impactStartTime": "2017-12-05T21:05:00Z",
+							"title": "ACTIVE: Virtual machines in West US",
+							"summary": "An outage alert is being investigated. More information will be provided as it is known.",
+							"header": "Your service might have been impacted by an Azure service issue",
+							"article": {
+								"articleContent": "<html>An outage alert is being investigated. More information will be provided as it is known</html>"
+							},
+							"links": [
+								{
+									"type": "Hyperlink",
+									"displayText": {
+										"value": "Request RCA",
+										"localizedValue": "Request RCA"
+									},
+									"extensionName": "Microsoft_Azure_Health",
+									"bladeName": "RequestRCABlade",
+									"parameters": {
+										"trackingId": "BC_1-FXZ",
+										"rcaRequested": "False"
+									}
+								},
+								{
+									"type": "Button",
+									"displayText": {
+										"value": "Sign up for updates",
+										"localizedValue": "Sign up for updates"
+									},
+									"extensionName": "Microsoft_Azure_Health",
+									"bladeName": "AzureHealthBrowseBlade",
+									"parameters": {
+										"trackingId": "BC_1-FXZ"
+									}
+								}
+							],
+							"level": "Warning",
+							"impactStartTime": "2018-11-07T00:00:00Z",
+							"impactMitigationTime": "0001-01-01T00:00:00",
 							"impact": [
 								{
 									"impactedService": "Virtual Machines",
@@ -30,40 +62,25 @@
 											"impactedSubscriptions": [
 												"{subscriptionId}"
 											],
-											"impactedResourcesCount": 2,
 											"lastUpdateTime": "2017-12-05T21:05:00Z"
 										}
 									]
 								}
-							]
-						}
-					},
-					{
-						"id": "/providers/Microsoft.ResourceHealth/events/VIRTUALMACHINES-WESTUS-DTR2",
-						"name": "VIRTUALMACHINES-WESTUS-DTR2",
-						"type": "/providers/Microsoft.ResourceHealth/events",
-						"properties": {
-							"eventType": "ServiceIssue",
-							"eventSource": "ResourceHealth",
-							"status": "Active",
-							"title": "Unavailable",
-							"summary": "Your virtual machine is unavailable",
-							"reason": "DTR2",
-							"impactStartTime": "2017-12-05T21:05:00Z",
-							"impact": [
+							],
+							"recommendedActions": {
+								"groupId": 2343,
+								"title": "Recommended actions title",
+								"actions": [
+									"action 1",
+									"action 2"
+								],
+								"localeCode": "en"
+							},
+							"faqs": [
 								{
-									"impactedService": "Virtual Machines",
-									"impactedRegions": [
-										{
-											"impactedRegion": "West US",
-											"status": "Active",
-											"impactedSubscriptions": [
-												"{subscriptionId}"
-											],
-											"impactedResourcesCount": 2,
-											"lastUpdateTime": "2017-12-05T21:05:00Z"
-										}
-									]
+									"question": "This is a question",
+									"answer": "This is an answer",
+									"localeCode": "en"
 								}
 							]
 						}

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySubscriptionId.json
@@ -51,7 +51,7 @@
 							],
 							"level": "Warning",
 							"impactStartTime": "2018-11-07T00:00:00Z",
-							"impactMitigationTime": "0001-01-01T00:00:00",
+							"impactMitigationTime": "2018-11-08T00:00:00Z",
 							"impact": [
 								{
 									"impactedService": "Virtual Machines",

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/Events_ListBySubscriptionId.json
@@ -1,0 +1,76 @@
+﻿{
+	"parameters": {
+		"subscriptionId": "subscriptionId",
+		"api-version": "2018-01-01",
+		"$filter": "service eq 'Virtual Machines' or region eq 'West US'"
+	},
+	"responses": {
+		"200": {
+			"body": {
+				"value": [
+					{
+						"id": "/providers/Microsoft.ResourceHealth/events/VIRTUALMACHINES-WESTUS-DTR1",
+						"name": "VIRTUALMACHINES-WESTUS-DTR1",
+						"type": "/providers/Microsoft.ResourceHealth/events",
+						"properties": {
+							"eventType": "ServiceIssue",
+							"eventSource": "ResourceHealth",
+							"status": "Active",
+							"title": "Unavailable",
+							"summary": "Your virtual machine is unavailable",
+							"reason": "DTR1",
+							"impactStartTime": "2017-12-05T21:05:00Z",
+							"impact": [
+								{
+									"impactedService": "Virtual Machines",
+									"impactedRegions": [
+										{
+											"impactedRegion": "West US",
+											"status": "Active",
+											"impactedSubscriptions": [
+												"{subscriptionId}"
+											],
+											"impactedResourcesCount": 2,
+											"lastUpdateTime": "2017-12-05T21:05:00Z"
+										}
+									]
+								}
+							]
+						}
+					},
+					{
+						"id": "/providers/Microsoft.ResourceHealth/events/VIRTUALMACHINES-WESTUS-DTR2",
+						"name": "VIRTUALMACHINES-WESTUS-DTR2",
+						"type": "/providers/Microsoft.ResourceHealth/events",
+						"properties": {
+							"eventType": "ServiceIssue",
+							"eventSource": "ResourceHealth",
+							"status": "Active",
+							"title": "Unavailable",
+							"summary": "Your virtual machine is unavailable",
+							"reason": "DTR2",
+							"impactStartTime": "2017-12-05T21:05:00Z",
+							"impact": [
+								{
+									"impactedService": "Virtual Machines",
+									"impactedRegions": [
+										{
+											"impactedRegion": "West US",
+											"status": "Active",
+											"impactedSubscriptions": [
+												"{subscriptionId}"
+											],
+											"impactedResourcesCount": 2,
+											"lastUpdateTime": "2017-12-05T21:05:00Z"
+										}
+									]
+								}
+							]
+						}
+					}
+				],
+				"nextLink": "{originalRequestUrl}?$skipToken={OpaquePageNumber}"
+			}
+		}
+	}
+}

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/ImpactedResources_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/ImpactedResources_ListBySubscriptionId.json
@@ -1,7 +1,7 @@
 ﻿{
 	"parameters": {
 		"subscriptionId": "subscriptionId",
-		"api-version": "2018-01-01",
+		"api-version": "2018-01-01-preview",
 		"$filter": "service eq 'Virtual Machines' or region eq 'West US'"
 	},
 	"responses": {

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/ImpactedResources_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/ImpactedResources_ListBySubscriptionId.json
@@ -1,7 +1,7 @@
 ﻿{
 	"parameters": {
 		"subscriptionId": "subscriptionId",
-		"api-version": "2018-01-01-preview",
+		"api-version": "2018-07-01-preview",
 		"$filter": "service eq 'Virtual Machines' or region eq 'West US'"
 	},
 	"responses": {

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/ImpactedResources_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/ImpactedResources_ListBySubscriptionId.json
@@ -12,28 +12,22 @@
 						"id": "<resourceId>/providers/Microsoft.ResourceHealth/impactedResources/current",
 						"name": "current",
 						"type": "Microsoft.ResourceHealth/impactedResources",
-						"location": "eastus",
 						"properties": {
 							"availabilityState": "Available",
 							"summary": "Vm is available",
 							"reasonType": "Unplanned",
-							"detailedStatus": "We have not seen any issues with your virtual machine",
-							"occuredTime": "2016-03-29T09:12:00Z",
-							"reportedTime": "2016-05-04T14:11:29.7598931Z"
+							"occuredTime": "2016-03-29T09:12:00Z"
 						}
 					},
 					{
 						"id": "<resourceId>/providers/Microsoft.ResourceHealth/impactedResources/current",
 						"name": "current",
 						"type": "Microsoft.ResourceHealth/impactedResources",
-						"location": "eastus",
 						"properties": {
 							"availabilityState": "Unavailable",
 							"summary": "We are sorry, we couldn't automatically recovery our virtualmachine",
 							"reasonType": "Unplanned",
-							"detailedStatus": "Diskproblemsarepreventingusfromautomaticallyrecoveringyourvirtualmachine",
-							"occuredTime": "2016-03-29T09:12:00Z",
-							"reportedTime": "2016-05-04T14:11:29.7598931Z"
+							"occuredTime": "2016-03-29T09:12:00Z"
 						}
 					}
 				],

--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/ImpactedResources_ListBySubscriptionId.json
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/preview/2018-08-01/examples/ImpactedResources_ListBySubscriptionId.json
@@ -1,0 +1,44 @@
+﻿{
+	"parameters": {
+		"subscriptionId": "subscriptionId",
+		"api-version": "2018-01-01",
+		"$filter": "service eq 'Virtual Machines' or region eq 'West US'"
+	},
+	"responses": {
+		"200": {
+			"body": {
+				"value": [
+					{
+						"id": "<resourceId>/providers/Microsoft.ResourceHealth/impactedResources/current",
+						"name": "current",
+						"type": "Microsoft.ResourceHealth/impactedResources",
+						"location": "eastus",
+						"properties": {
+							"availabilityState": "Available",
+							"summary": "Vm is available",
+							"reasonType": "Unplanned",
+							"detailedStatus": "We have not seen any issues with your virtual machine",
+							"occuredTime": "2016-03-29T09:12:00Z",
+							"reportedTime": "2016-05-04T14:11:29.7598931Z"
+						}
+					},
+					{
+						"id": "<resourceId>/providers/Microsoft.ResourceHealth/impactedResources/current",
+						"name": "current",
+						"type": "Microsoft.ResourceHealth/impactedResources",
+						"location": "eastus",
+						"properties": {
+							"availabilityState": "Unavailable",
+							"summary": "We are sorry, we couldn't automatically recovery our virtualmachine",
+							"reasonType": "Unplanned",
+							"detailedStatus": "Diskproblemsarepreventingusfromautomaticallyrecoveringyourvirtualmachine",
+							"occuredTime": "2016-03-29T09:12:00Z",
+							"reportedTime": "2016-05-04T14:11:29.7598931Z"
+						}
+					}
+				],
+				"nextLink": "{originalRequestUrl}?$skipToken={OpaquePageNumber}"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Resource Health RP changes for new resource type /events and /impactedResources.

This is a re-open from previous PR https://github.com/Azure/azure-rest-api-specs/pull/2127 which was closed due to inactivity around an year back. Starting a new one with first iteration for changes which were already signed off by ARM (please check label in previous PR). Will add another update/iteration with changes that have happened since then, should be minor additions of additional properties.

We want a new preview api-version 2018-01-01-preview.