### PR TITLE
[Tooling] Updating script to handle output of batch processing from autorest

### DIFF
--- a/scripts/momentOfTruth.js
+++ b/scripts/momentOfTruth.js
@@ -66,6 +66,7 @@ async function getLinterResult(swaggerPath) {
 
     let resultString = stdout + stderr;
     if (resultString.indexOf('{') !== -1) {
+        resultString = resultString.replace(/Processing batch task - {.*} \.\n/g, "");
         resultString = "[" + resultString.substring(resultString.indexOf('{')).trim().replace(/\}\n\{/g, "},\n{") + "]";
         //console.log('>>>>>> Trimmed Result...');
         //console.log(resultString);


### PR DESCRIPTION
I'm updating the script to remove the line added when processing batch tasks in AutoRest output, as we process the string. 
I've also requested an update to AutoRest to honor json as the message-format switch is passed, so hopefully we can remove some of this processing in the future.