### PR TITLE
Revert "Fix the ARM R2062 error for Microsoft.Resources"

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2018-05-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2018-05-01/resources.json
@@ -3201,7 +3201,6 @@
           "description": "The list of tag values."
         }
       },
-      "x-ms-azure-resource": true,
       "description": "Tag details."
     },
     "TagsListResult": {


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#4600

Tags isnt an Azure resource, so we should not add that flag. And this can cause some potential code breaking.