### PR TITLE
[WaitForARMFeedback] Add api get_services_by_subscription of Azure Search

### DIFF
--- a/specification/search/resource-manager/Microsoft.Search/stable/2015-08-19/examples/SearchListServicesBySubscription.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2015-08-19/examples/SearchListServicesBySubscription.json
@@ -1,0 +1,54 @@
+{
+    "parameters": {
+        "api-version": "2015-08-19",
+        "subscriptionId": "subid"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Search/searchServices/mysearchservice",
+                        "name": "mysearchservice",
+                        "location": "westus",
+                        "type": "Microsoft.Search/searchServices",
+                        "tags": {
+                            "app-name": "My e-commerce app"
+                        },
+                        "sku": {
+                            "name": "standard"
+                        },
+                        "properties":{
+                            "replicaCount": 3,
+                            "partitionCount": 1,
+                            "status": "running",
+                            "statusDetails": "",
+                            "hostingMode": "default",
+                            "provisioningState": "succeeded"
+                        }
+                    },
+                    {
+                        "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Search/searchServices/mysearchservice2",
+                        "name": "mysearchservice2",
+                        "location": "eastus",
+                        "type": "Microsoft.Search/searchServices",
+                        "tags": {
+                            "app-name": "My e-commerce app"
+                        },
+                        "sku": {
+                            "name": "basic"
+                        },
+                        "properties":{
+                            "replicaCount": 1,
+                            "partitionCount": 1,
+                            "status": "running",
+                            "statusDetails": "",
+                            "hostingMode": "default",
+                            "provisioningState": "succeeded"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/search/resource-manager/Microsoft.Search/stable/2015-08-19/search.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2015-08-19/search.json
@@ -594,7 +594,7 @@
         },
         "operationId": "Services_ListBySubscription",
         "x-ms-examples": {
-          "SearchListServicesByResourceGroup": { "$ref": "./examples/SearchListServicesBySubscription.json" }
+          "SearchListServicesBySubscription": { "$ref": "./examples/SearchListServicesBySubscription.json" }
         },
         "description": "Gets a list of all Search services in the given subscription.",
         "externalDocs": {

--- a/specification/search/resource-manager/Microsoft.Search/stable/2015-08-19/search.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2015-08-19/search.json
@@ -584,6 +584,49 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Search/searchServices": {
+      "get": {
+        "tags": [
+          "Services"
+        ],
+        "x-ms-pageable": {
+          "nextLinkName": null
+        },
+        "operationId": "Services_ListBySubscription",
+        "x-ms-examples": {
+          "SearchListServicesByResourceGroup": { "$ref": "./examples/SearchListServicesBySubscription.json" }
+        },
+        "description": "Gets a list of all Search services in the given subscription.",
+        "externalDocs": {
+          "url": "https://aka.ms/search-manage"
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The operation succeeded. The response contains the list of all Search service definitions for the given subscription.",
+            "schema": {
+              "$ref": "#/definitions/SearchServiceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/providers/Microsoft.Search/checkNameAvailability": {
       "post": {
         "tags": [


### PR DESCRIPTION
Add path of API "get search services by subscription" (GET/SUBSCRIPTIONS/PROVIDERS/MICROSOFT.SEARCH/SEARCHSERVICES) in the spec of API version 2015-08-19 of Azure Search (Microsoft.Search). Along with a sample.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
