### PR TITLE
Suppress the error because TagDetails is not an Azure resource

### DIFF
--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -315,6 +315,10 @@ directive:
     from: resources.json
     where: $.definitions.TagDetails
     reason: TagDetails will be deprecated soon
+  - suppress: XmsResourceInPutResponse
+    from: resources.json
+    where: $.paths["/subscriptions/{subscriptionId}/tagNames/{tagName}"].put
+    reason: TagDetails is not an Azure resource
   - suppress: BodyTopLevelProperties
     from: managedapplications.json
     where: $.definitions.Appliance.properties


### PR DESCRIPTION
A suppression rule for the following error because TagDetails is not an Azure resource.
ERROR (XmsResourceInPutResponse/R2062/ARMViolation): The 200 response model for an ARM PUT operation must have x-ms-azure-resource extension set to true in its hierarchy. Operation: 'Tags_CreateOrUpdate' Model: 'TagDetails'.
    - file:///C:/Users/ifokunor/azure-rest-api-specs/specification/resources/resource-manager/Microsoft.Resources/stable/2018-05-01/resources.json:2061:6 ($.paths["/subscriptions/{subscriptionId}/tagNames/{tagName}"].put) 