### PR TITLE
Add server creation parameters to Postgres ResourceProvider for SDK

### DIFF
--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ReplicasListByServer.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ReplicasListByServer.json
@@ -1,0 +1,156 @@
+{
+    "parameters": {
+      "serverName": "testserver-master",
+      "resourceGroupName": "TestGroup_WestCentralUS",
+      "api-version": "2017-12-01-preview",
+      "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    },
+    "responses": {
+      "200": {
+        "body": {
+          "value": [
+            {
+              "sku": {
+                "name": "GP_Gen4_16",
+                "tier": "GeneralPurpose",
+                "family": "Gen4",
+                "capacity": 16
+              },
+              "properties": {
+                "administratorLogin": "postgres",
+                "storageProfile": {
+                  "storageMB": 2048000,
+                  "backupRetentionDays": 7,
+                  "geoRedundantBackup": "Disabled"
+                },
+                "version": "9.6",
+                "sslEnforcement": "Disabled",
+                "userVisibleState": "Ready",
+                "fullyQualifiedDomainName": "testserver-replica1.postgres.database.azure.com",
+                "earliestRestoreDate": "2018-06-12T00:05:03.2695756+00:00",
+                "replicationRole": "Replica",
+                "masterServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-master",
+                "replicaCapacity": 0
+              },
+              "location": "westcentralus",
+              "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-replica1",
+              "name": "testserver-replica1",
+              "type": "Microsoft.DBforPostgreSQL/servers"
+            },
+            {
+              "sku": {
+                "name": "GP_Gen4_16",
+                "tier": "GeneralPurpose",
+                "family": "Gen4",
+                "capacity": 16
+              },
+              "properties": {
+                "administratorLogin": "postgres",
+                "storageProfile": {
+                  "storageMB": 2048000,
+                  "backupRetentionDays": 7,
+                  "geoRedundantBackup": "Disabled"
+                },
+                "version": "9.6",
+                "sslEnforcement": "Disabled",
+                "userVisibleState": "Ready",
+                "fullyQualifiedDomainName": "testserver-replica2.postgres.database.azure.com",
+                "earliestRestoreDate": "2018-06-12T00:05:03.2695756+00:00",
+                "replicationRole": "Replica",
+                "masterServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-master",
+                "replicaCapacity": 0
+              },
+              "location": "westcentralus",
+              "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-replica2",
+              "name": "testserver-replica2",
+              "type": "Microsoft.DBforPostgreSQL/servers"
+            },
+            {
+              "sku": {
+                "name": "GP_Gen4_16",
+                "tier": "GeneralPurpose",
+                "family": "Gen4",
+                "capacity": 16
+              },
+              "properties": {
+                "administratorLogin": "postgres",
+                "storageProfile": {
+                  "storageMB": 2048000,
+                  "backupRetentionDays": 7,
+                  "geoRedundantBackup": "Disabled"
+                },
+                "version": "9.6",
+                "sslEnforcement": "Disabled",
+                "userVisibleState": "Ready",
+                "fullyQualifiedDomainName": "testserver-replica3.postgres.database.azure.com",
+                "earliestRestoreDate": "2018-06-12T00:05:03.2695756+00:00",
+                "replicationRole": "Replica",
+                "masterServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-master",
+                "replicaCapacity": 0
+              },
+              "location": "westcentralus",
+              "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-replica3",
+              "name": "testserver-replica3",
+              "type": "Microsoft.DBforPostgreSQL/servers"
+            },
+            {
+              "sku": {
+                "name": "GP_Gen4_16",
+                "tier": "GeneralPurpose",
+                "family": "Gen4",
+                "capacity": 16
+              },
+              "properties": {
+                "administratorLogin": "postgres",
+                "storageProfile": {
+                  "storageMB": 2048000,
+                  "backupRetentionDays": 7,
+                  "geoRedundantBackup": "Disabled"
+                },
+                "version": "9.6",
+                "sslEnforcement": "Disabled",
+                "userVisibleState": "Ready",
+                "fullyQualifiedDomainName": "testserver-replica4.postgres.database.azure.com",
+                "earliestRestoreDate": "2018-06-12T00:05:03.2695756+00:00",
+                "replicationRole": "Replica",
+                "masterServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-master",
+                "replicaCapacity": 0
+              },
+              "location": "westcentralus",
+              "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-replica4",
+              "name": "testserver-replica4",
+              "type": "Microsoft.DBforPostgreSQL/servers"
+            },
+            {
+              "sku": {
+                "name": "GP_Gen4_16",
+                "tier": "GeneralPurpose",
+                "family": "Gen4",
+                "capacity": 16
+              },
+              "properties": {
+                "administratorLogin": "postgres",
+                "storageProfile": {
+                  "storageMB": 2048000,
+                  "backupRetentionDays": 7,
+                  "geoRedundantBackup": "Disabled"
+                },
+                "version": "9.6",
+                "sslEnforcement": "Disabled",
+                "userVisibleState": "Ready",
+                "fullyQualifiedDomainName": "testserver-replica5.postgres.database.azure.com",
+                "earliestRestoreDate": "2018-06-12T00:05:03.2695756+00:00",
+                "replicationRole": "Replica",
+                "masterServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-master",
+                "replicaCapacity": 0
+              },
+              "location": "westcentralus",
+              "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-replica5",
+              "name": "testserver-replica5",
+              "type": "Microsoft.DBforPostgreSQL/servers"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerCreateGeoRestoreMode.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerCreateGeoRestoreMode.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "serverName": "targetserver",
+    "resourceGroupName": "TargetResourceGroup",
+    "api-version": "2017-12-01",
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "parameters": {
+      "location": "Japan West",
+      "properties": {
+        "createMode": "GeoRestore",
+        "sourceServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/SourceResourceGroup/providers/Microsoft.DBforPostgreSQL/servers/sourceserver"
+      },
+      "sku": {
+          "name": "GP_Gen4_2",
+          "tier": "GeneralPurpose",
+          "family": "Gen4",
+          "capacity": 2
+      },
+      "tags": {
+        "ElasticServer": "1"
+      }
+    }
+  },
+  "responses": {
+      "201": {
+          "body": {
+            "sku": {
+              "name": "GP_Gen4_2",
+              "tier": "GeneralPurpose",
+              "family": "Gen4",
+              "capacity": 2
+            },
+            "properties": {
+              "administratorLogin": "cloudsa",
+              "storageProfile": {
+                "storageMB": 128000,
+                "backupRetentionDays": 7,
+                "geoRedundantBackup": "Disabled"
+              },
+              "version": "9.6",
+              "sslEnforcement": "Enabled",
+              "userVisibleState": "Ready",
+              "fullyQualifiedDomainName": "targetserver.postgres.database.azure.com",
+              "earliestRestoreDate": "2018-03-14T21:08:24.637+00:00"
+            },
+            "location": "westus",
+            "tags": {
+              "ElasticServer": "1"
+            },
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/targetserver",
+            "name": "targetserver",
+            "type": "Microsoft.DBforPostgreSQL/servers"
+          }
+        },
+        "200": {
+          "body": {
+            "sku": {
+              "name": "GP_Gen4_2",
+              "tier": "GeneralPurpose",
+              "family": "Gen4",
+              "capacity": 2
+            },
+            "properties": {
+              "administratorLogin": "cloudsa",
+              "storageProfile": {
+                "storageMB": 128000,
+                "backupRetentionDays": 7,
+                "geoRedundantBackup": "Disabled"
+              },
+              "version": "9.6",
+              "sslEnforcement": "Enabled",
+              "userVisibleState": "Ready",
+              "fullyQualifiedDomainName": "targetserver.postgres.database.azure.com",
+              "earliestRestoreDate": "2018-03-14T21:08:24.637+00:00"
+            },
+            "location": "westus",
+            "tags": {
+              "ElasticServer": "1"
+            },
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/targetserver",
+            "name": "targetserver",
+            "type": "Microsoft.DBforPostgreSQL/servers"
+          }
+        },
+          "202": {}
+  }
+}

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerCreatePointInTimeRestore.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerCreatePointInTimeRestore.json
@@ -1,0 +1,88 @@
+{
+    "parameters": {
+        "serverName": "targetserver",
+        "resourceGroupName": "TargetResourceGroup",
+        "api-version": "2017-12-01-preview",
+        "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "parameters": {
+            "location": "brazilsouth",
+            "properties": {
+                "restorePointInTime": "2017-12-14T00:00:37.467Z",
+                "createMode": "PointInTimeRestore",
+                "sourceServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/SourceResourceGroup/providers/Microsoft.DBforPostgreSQL/servers/sourceserver"
+            },
+            "sku": {
+                "name": "B_Gen4_2",
+                "tier": "Basic",
+                "capacity": 2,
+                "family": "Gen4"
+            },
+            "tags": {
+                "ElasticServer": "1"
+            }
+        }
+    },
+    "responses": {
+        "201": {
+            "body": {
+                "sku": {
+                    "name": "B_Gen4_2",
+                    "tier": "Basic",
+                    "family": "Gen4",
+                    "capacity": 2
+                },
+                "properties": {
+                    "administratorLogin": "cloudsa",
+                    "storageProfile": {
+                        "storageMB": 128000,
+                        "backupRetentionDays": 7,
+                        "geoRedundantBackup": "Disabled"
+                    },
+                    "version": "9.6",
+                    "sslEnforcement": "Enabled",
+                    "userVisibleState": "Ready",
+                    "fullyQualifiedDomainName": "targetserver.postgres.database.azure.com",
+                    "earliestRestoreDate": "2017-12-14T21:08:24.637+00:00"
+                },
+                "location": "brazilsouth",
+                "tags": {
+                    "ElasticServer": "1"
+                },
+                "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/targetserver",
+                "name": "targetserver",
+                "type": "Microsoft.DBforPostgreSQL/servers"
+            }
+        },
+        "200": {
+            "body": {
+                "sku": {
+                    "name": "B_Gen4_2",
+                    "tier": "Basic",
+                    "family": "Gen4",
+                    "capacity": 2
+                },
+                "properties": {
+                    "administratorLogin": "cloudsa",
+                    "storageProfile": {
+                        "storageMB": 128000,
+                        "backupRetentionDays": 7,
+                        "geoRedundantBackup": "Disabled"
+                    },
+                    "version": "9.6",
+                    "sslEnforcement": "Enabled",
+                    "userVisibleState": "Ready",
+                    "fullyQualifiedDomainName": "targetserver.postgres.database.azure.com",
+                    "earliestRestoreDate": "2017-12-14T21:08:24.637+00:00"
+                },
+                "location": "brazilsouth",
+                "tags": {
+                    "ElasticServer": "1"
+                },
+                "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.DBforPostgreSQL/servers/targetserver",
+                "name": "targetserver",
+                "type": "Microsoft.DBforPostgreSQL/servers"
+            }
+        },
+        "202": {}
+    }
+}

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerCreateReplicaMode.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerCreateReplicaMode.json
@@ -1,0 +1,78 @@
+{
+    "parameters": {
+        "serverName": "testserver-replica1",
+        "resourceGroupName": "TestGroup_WestCentralUS",
+        "api-version": "2017-12-01-preview",
+        "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "parameters": {
+            "Location": "westcentralus",
+            "Properties": {
+                "createMode": "Replica",
+                "sourceServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-master"
+            }
+        }
+    },
+    "responses": {
+        "201": {
+            "body": {
+                "sku": {
+                    "name": "GP_Gen4_2",
+                    "tier": "GeneralPurpose",
+                    "family": "Gen4",
+                    "capacity": 2
+                },
+                "properties": {
+                    "administratorLogin": "postgres",
+                    "storageProfile": {
+                        "storageMB": 2048000,
+                        "backupRetentionDays": 7,
+                        "geoRedundantBackup": "Disabled"
+                    },
+                    "version": "9.6",
+                    "sslEnforcement": "Disabled",
+                    "userVisibleState": "Ready",
+                    "fullyQualifiedDomainName": "testserver-replica1.postgres.database.azure.com",
+                    "earliestRestoreDate": "2018-06-20T00:17:56.677+00:00",
+                    "replicationRole": "Replica",
+                    "masterServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-master",
+                    "replicaCapacity": 0
+                },
+                "location": "westcentralus",
+                "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-replica1",
+                "name": "testserver-replica1",
+                "type": "Microsoft.DBforPostgreSQL/servers"
+            }
+        },
+        "200": {
+            "body": {
+                "sku": {
+                    "name": "GP_Gen4_2",
+                    "tier": "GeneralPurpose",
+                    "family": "Gen4",
+                    "capacity": 2
+                },
+                "properties": {
+                    "administratorLogin": "postgres",
+                    "storageProfile": {
+                        "storageMB": 2048000,
+                        "backupRetentionDays": 7,
+                        "geoRedundantBackup": "Disabled"
+                    },
+                    "version": "9.6",
+                    "sslEnforcement": "Disabled",
+                    "userVisibleState": "Ready",
+                    "fullyQualifiedDomainName": "testserver-replica1.postgres.database.azure.com",
+                    "earliestRestoreDate": "2018-06-20T00:17:56.677+00:00",
+                    "replicationRole": "Replica",
+                    "masterServerId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-master",
+                    "replicaCapacity": 0
+                },
+                "location": "westcentralus",
+                "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup_WestCentralUS/providers/Microsoft.DBforPostgreSQL/servers/testserver-replica1",
+                "name": "testserver-replica1",
+                "type": "Microsoft.DBforPostgreSQL/servers"
+            }
+        },
+        "202": {}
+    }
+}

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerGet.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/examples/ServerGet.json
@@ -31,8 +31,12 @@
           "administratorLogin": "cloudsa",
           "sslEnforcement": "Enabled",
           "userVisibleState": "Ready",
-          "fullyQualifiedDomainName": "testserver.test-vm1.onebox.xdb.mscds.com",
-          "version": "9.6"
+          "fullyQualifiedDomainName": "testserver.postgres.database.azure.com",
+          "version": "9.6",
+          "earliestRestoreDate": "2018-06-12T21:42:59.6651019+00:00",
+          "replicationRole": "None",
+          "masterServerId": "",
+          "replicaCapacity": 5
         }
       }
     }

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/postgresql.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/postgresql.json
@@ -41,8 +41,17 @@
         ],
         "operationId": "Servers_Create",
         "x-ms-examples": {
-          "ServerCreate": {
+          "Create a new server": {
             "$ref": "./examples/ServerCreate.json"
+          },
+          "Create a database as a point in time restore": {
+            "$ref": "./examples/ServerCreatePointInTimeRestore.json"
+          },
+          "Create a server as a geo restore ": {
+            "$ref": "./examples/ServerCreateGeoRestoreMode.json"
+          },
+          "Create a replica server": {
+            "$ref": "./examples/ServerCreateReplicaMode.json"
           }
         },
         "description": "Creates a new server, or will overwrite an existing server.",
@@ -262,6 +271,45 @@
           },
           {
             "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ServerListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/servers/{serverName}/Replicas": {
+      "get": {
+        "tags": [
+          "Replicas"
+        ],
+        "operationId": "Replicas_ListByServer",
+        "x-ms-examples": {
+          "ReplicasListByServer": {
+            "$ref": "./examples/ReplicasListByServer.json"
+          }
+        },
+        "description": "List all the replicas for a given server.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ServerNameParameter"
           }
         ],
         "responses": {
@@ -1006,6 +1054,20 @@
         "storageProfile": {
           "$ref": "#/definitions/StorageProfile",
           "description": "Storage profile of a server."
+        },
+        "replicationRole": {
+          "type": "string",
+          "description": "The replication role of the server."
+        },
+        "masterServerId": {
+          "type": "string",
+          "description": "The master server id of a relica server."
+        },
+        "replicaCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 0,
+          "description": "The maximum number of replicas that a master server can have."
         }
       },
       "description": "The properties of a server."
@@ -1059,7 +1121,9 @@
           "description": "The mode to create a new server.",
           "enum": [
             "Default",
-            "PointInTimeRestore"
+            "PointInTimeRestore",
+            "GeoRestore",
+            "Replica"
           ],
           "x-ms-enum": {
             "name": "CreateMode",
@@ -1115,7 +1179,43 @@
         "sourceServerId",
         "restorePointInTime"
       ],
-      "description": "The properties to a new server by restoring from a backup."
+      "description": "The properties used to create a new server by restoring from a backup."
+    },
+    "ServerPropertiesForGeoRestore": {
+      "x-ms-discriminator-value": "GeoRestore",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerPropertiesForCreate"
+        }
+      ],
+      "properties": {
+        "sourceServerId": {
+          "type": "string",
+          "description": "The source server id to restore from."
+        }
+      },
+      "required": [
+        "sourceServerId"
+      ],
+      "description": "The properties used to create a new server by restoring to a different region from a geo replicated backup."
+    },
+    "ServerPropertiesForReplica": {
+      "x-ms-discriminator-value": "Replica",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerPropertiesForCreate"
+        }
+      ],
+      "properties": {
+        "sourceServerId": {
+          "type": "string",
+          "description": "The master server id to create replica from."
+        }
+      },
+      "required": [
+        "sourceServerId"
+      ],
+      "description": "The properties to create a new replica."
     },
     "Sku": {
       "properties": {
@@ -1478,10 +1578,6 @@
     },
     "LogFileProperties": {
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Log file name."
-        },
         "sizeInKB": {
           "type": "integer",
           "format": "int64",
@@ -1558,15 +1654,6 @@
         "hardwareGeneration": {
           "type": "string",
           "description": "Hardware generation associated with the service level objective"
-        }
-      },
-      "description": "Service level objectives for performance tier."
-    },
-    "PerformanceTierProperties": {
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "ID of the performance tier."
         },
         "maxBackupRetentionDays": {
           "type": "integer",
@@ -1585,6 +1672,15 @@
           "type": "integer",
           "format": "int32",
           "description": "Max storage allowed for a server."
+        }
+      },
+      "description": "Service level objectives for performance tier."
+    },
+    "PerformanceTierProperties": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID of the performance tier."
         },
         "serviceLevelObjectives": {
           "type": "array",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/postgresql.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/postgresql.json
@@ -1061,7 +1061,7 @@
         },
         "masterServerId": {
           "type": "string",
-          "description": "The master server id of a relica server."
+          "description": "The master server id of a replica server."
         },
         "replicaCapacity": {
           "type": "integer",


### PR DESCRIPTION
This PR is a request to merge, the change was already reviewed in https://github.com/Azure/azure-rest-api-specs-pr/pull/574/
 
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
