### PR TITLE
[Azure Search] Add SkillsetOperations to C# code generation settings

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/readme.md
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/readme.md
@@ -108,7 +108,8 @@ directive:
     where: $
     transform: >
       if ( $.includes("class DataSourcesOperations") || $.includes("class IndexersOperations") || 
-        $.includes("class IndexesOperations") ||  $.includes("class SynonymMapsOperations") ) 
+        $.includes("class IndexesOperations") ||  $.includes("class SynonymMapsOperations") ||
+        $.includes("class SkillsetsOperations") ) 
         
         return $.
           replace(/this.SearchServiceName/g,"Client.SearchServiceName").


### PR DESCRIPTION
Add SkillsetOperations as one of the classes that have special code generation settings in the AutoRest configuration file. This allows SkillsetOperations in the SDK to be generated directly from the specification without hand-editing.

FYI: @brjohnstmsft 


### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
