### PR TITLE
[Storage] Fix the UseSubDomainName

### DIFF
--- a/specification/storage/resource-manager/Microsoft.Storage/preview/2015-05-01-preview/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/preview/2015-05-01-preview/storage.json
@@ -510,7 +510,7 @@
           "type": "string",
           "description": "Gets or sets the custom domain name. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates"
         }

--- a/specification/storage/resource-manager/Microsoft.Storage/preview/2018-03-01-preview/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/preview/2018-03-01-preview/storage.json
@@ -1032,7 +1032,7 @@
           "type": "string",
           "description": "Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates."
         }

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2015-06-15/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2015-06-15/storage.json
@@ -523,7 +523,7 @@
           "type": "string",
           "description": "The custom domain name. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates"
         }

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2016-01-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2016-01-01/storage.json
@@ -501,7 +501,7 @@
           "type": "string",
           "description": "Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates."
         }

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2016-05-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2016-05-01/storage.json
@@ -565,7 +565,7 @@
           "type": "string",
           "description": "Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates."
         }

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2016-12-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2016-12-01/storage.json
@@ -568,7 +568,7 @@
           "type": "string",
           "description": "Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates."
         }

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2017-06-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2017-06-01/storage.json
@@ -900,7 +900,7 @@
           "type": "string",
           "description": "Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates."
         }

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2017-10-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2017-10-01/storage.json
@@ -901,7 +901,7 @@
           "type": "string",
           "description": "Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates."
         }

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2018-02-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2018-02-01/storage.json
@@ -964,7 +964,7 @@
           "type": "string",
           "description": "Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates."
         }

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2018-07-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2018-07-01/storage.json
@@ -940,7 +940,7 @@
           "type": "string",
           "description": "Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source."
         },
-        "useSubDomain": {
+        "useSubDomainName": {
           "type": "boolean",
           "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates."
         }


### PR DESCRIPTION
This PR is to fix the issue https://github.com/Azure/azure-sdk-for-python/issues/4013 
The "useSubDomain" should be “useSubDomainName” from day one.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
