### PR TITLE
removed confusing readonly parameters from example

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/VirtualNetworkGatewayUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-02-01/examples/VirtualNetworkGatewayUpdate.json
@@ -17,9 +17,7 @@
                             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/gwpip"
                         }
                         },
-                        "name": "gwipconfig1",
-                        "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw/ipConfigurations/gwipconfig1"
+                        "name": "gwipconfig1"
                     }
                 ],
                 "gatewayType": "Vpn",
@@ -28,18 +26,14 @@
                 "activeActive": false,
                 "sku": {
                 "name": "VpnGw1",
-                "tier": "VpnGw1",
-                "capacity": 0
+                "tier": "VpnGw1"
                 },
                 "bgpSettings": {
                 "asn": 65515,
                 "bgpPeeringAddress": "10.0.1.30",
                 "peerWeight": 0
-                },
-                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+                }
             },
-            "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw",
             "location": "centralus"
         }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/VirtualNetworkGatewayUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-04-01/examples/VirtualNetworkGatewayUpdate.json
@@ -17,9 +17,7 @@
                             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/gwpip"
                         }
                         },
-                        "name": "gwipconfig1",
-                        "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw/ipConfigurations/gwipconfig1"
+                        "name": "gwipconfig1"
                     }
                 ],
                 "gatewayType": "Vpn",
@@ -28,18 +26,14 @@
                 "activeActive": false,
                 "sku": {
                 "name": "VpnGw1",
-                "tier": "VpnGw1",
-                "capacity": 0
+                "tier": "VpnGw1"
                 },
                 "bgpSettings": {
                 "asn": 65515,
                 "bgpPeeringAddress": "10.0.1.30",
                 "peerWeight": 0
-                },
-                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+                }
             },
-            "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw",
             "location": "centralus"
         }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkGatewayUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-06-01/examples/VirtualNetworkGatewayUpdate.json
@@ -17,9 +17,7 @@
                             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/gwpip"
                         }
                         },
-                        "name": "gwipconfig1",
-                        "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw/ipConfigurations/gwipconfig1"
+                        "name": "gwipconfig1"
                     }
                 ],
                 "gatewayType": "Vpn",
@@ -28,18 +26,14 @@
                 "activeActive": false,
                 "sku": {
                 "name": "VpnGw1",
-                "tier": "VpnGw1",
-                "capacity": 0
+                "tier": "VpnGw1"
                 },
                 "bgpSettings": {
                 "asn": 65515,
                 "bgpPeeringAddress": "10.0.1.30",
                 "peerWeight": 0
-                },
-                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+                }
             },
-            "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw",
             "location": "centralus"
         }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkGatewayUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkGatewayUpdate.json
@@ -17,9 +17,7 @@
                             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/gwpip"
                         }
                         },
-                        "name": "gwipconfig1",
-                        "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw/ipConfigurations/gwipconfig1"
+                        "name": "gwipconfig1"
                     }
                 ],
                 "gatewayType": "Vpn",
@@ -28,18 +26,14 @@
                 "activeActive": false,
                 "sku": {
                 "name": "VpnGw1",
-                "tier": "VpnGw1",
-                "capacity": 0
+                "tier": "VpnGw1"
                 },
                 "bgpSettings": {
                 "asn": 65515,
                 "bgpPeeringAddress": "10.0.1.30",
                 "peerWeight": 0
-                },
-                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+                }
             },
-            "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw",
             "location": "centralus"
         }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkGatewayUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkGatewayUpdate.json
@@ -17,9 +17,7 @@
                             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/gwpip"
                         }
                         },
-                        "name": "gwipconfig1",
-                        "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw/ipConfigurations/gwipconfig1"
+                        "name": "gwipconfig1"
                     }
                 ],
                 "gatewayType": "Vpn",
@@ -28,18 +26,14 @@
                 "activeActive": false,
                 "sku": {
                 "name": "VpnGw1",
-                "tier": "VpnGw1",
-                "capacity": 0
+                "tier": "VpnGw1"
                 },
                 "bgpSettings": {
                 "asn": 65515,
                 "bgpPeeringAddress": "10.0.1.30",
                 "peerWeight": 0
-                },
-                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+                }
             },
-            "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw",
             "location": "centralus"
         }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkGatewayUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkGatewayUpdate.json
@@ -17,9 +17,7 @@
                             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/gwpip"
                         }
                         },
-                        "name": "gwipconfig1",
-                        "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw/ipConfigurations/gwipconfig1"
+                        "name": "gwipconfig1"
                     }
                 ],
                 "gatewayType": "Vpn",
@@ -28,18 +26,14 @@
                 "activeActive": false,
                 "sku": {
                 "name": "VpnGw1",
-                "tier": "VpnGw1",
-                "capacity": 0
+                "tier": "VpnGw1"
                 },
                 "bgpSettings": {
                 "asn": 65515,
                 "bgpPeeringAddress": "10.0.1.30",
                 "peerWeight": 0
-                },
-                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+                }
             },
-            "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw",
             "location": "centralus"
         }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/VirtualNetworkGatewayUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/VirtualNetworkGatewayUpdate.json
@@ -17,9 +17,7 @@
                             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/gwpip"
                         }
                         },
-                        "name": "gwipconfig1",
-                        "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw/ipConfigurations/gwipconfig1"
+                        "name": "gwipconfig1"
                     }
                 ],
                 "gatewayType": "Vpn",
@@ -28,18 +26,14 @@
                 "activeActive": false,
                 "sku": {
                 "name": "VpnGw1",
-                "tier": "VpnGw1",
-                "capacity": 0
+                "tier": "VpnGw1"
                 },
                 "bgpSettings": {
                 "asn": 65515,
                 "bgpPeeringAddress": "10.0.1.30",
                 "peerWeight": 0
-                },
-                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+                }
             },
-            "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw",
             "location": "centralus"
         }
     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/VirtualNetworkGatewayUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/VirtualNetworkGatewayUpdate.json
@@ -17,9 +17,7 @@
                             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/gwpip"
                         }
                         },
-                        "name": "gwipconfig1",
-                        "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw/ipConfigurations/gwipconfig1"
+                        "name": "gwipconfig1"
                     }
                 ],
                 "gatewayType": "Vpn",
@@ -28,18 +26,14 @@
                 "activeActive": false,
                 "sku": {
                 "name": "VpnGw1",
-                "tier": "VpnGw1",
-                "capacity": 0
+                "tier": "VpnGw1"
                 },
                 "bgpSettings": {
                 "asn": 65515,
                 "bgpPeeringAddress": "10.0.1.30",
                 "peerWeight": 0
-                },
-                "resourceGuid": "00000000-0000-0000-0000-000000000000"
+                }
             },
-            "etag": "W/\"00000000-0000-0000-0000-000000000000\"",
-            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vpngw",
             "location": "centralus"
         }
     },


### PR DESCRIPTION
Removed parameters that are readonly and unnecessary when creating Virtual Network Gateway:
- etag
- id
- capacity (always set to 2 by the service, any other value passed is ignored)

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
