### PR TITLE
[LabServices] Fix typo, remove required from optional param

### DIFF
--- a/specification/labservices/resource-manager/Microsoft.LabServices/stable/2018-10-15/ML.json
+++ b/specification/labservices/resource-manager/Microsoft.LabServices/stable/2018-10-15/ML.json
@@ -152,11 +152,11 @@
             "type": "string"
           },
           {
-            "name": "personalPerferencesOperationsPayload",
+            "name": "personalPreferencesOperationsPayload",
             "in": "body",
             "description": "Represents payload for any Environment operations like get, start, stop, connect",
             "required": true,
-            "schema": { "$ref": "#/definitions/PersonalPerferencesOperationsPayload" }
+            "schema": { "$ref": "#/definitions/PersonalPreferencesOperationsPayload" }
           },
           { "$ref": "#/parameters/api-version" }
         ],
@@ -2505,7 +2505,6 @@
     },
     "Environment": {
       "description": "Represents an environment instance",
-      "required": [ "properties" ],
       "type": "object",
       "allOf": [ { "$ref": "#/definitions/Resource" } ],
       "properties": {
@@ -2677,7 +2676,6 @@
     },
     "EnvironmentSetting": {
       "description": "Represents settings of an environment, from which environment instances would be created",
-      "required": [ "properties" ],
       "type": "object",
       "allOf": [ { "$ref": "#/definitions/Resource" } ],
       "properties": {
@@ -3615,7 +3613,7 @@
         }
       }
     },
-    "PersonalPerferencesOperationsPayload": {
+    "PersonalPreferencesOperationsPayload": {
       "description": "Represents payload for any Environment operations like get, start, stop, connect",
       "type": "object",
       "properties": {


### PR DESCRIPTION
### Contribution checklist:
- [X] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [X] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).


This is a simple fix to two issues:
- typo in one of the parameters - resolves https://github.com/Azure/azure-rest-api-specs/issues/4741
- Required was put in two places where it shouldn't have been since flattening of properties was added in the last iteration.