### PR TITLE
typo: edgedateway -> edgegateway

### DIFF
--- a/specification/edgegateway/resource-manager/readme.ruby.md
+++ b/specification/edgegateway/resource-manager/readme.ruby.md
@@ -3,7 +3,7 @@
 These settings apply only when `--ruby` is specified on the command line.
 
 ``` yaml $(ruby)
-package-name: azure_mgmt_edgedateway
+package-name: azure_mgmt_edgegateway
 package-version: "0.0.1"
 azure-arm: true
 ```
@@ -22,5 +22,5 @@ Please also specify `--ruby-sdks-folder=<path to the root directory of your azur
 
 ``` yaml $(tag) == 'package-2018-07' && $(ruby)
 namespace: "Azure::Compute::Mgmt::V2018_07_01"
-output-folder: $(ruby-sdks-folder)/management/azure_mgmt_edgedateway/lib
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_edgegateway/lib
 ```

--- a/specification/edgegateway/resource-manager/readme.typescript.md
+++ b/specification/edgegateway/resource-manager/readme.typescript.md
@@ -8,7 +8,7 @@ typescript:
   azure-arm: true
   license-header: MICROSOFT_MIT_NO_VERSION
   payload-flattening-threshold: 2
-  package-name: "@azure/arm-edgedateway"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-edgedateway"
+  package-name: "@azure/arm-edgegateway"
+  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-edgegateway"
   generate-metadata: true
 ```


### PR DESCRIPTION
Not sure if anything else needs to be changed for the rename, but it wasn't matching the namespace