### PR TITLE
[Compute] suppress PATCH validation for deprecated ACS service

### DIFF
--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -177,6 +177,14 @@ directive:
     suppress:
       - DefinitionsPropertiesNamesCamelCase
 
+  - where:
+      - $.definitions.ContainerService
+    suppress:
+      - TrackedResourcePatchOperation
+    reason:
+      - ACS service is deprecated so a PATCH endpoint won't be implemented
+
+
 ```
 ### Tag: package-2018-10-01
 


### PR DESCRIPTION
Silences a "no PATCH endpoint" error for the old version of the ACS spec that lives under /compute.

Note that this same error is already suppressed for the more recent versions of the ACS spec here: https://github.com/Azure/azure-rest-api-specs/blob/master/specification/containerservice/resource-manager/readme.md#suppression

cc: @jskulavik 

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
