### PR TITLE
Remove AzureDataLakeStoreCosmosStructuredStreamDataset since it's internal only

### DIFF
--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Dataset.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Dataset.json
@@ -763,47 +763,6 @@
         "tableName"
       ]
     },
-    "AzureDataLakeStoreCosmosStructuredStreamDataset": {
-      "x-ms-discriminator-value": "AzureDataLakeStoreCosmosStructuredStreamFile",
-      "description": "Azure Data Lake Store Cosmos Structured Stream dataset.",
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Dataset"
-        }
-      ],
-      "properties": {
-        "typeProperties": {
-          "description": "Azure Data Lake Store Cosmos Structured Stream dataset properties.",
-          "x-ms-client-flatten": true,
-          "$ref": "#/definitions/AzureDataLakeStoreCosmosStructuredStreamDatasetTypeProperties"
-        }
-      },
-      "required": [
-        "typeProperties"
-      ]
-    },
-    "AzureDataLakeStoreCosmosStructuredStreamDatasetTypeProperties": {
-      "description": "Azure Data Lake Store Cosmos Structured Stream dataset properties.",
-      "properties": {
-        "folderPath": {
-          "type": "object",
-          "description": "Path to the folder in the Azure Data Lake Store. Type: string (or Expression with resultType string)."
-        },
-        "fileName": {
-          "type": "object",
-          "description": "The name of the file in the Azure Data Lake Store. Type: string (or Expression with resultType string)."
-        },
-        "generatedFromActivity": {
-          "type": "object",
-          "description": "Flag to indicate if this dataset is been generated from Compilation Activity. Type: boolean (or Expression with resultType boolean)."
-        }
-      },
-      "required": [
-        "folderPath",
-        "fileName"
-      ]
-    },
     "FileShareDataset": {
       "x-ms-discriminator-value": "FileShare",
       "description": "An on-premises file system dataset.",


### PR DESCRIPTION

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
