### PR TITLE
Fix for lintdiff tool memory issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - MODE=model PR_ONLY=true CHECK_NAME="Model Validator"
     # - MODE=model PR_ONLY=false
     - MODE=BreakingChange PR_ONLY=true CHECK_NAME="Breaking Changes"
-    - MODE=lintdiff PR_ONLY=true CHECK_NAME="Linter Diff"
+    - MODE=lintdiff PR_ONLY=true CHECK_NAME="Linter Diff" NODE_OPTIONS=--max-old-space-size=8192
 matrix:
   fast_finish: true
   allow_failures:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,8 @@ jobs:
   - script: 'node scripts/breaking-change.js'
 
 - job: "LintDiff"
+  variables:
+    NODE_OPTIONS: 'max-old-space-size=8192'
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
 
 - job: "LintDiff"
   variables:
-    NODE_OPTIONS: 'max-old-space-size=8192'
+    NODE_OPTIONS: '--max-old-space-size=8192'
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
