### PR TITLE
adding missing location parameter to networking examples

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -103,7 +104,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "frontendIPConfigurations": [
@@ -214,7 +215,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "frontendIPConfigurations": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -10,7 +10,8 @@
         "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 10,
         "publicIPAddressVersion": "IPv4"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -18,7 +19,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -36,7 +37,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -28,7 +30,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/PublicIpAddressCreateDns.json
@@ -8,7 +8,8 @@
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
-        }
+        },
+        "location": "eastus"
       }
     }
   },
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-06-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -103,7 +104,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -218,7 +219,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-08-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -103,7 +104,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -218,7 +219,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-09-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -103,7 +104,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -218,7 +219,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-10-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -103,7 +104,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -218,7 +219,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -54,7 +55,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -110,7 +111,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2017-11-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -103,7 +104,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -218,7 +219,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -54,7 +55,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -110,7 +111,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/PublicIpAddressCreateDns.json
@@ -10,14 +10,15 @@
           "domainNameLabel": "dnslbl"
         }
       }
-    }
+    },
+    "location": "eastus"
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-01-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -103,7 +104,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -218,7 +219,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -54,7 +55,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -110,7 +111,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,7 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
+    "location": "eastus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +12,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +40,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -103,7 +104,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -218,7 +219,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -54,7 +55,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -110,7 +111,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -103,7 +104,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -218,7 +219,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -54,7 +55,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -110,7 +111,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -105,7 +106,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -222,7 +223,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -55,7 +56,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -112,7 +113,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,15 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {},
+    "location": "eastus"
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +32,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -105,7 +106,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -222,7 +223,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -55,7 +56,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -112,7 +113,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateSubnetWithAddressPrefixes.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateSubnetWithAddressPrefixes.json
@@ -22,7 +22,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -31,7 +32,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -61,7 +62,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateSubnetWithDelegation.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateSubnetWithDelegation.json
@@ -27,7 +27,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -36,7 +37,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subId/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -75,7 +76,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subId/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreate.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -105,7 +106,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -222,7 +223,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateStandardSku.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateStandardSku.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "sku": {
         "name": "Standard"
       },
@@ -106,7 +107,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },
@@ -221,7 +222,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Standard"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -55,7 +56,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -112,7 +113,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,7 @@
     "resourceGroupName" : "rg1",
     "loadBalancerName" : "lb",
     "parameters": {
+      "location": "eastus",
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -104,7 +105,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },
@@ -220,7 +221,7 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
-        "location": "westus",
+        "location": "eastus",
         "sku": {
             "name": "Basic"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkInterfaceCreate.json
@@ -20,7 +20,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkSecurityGroupCreate.json
@@ -4,7 +4,9 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "networkSecurityGroupName" : "testnsg",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
@@ -12,7 +14,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],
@@ -122,7 +124,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [ ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkSecurityGroupCreateWithRule.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/NetworkSecurityGroupCreateWithRule.json
@@ -21,7 +21,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -30,7 +31,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [
@@ -156,7 +157,7 @@
         "name": "testnsg",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/testnsg",
         "type": "Microsoft.Network/networkSecurityGroups",
-        "location": "westus",
+        "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
           "securityRules": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpAddressCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpAddressCreateCustomizedValues.json
@@ -13,7 +13,8 @@
       },
       "sku": {
         "name": "Standard"
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +22,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",
@@ -42,7 +43,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "zones": [ "1" ],
         "properties" : {
           "provisioningState" : "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpAddressCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpAddressCreateDefaults.json
@@ -4,14 +4,16 @@
     "subscriptionId" : "subid",
     "resourceGroupName": "rg1",
     "publicIpAddressName": "test-ip",
-    "parameters": {}
+    "parameters": {
+      "location": "eastus"
+    }
   },
   "responses" : {
     "200" : {
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -31,7 +33,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpAddressCreateDns.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpAddressCreateDns.json
@@ -9,7 +9,8 @@
         "dnsSettings": {
           "domainNameLabel": "dnslbl"
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -17,7 +18,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",
@@ -38,7 +39,7 @@
       "body" : {
         "name" : "testDNS-ip",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ip",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "publicIPAddressVersion" : "IPv4",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreate.json
@@ -4,7 +4,6 @@
     "subscriptionId" : "subid",
     "resourceGroupName" : "rg1",
     "virtualNetworkName" : "test-vnet",
-    "location": "westus",
     "parameters": {
       "properties": {
         "addressSpace": {
@@ -12,7 +11,8 @@
             "10.0.0.0/16"
           ]
         }
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -21,7 +21,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -39,7 +39,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateServiceEndpoints.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateServiceEndpoints.json
@@ -24,7 +24,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -33,7 +34,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -72,7 +73,7 @@
         "name" : "vnet1",
         "id" : "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateSubnet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateSubnet.json
@@ -19,7 +19,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -28,7 +29,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -55,7 +56,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateSubnetWithAddressPrefixes.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateSubnetWithAddressPrefixes.json
@@ -22,7 +22,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -31,7 +32,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -61,7 +62,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateSubnetWithDelegation.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateSubnetWithDelegation.json
@@ -27,7 +27,8 @@
             }
           }
         ]
-      }
+      },
+      "location": "eastus"
     }
   },
   "responses" : {
@@ -36,7 +37,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subId/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {
@@ -75,7 +76,7 @@
         "name" : "test-vnet",
         "id" : "/subscriptions/subId/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet",
         "type" : "Microsoft.Network/virtualNetworks",
-        "location" : "westus",
+        "location" : "eastus",
         "properties" : {
           "provisioningState" : "Succeeded",
           "addressSpace" : {


### PR DESCRIPTION
"location" is required parameter and it was missing from several network examples.
this pr is also updating all return values to "eastus" for consistency.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
