### PR TITLE
typo: Microsoft.GuestConfiguration

### DIFF
--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/preview/2018-01-20-preview/guestconfiguration.json
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/preview/2018-01-20-preview/guestconfiguration.json
@@ -117,7 +117,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The guest configuration assingment name."
+            "description": "The guest configuration assignment name."
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
@@ -172,7 +172,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The guest configuration assingment name."
+            "description": "The guest configuration assignment name."
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
@@ -352,7 +352,7 @@
           "enum": [
             "DSC"
           ]
-        }, 
+        },
         "name": {
           "type": "string",
           "readOnly": true,

--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/preview/2018-06-30-preview/guestconfiguration.json
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/preview/2018-06-30-preview/guestconfiguration.json
@@ -111,7 +111,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The guest configuration assingment name."
+            "description": "The guest configuration assignment name."
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
@@ -217,7 +217,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The guest configuration assingment name."
+            "description": "The guest configuration assignment name."
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
@@ -397,7 +397,7 @@
           "enum": [
             "DSC"
           ]
-        }, 
+        },
         "name": {
           "type": "string",
           "description": "Name of the guest configuration."
@@ -458,7 +458,7 @@
             "ApplyOnly",
             "ApplyAndMonitor",
             "ApplyAndAutoCorrect"
-          ]     
+          ]
         },
         "allowModuleOverwrite": {
           "type": "string",
@@ -470,7 +470,7 @@
           "enum": [
             "True",
             "False"
-          ]       
+          ]
         },
         "actionAfterReboot": {
           "type": "string",
@@ -483,7 +483,7 @@
           "enum": [
             "ContinueConfiguration",
             "StopConfiguration"
-          ]     
+          ]
         },
         "refreshFrequencyMins": {
           "type": "number",
@@ -503,7 +503,7 @@
           "enum": [
             "True",
             "False"
-          ]     
+          ]
         },
         "configurationModeFrequencyMins": {
           "type": "number",
@@ -758,7 +758,7 @@
         "properties": {
           "type": "object",
           "readOnly": true,
-          "description": "Properties of a guest configuation assignment resource."
+          "description": "Properties of a guest configuration assignment resource."
         }
       },
       "description": "The guest configuration assignment resource."

--- a/specification/guestconfiguration/resource-manager/readme.md
+++ b/specification/guestconfiguration/resource-manager/readme.md
@@ -55,7 +55,7 @@ directive:
   - suppress: OperationsAPIImplementation
     from: guestconfiguration.json
     where: $.paths
-    reason: Microsoft.GuestConfiguration is a proxy resource provider under Microsoft.Compute. However, Operations API for is implmented. So, suppressing the false positive. Please refer PR https://github.com/Azure/azure-rest-api-specs-pr/pull/540
+    reason: Microsoft.GuestConfiguration is a proxy resource provider under Microsoft.Compute. However, Operations API for is implemented. So, suppressing the false positive. Please refer PR https://github.com/Azure/azure-rest-api-specs-pr/pull/540
 ```
 ---
 # Code Generation


### PR DESCRIPTION
- implmented -> implemented
- assingment -> assignment
- configuation -> configuration
- trim trailing whitespace
