### PR TITLE
[App Service] Update swagger spec for ANT80 (#5111)

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/AppServicePlans.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/AppServicePlans.json
@@ -1528,10 +1528,6 @@
               "type": "string",
               "readOnly": true
             },
-            "adminSiteName": {
-              "description": "App Service plan administration site.",
-              "type": "string"
-            },
             "hostingEnvironmentProfile": {
               "$ref": "./CommonDefinitions.json#/definitions/HostingEnvironmentProfile",
               "description": "Specification for the App Service Environment to use for the App Service plan.",

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/CommonDefinitions.json
@@ -300,10 +300,6 @@
               "type": "string",
               "readOnly": true
             },
-            "adminSiteName": {
-              "description": "App Service plan administration site.",
-              "type": "string"
-            },
             "hostingEnvironmentProfile": {
               "$ref": "#/definitions/HostingEnvironmentProfile",
               "description": "Specification for the App Service Environment to use for the App Service plan.",
@@ -991,6 +987,21 @@
         }
       }
     },
+    "GeoDistribution": {
+      "description": "A global distribution definition.",
+      "type": "object",
+      "properties": {
+        "location": {
+          "description": "Location.",
+          "type": "string"
+        },
+        "numberOfWorkers": {
+          "format": "int32",
+          "description": "NumberOfWorkers.",
+          "type": "integer"
+        }
+      }
+    },
     "HandlerMapping": {
       "description": "The IIS handler mappings used to define which handler processes HTTP requests with certain extension. \nFor example, it is used to configure php-cgi.exe process to handle all HTTP requests with *.php extension.",
       "type": "object",
@@ -1205,9 +1216,6 @@
     },
     "IpSecurityRestriction": {
       "description": "IP security restriction on an app.",
-      "required": [
-        "ipAddress"
-      ],
       "type": "object",
       "properties": {
         "ipAddress": {
@@ -1217,6 +1225,20 @@
         "subnetMask": {
           "description": "Subnet mask for the range of IP addresses the restriction is valid for.",
           "type": "string"
+        },
+        "vnetSubnetResourceId": {
+          "description": "Virtual network resource id",
+          "type": "string"
+        },
+        "vnetTrafficTag": {
+          "format": "int32",
+          "description": "(internal) Vnet traffic tag",
+          "type": "integer"
+        },
+        "subnetTrafficTag": {
+          "format": "int32",
+          "description": "(internal) Subnet traffic tag",
+          "type": "integer"
         },
         "action": {
           "description": "Allow or Deny access for this IP range.",
@@ -2066,6 +2088,10 @@
               "description": "<code>true</code> to enable client certificate authentication (TLS mutual authentication); otherwise, <code>false</code>. Default is <code>false</code>.",
               "type": "boolean"
             },
+            "clientCertExclusionPaths": {
+              "description": "client certificate authentication comma-separated exclusion paths",
+              "type": "string"
+            },
             "hostNamesDisabled": {
               "description": "<code>true</code> to disable the public hostnames of the app; otherwise, <code>false</code>.\n If <code>true</code>, the app is only accessible via API management process.",
               "type": "boolean"
@@ -2132,6 +2158,35 @@
             "httpsOnly": {
               "description": "HttpsOnly: configures a web site to accept only https requests. Issues redirect for\nhttp requests",
               "type": "boolean"
+            },
+            "redundancyMode": {
+              "description": "Site redundancy mode",
+              "enum": [
+                "None",
+                "Manual",
+                "Failover",
+                "ActiveActive",
+                "GeoRedundant"
+              ],
+              "type": "string",
+              "x-ms-enum": {
+                "name": "RedundancyMode",
+                "modelAsString": false
+              }
+            },
+            "inProgressOperationId": {
+              "format": "uuid",
+              "description": "Specifies an operation id if this site has a pending operation.",
+              "type": "string",
+              "readOnly": true,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "geoDistributions": {
+              "description": "GeoDistributions for this site",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GeoDistribution"
+              }
             }
           },
           "x-ms-client-flatten": true

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/Provider.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/Provider.json
@@ -240,6 +240,10 @@
         "isDefault": {
           "description": "<code>true</code> if this is the default minor version; otherwise, <code>false</code>.",
           "type": "boolean"
+        },
+        "isRemoteDebuggingEnabled": {
+          "description": "<code>true</code> if this supports Remote Debugging, otherwise <code>false</code>.",
+          "type": "boolean"
         }
       }
     }

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/Recommendations.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/Recommendations.json
@@ -116,6 +116,307 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{hostingEnvironmentName}/recommendationHistory": {
+      "get": {
+        "tags": [
+          "Recommendations"
+        ],
+        "summary": "Get past recommendations for an app, optionally specified by the time range.",
+        "description": "Get past recommendations for an app, optionally specified by the time range.",
+        "operationId": "Recommendations_ListHistoryForHostingEnvironment",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "hostingEnvironmentName",
+            "in": "path",
+            "description": "Name of the hosting environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "expiredOnly",
+            "in": "query",
+            "description": "Specify <code>false</code> to return all recommendations. The default is <code>true</code>, which returns only expired recommendations.",
+            "type": "boolean"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter is specified by using OData syntax. Example: $filter=channel eq 'Api' or channel eq 'Notification' and startTime eq 2014-01-01T00:00:00Z and endTime eq 2014-12-31T23:59:59Z and timeGrain eq duration'[PT1H|PT1M|P1D]",
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/RecommendationCollection"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{hostingEnvironmentName}/recommendations": {
+      "get": {
+        "tags": [
+          "Recommendations"
+        ],
+        "summary": "Get all recommendations for an app.",
+        "description": "Get all recommendations for an app.",
+        "operationId": "Recommendations_ListRecommendedRulesForHostingEnvironment",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "hostingEnvironmentName",
+            "in": "path",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "featured",
+            "in": "query",
+            "description": "Specify <code>true</code> to return only the most critical recommendations. The default is <code>false</code>, which returns all recommendations.",
+            "type": "boolean"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Return only channels specified in the filter. Filter is specified by using OData syntax. Example: $filter=channel eq 'Api' or channel eq 'Notification'",
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/RecommendationCollection"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{hostingEnvironmentName}/recommendations/disable": {
+      "post": {
+        "tags": [
+          "Recommendations"
+        ],
+        "summary": "Disable all recommendations for an app.",
+        "description": "Disable all recommendations for an app.",
+        "operationId": "Recommendations_DisableAllForHostingEnvironment",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "query",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "hostingEnvironmentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{hostingEnvironmentName}/recommendations/reset": {
+      "post": {
+        "tags": [
+          "Recommendations"
+        ],
+        "summary": "Reset all recommendation opt-out settings for an app.",
+        "description": "Reset all recommendation opt-out settings for an app.",
+        "operationId": "Recommendations_ResetAllFiltersForHostingEnvironment",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "query",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "hostingEnvironmentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{hostingEnvironmentName}/recommendations/{name}": {
+      "get": {
+        "tags": [
+          "Recommendations"
+        ],
+        "summary": "Get a recommendation rule for an app.",
+        "description": "Get a recommendation rule for an app.",
+        "operationId": "Recommendations_GetRuleDetailsByHostingEnvironment",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "hostingEnvironmentName",
+            "in": "path",
+            "description": "Name of the hosting environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the recommendation.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "updateSeen",
+            "in": "query",
+            "description": "Specify <code>true</code> to update the last-seen timestamp of the recommendation object.",
+            "type": "boolean"
+          },
+          {
+            "name": "recommendationId",
+            "in": "query",
+            "description": "The GUID of the recommendation object if you query an expired one. You don't need to specify it to query an active entry.",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/RecommendationRule"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{hostingEnvironmentName}/recommendations/{name}/disable": {
+      "post": {
+        "tags": [
+          "Recommendations"
+        ],
+        "summary": "Disables the specific rule for a web site permanently.",
+        "description": "Disables the specific rule for a web site permanently.",
+        "operationId": "Recommendations_DisableRecommendationForHostingEnvironment",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "query",
+            "description": "Site name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Rule name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "hostingEnvironmentName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully disabled recommendations."
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{siteName}/recommendationHistory": {
       "get": {
         "tags": [

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/ResourceProvider.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/ResourceProvider.json
@@ -578,6 +578,47 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/validateContainerSettings": {
+      "post": {
+        "summary": "Validate if the container settings are correct.",
+        "description": "Validate if the container settings are correct.",
+        "operationId": "ValidateContainerSettings",
+        "parameters": [
+          {
+            "name": "validateContainerSettingsRequest",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateContainerSettingsRequest"
+            }
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/validateMoveResources": {
       "post": {
         "summary": "Validate whether a resource can be moved.",
@@ -1043,6 +1084,36 @@
           "description": "Link to next page of resources.",
           "type": "string",
           "readOnly": true
+        }
+      }
+    },
+    "ValidateContainerSettingsRequest": {
+      "description": "Container settings validation request context",
+      "type": "object",
+      "properties": {
+        "baseUrl": {
+          "description": "Base URL of the container registry",
+          "type": "string"
+        },
+        "username": {
+          "description": "Username for to access the container registry",
+          "type": "string"
+        },
+        "password": {
+          "description": "Password for to access the container registry",
+          "type": "string"
+        },
+        "repository": {
+          "description": "Repository name (image name)",
+          "type": "string"
+        },
+        "tag": {
+          "description": "Image tag",
+          "type": "string"
+        },
+        "platform": {
+          "description": "Platform (windows or linux)",
+          "type": "string"
         }
       }
     },

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/WebApps.json
@@ -1632,180 +1632,6 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/networkConfig/virtualNetwork": {
-      "get": {
-        "tags": [
-          "WebApps"
-        ],
-        "summary": "Gets a Swift Virtual Network connection.",
-        "description": "Gets a Swift Virtual Network connection.",
-        "operationId": "WebApps_GetSwiftVirtualNetworkConnection",
-        "parameters": [
-          {
-            "$ref": "#/parameters/resourceGroupNameParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Name of the app.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "$ref": "#/parameters/subscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/apiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          "default": {
-            "description": "App Service error response.",
-            "schema": {
-              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "WebApps"
-        ],
-        "summary": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\r\nin use by another App Service Plan other than the one this App is in.",
-        "description": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\nin use by another App Service Plan other than the one this App is in.",
-        "operationId": "WebApps_CreateOrUpdateSwiftVirtualNetworkConnection",
-        "parameters": [
-          {
-            "$ref": "#/parameters/resourceGroupNameParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Name of the app.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "connectionEnvelope",
-            "in": "body",
-            "description": "Properties of the Virtual Network connection. See example.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          {
-            "$ref": "#/parameters/subscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/apiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          "default": {
-            "description": "App Service error response.",
-            "schema": {
-              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "WebApps"
-        ],
-        "summary": "Deletes a Swift Virtual Network connection from an app (or deployment slot).",
-        "description": "Deletes a Swift Virtual Network connection from an app (or deployment slot).",
-        "operationId": "WebApps_DeleteSwiftVirtualNetwork",
-        "parameters": [
-          {
-            "$ref": "#/parameters/resourceGroupNameParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Name of the app.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "$ref": "#/parameters/subscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/apiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully deleted virtual network."
-          },
-          "404": {
-            "description": "Virtual network does not exist."
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "WebApps"
-        ],
-        "summary": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\r\nin use by another App Service Plan other than the one this App is in.",
-        "description": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\nin use by another App Service Plan other than the one this App is in.",
-        "operationId": "WebApps_UpdateSwiftVirtualNetworkConnection",
-        "parameters": [
-          {
-            "$ref": "#/parameters/resourceGroupNameParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Name of the app.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "connectionEnvelope",
-            "in": "body",
-            "description": "Properties of the Virtual Network connection. See example.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          {
-            "$ref": "#/parameters/subscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/apiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          "default": {
-            "description": "App Service error response.",
-            "schema": {
-              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
-            }
-          }
-        }
-      }
-    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/web": {
       "get": {
         "tags": [
@@ -5046,6 +4872,180 @@
             "description": "OK",
             "schema": {
               "$ref": "#/definitions/MigrateMySqlStatus"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/networkConfig/virtualNetwork": {
+      "get": {
+        "tags": [
+          "WebApps"
+        ],
+        "summary": "Gets a Swift Virtual Network connection.",
+        "description": "Gets a Swift Virtual Network connection.",
+        "operationId": "WebApps_GetSwiftVirtualNetworkConnection",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "WebApps"
+        ],
+        "summary": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\r\nin use by another App Service Plan other than the one this App is in.",
+        "description": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\nin use by another App Service Plan other than the one this App is in.",
+        "operationId": "WebApps_CreateOrUpdateSwiftVirtualNetworkConnection",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionEnvelope",
+            "in": "body",
+            "description": "Properties of the Virtual Network connection. See example.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
+            }
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "WebApps"
+        ],
+        "summary": "Deletes a Swift Virtual Network connection from an app (or deployment slot).",
+        "description": "Deletes a Swift Virtual Network connection from an app (or deployment slot).",
+        "operationId": "WebApps_DeleteSwiftVirtualNetwork",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted virtual network."
+          },
+          "404": {
+            "description": "Virtual network does not exist."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "WebApps"
+        ],
+        "summary": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\r\nin use by another App Service Plan other than the one this App is in.",
+        "description": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\nin use by another App Service Plan other than the one this App is in.",
+        "operationId": "WebApps_UpdateSwiftVirtualNetworkConnection",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionEnvelope",
+            "in": "body",
+            "description": "Properties of the Virtual Network connection. See example.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
+            }
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
             }
           },
           "default": {
@@ -8723,208 +8723,6 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/networkConfig/virtualNetwork": {
-      "get": {
-        "tags": [
-          "WebApps"
-        ],
-        "summary": "Gets a Swift Virtual Network connection.",
-        "description": "Gets a Swift Virtual Network connection.",
-        "operationId": "WebApps_GetSwiftVirtualNetworkConnectionSlot",
-        "parameters": [
-          {
-            "$ref": "#/parameters/resourceGroupNameParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Name of the app.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "slot",
-            "in": "path",
-            "description": "Name of the deployment slot. If a slot is not specified, the API will get a gateway for the production slot's Virtual Network.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "$ref": "#/parameters/subscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/apiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          "default": {
-            "description": "App Service error response.",
-            "schema": {
-              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "WebApps"
-        ],
-        "summary": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\r\nin use by another App Service Plan other than the one this App is in.",
-        "description": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\nin use by another App Service Plan other than the one this App is in.",
-        "operationId": "WebApps_CreateOrUpdateSwiftVirtualNetworkConnectionSlot",
-        "parameters": [
-          {
-            "$ref": "#/parameters/resourceGroupNameParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Name of the app.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "connectionEnvelope",
-            "in": "body",
-            "description": "Properties of the Virtual Network connection. See example.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          {
-            "name": "slot",
-            "in": "path",
-            "description": "Name of the deployment slot. If a slot is not specified, the API will add or update connections for the production slot.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "$ref": "#/parameters/subscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/apiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          "default": {
-            "description": "App Service error response.",
-            "schema": {
-              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "WebApps"
-        ],
-        "summary": "Deletes a Swift Virtual Network connection from an app (or deployment slot).",
-        "description": "Deletes a Swift Virtual Network connection from an app (or deployment slot).",
-        "operationId": "WebApps_DeleteSwiftVirtualNetworkSlot",
-        "parameters": [
-          {
-            "$ref": "#/parameters/resourceGroupNameParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Name of the app.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "slot",
-            "in": "path",
-            "description": "Name of the deployment slot. If a slot is not specified, the API will delete the connection for the production slot.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "$ref": "#/parameters/subscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/apiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully deleted virtual network."
-          },
-          "404": {
-            "description": "Virtual network does not exist."
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "WebApps"
-        ],
-        "summary": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\r\nin use by another App Service Plan other than the one this App is in.",
-        "description": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\nin use by another App Service Plan other than the one this App is in.",
-        "operationId": "WebApps_UpdateSwiftVirtualNetworkConnectionSlot",
-        "parameters": [
-          {
-            "$ref": "#/parameters/resourceGroupNameParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Name of the app.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "connectionEnvelope",
-            "in": "body",
-            "description": "Properties of the Virtual Network connection. See example.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          {
-            "name": "slot",
-            "in": "path",
-            "description": "Name of the deployment slot. If a slot is not specified, the API will add or update connections for the production slot.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "$ref": "#/parameters/subscriptionIdParameter"
-          },
-          {
-            "$ref": "#/parameters/apiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/SwiftVirtualNetwork"
-            }
-          },
-          "default": {
-            "description": "App Service error response.",
-            "schema": {
-              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
-            }
-          }
-        }
-      }
-    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/web": {
       "get": {
         "tags": [
@@ -12509,6 +12307,208 @@
             "description": "OK",
             "schema": {
               "$ref": "#/definitions/MigrateMySqlStatus"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/networkConfig/virtualNetwork": {
+      "get": {
+        "tags": [
+          "WebApps"
+        ],
+        "summary": "Gets a Swift Virtual Network connection.",
+        "description": "Gets a Swift Virtual Network connection.",
+        "operationId": "WebApps_GetSwiftVirtualNetworkConnectionSlot",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "slot",
+            "in": "path",
+            "description": "Name of the deployment slot. If a slot is not specified, the API will get a gateway for the production slot's Virtual Network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "WebApps"
+        ],
+        "summary": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\r\nin use by another App Service Plan other than the one this App is in.",
+        "description": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\nin use by another App Service Plan other than the one this App is in.",
+        "operationId": "WebApps_CreateOrUpdateSwiftVirtualNetworkConnectionSlot",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionEnvelope",
+            "in": "body",
+            "description": "Properties of the Virtual Network connection. See example.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
+            }
+          },
+          {
+            "name": "slot",
+            "in": "path",
+            "description": "Name of the deployment slot. If a slot is not specified, the API will add or update connections for the production slot.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "./CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "WebApps"
+        ],
+        "summary": "Deletes a Swift Virtual Network connection from an app (or deployment slot).",
+        "description": "Deletes a Swift Virtual Network connection from an app (or deployment slot).",
+        "operationId": "WebApps_DeleteSwiftVirtualNetworkSlot",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "slot",
+            "in": "path",
+            "description": "Name of the deployment slot. If a slot is not specified, the API will delete the connection for the production slot.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted virtual network."
+          },
+          "404": {
+            "description": "Virtual network does not exist."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "WebApps"
+        ],
+        "summary": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\r\nin use by another App Service Plan other than the one this App is in.",
+        "description": "Integrates this Web App with a Virtual Network. This requires that 1) \"swiftSupported\" is true when doing a GET against this resource, and 2) that the target Subnet has already been delegated, and is not\nin use by another App Service Plan other than the one this App is in.",
+        "operationId": "WebApps_UpdateSwiftVirtualNetworkConnectionSlot",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the app.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionEnvelope",
+            "in": "body",
+            "description": "Properties of the Virtual Network connection. See example.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
+            }
+          },
+          {
+            "name": "slot",
+            "in": "path",
+            "description": "Name of the deployment slot. If a slot is not specified, the API will add or update connections for the production slot.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SwiftVirtualNetwork"
             }
           },
           "default": {
@@ -20826,6 +20826,10 @@
               "description": "<code>true</code> to enable client certificate authentication (TLS mutual authentication); otherwise, <code>false</code>. Default is <code>false</code>.",
               "type": "boolean"
             },
+            "clientCertExclusionPaths": {
+              "description": "client certificate authentication comma-separated exclusion paths",
+              "type": "string"
+            },
             "hostNamesDisabled": {
               "description": "<code>true</code> to disable the public hostnames of the app; otherwise, <code>false</code>.\n If <code>true</code>, the app is only accessible via API management process.",
               "type": "boolean"
@@ -20892,6 +20896,35 @@
             "httpsOnly": {
               "description": "HttpsOnly: configures a web site to accept only https requests. Issues redirect for\nhttp requests",
               "type": "boolean"
+            },
+            "redundancyMode": {
+              "description": "Site redundancy mode",
+              "enum": [
+                "None",
+                "Manual",
+                "Failover",
+                "ActiveActive",
+                "GeoRedundant"
+              ],
+              "type": "string",
+              "x-ms-enum": {
+                "name": "RedundancyMode",
+                "modelAsString": false
+              }
+            },
+            "inProgressOperationId": {
+              "format": "uuid",
+              "description": "Specifies an operation id if this site has a pending operation.",
+              "type": "string",
+              "readOnly": true,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "geoDistributions": {
+              "description": "GeoDistributions for this site",
+              "type": "array",
+              "items": {
+                "$ref": "./CommonDefinitions.json#/definitions/GeoDistribution"
+              }
             }
           },
           "x-ms-client-flatten": true

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/Certificates.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/Certificates.json
@@ -1,0 +1,636 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-11-01",
+    "title": "Certificates API Client"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Web/certificates": {
+      "get": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Get all certificates for a subscription.",
+        "description": "Get all certificates for a subscription.",
+        "operationId": "Certificates_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/CertificateCollection"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Certificates for subscription": {
+            "$ref": "./examples/ListCertificates.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/certificates": {
+      "get": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Get all certificates in a resource group.",
+        "description": "Get all certificates in a resource group.",
+        "operationId": "Certificates_ListByResourceGroup",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "schema": {
+              "$ref": "#/definitions/CertificateCollection"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Certificates by resource group": {
+            "$ref": "./examples/ListCertificatesByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/certificates/{name}": {
+      "get": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Get a certificate.",
+        "description": "Get a certificate.",
+        "operationId": "Certificates_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Certificate": {
+            "$ref": "./examples/GetCertificate.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Create or update a certificate.",
+        "description": "Create or update a certificate.",
+        "operationId": "Certificates_CreateOrUpdate",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateEnvelope",
+            "in": "body",
+            "description": "Details of certificate, if it exists already.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create Or Update Certificate": {
+            "$ref": "./examples/CreateOrUpdateCertificate.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Delete a certificate.",
+        "description": "Delete a certificate.",
+        "operationId": "Certificates_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted certificate."
+          },
+          "204": {
+            "description": "Certificate does not exist."
+          }
+        },
+        "x-ms-examples": {
+          "Delete Certificate": {
+            "$ref": "./examples/DeleteCertificate.json"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Create or update a certificate.",
+        "description": "Create or update a certificate.",
+        "operationId": "Certificates_Update",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateEnvelope",
+            "in": "body",
+            "description": "Details of certificate, if it exists already.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CertificatePatchResource"
+            }
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          "default": {
+            "description": "App Service error response.",
+            "schema": {
+              "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Certificate": {
+            "$ref": "./examples/PatchCertificate.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Certificate": {
+      "description": "SSL certificate for an app.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "description": "Certificate resource specific properties",
+          "required": [
+            "password"
+          ],
+          "properties": {
+            "friendlyName": {
+              "description": "Friendly name of the certificate.",
+              "type": "string",
+              "readOnly": true
+            },
+            "subjectName": {
+              "description": "Subject name of the certificate.",
+              "type": "string",
+              "readOnly": true
+            },
+            "hostNames": {
+              "description": "Host names the certificate applies to.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "pfxBlob": {
+              "format": "byte",
+              "description": "Pfx blob.",
+              "type": "string"
+            },
+            "siteName": {
+              "description": "App name.",
+              "type": "string",
+              "readOnly": true
+            },
+            "selfLink": {
+              "description": "Self link.",
+              "type": "string",
+              "readOnly": true
+            },
+            "issuer": {
+              "description": "Certificate issuer.",
+              "type": "string",
+              "readOnly": true
+            },
+            "issueDate": {
+              "format": "date-time",
+              "description": "Certificate issue Date.",
+              "type": "string",
+              "readOnly": true
+            },
+            "expirationDate": {
+              "format": "date-time",
+              "description": "Certificate expiration date.",
+              "type": "string",
+              "readOnly": true
+            },
+            "password": {
+              "description": "Certificate password.",
+              "type": "string",
+              "x-ms-mutability": [
+                "create"
+              ]
+            },
+            "thumbprint": {
+              "description": "Certificate thumbprint.",
+              "type": "string",
+              "readOnly": true
+            },
+            "valid": {
+              "description": "Is the certificate valid?.",
+              "type": "boolean",
+              "readOnly": true
+            },
+            "cerBlob": {
+              "format": "byte",
+              "description": "Raw bytes of .cer file",
+              "type": "string",
+              "readOnly": true
+            },
+            "publicKeyHash": {
+              "description": "Public key hash.",
+              "type": "string",
+              "readOnly": true
+            },
+            "hostingEnvironmentProfile": {
+              "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/HostingEnvironmentProfile",
+              "description": "Specification for the App Service Environment to use for the certificate.",
+              "readOnly": true
+            },
+            "keyVaultId": {
+              "description": "Key Vault Csm resource Id.",
+              "type": "string"
+            },
+            "keyVaultSecretName": {
+              "description": "Key Vault secret name.",
+              "type": "string"
+            },
+            "keyVaultSecretStatus": {
+              "description": "Status of the Key Vault secret.",
+              "enum": [
+                "Initialized",
+                "WaitingOnCertificateOrder",
+                "Succeeded",
+                "CertificateOrderFailed",
+                "OperationNotPermittedOnKeyVault",
+                "AzureServiceUnauthorizedToAccessKeyVault",
+                "KeyVaultDoesNotExist",
+                "KeyVaultSecretDoesNotExist",
+                "UnknownError",
+                "ExternalPrivateKey",
+                "Unknown"
+              ],
+              "type": "string",
+              "readOnly": true,
+              "x-ms-enum": {
+                "name": "KeyVaultSecretStatus",
+                "modelAsString": false
+              }
+            },
+            "serverFarmId": {
+              "description": "Resource ID of the associated App Service plan, formatted as: \"/subscriptions/{subscriptionID}/resourceGroups/{groupName}/providers/Microsoft.Web/serverfarms/{appServicePlanName}\".",
+              "type": "string"
+            }
+          },
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "CertificateCollection": {
+      "description": "Collection of certificates.",
+      "required": [
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Collection of resources.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Certificate"
+          }
+        },
+        "nextLink": {
+          "description": "Link to next page of resources.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "CertificatePatchResource": {
+      "description": "ARM resource for a certificate.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/ProxyOnlyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "description": "CertificatePatchResource resource specific properties",
+          "required": [
+            "password"
+          ],
+          "properties": {
+            "friendlyName": {
+              "description": "Friendly name of the certificate.",
+              "type": "string",
+              "readOnly": true
+            },
+            "subjectName": {
+              "description": "Subject name of the certificate.",
+              "type": "string",
+              "readOnly": true
+            },
+            "hostNames": {
+              "description": "Host names the certificate applies to.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "pfxBlob": {
+              "format": "byte",
+              "description": "Pfx blob.",
+              "type": "string"
+            },
+            "siteName": {
+              "description": "App name.",
+              "type": "string",
+              "readOnly": true
+            },
+            "selfLink": {
+              "description": "Self link.",
+              "type": "string",
+              "readOnly": true
+            },
+            "issuer": {
+              "description": "Certificate issuer.",
+              "type": "string",
+              "readOnly": true
+            },
+            "issueDate": {
+              "format": "date-time",
+              "description": "Certificate issue Date.",
+              "type": "string",
+              "readOnly": true
+            },
+            "expirationDate": {
+              "format": "date-time",
+              "description": "Certificate expiration date.",
+              "type": "string",
+              "readOnly": true
+            },
+            "password": {
+              "description": "Certificate password.",
+              "type": "string",
+              "x-ms-mutability": [
+                "create"
+              ]
+            },
+            "thumbprint": {
+              "description": "Certificate thumbprint.",
+              "type": "string",
+              "readOnly": true
+            },
+            "valid": {
+              "description": "Is the certificate valid?.",
+              "type": "boolean",
+              "readOnly": true
+            },
+            "cerBlob": {
+              "format": "byte",
+              "description": "Raw bytes of .cer file",
+              "type": "string",
+              "readOnly": true
+            },
+            "publicKeyHash": {
+              "description": "Public key hash.",
+              "type": "string",
+              "readOnly": true
+            },
+            "hostingEnvironmentProfile": {
+              "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/HostingEnvironmentProfile",
+              "description": "Specification for the App Service Environment to use for the certificate.",
+              "readOnly": true
+            },
+            "keyVaultId": {
+              "description": "Key Vault Csm resource Id.",
+              "type": "string"
+            },
+            "keyVaultSecretName": {
+              "description": "Key Vault secret name.",
+              "type": "string"
+            },
+            "keyVaultSecretStatus": {
+              "description": "Status of the Key Vault secret.",
+              "enum": [
+                "Initialized",
+                "WaitingOnCertificateOrder",
+                "Succeeded",
+                "CertificateOrderFailed",
+                "OperationNotPermittedOnKeyVault",
+                "AzureServiceUnauthorizedToAccessKeyVault",
+                "KeyVaultDoesNotExist",
+                "KeyVaultSecretDoesNotExist",
+                "UnknownError",
+                "ExternalPrivateKey",
+                "Unknown"
+              ],
+              "type": "string",
+              "readOnly": true,
+              "x-ms-enum": {
+                "name": "KeyVaultSecretStatus",
+                "modelAsString": false
+              }
+            },
+            "serverFarmId": {
+              "description": "Resource ID of the associated App Service plan, formatted as: \"/subscriptions/{subscriptionID}/resourceGroups/{groupName}/providers/Microsoft.Web/serverfarms/{appServicePlanName}\".",
+              "type": "string"
+            }
+          },
+          "x-ms-client-flatten": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "subscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Your Azure subscription ID. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000).",
+      "required": true,
+      "type": "string"
+    },
+    "resourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "Name of the resource group to which the resource belongs.",
+      "required": true,
+      "type": "string",
+      "maxLength": 90,
+      "minLength": 1,
+      "pattern": "^[-\\w\\._\\(\\)]+[^\\.]$",
+      "x-ms-parameter-location": "method"
+    },
+    "apiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "API Version",
+      "required": true,
+      "type": "string"
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ]
+}

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/CreateOrUpdateCertificate.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/CreateOrUpdateCertificate.json
@@ -1,0 +1,49 @@
+{
+    "parameters": {
+        "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+        "resourceGroupName": "testrg123",
+        "name": "testc6282",
+        "api-version": "2018-02-01",
+        "certificateEnvelope": {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/certificates/testc6282",
+            "name": "testc6282",
+            "type": "Microsoft.Web/certificates",
+            "location": "East US",
+            "properties": {
+              "friendlyName": "",
+              "subjectName": "ServerCert",
+              "hostNames": [
+                "ServerCert"
+              ],
+              "issuer": "CACert",
+              "issueDate": "2015-11-12T23:40:25+00:00",
+              "expirationDate": "2039-12-31T23:59:59+00:00",
+              "thumbprint": "FE703D7411A44163B6D32B3AD9B03E175886EBFE",
+              "password": "SWsSsd__233$Sdsds#%Sd!"
+            }
+        }
+    },
+    "responses": {
+        "200": {
+            "headers": {},
+            "body": {
+                "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/certificates/testc6282",
+                "name": "testc6282",
+                "type": "Microsoft.Web/certificates",
+                "location": "East US",
+                "properties": {
+                  "friendlyName": "",
+                  "subjectName": "ServerCert",
+                  "hostNames": [
+                    "ServerCert"
+                  ],
+                  "issuer": "CACert",
+                  "issueDate": "2015-11-12T23:40:25+00:00",
+                  "expirationDate": "2039-12-31T23:59:59+00:00",
+                  "thumbprint": "FE703D7411A44163B6D32B3AD9B03E175886EBFE",
+                  "password": "SWsSsd__233$Sdsds#%Sd!"
+                }
+            }
+        }
+    }
+}

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/DeleteCertificate.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/DeleteCertificate.json
@@ -1,0 +1,12 @@
+{
+    "parameters": {
+        "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+        "resourceGroupName": "testrg123",
+        "name": "testc6282",
+        "api-version": "2018-02-01"
+    },
+    "responses": {
+        "200": { },
+        "204": { }
+    }
+}

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/GetCertificate.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/GetCertificate.json
@@ -1,0 +1,31 @@
+{
+    "parameters": {
+        "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+        "resourceGroupName": "testrg123",
+        "name": "testc6282",
+        "api-version": "2018-02-01"
+    },
+    "responses": {
+        "200": {
+            "headers": {},
+            "body": {
+                "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/certificates/testc6282",
+                "name": "testc6282",
+                "type": "Microsoft.Web/certificates",
+                "location": "East US",
+                "properties": {
+                    "friendlyName": "",
+                    "subjectName": "ServerCert",
+                    "hostNames": [
+                        "ServerCert"
+                    ],
+                    "issuer": "CACert",
+                    "issueDate": "2015-11-12T23:40:25+00:00",
+                    "expirationDate": "2039-12-31T23:59:59+00:00",
+                    "thumbprint": "FE703D7411A44163B6D32B3AD9B03E175886EBFE",
+                    "password": "SWsSsd__233$Sdsds#%Sd!"
+                }
+            }
+        }
+    }
+}

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/ListCertificates.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/ListCertificates.json
@@ -1,0 +1,51 @@
+{
+    "parameters": {
+        "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+        "api-version": "2018-02-01"
+    },
+    "responses": {
+        "200": {
+            "headers": {},
+            "body": {
+                "value": [
+                    {
+                        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/certificates/testc6282",
+                        "name": "testc6282",
+                        "type": "Microsoft.Web/certificates",
+                        "location": "East US",
+                        "properties": {
+                            "friendlyName": "",
+                            "subjectName": "ServerCert",
+                            "hostNames": [
+                                "ServerCert"
+                            ],
+                            "issuer": "CACert",
+                            "issueDate": "2015-11-12T23:40:25+00:00",
+                            "expirationDate": "2039-12-31T23:59:59+00:00",
+                            "thumbprint": "FE703D7411A44163B6D32B3AD9B03E175886EBFE",
+                            "password": "SWsSsd__233$Sdsds#%Sd!"
+                        }
+                    },
+                    {
+                        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/certificates/testc4912",
+                        "name": "testc4912",
+                        "type": "Microsoft.Web/certificates",
+                        "location": "West US",
+                        "properties": {
+                            "friendlyName": "",
+                            "subjectName": "ServerCert2",
+                            "hostNames": [
+                                "ServerCert2"
+                            ],
+                            "issuer": "CACert",
+                            "issueDate": "2015-12-12T23:40:25+00:00",
+                            "expirationDate": "2040-12-31T23:59:59+00:00",
+                            "thumbprint": "FE703D7411A44163B6D32B3AD9B0490D5886EBFE",
+                            "password": "SWsSsd__233$Sdsds#%Sd!"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/ListCertificatesByResourceGroup.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/ListCertificatesByResourceGroup.json
@@ -1,0 +1,52 @@
+{
+    "parameters": {
+        "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+        "resourceGroupName": "testrg123",
+        "api-version": "2018-02-01"
+    },
+    "responses": {
+        "200": {
+            "headers": {},
+            "body": {
+                "value": [
+                    {
+                        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/certificates/testc6282",
+                        "name": "testc6282",
+                        "type": "Microsoft.Web/certificates",
+                        "location": "East US",
+                        "properties": {
+                            "friendlyName": "",
+                            "subjectName": "ServerCert",
+                            "hostNames": [
+                                "ServerCert"
+                            ],
+                            "issuer": "CACert",
+                            "issueDate": "2015-11-12T23:40:25+00:00",
+                            "expirationDate": "2039-12-31T23:59:59+00:00",
+                            "thumbprint": "FE703D7411A44163B6D32B3AD9B03E175886EBFE",
+                            "password": "SWsSsd__233$Sdsds#%Sd!"
+                        }
+                    },
+                    {
+                        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/certificates/testc4912",
+                        "name": "testc4912",
+                        "type": "Microsoft.Web/certificates",
+                        "location": "West US",
+                        "properties": {
+                            "friendlyName": "",
+                            "subjectName": "ServerCert2",
+                            "hostNames": [
+                                "ServerCert2"
+                            ],
+                            "issuer": "CACert",
+                            "issueDate": "2015-12-12T23:40:25+00:00",
+                            "expirationDate": "2040-12-31T23:59:59+00:00",
+                            "thumbprint": "FE703D7411A44163B6D32B3AD9B0490D5886EBFE",
+                            "password": "SWsSsd__233$Sdsds#%Sd!"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/PatchCertificate.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/examples/PatchCertificate.json
@@ -1,0 +1,39 @@
+{
+    "parameters": {
+        "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+        "resourceGroupName": "testrg123",
+        "name": "testc6282",
+        "api-version": "2018-02-01",
+        "certificateEnvelope": {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/certificates/testc6282",
+            "name": "testc6282",
+            "type": "Microsoft.Web/certificates",
+            "properties": {
+              "password": "SWsSsd__233$Sdsds#%Sd!"
+            }
+        }
+    },
+    "responses": {
+        "200": {
+            "headers": {},
+            "body": {
+                "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/certificates/testc6282",
+                "name": "testc6282",
+                "type": "Microsoft.Web/certificates",
+                "location": "East US",
+                "properties": {
+                  "friendlyName": "",
+                  "subjectName": "ServerCert",
+                  "hostNames": [
+                    "ServerCert"
+                  ],
+                  "issuer": "CACert",
+                  "issueDate": "2015-11-12T23:40:25+00:00",
+                  "expirationDate": "2039-12-31T23:59:59+00:00",
+                  "thumbprint": "FE703D7411A44163B6D32B3AD9B03E175886EBFE",
+                  "password": "SWsSsd__233$Sdsds#%Sd!"
+                }
+            }
+        }
+    }
+}

--- a/specification/web/resource-manager/readme.md
+++ b/specification/web/resource-manager/readme.md
@@ -34,8 +34,39 @@ These are the global settings for the Web API.
 title: WebSiteManagementClient
 description: WebSite Management Client
 openapi-type: arm
-tag: package-2018-02
+tag: package-2018-11
 ```
+
+### Tag: package-2018-11
+
+These settings apply only when `--tag=package-2018-11` is specified on the command line.
+
+``` yaml $(tag) == 'package-2018-11'
+input-file:
+- Microsoft.CertificateRegistration/stable/2018-02-01/AppServiceCertificateOrders.json
+- Microsoft.CertificateRegistration/stable/2018-02-01/CertificateRegistrationProvider.json
+- Microsoft.DomainRegistration/stable/2018-02-01/Domains.json
+- Microsoft.DomainRegistration/stable/2018-02-01/TopLevelDomains.json
+- Microsoft.DomainRegistration/stable/2018-02-01/DomainRegistrationProvider.json
+- Microsoft.Web/stable/2018-11-01/Certificates.json
+- Microsoft.Web/stable/2018-02-01/CommonDefinitions.json
+- Microsoft.Web/stable/2018-02-01/DeletedWebApps.json
+- Microsoft.Web/stable/2018-02-01/Diagnostics.json
+- Microsoft.Web/stable/2018-02-01/Provider.json
+- Microsoft.Web/stable/2018-02-01/Recommendations.json
+- Microsoft.Web/stable/2018-02-01/ResourceProvider.json
+- Microsoft.Web/stable/2018-02-01/WebApps.json
+- Microsoft.Web/stable/2018-02-01/AppServiceEnvironments.json
+- Microsoft.Web/stable/2018-02-01/AppServicePlans.json
+- Microsoft.Web/stable/2018-02-01/ResourceHealthMetadata.json
+directive:
+  # suppress each RPC 3019 error
+- where: $.definitions.Identifier.properties
+  suppress: R3019
+  reason: It's an old API, will resolve in next API version
+  approved-by: "@ravbhatnagar"
+```
+
 
 ### Tag: package-2018-02
 
@@ -66,7 +97,6 @@ directive:
   reason: It's an old API, will resolve in next API version
   approved-by: "@ravbhatnagar"
 ```
-
 
 ### Tag: package-2016-09
 


### PR DESCRIPTION
* Update swagger spec for ANT80

* Fix some spelling errors that were reverted by previous commit

* Move certificate examples to new API version folder

* Add the 2018-02-01 certificates files back

* This change is already merged into master. Cherry-picking to ANT80  branch. 

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [X] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [X] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [X] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
