### PR TITLE
[Azure Search] Add transform directives for C# generation

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2017-11-11-preview/searchindex.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2017-11-11-preview/searchindex.json
@@ -67,7 +67,7 @@
     "/docs/autocomplete": {
       "get": {
         "tags": [
-          "Autocomplete"
+          "DocumentsProxy"
         ],
         "operationId": "DocumentsProxy_AutocompleteGet",
         "x-ms-examples": {
@@ -188,7 +188,7 @@
       },
       "post": {
         "tags": [
-          "Autocomplete"
+          "DocumentsProxy"
         ],
         "operationId": "DocumentsProxy_AutocompletePost",
         "x-ms-examples": {

--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2017-11-11-preview/searchindex.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2017-11-11-preview/searchindex.json
@@ -34,9 +34,9 @@
     "/docs/$count": {
       "get": {
         "tags": [
-          "DocumentsProxy"
+          "Documents"
         ],
-        "operationId": "DocumentsProxy_Count",
+        "operationId": "Documents_Count",
         "x-ms-examples": {
           "SearchIndexCountDocuments": { "$ref": "./examples/SearchIndexCountDocuments.json" }
         },
@@ -67,9 +67,9 @@
     "/docs/autocomplete": {
       "get": {
         "tags": [
-          "DocumentsProxy"
+          "Documents"
         ],
-        "operationId": "DocumentsProxy_AutocompleteGet",
+        "operationId": "Documents_AutocompleteGet",
         "x-ms-examples": {
           "SearchIndexGetAutocomplete": { "$ref": "./examples/SearchIndexGetAutocomplete.json" }
         },
@@ -188,9 +188,9 @@
       },
       "post": {
         "tags": [
-          "DocumentsProxy"
+          "Documents"
         ],
-        "operationId": "DocumentsProxy_AutocompletePost",
+        "operationId": "Documents_AutocompletePost",
         "x-ms-examples": {
           "SearchIndexPostAutocomplete": { "$ref": "./examples/SearchIndexPostAutocomplete.json" }
         },

--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2017-11-11-preview/searchindex.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2017-11-11-preview/searchindex.json
@@ -37,13 +37,13 @@
           "Documents"
         ],
         "operationId": "Documents_Count",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/Count-Documents"
+        },
         "x-ms-examples": {
           "SearchIndexCountDocuments": { "$ref": "./examples/SearchIndexCountDocuments.json" }
         },
         "description": "Queries the number of documents in the Azure Search index.",
-        "externalDocs": {
-          "url": "https://docs.microsoft.com/rest/api/searchservice/Count-Documents"
-        },
         "parameters": [
           {
             "$ref": "#/parameters/ClientRequestIdParameter"
@@ -70,6 +70,9 @@
           "Documents"
         ],
         "operationId": "Documents_AutocompleteGet",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/autocomplete"
+        },
         "x-ms-examples": {
           "SearchIndexGetAutocomplete": { "$ref": "./examples/SearchIndexGetAutocomplete.json" }
         },
@@ -147,7 +150,7 @@
             "in": "query",
             "type": "number",
             "format": "double",
-            "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by am autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80.",
+            "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by an autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80.",
             "x-ms-parameter-grouping": {
               "name": "AutocompleteParameters"
             }
@@ -191,6 +194,9 @@
           "Documents"
         ],
         "operationId": "Documents_AutocompletePost",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/autocomplete"
+        },
         "x-ms-examples": {
           "SearchIndexPostAutocomplete": { "$ref": "./examples/SearchIndexPostAutocomplete.json" }
         },
@@ -353,7 +359,7 @@
         "orderby": {
           "x-ms-client-name": "OrderBy",
           "type": "string",
-          "description": "The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
+          "description": "The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
         },
         "queryType": {
           "$ref": "#/definitions/QueryType",
@@ -364,7 +370,7 @@
           "items": {
             "type": "string"
           },
-          "description": "The list of parameter values to be used in scoring functions (for example, referencePointParameter) using the format name:value. For example, if the scoring profile defines a function with a parameter called 'mylocation' the parameter string would be \"mylocation:-122.2,44.8\"(without the quotes)."
+          "description": "The list of parameter values to be used in scoring functions (for example, referencePointParameter) using the format name-values. For example, if the scoring profile defines a function with a parameter called 'mylocation' the parameter string would be \"mylocation--122.2,44.8\"(without the quotes)."
         },
         "scoringProfile": {
           "type": "string",
@@ -375,7 +381,7 @@
             "url": "https://docs.microsoft.com/rest/api/searchservice/Simple-query-syntax-in-Azure-Search"
           },
           "type": "string",
-          "description": "A full-text search query expression; Use null or \"*\" to match all documents."
+          "description": "A full-text search query expression; Use \"*\" or omit this parameter to match all documents."
         },
         "searchFields": {
           "type": "string",
@@ -434,7 +440,7 @@
         "orderby": {
           "x-ms-client-name": "OrderBy",
           "type": "string",
-          "description": "The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to the geo.distance() function. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
+          "description": "The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 Orderby clauses."
         },
         "search": {
           "type": "string",
@@ -487,7 +493,7 @@
         "minimumCoverage": {
           "type": "number",
           "format": "double",
-          "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by am autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80."
+          "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by an autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80."
         },
         "searchFields": {
           "type": "string",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md
@@ -101,3 +101,23 @@ csharp:
   clear-output-folder: true
   output-folder: $(csharp-sdks-folder)/Search/DataPlane/Microsoft.Azure.Search.Data/Generated
 ```
+
+### Tweak generated code
+
+Use the below directives sparingly. Every modification we make in here, we potentially have to replicate for every target language.
+
+``` yaml $(csharp)
+directive:
+  # Make all Proxy types internal so we can version them freely.
+  - from: source-file-csharp
+    where: $
+    transform: return $.replace( /public partial interface IDocumentsProxyOperations/g, "internal partial interface IDocumentsProxyOperations" )
+
+  # Change the public property on ISearchIndexClient and SearchIndexClient to refer to our public interface instead of the internal one.
+  - from: source-file-csharp
+    where: $
+    transform: >-
+      return $.replace( /Gets the IDocumentsProxyOperations./g, "Gets the IDocumentsOperations." ).
+        replace( /IDocumentsProxyOperations DocumentsProxy { get;/g, "IDocumentsOperations Documents { get;" ).
+        replace( /DocumentsProxy = new DocumentsProxyOperations\(this\);/g, "Documents = new DocumentsOperations\(this\);" )
+```

--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md
@@ -108,12 +108,15 @@ Use the below directives sparingly. Every modification we make in here, we poten
 
 ``` yaml $(csharp)
 directive:
-  # Make the IDocumentsProxyOperations interface internal so we can version it freely. This requires three changes:
-  #   1. Make the interface itself internal
-  #   2. Make the DocumentsProxy property of SearchIndexClient internal
-  #   3. Rename the interface property and its type from DocumentsProxy to Documents, effectively removing the property
-  #      from the ISearchIndexClient interface
-  # Its replacement property, Documents of type IDocumentsOperations, is hand-written so that it can delegate to DocumentsProxy.
+  # Rename the IDocumentsOperations interface and implementation, then make the interface internal so we can version it freely.
+  # This requires these changes:
+  #   1. Globally rename the interface and implementation class, along with comments and constructors
+  #   2. Make the interface itself internal
+  #   3. Make the SearchIndexClient.Documents property internal and rename it to DocumentsProxy
+  #   4. Rename the type of the ISearchIndexClient.Documents property back to IDocumentsOperations, effectively removing the
+  #      generated property from the interface (this reverses step 1 above just for this case)
+  #
+  # The ISearchIndexClient.Documents property is of type IDocumentsOperations, which is hand-written and delegates to DocumentsProxy.
   # This allows us to do two things:
   #   1. Abstract away the detail of whether GET or POST is used for read operations (Search, Suggest, etc.)
   #   2. Add methods with type parameters and custom serialization to make our SDK easier to use in strongly-typed scenarios
@@ -121,7 +124,9 @@ directive:
   - from: source-file-csharp
     where: $
     transform: >-
-      return $.replace( /public (partial interface IDocumentsProxyOperations)/g, "internal $1" ).
-        replace( /public virtual (IDocumentsProxyOperations DocumentsProxy { get;)/g, "internal $1" ).
-        replace( /(Gets the )IDocumentsProxyOperations(.\s*\n\s*\/\/\/ <\/summary>\s*\n\s*)IDocumentsProxyOperations DocumentsProxy ({ get; })/g, "$1IDocumentsOperations$2IDocumentsOperations Documents $3" )
+      return $.replace( /DocumentsOperations/g, "DocumentsProxyOperations" ).
+        replace( /public (partial interface IDocumentsProxyOperations)/g, "internal $1" ).
+        replace( /public virtual IDocumentsProxyOperations Documents ({ get;)/g, "internal IDocumentsProxyOperations DocumentsProxy $1" ).
+        replace( /Documents = new DocumentsProxyOperations\(this\);/g, "DocumentsProxy = new DocumentsProxyOperations\(this\);" ).
+        replace( /(Gets the) IDocumentsProxyOperations(.\s*\n\s*\/\/\/ <\/summary>\s*\n\s*)IDocumentsProxyOperations (Documents { get; })/g, "$1 IDocumentsOperations$2IDocumentsOperations $3" )
 ```


### PR DESCRIPTION
This applies only to the `Microsoft.Azure.Search.Data` package, the source for which is in azure-sdk-for-net.

We'll be using transform directives more often in the future, so it seemed like a good idea to port our current hacky PowerShell script to this new mechanism. The PowerShell script lives in azure-sdk-for-net, and will be removed in a future PR.

Also did a drive-by fix of an incorrect tag in the searchindex spec. This has no effect on code generation.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
