### PR TITLE
EventGrid StorageBlobCreatedEventData: Make contentLength field long instead of int to account for blob sizes greater than 2 GB.

### DIFF
--- a/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/Storage.json
+++ b/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/Storage.json
@@ -33,7 +33,8 @@
                 },
                 "contentLength": {
                     "description": "The size of the blob in bytes. This is the same as what would be returned in the Content-Length header from the blob.",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                 },
                 "blobType": {
                     "description": "The type of blob.",


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [X] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [X] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [X] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
