### PR TITLE
fix: network/resource-manager/Microsoft.Network

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2016-03-30/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2016-03-30/network.json
@@ -5146,9 +5146,6 @@
           "description": "path ."
         }
       },
-      "required": [
-        "nextHopType"
-      ],
       "description": "The routes table associated with the ExpressRouteCircuit"
     },
     "ExpressRouteCircuitsRoutesTableListResult": {
@@ -5192,9 +5189,6 @@
           "description": "Current state of the BGP session, and the number of prefixes that have been received from a neighbor or peer group."
         }
       },
-      "required": [
-        "nextHopType"
-      ],
       "description": "The routes table associated with the ExpressRouteCircuit"
     },
     "ExpressRouteCircuitsRoutesTableSummaryListResult": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2016-06-01/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2016-06-01/network.json
@@ -5557,9 +5557,6 @@
           "description": "path ."
         }
       },
-      "required": [
-        "nextHopType"
-      ],
       "description": "The routes table associated with the ExpressRouteCircuit"
     },
     "ExpressRouteCircuitsRoutesTableListResult": {
@@ -5603,9 +5600,6 @@
           "description": "Current state of the BGP session, and the number of prefixes that have been received from a neighbor or peer group."
         }
       },
-      "required": [
-        "nextHopType"
-      ],
       "description": "The routes table associated with the ExpressRouteCircuit"
     },
     "ExpressRouteCircuitsRoutesTableSummaryListResult": {


### PR DESCRIPTION
Remove nextHopType as required because it is not a property. This build will likely fail because of other existing errors in the swagger file for duplicate paths
May be better handled by https://github.com/Azure/azure-rest-api-specs/blob/master/specification/network/resource-manager/readme.md#suppression but I'm not sure