### PR TITLE
typo: Microsoft.DataFactory

### DIFF
--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/preview/2017-09-01-preview/entityTypes/Pipeline.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/preview/2017-09-01-preview/entityTypes/Pipeline.json
@@ -2819,7 +2819,7 @@
       ]
     },
     "FilterActivityTypeProperties": {
-      "description": "Fitler activity properties.",
+      "description": "Filter activity properties.",
       "properties": {
         "items": {
           "description": "Input array on which filter should be applied.",

--- a/specification/datafactory/resource-manager/readme.md
+++ b/specification/datafactory/resource-manager/readme.md
@@ -94,7 +94,7 @@ python:
   license-header: MICROSOFT_MIT_NO_VERSION
   payload-flattening-threshold: 2
   namespace: azure.mgmt.datafactory
-  package-name: azure-mgmt-dafactory
+  package-name: azure-mgmt-datafactory
   package-version: 1.0.0
   clear-output-folder: true
 ```
@@ -188,7 +188,7 @@ directive:
     from: datafactory.json
     reason:
       - Flattening does not work well with polymorphic models.
-      - TriggerResource.properties is an arbitary dictionary and cannot be flattened.
+      - TriggerResource.properties is an arbitrary dictionary and cannot be flattened.
   - suppress: R2018  # XmsEnumValidation
     where:
       - $.definitions.Expression.properties.type
@@ -256,7 +256,7 @@ directive:
       - $.definitions.SelfHostedIntegrationRuntimeNode.properties.isActiveDispatcher
       - $.definitions.IntegrationRuntimeConnectionInfo.properties.isIdentityCertExprired
     reason:
-      - toBeExportedForShoebox is property we send to Azure Monitor which requries the boolean type
+      - toBeExportedForShoebox is property we send to Azure Monitor which requires the boolean type
       - The other properties are simple and self explanatory
 
 ```


### PR DESCRIPTION
- azure-mgmt-dafactory -> azure-mgmt-datafactory
- arbitary -> arbitrary
- requries -> requires
- Fitler -> Filter

Note sure if the package name change is breaking or was a mistake. The only references to that name are:
https://github.com/Azure/AzSwaggerSpecsTestClone/blob/eafe87ad31564e59fc2eaf0b616fc7c563eaeaec/specification/datafactory/resource-manager/readme.md#python
and
https://github.com/Azure/azure-sdk-for-python/blob/41e37c8a10876db40697a63e828ed7cafc19c7d6/azure-mgmt-datafactory/azure/mgmt/datafactory/data_factory_management_client.py#L54