### PR TITLE
Updating Blueprint spec to include resource group tags

### DIFF
--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
@@ -1205,7 +1205,19 @@
             "type": "string",
             "description": "Name of peer artifact."
           }
+        },
+        "tags": {
+          "description": "Tags to be assigned to this resource group.",
+          "$ref": "#/definitions/ResourceGroupTagCollection"
         }
+      }
+    },
+    "ResourceGroupTagCollection": {
+      "description": "A dictionary of resource group tag values.",
+      "type": "object",
+      "properties": {},
+      "additionalProperties": {
+        "type": "string"
       }
     },
     "ParameterDefinitionMetadata": {


### PR DESCRIPTION
Updating latest Blueprint preview API to include resource group tagging, which was missing from our existing swagger.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
