### PR TITLE
chore: Use `npm ci` on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,28 +64,28 @@ script:
     fi
   - >-
     if [[ $MODE == 'syntax' ]]; then
-      npm install
+      npm ci
       npm test -- test/syntax.js
     fi
   - >-
     if [[ $MODE == 'semantic' ]]; then
-      npm install
+      npm ci
       node scripts/semanticValidation.js
     fi
   - >-
     if [[ $MODE == 'model' ]]; then
-      npm install
+      npm ci
       node scripts/modelValidation.js
     fi
   - >-
     if [[ $MODE == 'BreakingChange' ]]; then
       scripts/install-dotnet.sh
-      npm install
+      npm ci
       node -- scripts/breaking-change.js
     fi
   - >-
     if [[ $MODE == 'lintdiff' ]]; then
       scripts/install-dotnet.sh
-      npm install
+      npm ci
       node scripts/momentOfTruth.js && node scripts/momentOfTruthPostProcessing.js
     fi


### PR DESCRIPTION
Uses the lock-file and doesn't try to validate for slightly quicker builds https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable