### PR TITLE
chore: Try indent `java` for apimanagment generation

### DIFF
--- a/specification/apimanagement/resource-manager/readme.md
+++ b/specification/apimanagement/resource-manager/readme.md
@@ -240,12 +240,13 @@ These settings apply only when `--java` is specified on the command line.
 Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-libraries-for-java clone>`.
 
 ``` yaml $(java)
-azure-arm: true
-fluent: true
-namespace: com.microsoft.azure.management.apimanagement
-license-header: MICROSOFT_MIT_NO_CODEGEN
-payload-flattening-threshold: 1
-output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-apimanagement
+java:
+  azure-arm: true
+  fluent: true
+  namespace: com.microsoft.azure.management.apimanagement
+  license-header: MICROSOFT_MIT_NO_CODEGEN
+  payload-flattening-threshold: 1
+  output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-apimanagement
 ```
 
 ### Java multi-api


### PR DESCRIPTION
Sorry for the noise if this doesn't work, just noticed on the last PR that Java didn't run and thought this might have been why