### PR TITLE
chore: Format BlobServicesGet.json

### DIFF
--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2018-07-01/examples/BlobServicesGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2018-07-01/examples/BlobServicesGet.json
@@ -15,63 +15,62 @@
         "type": "Microsoft.Storage/storageAccounts/blobServices",
         "properties": {
           "cors": {
-            "corsRules": [
-              {
+            "corsRules": [{
                 "allowedOrigins": [
-					"http://www.contoso.com",
-                    "http://www.fabrikam.com"
-				],
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
                 "allowedMethods": [
-                    "GET",
-                    "HEAD",
-                    "POST",
-                    "OPTIONS",
-                    "MERGE",
-                    "PUT"
-                ],    
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
                 "maxAgeInSeconds": 100,
                 "exposedHeaders": [
-					"x-ms-meta-*"
-				],
+                  "x-ms-meta-*"
+                ],
                 "allowedHeaders": [
-					"x-ms-meta-abc",
-					"x-ms-meta-data*",
-					"x-ms-meta-target*"
-				],
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ]
               },
               {
                 "allowedOrigins": [
-					"*"
-				],
+                  "*"
+                ],
                 "allowedMethods": [
-                    "GET"
+                  "GET"
                 ],
                 "maxAgeInSeconds": 2,
                 "exposedHeaders": [
-					"*"
-				],
+                  "*"
+                ],
                 "allowedHeaders": [
-					"*"
-				],
+                  "*"
+                ]
               },
               {
                 "allowedOrigins": [
-					"http://www.abc23.com",
-                    "https://www.fabrikam.com/*"
-				],
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
                 "allowedMethods": [
-                    "GET",
-                    "PUT"
+                  "GET",
+                  "PUT"
                 ],
                 "maxAgeInSeconds": 2000,
                 "exposedHeaders": [
-					"x-ms-meta-abc",
-					"x-ms-meta-data*",
-					"x -ms-meta-target*"
-				],
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x -ms-meta-target*"
+                ],
                 "allowedHeaders": [
-					"x-ms-meta-12345675754564*"
-				],
+                  "x-ms-meta-12345675754564*"
+                ]
               }
             ]
           },


### PR DESCRIPTION
- Remove trailing comma that failed the JSON.parse in semantic validation
- Tabs -> spaces

Notice this from https://travis-ci.org/Azure/azure-rest-api-specs/jobs/461940926#L3255