### PR TITLE
typo: search/resource-manager/Microsoft.Search

### DIFF
--- a/specification/search/resource-manager/Microsoft.Search/stable/2015-08-19/search.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2015-08-19/search.json
@@ -894,7 +894,7 @@
             "url": "https://aka.ms/search-rp-info"
           },
           "x-ms-mutability": [
-            "create", 
+            "create",
             "read"
           ]
         },
@@ -928,13 +928,13 @@
         "type": "object",
         "description": "Describes a particular API error with an error code and a message.",
         "properties": {
-            "code": { 
+            "code": {
               "type": "string",
-              "description": "An error code that describes the error condition more precisely than an HTTP status code. Can be used to programatically handle specific error cases."
+              "description": "An error code that describes the error condition more precisely than an HTTP status code. Can be used to programmatically handle specific error cases."
             },
             "message": {
               "type": "string",
-              "description": "A message that describes the error in detail and provides debugging information." 
+              "description": "A message that describes the error in detail and provides debugging information."
             },
             "target": {
               "type": "string",


### PR DESCRIPTION
- programatically -> programmatically
- Trim trailing space
