### PR TITLE
Add globalReachEnabled, Add Get and list for peer express route circuit connections.

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/ExpressRouteCircuitConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/ExpressRouteCircuitConnectionList.json
@@ -1,6 +1,5 @@
 {
     "parameters": {
-      "connectionName": "circuitConnectionUSAUS",
       "resourceGroupName": "rg1",
       "api-version": "2018-12-01",
       "subscriptionId": "subid1",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PeerExpressRouteCircuitConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PeerExpressRouteCircuitConnectionGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "connectionName": "60aee347-e889-4a42-8c1b-0aae8b1e4013",
+    "resourceGroupName": "rg1",
+    "api-version": "2018-12-01",
+    "subscriptionId": "subid1",
+    "circuitName": "ExpressRouteARMCircuitA",
+    "peeringName": "AzurePrivatePeering"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "60aee347-e889-4a42-8c1b-0aae8b1e4013",
+        "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.Network/expressRouteCircuits/ExpressRouteARMCircuitA/peerings/AzurePrivatePeering/peerConnections/60aee347-e889-4a42-8c1b-0aae8b1e4013",
+        "etag": "W/\"6ffbbb06-da20-44ca-a34f-280c4653b1e9\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "expressRouteCircuitPeering": {
+            "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.Network/expressRouteCircuits/ExpressRouteARMCircuitA/peerings/AzurePrivatePeering"
+          },
+          "peerExpressRouteCircuitPeering": {
+            "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.Network/expressRouteCircuits/ExpressRouteARMCircuitB/peerings/AzurePrivatePeering"
+          },
+          "addressPrefix": "20.0.0.0/29",
+          "circuitConnectionStatus": "Connected",
+          "connectionName": "circuitConnectionWestusEastus",
+          "authResourceGuid": ""
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PeerExpressRouteCircuitConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PeerExpressRouteCircuitConnectionList.json
@@ -1,0 +1,53 @@
+{
+    "parameters": {
+      "resourceGroupName": "rg1",
+      "api-version": "2018-12-01",
+      "subscriptionId": "subid1",
+      "circuitName": "ExpressRouteARMCircuitA",
+      "peeringName": "AzurePrivatePeering"
+    },
+    "responses": {
+      "200": {
+        "body": {
+            "value": [
+              {
+                "name": "60aee347-e889-4a42-8c1b-0aae8b1e4013",
+                "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.Network/expressRouteCircuits/ExpressRouteARMCircuitA/peerings/AzurePrivatePeering/peerConnections/60aee347-e889-4a42-8c1b-0aae8b1e4013",
+                "etag": "W/\"6ffbbb06-da20-44ca-a34f-280c4653b1e9\"",
+                "properties": {
+                  "provisioningState": "Succeeded",
+                  "expressRouteCircuitPeering": {
+                    "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.Network/expressRouteCircuits/ExpressRouteARMCircuitA/peerings/AzurePrivatePeering"
+                  },
+                  "peerExpressRouteCircuitPeering": {
+                    "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.Network/expressRouteCircuits/ExpressRouteARMCircuitB/peerings/AzurePrivatePeering"
+                  },
+                  "addressPrefix": "20.0.0.0/29",
+                  "circuitConnectionStatus": "Connected",
+                  "connectionName": "circuitConnectionWestusEastus",
+                  "authResourceGuid": ""
+                }
+              },
+              {
+                "name": "c8b17193-8dd3-4f61-866d-8cdd2e2e268e",
+                "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.Network/expressRouteCircuits/ExpressRouteARMCircuitA/peerings/AzurePrivatePeering/peerConnections/c8b17193-8dd3-4f61-866d-8cdd2e2e268e",
+                "etag": "W/\"6ffbbb06-da20-44ca-a34f-280c4653b1e9\"",
+                "properties": {
+                  "provisioningState": "Succeeded",
+                  "expressRouteCircuitPeering": {
+                    "id": "/subscriptions/subid1/resourceGroups/rg1/providers/Microsoft.Network/expressRouteCircuits/ExpressRouteARMCircuitA/peerings/AzurePrivatePeering"
+                  },
+                  "peerExpressRouteCircuitPeering": {
+                    "id": "/subscriptions/subid2/resourceGroups/rg1/providers/Microsoft.Network/expressRouteCircuits/ExpressRouteARMCircuitC/peerings/AzurePrivatePeering"
+                  },
+                  "addressPrefix": "30.0.0.0/29",
+                  "circuitConnectionStatus": "Connected",
+                  "connectionName": "circuitConnectionCentralusEastus",
+                  "authResourceGuid": "64283012-d377-421d-8398-f6aeb2ac7ea0"
+                }
+              }
+          ]
+        }
+      }
+    }
+  }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/expressRouteCircuit.json
@@ -690,6 +690,116 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/peerConnections/{connectionName}": {
+      "get": {
+        "tags": [
+          "PeerExpressRouteCircuitConnections"
+        ],
+        "operationId": "PeerExpressRouteCircuitConnections_Get",
+        "description": "Gets the specified Peer Express Route Circuit Connection from the specified express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the express route circuit."
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peer express route circuit connection."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting Peer Express Route Circuit Connection resource.",
+            "schema": {
+              "$ref": "#/definitions/PeerExpressRouteCircuitConnection"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PeerExpressRouteCircuitConnectionGet": {
+            "$ref": "./examples/PeerExpressRouteCircuitConnectionGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/peerConnections": {
+      "get": {
+        "tags": [
+          "PeerExpressRouteCircuitConnections"
+        ],
+        "operationId": "PeerExpressRouteCircuitConnections_List",
+        "description": "Gets all global reach peer connections associated with a private peering in an express route circuit.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the circuit."
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the peering."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a list of PeerExpressRouteCircuitConnections resources.",
+            "schema": {
+              "$ref": "#/definitions/PeerExpressRouteCircuitConnectionListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": { 
+          "List Peer ExpressRouteCircuit Connection": { "$ref": "./examples/PeerExpressRouteCircuitConnectionList.json" } 
+        }
+      }
+    },        
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}": {
       "delete": {
         "tags": [
@@ -1510,6 +1620,14 @@
             "$ref": "#/definitions/ExpressRouteCircuitConnection"
           },
           "description": "The list of circuit connections associated with Azure Private Peering for this circuit."
+        },
+        "peeredConnections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PeerExpressRouteCircuitConnection"
+          },
+          "readOnly": true,
+          "description": "The list of peered circuit connections associated with Azure Private Peering for this circuit."
         }
       }
     },
@@ -1655,6 +1773,88 @@
       },
       "description": "Response for ListConnections API service call retrieves all global reach connections that belongs to a Private Peering for an ExpressRouteCircuit."
     },
+    "PeerExpressRouteCircuitConnectionPropertiesFormat": {
+      "properties": {
+        "expressRouteCircuitPeering": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Reference to Express Route Circuit Private Peering Resource of the circuit."
+        },
+        "peerExpressRouteCircuitPeering": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Reference to Express Route Circuit Private Peering Resource of the peered circuit."
+        },
+        "addressPrefix": {
+          "type": "string",
+          "description": "/29 IP address space to carve out Customer addresses for tunnels."
+        },
+        "circuitConnectionStatus": {
+          "type": "string",
+          "description": "Express Route Circuit Connection State. Possible values are: 'Connected' and 'Disconnected'.",
+          "enum": [
+            "Connected",
+            "Connecting",
+            "Disconnected"
+          ],
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "circuitConnectionStatus",
+            "modelAsString": true
+          }
+        },
+        "connectionName": {
+          "type": "string",
+          "description": "The name of the express route circuit connection resource."
+        },
+        "authResourceGuid": {
+          "type": "string",
+          "description": "The resource guid of the authorization used for the express route circuit connection."
+        },
+        "provisioningState": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Provisioning state of the peer express route circuit connection resource. Possible values are: 'Succeded', 'Updating', 'Deleting', and 'Failed'."
+        }
+      }
+    },
+    "PeerExpressRouteCircuitConnection": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PeerExpressRouteCircuitConnectionPropertiesFormat"
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Peer Express Route Circuit Connection in an ExpressRouteCircuitPeering resource."
+    },
+    "PeerExpressRouteCircuitConnectionListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PeerExpressRouteCircuitConnection"
+          },
+          "description": "The global reach peer circuit connection associated with Private Peering in an ExpressRoute Circuit."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListPeeredConnections API service call retrieves all global reach peer circuit connections that belongs to a Private Peering for an ExpressRouteCircuit."
+    },    
     "ExpressRouteCircuitSku": {
       "properties": {
         "name": {
@@ -1779,9 +1979,9 @@
           "type": "string",
           "description": "The GatewayManager Etag."
         },
-        "allowGlobalReach": {
+        "globalReachEnabled": {
           "type": "boolean",
-          "description": "Flag to enable Global Reach on the circuit."
+          "description": "Flag denoting Global reach status."
         }
       },
       "description": "Properties of ExpressRouteCircuit."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/expressRouteCircuit.json
@@ -1979,6 +1979,10 @@
           "type": "string",
           "description": "The GatewayManager Etag."
         },
+        "allowGlobalReach": {
+          "type": "boolean",
+          "description": "Flag to enable Global Reach on the circuit."
+        },
         "globalReachEnabled": {
           "type": "boolean",
           "description": "Flag denoting Global reach status."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/expressRouteCircuit.json
@@ -1812,7 +1812,7 @@
         "provisioningState": {
           "type": "string",
           "readOnly": true,
-          "description": "Provisioning state of the peer express route circuit connection resource. Possible values are: 'Succeded', 'Updating', 'Deleting', and 'Failed'."
+          "description": "Provisioning state of the peer express route circuit connection resource. Possible values are: 'Succeeded', 'Updating', 'Deleting', and 'Failed'."
         }
       }
     },


### PR DESCRIPTION
Added GlobalReachEnabled field. Added GET and List apis for peer express route circuit connections. Removed AllowGlobalReach. The field was added only in rest-apis-specs project and then abandoned afterwards in favor of GlobalReachEnabled.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [X] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.   - I ran linter check, but it kept getting stuck at _still working!_ spinner. I executed auto-reset and oav on my machine, and they both passed.

### ARM API Review Checklist
- [X] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.
_How do I add label WaitForARMFeedback?_


Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
