### PR TITLE
[LogicApps] Fix more acronyms that don't match API

### DIFF
--- a/specification/logic/resource-manager/Microsoft.Logic/preview/2018-07-01-preview/logic.json
+++ b/specification/logic/resource-manager/Microsoft.Logic/preview/2018-07-01-preview/logic.json
@@ -7142,23 +7142,23 @@
     "AS2MdnSettings": {
       "type": "object",
       "required": [
-        "needMdn",
-        "signMdn",
-        "sendMdnAsynchronously",
-        "signOutboundMdnIfOptional",
-        "sendInboundMdnToMessageBox",
+        "needMDN",
+        "signMDN",
+        "sendMDNAsynchronously",
+        "signOutboundMDNIfOptional",
+        "sendInboundMDNToMessageBox",
         "micHashingAlgorithm"
       ],
       "properties": {
-        "needMdn": {
+        "needMDN": {
           "type": "boolean",
           "description": "The value indicating whether to send or request a MDN."
         },
-        "signMdn": {
+        "signMDN": {
           "type": "boolean",
           "description": "The value indicating whether the MDN needs to be signed or not."
         },
-        "sendMdnAsynchronously": {
+        "sendMDNAsynchronously": {
           "type": "boolean",
           "description": "The value indicating whether to send the asynchronous MDN."
         },
@@ -7170,7 +7170,7 @@
           "type": "string",
           "description": "The disposition notification to header value."
         },
-        "signOutboundMdnIfOptional": {
+        "signOutboundMDNIfOptional": {
           "type": "boolean",
           "description": "The value indicating whether to sign the outbound MDN if optional."
         },
@@ -7178,7 +7178,7 @@
           "type": "string",
           "description": "The MDN text."
         },
-        "sendInboundMdnToMessageBox": {
+        "sendInboundMDNToMessageBox": {
           "type": "boolean",
           "description": "The value indicating whether to send inbound MDN to message box."
         },
@@ -7193,12 +7193,12 @@
       "type": "object",
       "required": [
         "overrideGroupSigningCertificate",
-        "enableNrrForInboundEncodedMessages",
-        "enableNrrForInboundDecodedMessages",
-        "enableNrrForOutboundMdn",
-        "enableNrrForOutboundEncodedMessages",
-        "enableNrrForOutboundDecodedMessages",
-        "enableNrrForInboundMdn"
+        "enableNRRForInboundEncodedMessages",
+        "enableNRRForInboundDecodedMessages",
+        "enableNRRForOutboundMDN",
+        "enableNRRForOutboundEncodedMessages",
+        "enableNRRForOutboundDecodedMessages",
+        "enableNRRForInboundMDN"
       ],
       "properties": {
         "overrideGroupSigningCertificate": {
@@ -7213,27 +7213,27 @@
           "type": "string",
           "description": "The name of the encryption certificate."
         },
-        "enableNrrForInboundEncodedMessages": {
+        "enableNRRForInboundEncodedMessages": {
           "type": "boolean",
           "description": "The value indicating whether to enable NRR for inbound encoded messages."
         },
-        "enableNrrForInboundDecodedMessages": {
+        "enableNRRForInboundDecodedMessages": {
           "type": "boolean",
           "description": "The value indicating whether to enable NRR for inbound decoded messages."
         },
-        "enableNrrForOutboundMdn": {
+        "enableNRRForOutboundMDN": {
           "type": "boolean",
           "description": "The value indicating whether to enable NRR for outbound MDN."
         },
-        "enableNrrForOutboundEncodedMessages": {
+        "enableNRRForOutboundEncodedMessages": {
           "type": "boolean",
           "description": "The value indicating whether to enable NRR for outbound encoded messages."
         },
-        "enableNrrForOutboundDecodedMessages": {
+        "enableNRRForOutboundDecodedMessages": {
           "type": "boolean",
           "description": "The value indicating whether to enable NRR for outbound decoded messages."
         },
-        "enableNrrForInboundMdn": {
+        "enableNRRForInboundMDN": {
           "type": "boolean",
           "description": "The value indicating whether to enable NRR for inbound MDN."
         },
@@ -7339,14 +7339,14 @@
       "type": "object",
       "required": [
         "suspendDuplicateMessage",
-        "resendIfMdnNotReceived"
+        "resendIfMDNNotReceived"
       ],
       "properties": {
         "suspendDuplicateMessage": {
           "type": "boolean",
           "description": "The value indicating whether to suspend duplicate message."
         },
-        "resendIfMdnNotReceived": {
+        "resendIfMDNNotReceived": {
           "type": "boolean",
           "description": "The value indicating whether to resend message If MDN is not received."
         }

--- a/specification/logic/resource-manager/readme.md
+++ b/specification/logic/resource-manager/readme.md
@@ -55,6 +55,18 @@ directive:
   - suppress: R3016
     reason: Existing properties, can't be changed without breaking API.
     #where:
+    #  - $.definitions.AS2ErrorSettings.properties.resendIfMDNNotReceived
+    #  - $.definitions.AS2MdnSettings.properties.needMDN
+    #  - $.definitions.AS2MdnSettings.properties.signMDN
+    #  - $.definitions.AS2MdnSettings.properties.sendMDNAsynchronously
+    #  - $.definitions.AS2MdnSettings.properties.signOutboundMDNIfOptional
+    #  - $.definitions.AS2MdnSettings.properties.sendInboundMDNToMessageBox
+    #  - $.definitions.AS2SecuritySettings.properties.enableNRRForInboundEncodedMessages
+    #  - $.definitions.AS2SecuritySettings.properties.enableNRRForInboundDecodedMessages
+    #  - $.definitions.AS2SecuritySettings.properties.enableNRRForOutboundMDN
+    #  - $.definitions.AS2SecuritySettings.properties.enableNRRForOutboundEncodedMessages
+    #  - $.definitions.AS2SecuritySettings.properties.enableNRRForOutboundDecodedMessages
+    #  - $.definitions.AS2SecuritySettings.properties.enableNRRForInboundMDN
     #  - $.definitions.EdifactValidationSettings.properties.validateEDITypes
     #  - $.definitions.EdifactValidationSettings.properties.validateXSDTypes
     #  - $.definitions.EdifactValidationOverride.properties.validateEDITypes


### PR DESCRIPTION
See #4769 for the original batch of fixes. We did X12 and Edifact and missed the AS2 acronyms. This will fix the rest of the them. The basic gist is that our existing APIs return the some acronyms as capitalized and this is causing issues in the case sensitive languages (such as Node) SDKs.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
