### PR TITLE
fix: Trailing comma causing JSON_PARSING_ERROR

### DIFF
--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/amlComputeListNodes.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/amlComputeListNodes.json
@@ -22,7 +22,7 @@
             "port": 50001
           }
         ],
-        "nextLink": "nextLink",
+        "nextLink": "nextLink"
       }
     }
   }


### PR DESCRIPTION
Not sure why the build in #4344 didn't fail when it was added, but the semantic PR_Only=false can't parse the file with the extra comma