### PR TITLE
Removed "x-ms-pageable" from the elevateAccess API

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/stable/2015-07-01/authorization.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/stable/2015-07-01/authorization.json
@@ -901,6 +901,23 @@
           }
         }
       }
+    }, 
+    "providers/Microsoft.Authorization/elevateAccess": {
+			"post": {
+				"tags": [
+					"ElevateAccess"
+				],
+				"operationId": "ElevateAccess_Post",
+				"description": "Elevates access for a Global Administrator.",
+				"parameters": {
+                    "$ref": "#/parameters/ApiVersionParameter"
+                },
+				"responses": {
+					"200": {
+						"description": "OK - Returns an HttpResponseMessage with HttpStatusCode 200."
+					}
+				}
+			}
     }
   },
   "definitions": {

--- a/specification/authorization/resource-manager/Microsoft.Authorization/stable/2015-07-01/authorization.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/stable/2015-07-01/authorization.json
@@ -864,6 +864,23 @@
           }
         }
       }
+    },    
+    "/providers/Microsoft.Authorization/elevateAccess": {
+			"post": {
+				"tags": [
+					"ElevateAccess"
+				],
+				"operationId": "ElevateAccess_Post",
+				"description": "Elevates access for a Global Administrator.",
+				"parameters": {
+          "$ref": "#/parameters/ApiVersionParameter"
+        },
+				"responses": {
+					"200": {
+						"description": "OK - Returns an HttpResponseMessage with HttpStatusCode 200."
+					}
+				}
+			}
     }
   },
   "x-ms-paths": {
@@ -901,23 +918,6 @@
           }
         }
       }
-    }, 
-    "providers/Microsoft.Authorization/elevateAccess": {
-			"post": {
-				"tags": [
-					"ElevateAccess"
-				],
-				"operationId": "ElevateAccess_Post",
-				"description": "Elevates access for a Global Administrator.",
-				"parameters": {
-                    "$ref": "#/parameters/ApiVersionParameter"
-                },
-				"responses": {
-					"200": {
-						"description": "OK - Returns an HttpResponseMessage with HttpStatusCode 200."
-					}
-				}
-			}
     }
   },
   "definitions": {

--- a/specification/authorization/resource-manager/Microsoft.Authorization/stable/2015-07-01/authorization.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/stable/2015-07-01/authorization.json
@@ -872,9 +872,11 @@
 				],
 				"operationId": "ElevateAccess_Post",
 				"description": "Elevates access for a Global Administrator.",
-				"parameters": {
-          "$ref": "#/parameters/ApiVersionParameter"
-        },
+				"parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
 				"responses": {
 					"200": {
 						"description": "OK - Returns an HttpResponseMessage with HttpStatusCode 200."


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
