### PR TITLE
[AKS] mark ACS endpoints as deprecated

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2016-03-30/containerService.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2016-03-30/containerService.json
@@ -18,6 +18,7 @@
   "paths": {
     "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/containerServices": {
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerServices"
         ],
@@ -46,6 +47,7 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}": {
       "put": {
+        "deprecated": true,
         "tags": [
           "ContainerServices"
         ],
@@ -105,6 +107,7 @@
         "x-ms-long-running-operation": true
       },
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -142,6 +145,7 @@
         }
       },
       "delete": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -182,6 +186,7 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices": {
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -268,7 +273,9 @@
         }
       },
       "description": "Profile for the container service orchestrator.",
-      "required": [ "orchestratorType" ]
+      "required": [
+        "orchestratorType"
+      ]
     },
     "ContainerServiceMasterProfile": {
       "properties": {
@@ -430,7 +437,9 @@
         }
       },
       "description": "SSH configuration for Linux-based VMs running on Azure.",
-      "required": ["publicKeys"]
+      "required": [
+        "publicKeys"
+      ]
     },
     "ContainerServiceSshPublicKey": {
       "properties": {
@@ -451,7 +460,9 @@
           "description": "Profile for the container service VM diagnostic agent."
         }
       },
-      "required": ["vmDiagnostics"]
+      "required": [
+        "vmDiagnostics"
+      ]
     },
     "ContainerServiceVMDiagnostics": {
       "properties": {
@@ -489,7 +500,7 @@
         "value": {
           "type": "array",
           "items": {
-             "$ref": "#/definitions/ContainerService"
+            "$ref": "#/definitions/ContainerService"
           },
           "description": "the list of container services."
         }

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2016-09-30/containerService.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2016-09-30/containerService.json
@@ -18,6 +18,7 @@
   "paths": {
     "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/containerServices": {
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerServices"
         ],
@@ -47,6 +48,7 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}": {
       "put": {
+        "deprecated": true,
         "tags": [
           "ContainerServices"
         ],
@@ -107,11 +109,12 @@
         "x-ms-long-running-operation": true
       },
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
         "operationId": "ContainerServices_Get",
-        "summary":"Gets the properties of the specified container service.",
+        "summary": "Gets the properties of the specified container service.",
         "description": "Gets the properties of the specified container service in the specified subscription and resource group. The operation returns the properties including state, orchestrator, number of masters and agents, and FQDNs of masters and agents. ",
         "parameters": [
           {
@@ -145,6 +148,7 @@
         }
       },
       "delete": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -186,6 +190,7 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices": {
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -265,7 +270,9 @@
         }
       },
       "description": "Properties to configure a custom container service cluster.",
-      "required": ["orchestrator"]
+      "required": [
+        "orchestrator"
+      ]
     },
     "ContainerServiceServicePrincipalProfile": {
       "properties": {
@@ -302,7 +309,9 @@
         }
       },
       "description": "Profile for the container service orchestrator.",
-      "required": [ "orchestratorType" ]
+      "required": [
+        "orchestratorType"
+      ]
     },
     "ContainerServiceMasterProfile": {
       "properties": {
@@ -469,7 +478,9 @@
         }
       },
       "description": "SSH configuration for Linux-based VMs running on Azure.",
-      "required": ["publicKeys"]
+      "required": [
+        "publicKeys"
+      ]
     },
     "ContainerServiceSshPublicKey": {
       "properties": {
@@ -490,7 +501,9 @@
           "description": "Profile for the container service VM diagnostic agent."
         }
       },
-      "required": ["vmDiagnostics"]
+      "required": [
+        "vmDiagnostics"
+      ]
     },
     "ContainerServiceVMDiagnostics": {
       "properties": {
@@ -528,7 +541,7 @@
         "value": {
           "type": "array",
           "items": {
-             "$ref": "#/definitions/ContainerService"
+            "$ref": "#/definitions/ContainerService"
           },
           "description": "the list of container services."
         },

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-01-31/containerService.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-01-31/containerService.json
@@ -36,6 +36,7 @@
   "paths": {
     "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/containerServices": {
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerServices"
         ],
@@ -70,6 +71,7 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}": {
       "put": {
+        "deprecated": true,
         "tags": [
           "ContainerServices"
         ],
@@ -135,11 +137,12 @@
         }
       },
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
         "operationId": "ContainerServices_Get",
-        "summary":"Gets the properties of the specified container service.",
+        "summary": "Gets the properties of the specified container service.",
         "description": "Gets the properties of the specified container service in the specified subscription and resource group. The operation returns the properties including state, orchestrator, number of masters and agents, and FQDNs of masters and agents. ",
         "parameters": [
           {
@@ -178,6 +181,7 @@
         }
       },
       "delete": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -224,6 +228,7 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices": {
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -308,7 +313,9 @@
         }
       },
       "description": "Properties to configure a custom container service cluster.",
-      "required": ["orchestrator"]
+      "required": [
+        "orchestrator"
+      ]
     },
     "ContainerServiceServicePrincipalProfile": {
       "properties": {
@@ -345,7 +352,9 @@
         }
       },
       "description": "Profile for the container service orchestrator.",
-      "required": [ "orchestratorType" ]
+      "required": [
+        "orchestratorType"
+      ]
     },
     "ContainerServiceMasterProfile": {
       "properties": {
@@ -512,7 +521,9 @@
         }
       },
       "description": "SSH configuration for Linux-based VMs running on Azure.",
-      "required": ["publicKeys"]
+      "required": [
+        "publicKeys"
+      ]
     },
     "ContainerServiceSshPublicKey": {
       "properties": {
@@ -533,7 +544,9 @@
           "description": "Profile for the container service VM diagnostic agent."
         }
       },
-      "required": ["vmDiagnostics"]
+      "required": [
+        "vmDiagnostics"
+      ]
     },
     "ContainerServiceVMDiagnostics": {
       "properties": {
@@ -571,7 +584,7 @@
         "value": {
           "type": "array",
           "items": {
-             "$ref": "#/definitions/ContainerService"
+            "$ref": "#/definitions/ContainerService"
           },
           "description": "the list of container services."
         },

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-07-01/containerService.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2017-07-01/containerService.json
@@ -36,6 +36,7 @@
   "paths": {
     "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/containerServices": {
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerServices"
         ],
@@ -70,6 +71,7 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}": {
       "put": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -131,6 +133,7 @@
         }
       },
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -170,6 +173,7 @@
         }
       },
       "delete": {
+        "deprecated": true,
         "tags": [
           "ContainerService"
         ],
@@ -212,6 +216,7 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices": {
       "get": {
+        "deprecated": true,
         "tags": [
           "ContainerServices"
         ],


### PR DESCRIPTION
[ACS will be retired](https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/) at the end of January, 2020. Users are encouraged to use [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/) instead.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
