### PR TITLE
fix: Example network/resource-manager/Microsoft.Network

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkWatcherPacketCaptureCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkWatcherPacketCaptureCreate.json
@@ -8,9 +8,9 @@
     "parameters" : {
       "properties" : {
         "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-        "bytesToCapturePerPacket" : "10000",
-        "totalBytesPerSession" : "100000",
-        "timeLimitInSeconds" : "100",
+        "bytesToCapturePerPacket" : 10000,
+        "totalBytesPerSession" : 100000,
+        "timeLimitInSeconds" : 100,
         "storageLocation" : {
           "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
           "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -34,9 +34,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkWatcherPacketCaptureGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkWatcherPacketCaptureGet.json
@@ -15,9 +15,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkWatcherPacketCapturesList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkWatcherPacketCapturesList.json
@@ -16,9 +16,9 @@
             "properties" : {
               "provisioningState" : "Updating",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -40,9 +40,9 @@
             "properties" : {
               "provisioningState" : "Succeeded",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc2.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkWatcherPacketCaptureCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkWatcherPacketCaptureCreate.json
@@ -8,9 +8,9 @@
     "parameters" : {
       "properties" : {
         "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-        "bytesToCapturePerPacket" : "10000",
-        "totalBytesPerSession" : "100000",
-        "timeLimitInSeconds" : "100",
+        "bytesToCapturePerPacket" : 10000,
+        "totalBytesPerSession" : 100000,
+        "timeLimitInSeconds" : 100,
         "storageLocation" : {
           "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
           "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -34,9 +34,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkWatcherPacketCaptureGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkWatcherPacketCaptureGet.json
@@ -15,9 +15,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkWatcherPacketCapturesList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkWatcherPacketCapturesList.json
@@ -16,9 +16,9 @@
             "properties" : {
               "provisioningState" : "Updating",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -40,9 +40,9 @@
             "properties" : {
               "provisioningState" : "Succeeded",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc2.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkWatcherPacketCaptureCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkWatcherPacketCaptureCreate.json
@@ -8,9 +8,9 @@
     "parameters" : {
       "properties" : {
         "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-        "bytesToCapturePerPacket" : "10000",
-        "totalBytesPerSession" : "100000",
-        "timeLimitInSeconds" : "100",
+        "bytesToCapturePerPacket" : 10000,
+        "totalBytesPerSession" : 100000,
+        "timeLimitInSeconds" : 100,
         "storageLocation" : {
           "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
           "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -34,9 +34,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkWatcherPacketCaptureGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkWatcherPacketCaptureGet.json
@@ -15,9 +15,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkWatcherPacketCapturesList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkWatcherPacketCapturesList.json
@@ -16,9 +16,9 @@
             "properties" : {
               "provisioningState" : "Updating",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -40,9 +40,9 @@
             "properties" : {
               "provisioningState" : "Succeeded",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc2.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkWatcherPacketCaptureCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkWatcherPacketCaptureCreate.json
@@ -8,9 +8,9 @@
     "parameters" : {
       "properties" : {
         "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-        "bytesToCapturePerPacket" : "10000",
-        "totalBytesPerSession" : "100000",
-        "timeLimitInSeconds" : "100",
+        "bytesToCapturePerPacket" : 10000,
+        "totalBytesPerSession" : 100000,
+        "timeLimitInSeconds" : 100,
         "storageLocation" : {
           "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
           "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -34,9 +34,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkWatcherPacketCaptureGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkWatcherPacketCaptureGet.json
@@ -15,9 +15,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkWatcherPacketCapturesList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkWatcherPacketCapturesList.json
@@ -16,9 +16,9 @@
             "properties" : {
               "provisioningState" : "Updating",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -40,9 +40,9 @@
             "properties" : {
               "provisioningState" : "Succeeded",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc2.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkWatcherPacketCaptureCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkWatcherPacketCaptureCreate.json
@@ -8,9 +8,9 @@
     "parameters" : {
       "properties" : {
         "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-        "bytesToCapturePerPacket" : "10000",
-        "totalBytesPerSession" : "100000",
-        "timeLimitInSeconds" : "100",
+        "bytesToCapturePerPacket" : 10000,
+        "totalBytesPerSession" : 100000,
+        "timeLimitInSeconds" : 100,
         "storageLocation" : {
           "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
           "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -34,9 +34,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkWatcherPacketCaptureGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkWatcherPacketCaptureGet.json
@@ -15,9 +15,9 @@
         "properties" : {
           "provisioningState" : "Updating",
           "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-          "bytesToCapturePerPacket" : "10000",
-          "totalBytesPerSession" : "100000",
-          "timeLimitInSeconds" : "100",
+          "bytesToCapturePerPacket" : 10000,
+          "totalBytesPerSession" : 100000,
+          "timeLimitInSeconds" : 100,
           "storageLocation" : {
             "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
             "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkWatcherPacketCapturesList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkWatcherPacketCapturesList.json
@@ -16,9 +16,9 @@
             "properties" : {
               "provisioningState" : "Updating",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc1.cap",
@@ -40,9 +40,9 @@
             "properties" : {
               "provisioningState" : "Succeeded",
               "target" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1",
-              "bytesToCapturePerPacket" : "10000",
-              "totalBytesPerSession" : "100000",
-              "timeLimitInSeconds" : "100",
+              "bytesToCapturePerPacket" : 10000,
+              "totalBytesPerSession" : 100000,
+              "timeLimitInSeconds" : 100,
               "storageLocation" : {
                 "storageId" : "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Storage/storageAccounts/pcstore",
                 "storagePath" : "https://mytestaccountname.blob.core.windows.net/capture/pc2.cap",


### PR DESCRIPTION
- bytesToCapturePerPacket is an integer
- totalBytesPerSession is an integer
- timeLimitInSeconds is an integer
