### PR TITLE
[AKS] add empty resource group validation

### DIFF
--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/preview/2018-08-01-preview/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/preview/2018-08-01-preview/managedClusters.json
@@ -113,6 +113,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           }
         ],
@@ -154,6 +155,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -199,6 +201,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -251,6 +254,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -296,6 +300,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -341,6 +346,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -384,6 +390,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -443,6 +450,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -496,6 +504,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -522,15 +531,15 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetServicePrincipalProfile":{
-      "post":{
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetServicePrincipalProfile": {
+      "post": {
         "tags": [
           "ManagedClusters"
         ],
         "operationId": "ManagedClusters_ResetServicePrincipalProfile",
         "summary": "Reset Service Principal Profile of a managed cluster.",
         "description": "Update the service principal Profile for a managed cluster.",
-        "parameters":[
+        "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -542,6 +551,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -559,7 +569,7 @@
               "$ref": "#/definitions/ManagedClusterServicePrincipalProfile"
             },
             "description": "Parameters supplied to the Reset Service Principal Profile operation for a Managed Cluster."
-          } 
+          }
         ],
         "responses": {
           "200": {
@@ -567,7 +577,7 @@
             "schema": {
               "$ref": "#/definitions/ManagedCluster"
             }
-          }, 
+          },
           "202": {
             "description": "Accepted",
             "schema": {
@@ -589,15 +599,15 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetAADProfile":{
-      "post":{
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetAADProfile": {
+      "post": {
         "tags": [
           "ManagedClusters"
         ],
         "operationId": "ManagedClusters_ResetAADProfile",
         "summary": "Reset AAD Profile of a managed cluster.",
         "description": "Update the AAD Profile for a managed cluster.",
-        "parameters":[
+        "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -609,6 +619,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -626,7 +637,7 @@
               "$ref": "#/definitions/ManagedClusterAADProfile"
             },
             "description": "Parameters supplied to the Reset AAD Profile operation for a Managed Cluster."
-          } 
+          }
         ],
         "responses": {
           "200": {
@@ -654,7 +665,7 @@
             "$ref": "./examples/ManagedClustersResetAADProfile.json"
           }
         }
-      } 
+      }
     }
   },
   "definitions": {
@@ -1079,7 +1090,7 @@
           "$ref": "#/definitions/OSType",
           "description": "OsType to be used to specify os type. Choose from Linux and Windows. Default to Linux."
         },
-        "maxCount":{
+        "maxCount": {
           "type": "integer",
           "format": "int32",
           "description": "Maximum number of nodes for auto-scaling"
@@ -1089,7 +1100,7 @@
           "format": "int32",
           "description": "Minimum number of nodes for auto-scaling"
         },
-        "enableAutoScaling":{
+        "enableAutoScaling": {
           "type": "boolean",
           "description": "Whether to enable auto-scaler"
         },
@@ -1105,7 +1116,7 @@
       ],
       "description": "Profile for the container service agent pool."
     },
-    "AgentPoolType":{
+    "AgentPoolType": {
       "type": "string",
       "enum": [
         "VirtualMachineScaleSets",
@@ -1544,10 +1555,10 @@
       },
       "description": "OsType to be used to specify os type. Choose from Linux and Windows. Default to Linux."
     },
-    "CredentialResults":{
+    "CredentialResults": {
       "properties": {
         "kubeconfigs": {
-          "type" : "array",
+          "type": "array",
           "readOnly": true,
           "items": {
             "$ref": "#/definitions/CredentialResult"
@@ -1559,7 +1570,7 @@
     "CredentialResult": {
       "type": "object",
       "properties": {
-        "name":{
+        "name": {
           "type": "string",
           "readOnly": true,
           "description": "The name of the credential."

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/preview/2018-09-30-preview/openShiftManagedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/preview/2018-09-30-preview/openShiftManagedClusters.json
@@ -6,12 +6,20 @@
     "version": "2018-09-30-preview"
   },
   "host": "management.azure.com",
-  "schemes": ["https"],
-  "consumes": ["application/json"],
-  "produces": ["application/json"],
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
   "security": [
     {
-      "azure_auth": ["user_impersonation"]
+      "azure_auth": [
+        "user_impersonation"
+      ]
     }
   ],
   "securityDefinitions": {
@@ -28,7 +36,9 @@
   "paths": {
     "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/openShiftManagedClusters": {
       "get": {
-        "tags": ["OpenShiftManagedClusters"],
+        "tags": [
+          "OpenShiftManagedClusters"
+        ],
         "operationId": "OpenShiftManagedClusters_List",
         "summary": "Gets a list of OpenShift managed clusters in the specified subscription.",
         "description": "Gets a list of OpenShift managed clusters in the specified subscription. The operation returns properties of each OpenShift managed cluster.",
@@ -60,7 +70,9 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/openShiftManagedClusters": {
       "get": {
-        "tags": ["OpenShiftManagedClusters"],
+        "tags": [
+          "OpenShiftManagedClusters"
+        ],
         "operationId": "OpenShiftManagedClusters_ListByResourceGroup",
         "summary": "Lists OpenShift managed clusters in the specified subscription and resource group.",
         "description": "Lists OpenShift managed clusters in the specified subscription and resource group. The operation returns properties of each OpenShift managed cluster.",
@@ -76,6 +88,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           }
         ],
@@ -99,7 +112,9 @@
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/openShiftManagedClusters/{resourceName}": {
       "get": {
-        "tags": ["OpenShiftManagedClusters"],
+        "tags": [
+          "OpenShiftManagedClusters"
+        ],
         "operationId": "OpenShiftManagedClusters_Get",
         "summary": "Gets a OpenShift managed cluster.",
         "description": "Gets the details of the managed OpenShift cluster with a specified resource group and name.",
@@ -115,6 +130,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -146,7 +162,9 @@
         }
       },
       "put": {
-        "tags": ["OpenShiftManagedClusters"],
+        "tags": [
+          "OpenShiftManagedClusters"
+        ],
         "operationId": "OpenShiftManagedClusters_CreateOrUpdate",
         "summary": "Creates or updates an OpenShift managed cluster.",
         "description": "Creates or updates a OpenShift managed cluster with the specified configuration for agents and OpenShift version.",
@@ -162,6 +180,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -209,7 +228,9 @@
         }
       },
       "patch": {
-        "tags": ["OpenShiftManagedClusters"],
+        "tags": [
+          "OpenShiftManagedClusters"
+        ],
         "operationId": "OpenShiftManagedClusters_UpdateTags",
         "summary": "Updates tags on an OpenShift managed cluster.",
         "description": "Updates an OpenShift managed cluster with the specified tags.",
@@ -225,6 +246,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -266,7 +288,9 @@
         }
       },
       "delete": {
-        "tags": ["OpenShiftManagedClusters"],
+        "tags": [
+          "OpenShiftManagedClusters"
+        ],
         "operationId": "OpenShiftManagedClusters_Delete",
         "summary": "Deletes an OpenShift managed cluster.",
         "description": "Deletes the OpenShift managed cluster with a specified resource group and name.",
@@ -282,6 +306,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -337,7 +362,10 @@
         "location": {
           "type": "string",
           "description": "Resource location",
-          "x-ms-mutability": ["read", "create"]
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "tags": {
           "type": "object",
@@ -347,7 +375,9 @@
           "description": "Resource tags"
         }
       },
-      "required": ["location"],
+      "required": [
+        "location"
+      ],
       "x-ms-azure-resource": true
     },
     "CloudError": {
@@ -441,7 +471,10 @@
     "OSType": {
       "type": "string",
       "default": "Linux",
-      "enum": ["Linux", "Windows"],
+      "enum": [
+        "Linux",
+        "Windows"
+      ],
       "x-ms-enum": {
         "name": "OSType",
         "modelAsString": true
@@ -493,7 +526,10 @@
     },
     "OpenShiftAgentPoolProfileRole": {
       "type": "string",
-      "enum": ["compute", "infra"],
+      "enum": [
+        "compute",
+        "infra"
+      ],
       "x-ms-enum": {
         "name": "OpenShiftAgentPoolProfileRole",
         "modelAsString": true
@@ -524,7 +560,10 @@
           "description": "OsType to be used to specify os type. Choose from Linux and Windows. Default to Linux."
         }
       },
-      "required": ["count", "vmSize"],
+      "required": [
+        "count",
+        "vmSize"
+      ],
       "description": "OpenShiftManagedClusterMaterPoolProfile contains configuration for OpenShift master VMs."
     },
     "OpenShiftManagedClusterAgentPoolProfile": {
@@ -556,7 +595,11 @@
           "$ref": "#/definitions/OpenShiftAgentPoolProfileRole"
         }
       },
-      "required": ["name", "count", "vmSize"],
+      "required": [
+        "name",
+        "count",
+        "vmSize"
+      ],
       "description": "Defines the configuration of the OpenShift cluster VMs."
     },
     "OpenShiftManagedClusterIdentityProvider": {
@@ -630,7 +673,9 @@
           "description": "Configures OpenShift authentication."
         }
       },
-      "required": ["openShiftVersion"],
+      "required": [
+        "openShiftVersion"
+      ],
       "description": "Properties of the OpenShift managed cluster."
     },
     "OpenShiftManagedCluster": {
@@ -656,7 +701,9 @@
     },
     "OpenShiftManagedClusterBaseIdentityProvider": {
       "discriminator": "kind",
-      "required": ["kind"],
+      "required": [
+        "kind"
+      ],
       "properties": {
         "kind": {
           "type": "string",

--- a/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
+++ b/specification/containerservices/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
@@ -113,6 +113,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           }
         ],
@@ -154,6 +155,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -199,6 +201,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -251,6 +254,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -296,6 +300,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -341,6 +346,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -384,6 +390,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -443,6 +450,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -496,6 +504,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -522,15 +531,15 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetServicePrincipalProfile":{
-      "post":{
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetServicePrincipalProfile": {
+      "post": {
         "tags": [
           "ManagedClusters"
         ],
         "operationId": "ManagedClusters_ResetServicePrincipalProfile",
         "summary": "Reset Service Principal Profile of a managed cluster.",
         "description": "Update the service principal Profile for a managed cluster.",
-        "parameters":[
+        "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -542,6 +551,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -559,7 +569,7 @@
               "$ref": "#/definitions/ManagedClusterServicePrincipalProfile"
             },
             "description": "Parameters supplied to the Reset Service Principal Profile operation for a Managed Cluster."
-          } 
+          }
         ],
         "responses": {
           "200": {
@@ -583,15 +593,15 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetAADProfile":{
-      "post":{
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetAADProfile": {
+      "post": {
         "tags": [
           "ManagedClusters"
         ],
         "operationId": "ManagedClusters_ResetAADProfile",
         "summary": "Reset AAD Profile of a managed cluster.",
         "description": "Update the AAD Profile for a managed cluster.",
-        "parameters":[
+        "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
           },
@@ -603,6 +613,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "minLength": 1,
             "description": "The name of the resource group."
           },
           {
@@ -620,7 +631,7 @@
               "$ref": "#/definitions/ManagedClusterAADProfile"
             },
             "description": "Parameters supplied to the Reset AAD Profile operation for a Managed Cluster."
-          } 
+          }
         ],
         "responses": {
           "200": {
@@ -642,7 +653,7 @@
             "$ref": "./examples/ManagedClustersResetAADProfile.json"
           }
         }
-      } 
+      }
     }
   },
   "definitions": {
@@ -1506,10 +1517,10 @@
       },
       "description": "OsType to be used to specify os type. Choose from Linux and Windows. Default to Linux."
     },
-    "CredentialResults":{
+    "CredentialResults": {
       "properties": {
         "kubeconfigs": {
-          "type" : "array",
+          "type": "array",
           "readOnly": true,
           "items": {
             "$ref": "#/definitions/CredentialResult"
@@ -1521,7 +1532,7 @@
     "CredentialResult": {
       "type": "object",
       "properties": {
-        "name":{
+        "name": {
           "type": "string",
           "readOnly": true,
           "description": "The name of the credential."


### PR DESCRIPTION
This avoids an inscrutable error in the CLI if the user specifies an empty resource group name. 
See Azure/azure-cli#7928 and #4506.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
