### PR TITLE
Correct DTL api versions in examples to 2018-09-15

### DIFF
--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_ClaimAnyVm.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_ClaimAnyVm.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "name": "{devtestlab-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "monitor": "true"
   },
   "responses": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_CreateEnvironment.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_CreateEnvironment.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "name": "{devtestlab-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "labVirtualMachineCreationParameter": {
       "properties": {
         "osType": "Linux",

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_CreateOrUpdate.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_CreateOrUpdate.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "name": "{devtestlab-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "lab": {
       "properties": {
         "labStorageType": "{Standard|Premium}"

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_Delete.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_Delete.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "name": "{devtestlab-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_GenerateUploadUri.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_GenerateUploadUri.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "name": "{devtestlab-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "generateUploadUriParameter": {
       "blobName": "{blob-name}"
     }

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_Get.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_Get.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "name": "{devtestlab-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_ListByResourceGroup.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_ListByResourceGroup.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_ListBySubscription.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_ListBySubscription.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "{subscription-id}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_Update.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/Labs_Update.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "name": "{devtestlab-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "lab": {
       "properties": {
         "labStorageType": "Premium"

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/ProviderOperations_List.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/ProviderOperations_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-      "api-version": "2018-10-15-preview"
+      "api-version": "2018-09-15"
   },
   "responses": {
       "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Claim.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Claim.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_CreateOrUpdate.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_CreateOrUpdate.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "labVirtualMachine": {
       "properties": {
         "osType": "Linux",

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Delete.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Delete.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Get.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Get.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_GetRdpFileContents.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_GetRdpFileContents.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_List.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_List.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Redeploy.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Redeploy.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "monitor": "true"
   },
   "responses": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Resize.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Resize.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "monitor": "true",
     "resizeLabVirtualMachineProperties": {
       "size": "Standard_A4_v2"

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Restart.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Restart.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "monitor": "true"
   },
   "responses": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Start.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Start.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "monitor": "true"
   },
   "responses": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Stop.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Stop.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_UnClaim.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_UnClaim.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "monitor": "true"
   },
   "responses": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Update.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualMachines_Update.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualmachine-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "labVirtualMachine": {
       "properties": {
         "notes": "Updated notes"

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_CreateOrUpdate.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_CreateOrUpdate.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualnetwork-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "virtualNetwork": {
       "location": "{azure-location}",
       "tags": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_Delete.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_Delete.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualnetwork-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_Get.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_Get.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualnetwork-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_List.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_List.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
-    "api-version": "2018-10-15-preview"
+    "api-version": "2018-09-15"
   },
   "responses": {
     "200": {

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_Update.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/stable/2018-09-15/examples/VirtualNetworks_Update.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "myResourceGroup",
     "labName": "{devtestlab-name}",
     "name": "{virtualnetwork-name}",
-    "api-version": "2018-10-15-preview",
+    "api-version": "2018-09-15",
     "virtualNetwork": {
       "properties": {
         "subnetOverrides": [


### PR DESCRIPTION
Quick fix to DTL examples, which have the incorrect API version in them.

See https://github.com/Azure/azure-rest-api-specs-pr/pull/658

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [X] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
