### PR TITLE
Revert "[AKS] add apiServerAuthorizedIPRanges property"

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2018-08-01-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2018-08-01-preview/managedClusters.json
@@ -1353,13 +1353,6 @@
         "aadProfile": {
           "$ref": "#/definitions/ManagedClusterAADProfile",
           "description": "Profile of Azure Active Directory configuration."
-        },
-        "apiServerAuthorizedIPRanges": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Authorized IP Ranges to kubernetes API server."
         }
       },
       "description": "Properties of the managed cluster."

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2018-03-31/managedClusters.json
@@ -1315,13 +1315,6 @@
         "aadProfile": {
           "$ref": "#/definitions/ManagedClusterAADProfile",
           "description": "Profile of Azure Active Directory configuration."
-        },
-        "apiServerAuthorizedIPRanges": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Authorized IP Ranges to kubernetes API server."
         }
       },
       "description": "Properties of the managed cluster."


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#5101

The feature is not available in production and will need a new API version. The previous merge was a mistake.