### PR TITLE
chore: Add initial .gitattributes for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,6 @@ SdkCodeGen
 # Visual Studio #
 .settings/
 .vs/
-.vscode/
 /app.js
 *.suo
 *.user
@@ -105,4 +104,9 @@ output/*
 errors.txt
 warnings.txt
 
-/dist/
+# VS Code files
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json


### PR DESCRIPTION
No normalizaton, just tested updated .gitignore for some excluded files
when checking with `git rm -rf --cached . && git add .` using the pattern from https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore

This is a lighter version of #3786, but the individual folders can be cleaned up when there are no pending PRs for a folder by running
- `git add --renormalize .`
- commit the normalized files