### PR TITLE
fix Go SDK codegen for labservices

### DIFF
--- a/specification/labservices/resource-manager/readme.go.md
+++ b/specification/labservices/resource-manager/readme.go.md
@@ -5,7 +5,7 @@ These settings apply only when `--go` is specified on the command line.
 ``` yaml $(go)
 go:
   license-header: MICROSOFT_APACHE_NO_VERSION
-  namespace: ML
+  namespace: labservices
   clear-output-folder: true
 ```
 
@@ -16,12 +16,11 @@ batch:
   - tag: package-2018-10
 ```
 
-
 ### Tag: package-2018-10 and go
 
 These settings apply only when `--tag=package-2018-10 --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag) == 'package-2018-10' && $(go)
-output-folder: $(go-sdk-folder)/services/labservices/mgmt/2018-10-15/$(namespace)
+output-folder: $(go-sdk-folder)/services/$(namespace)/mgmt/2018-10-15/$(namespace)
 ```


### PR DESCRIPTION
Package name can't be upper-case characters.
Make package name uniform with other SDKs.
