### PR TITLE
fix: Package name for Microsoft Docs Authoring

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
         "EditorConfig.EditorConfig",
-        "vscode-docs-authoring"
+        "docsmsft.docs-authoring-pack"
     ]
 }


### PR DESCRIPTION
Was throwing a warning because it's supposed to be publisher.extension name format