### PR TITLE
[AKS] add C# config to readme.md

### DIFF
--- a/specification/containerservices/resource-manager/readme.md
+++ b/specification/containerservices/resource-manager/readme.md
@@ -212,6 +212,21 @@ swagger-to-sdk:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_container_service']
 ```
 
+## C#
+
+These settings apply only when `--csharp` is specified on the command line.
+Please also specify `--csharp-sdks-folder=<path to "SDKs" directory of your azure-sdk-for-net clone>`.
+
+``` yaml $(csharp)
+csharp:
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  namespace: Microsoft.Azure.Management.ContainerServices
+  payload-flattening-threshold: 1
+  output-folder: $(csharp-sdks-folder)/ContainerServices/Management.ContainerServices/Generated
+  clear-output-folder: true
+```
+
 ## Go
 
 See configuration in [readme.go.md](./readme.go.md)

--- a/specification/containerservices/resource-manager/readme.md
+++ b/specification/containerservices/resource-manager/readme.md
@@ -201,8 +201,6 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-    after_scripts:
-      - python ./scripts/multiapi_init_gen.py azure-mgmt-containerservice
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
@@ -221,10 +219,38 @@ Please also specify `--csharp-sdks-folder=<path to "SDKs" directory of your azur
 csharp:
   azure-arm: true
   license-header: MICROSOFT_MIT_NO_VERSION
-  namespace: Microsoft.Azure.Management.ContainerServices
+  namespace: Microsoft.Azure.Management.ContainerService
   payload-flattening-threshold: 1
-  output-folder: $(csharp-sdks-folder)/ContainerServices/Management.ContainerServices/Generated
+  output-folder: $(csharp-sdks-folder)/ContainerService/Management.ContainerService/Generated
   clear-output-folder: true
+```
+
+## Python
+
+These settings apply only when `--python` is specified on the command line.
+Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
+Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
+
+``` yaml $(python)
+python-mode: create
+python:
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  payload-flattening-threshold: 2
+  namespace: azure.mgmt.containerservice
+  package-name: azure-mgmt-containerservice
+  package-version: 1.0.0
+  clear-output-folder: true
+```
+``` yaml $(python) && $(python-mode) == 'update'
+python:
+  no-namespace-folders: true
+  output-folder: $(python-sdks-folder)/azure-mgmt-containerservice/azure/mgmt/containerservice
+```
+``` yaml $(python) && $(python-mode) == 'create'
+python:
+  basic-setup-py: true
+  output-folder: $(python-sdks-folder)/azure-mgmt-containerservice
 ```
 
 ## Go
@@ -248,6 +274,7 @@ description: "Container Service Client"
 ```
 
 ### Java multi-api
+
 ``` yaml $(java) && $(multiapi)
 batch:
   - tag: package-2017-09-only

--- a/specification/containerservices/resource-manager/readme.md
+++ b/specification/containerservices/resource-manager/readme.md
@@ -206,6 +206,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/containerservices/resource-manager/readme.md
+++ b/specification/containerservices/resource-manager/readme.md
@@ -201,6 +201,8 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
+    after_scripts:
+      - python ./scripts/multiapi_init_gen.py azure-mgmt-containerservice
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
@@ -223,34 +225,6 @@ csharp:
   payload-flattening-threshold: 1
   output-folder: $(csharp-sdks-folder)/ContainerService/Management.ContainerService/Generated
   clear-output-folder: true
-```
-
-## Python
-
-These settings apply only when `--python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
-
-``` yaml $(python)
-python-mode: create
-python:
-  azure-arm: true
-  license-header: MICROSOFT_MIT_NO_VERSION
-  payload-flattening-threshold: 2
-  namespace: azure.mgmt.containerservice
-  package-name: azure-mgmt-containerservice
-  package-version: 1.0.0
-  clear-output-folder: true
-```
-``` yaml $(python) && $(python-mode) == 'update'
-python:
-  no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-containerservice/azure/mgmt/containerservice
-```
-``` yaml $(python) && $(python-mode) == 'create'
-python:
-  basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-containerservice
 ```
 
 ## Go


### PR DESCRIPTION
Adds a `--csharp` config for ACS/AKS/OSA. cc: @jskulavik.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
