### PR TITLE
fix: Example automation\resource-manager\Microsoft.Automation

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/examples/listConnectionsByAutomationAccount_Next100.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/examples/listConnectionsByAutomationAccount_Next100.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "rg",
     "automationAccountName": "myAutomationAccount28",
     "api-version": "2015-10-31",
-	"skip": "100"
+    "$skip": 100
   },
   "responses": {
     "200": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/examples/listVariables_Next100.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/examples/listVariables_Next100.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "rg",
     "automationAccountName": "sampleAccount9",
     "api-version": "2015-10-31",
-	"skip":"100"
+    "$skip": 100
   },
   "responses": {
     "200": {


### PR DESCRIPTION
- "skip" -> "$skip", although neither is defined in the model
