### PR TITLE
chore: Enable whitespace trimming in JSON files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,4 +6,4 @@ root = true
 [*.json]
 indent_style = space
 indent_size = 2
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true


### PR DESCRIPTION
Meant to set this as `true` originally, but realized I left it as false when it wasn't trimming on save 😝 