### PR TITLE
[Hub Generated] Review request for Microsoft.Devices to add version 2019-03-12

### DIFF
--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/checkNameAvailability.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/checkNameAvailability.json
@@ -1,0 +1,20 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "operationInputs": {
+            "name": "test-request"
+        }
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "nameAvailable": true,
+                "reason": "Invalid",
+                "message": ""
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/checkNameAvailability.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/checkNameAvailability.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "operationInputs": {
             "name": "test-request"

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certificatescreateorupdate.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certificatescreateorupdate.json
@@ -1,0 +1,44 @@
+{
+    "parameters": {
+        "resourceName": "iothub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version":"2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "certificateName": "cert",
+        "certificateDescription":{
+            "certificate": "############################################"
+        }
+      },
+      "responses": {
+        "201": {  "body": {
+          "properties": {
+              "subject": "CN=testdevice1",
+              "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+              "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+              "isVerified": false,
+              "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+              "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+            },
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServives/myFirstProvisioningService/certificates/cert",
+            "name": "cert",
+            "type": "Microsoft.Devices/IotHubs/Certificates",
+            "etag": "AAAAAAExpNs="
+        }},
+        "200": {
+          "body": {
+            "properties": {
+                "subject": "CN=testdevice1",
+                "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+                "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+                "isVerified": false,
+                "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+                "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+              },
+              "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServives/myFirstProvisioningService/certificates/cert",
+              "name": "cert",
+              "type": "Microsoft.Devices/IotHubs/Certificates",
+              "etag": "AAAAAAExpNs="
+          }
+        }
+      }
+    }

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certificatescreateorupdate.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certificatescreateorupdate.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "iothub",
         "resourceGroupName": "myResourceGroup",
-        "api-version":"2018-12-01-preview",
+        "api-version":"2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "certificateName": "cert",
         "certificateDescription":{

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certificatesdelete.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certificatesdelete.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "myhub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "certificateName": "cert",
         "If-Match": "AAAAAAAADGk="

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certificatesdelete.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certificatesdelete.json
@@ -1,0 +1,14 @@
+{
+    "parameters": {
+        "resourceName": "myhub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "certificateName": "cert",
+        "If-Match": "AAAAAAAADGk="
+    },
+    "responses": {
+        "200": {},
+        "204": {}
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certverify.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certverify.json
@@ -1,0 +1,31 @@
+{
+    "parameters": {
+        "resourceName": "myFirstProvisioningService",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "certificateName": "cert",
+        "If-Match": "AAAAAAAADGk=",
+        "certificateVerificationBody": {
+            "certificate": "#####################################"
+        }
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "properties": {
+                    "subject": "CN=andbucdevice1",
+                    "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+                    "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+                    "isVerified": true,
+                    "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+                    "updated": "Thu, 12 Oct 2017 19:26:56 GMT"
+                },
+                "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/certificates/cert",
+                "name": "cert",
+                "type": "Microsoft.Devices/IotHubs/Certificates",
+                "etag": "AAAAAAExpTQ="
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certverify.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_certverify.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "myFirstProvisioningService",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "certificateName": "cert",
         "If-Match": "AAAAAAAADGk=",

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createOrUpdate.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createOrUpdate.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "iotHubDescription": {
             "name": "iot-dps-cit-hub-1",

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createOrUpdate.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createOrUpdate.json
@@ -11,17 +11,6 @@
             "tags": {},
             "etag": "AAAAAAFD6M4=",
             "properties": {
-                "operationsMonitoringProperties": {
-                    "events": {
-                        "None": "None",
-                        "Connections": "None",
-                        "DeviceTelemetry": "None",
-                        "C2DCommands": "None",
-                        "DeviceIdentityOperations": "None",
-                        "FileUploadOperations": "None",
-                        "Routes": "None"
-                    }
-                },
                 "state": "Active",
                 "provisioningState": "Succeeded",
                 "ipFilterRules": [],
@@ -35,16 +24,6 @@
                             "1"
                         ],
                         "path": "iot-dps-cit-hub-1",
-                        "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
-                    },
-                    "operationsMonitoringEvents": {
-                        "retentionTimeInDays": 1,
-                        "partitionCount": 2,
-                        "partitionIds": [
-                            "0",
-                            "1"
-                        ],
-                        "path": "iot-dps-cit-hub-1-operationmonitoring",
                         "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
                     }
                 },
@@ -109,17 +88,6 @@
                 "tags": {},
                 "etag": "AAAAAAFD6M4=",
                 "properties": {
-                    "operationsMonitoringProperties": {
-                        "events": {
-                            "None": "None",
-                            "Connections": "None",
-                            "DeviceTelemetry": "None",
-                            "C2DCommands": "None",
-                            "DeviceIdentityOperations": "None",
-                            "FileUploadOperations": "None",
-                            "Routes": "None"
-                        }
-                    },
                     "state": "Active",
                     "provisioningState": "Succeeded",
                     "ipFilterRules": [],
@@ -133,16 +101,6 @@
                                 "1"
                             ],
                             "path": "iot-dps-cit-hub-1",
-                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
-                        },
-                        "operationsMonitoringEvents": {
-                            "retentionTimeInDays": 1,
-                            "partitionCount": 2,
-                            "partitionIds": [
-                                "0",
-                                "1"
-                            ],
-                            "path": "iot-dps-cit-hub-1-operationmonitoring",
                             "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
                         }
                     },
@@ -206,17 +164,6 @@
                 "tags": {},
                 "etag": "AAAAAAFD6M4=",
                 "properties": {
-                    "operationsMonitoringProperties": {
-                        "events": {
-                            "None": "None",
-                            "Connections": "None",
-                            "DeviceTelemetry": "None",
-                            "C2DCommands": "None",
-                            "DeviceIdentityOperations": "None",
-                            "FileUploadOperations": "None",
-                            "Routes": "None"
-                        }
-                    },
                     "state": "Active",
                     "provisioningState": "Succeeded",
                     "ipFilterRules": [],
@@ -230,16 +177,6 @@
                                 "1"
                             ],
                             "path": "iot-dps-cit-hub-1",
-                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
-                        },
-                        "operationsMonitoringEvents": {
-                            "retentionTimeInDays": 1,
-                            "partitionCount": 2,
-                            "partitionIds": [
-                                "0",
-                                "1"
-                            ],
-                            "path": "iot-dps-cit-hub-1-operationmonitoring",
                             "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
                         }
                     },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createOrUpdate.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createOrUpdate.json
@@ -1,0 +1,301 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "iotHubDescription": {
+            "name": "iot-dps-cit-hub-1",
+            "type": "Microsoft.Devices/IotHubs",
+            "location": "centraluseuap",
+            "tags": {},
+            "etag": "AAAAAAFD6M4=",
+            "properties": {
+                "operationsMonitoringProperties": {
+                    "events": {
+                        "None": "None",
+                        "Connections": "None",
+                        "DeviceTelemetry": "None",
+                        "C2DCommands": "None",
+                        "DeviceIdentityOperations": "None",
+                        "FileUploadOperations": "None",
+                        "Routes": "None"
+                    }
+                },
+                "state": "Active",
+                "provisioningState": "Succeeded",
+                "ipFilterRules": [],
+                "hostName": "iot-dps-cit-hub-1.azure-devices.net",
+                "eventHubEndpoints": {
+                    "events": {
+                        "retentionTimeInDays": 1,
+                        "partitionCount": 2,
+                        "partitionIds": [
+                            "0",
+                            "1"
+                        ],
+                        "path": "iot-dps-cit-hub-1",
+                        "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                    },
+                    "operationsMonitoringEvents": {
+                        "retentionTimeInDays": 1,
+                        "partitionCount": 2,
+                        "partitionIds": [
+                            "0",
+                            "1"
+                        ],
+                        "path": "iot-dps-cit-hub-1-operationmonitoring",
+                        "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                    }
+                },
+                "routing": {
+                    "endpoints": {
+                        "serviceBusQueues": [],
+                        "serviceBusTopics": [],
+                        "eventHubs": [],
+                        "storageContainers": []
+                    },
+                    "routes": [],
+                    "fallbackRoute": {
+                        "name": "$fallback",
+                        "source": "DeviceMessages",
+                        "condition": "true",
+                        "endpointNames": [
+                            "events"
+                        ],
+                        "isEnabled": true
+                    }
+                },
+                "storageEndpoints": {
+                    "$default": {
+                        "sasTtlAsIso8601": "PT1H",
+                        "connectionString": "",
+                        "containerName": ""
+                    }
+                },
+                "messagingEndpoints": {
+                    "fileNotifications": {
+                        "lockDurationAsIso8601": "PT1M",
+                        "ttlAsIso8601": "PT1H",
+                        "maxDeliveryCount": 10
+                    }
+                },
+                "enableFileUploadNotifications": false,
+                "cloudToDevice": {
+                    "maxDeliveryCount": 10,
+                    "defaultTtlAsIso8601": "PT1H",
+                    "feedback": {
+                        "lockDurationAsIso8601": "PT1M",
+                        "ttlAsIso8601": "PT1H",
+                        "maxDeliveryCount": 10
+                    }
+                },
+                "features": "None"
+            },
+            "sku": {
+                "name": "S1",
+                "tier": "Standard",
+                "capacity": 1
+            }
+        }
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "id": "/subscriptions/ae24ff83-d2ca-4fc8-9717-05dae4bba489/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/testHub",
+                "name": "testHub",
+                "type": "Microsoft.Devices/IotHubs",
+                "location": "centraluseuap",
+                "tags": {},
+                "etag": "AAAAAAFD6M4=",
+                "properties": {
+                    "operationsMonitoringProperties": {
+                        "events": {
+                            "None": "None",
+                            "Connections": "None",
+                            "DeviceTelemetry": "None",
+                            "C2DCommands": "None",
+                            "DeviceIdentityOperations": "None",
+                            "FileUploadOperations": "None",
+                            "Routes": "None"
+                        }
+                    },
+                    "state": "Active",
+                    "provisioningState": "Succeeded",
+                    "ipFilterRules": [],
+                    "hostName": "iot-dps-cit-hub-1.azure-devices.net",
+                    "eventHubEndpoints": {
+                        "events": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        },
+                        "operationsMonitoringEvents": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1-operationmonitoring",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        }
+                    },
+                    "routing": {
+                        "endpoints": {
+                            "serviceBusQueues": [],
+                            "serviceBusTopics": [],
+                            "eventHubs": [],
+                            "storageContainers": []
+                        },
+                        "routes": [],
+                        "fallbackRoute": {
+                            "name": "$fallback",
+                            "source": "DeviceMessages",
+                            "condition": "true",
+                            "endpointNames": [
+                                "events"
+                            ],
+                            "isEnabled": true
+                        }
+                    },
+                    "storageEndpoints": {
+                        "$default": {
+                            "sasTtlAsIso8601": "PT1H",
+                            "connectionString": "",
+                            "containerName": ""
+                        }
+                    },
+                    "messagingEndpoints": {
+                        "fileNotifications": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "enableFileUploadNotifications": false,
+                    "cloudToDevice": {
+                        "maxDeliveryCount": 10,
+                        "defaultTtlAsIso8601": "PT1H",
+                        "feedback": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "features": "None"
+                },
+                "sku": {
+                    "name": "S1",
+                    "tier": "Standard",
+                    "capacity": 1
+                }
+            }
+        },
+        "201": {
+            "body": {
+                "id": "/subscriptions/ae24ff83-d2ca-4fc8-9717-05dae4bba489/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/testHub",
+                "name": "testHub",
+                "type": "Microsoft.Devices/IotHubs",
+                "location": "centraluseuap",
+                "tags": {},
+                "etag": "AAAAAAFD6M4=",
+                "properties": {
+                    "operationsMonitoringProperties": {
+                        "events": {
+                            "None": "None",
+                            "Connections": "None",
+                            "DeviceTelemetry": "None",
+                            "C2DCommands": "None",
+                            "DeviceIdentityOperations": "None",
+                            "FileUploadOperations": "None",
+                            "Routes": "None"
+                        }
+                    },
+                    "state": "Active",
+                    "provisioningState": "Succeeded",
+                    "ipFilterRules": [],
+                    "hostName": "iot-dps-cit-hub-1.azure-devices.net",
+                    "eventHubEndpoints": {
+                        "events": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        },
+                        "operationsMonitoringEvents": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1-operationmonitoring",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        }
+                    },
+                    "routing": {
+                        "endpoints": {
+                            "serviceBusQueues": [],
+                            "serviceBusTopics": [],
+                            "eventHubs": [],
+                            "storageContainers": []
+                        },
+                        "routes": [],
+                        "fallbackRoute": {
+                            "name": "$fallback",
+                            "source": "DeviceMessages",
+                            "condition": "true",
+                            "endpointNames": [
+                                "events"
+                            ],
+                            "isEnabled": true
+                        }
+                    },
+                    "storageEndpoints": {
+                        "$default": {
+                            "sasTtlAsIso8601": "PT1H",
+                            "connectionString": "",
+                            "containerName": ""
+                        }
+                    },
+                    "messagingEndpoints": {
+                        "fileNotifications": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "enableFileUploadNotifications": false,
+                    "cloudToDevice": {
+                        "maxDeliveryCount": 10,
+                        "defaultTtlAsIso8601": "PT1H",
+                        "feedback": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "features": "None"
+                },
+                "sku": {
+                    "name": "S1",
+                    "tier": "Standard",
+                    "capacity": 1
+                }
+            }
+        }
+    }
+}
+
+
+

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createconsumergroup.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createconsumergroup.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "eventHubEndpointName": "events",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "name": "test"

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createconsumergroup.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_createconsumergroup.json
@@ -1,0 +1,23 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "eventHubEndpointName": "events",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "name": "test"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "properties": {
+                    "created": "Thu, 15 Jun 2017 19:20:58 GMT"
+                },
+                "id": "/subscriptions/cmd-sub-1/resourceGroups/cmd-rg-1/providers/Microsoft.Devices/IotHubs/test-hub-2/eventHubEndpoints/events/ConsumerGroups/%24Default",
+                "name": "test",
+                "type": "Microsoft.Devices/IotHubs/EventHubEndpoints/ConsumerGroups",
+                "etag": "AAAAAAFD6M4="
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_delete.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_delete.json
@@ -1,0 +1,206 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/testHub",
+                "name": "testHub",
+                "type": "Microsoft.Devices/IotHubs",
+                "location": "centraluseuap",
+                "tags": {},
+                "etag": "AAAAAAFD6M4=",
+                "properties": {
+                    "operationsMonitoringProperties": {
+                        "events": {
+                            "None": "None",
+                            "Connections": "None",
+                            "DeviceTelemetry": "None",
+                            "C2DCommands": "None",
+                            "DeviceIdentityOperations": "None",
+                            "FileUploadOperations": "None",
+                            "Routes": "None"
+                        }
+                    },
+                    "state": "Active",
+                    "provisioningState": "Succeeded",
+                    "ipFilterRules": [],
+                    "hostName": "iot-dps-cit-hub-1.azure-devices.net",
+                    "eventHubEndpoints": {
+                        "events": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        },
+                        "operationsMonitoringEvents": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1-operationmonitoring",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        }
+                    },
+                    "routing": {
+                        "endpoints": {
+                            "serviceBusQueues": [],
+                            "serviceBusTopics": [],
+                            "eventHubs": [],
+                            "storageContainers": []
+                        },
+                        "routes": [],
+                        "fallbackRoute": {
+                            "source": "DeviceMessages",
+                            "condition": "true",
+                            "endpointNames": [
+                                "events"
+                            ],
+                            "isEnabled": true
+                        }
+                    },
+                    "storageEndpoints": {
+                        "$default": {
+                            "sasTtlAsIso8601": "PT1H",
+                            "connectionString": "",
+                            "containerName": ""
+                        }
+                    },
+                    "messagingEndpoints": {
+                        "fileNotifications": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "enableFileUploadNotifications": false,
+                    "cloudToDevice": {
+                        "maxDeliveryCount": 10,
+                        "defaultTtlAsIso8601": "PT1H",
+                        "feedback": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "features": "None"
+                },
+                "sku": {
+                    "name": "S1",
+                    "tier": "Standard",
+                    "capacity": 1
+                }
+            }
+        },
+        "204": {},
+        "202": {
+            "body": {
+                "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/testHub",
+                "name": "testHub",
+                "type": "Microsoft.Devices/IotHubs",
+                "location": "centraluseuap",
+                "tags": {},
+                "etag": "AAAAAAFD6M4=",
+                "properties": {
+                    "operationsMonitoringProperties": {
+                        "events": {
+                            "None": "None",
+                            "Connections": "None",
+                            "DeviceTelemetry": "None",
+                            "C2DCommands": "None",
+                            "DeviceIdentityOperations": "None",
+                            "FileUploadOperations": "None",
+                            "Routes": "None"
+                        }
+                    },
+                    "state": "Active",
+                    "provisioningState": "Succeeded",
+                    "ipFilterRules": [],
+                    "hostName": "iot-dps-cit-hub-1.azure-devices.net",
+                    "eventHubEndpoints": {
+                        "events": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        },
+                        "operationsMonitoringEvents": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1-operationmonitoring",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        }
+                    },
+                    "routing": {
+                        "endpoints": {
+                            "serviceBusQueues": [],
+                            "serviceBusTopics": [],
+                            "eventHubs": [],
+                            "storageContainers": []
+                        },
+                        "routes": [],
+                        "fallbackRoute": {
+                            "source": "DeviceMessages",
+                            "condition": "true",
+                            "endpointNames": [
+                                "events"
+                            ],
+                            "isEnabled": true
+                        }
+                    },
+                    "storageEndpoints": {
+                        "$default": {
+                            "sasTtlAsIso8601": "PT1H",
+                            "connectionString": "",
+                            "containerName": ""
+                        }
+                    },
+                    "messagingEndpoints": {
+                        "fileNotifications": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "enableFileUploadNotifications": false,
+                    "cloudToDevice": {
+                        "maxDeliveryCount": 10,
+                        "defaultTtlAsIso8601": "PT1H",
+                        "feedback": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "features": "None"
+                },
+                "sku": {
+                    "name": "S1",
+                    "tier": "Standard",
+                    "capacity": 1
+                }
+            }
+        },
+        "404": {
+            "body": {}
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_delete.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_delete.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_delete.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_delete.json
@@ -15,17 +15,6 @@
                 "tags": {},
                 "etag": "AAAAAAFD6M4=",
                 "properties": {
-                    "operationsMonitoringProperties": {
-                        "events": {
-                            "None": "None",
-                            "Connections": "None",
-                            "DeviceTelemetry": "None",
-                            "C2DCommands": "None",
-                            "DeviceIdentityOperations": "None",
-                            "FileUploadOperations": "None",
-                            "Routes": "None"
-                        }
-                    },
                     "state": "Active",
                     "provisioningState": "Succeeded",
                     "ipFilterRules": [],
@@ -39,16 +28,6 @@
                                 "1"
                             ],
                             "path": "iot-dps-cit-hub-1",
-                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
-                        },
-                        "operationsMonitoringEvents": {
-                            "retentionTimeInDays": 1,
-                            "partitionCount": 2,
-                            "partitionIds": [
-                                "0",
-                                "1"
-                            ],
-                            "path": "iot-dps-cit-hub-1-operationmonitoring",
                             "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
                         }
                     },
@@ -112,17 +91,6 @@
                 "tags": {},
                 "etag": "AAAAAAFD6M4=",
                 "properties": {
-                    "operationsMonitoringProperties": {
-                        "events": {
-                            "None": "None",
-                            "Connections": "None",
-                            "DeviceTelemetry": "None",
-                            "C2DCommands": "None",
-                            "DeviceIdentityOperations": "None",
-                            "FileUploadOperations": "None",
-                            "Routes": "None"
-                        }
-                    },
                     "state": "Active",
                     "provisioningState": "Succeeded",
                     "ipFilterRules": [],
@@ -136,16 +104,6 @@
                                 "1"
                             ],
                             "path": "iot-dps-cit-hub-1",
-                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
-                        },
-                        "operationsMonitoringEvents": {
-                            "retentionTimeInDays": 1,
-                            "partitionCount": 2,
-                            "partitionIds": [
-                                "0",
-                                "1"
-                            ],
-                            "path": "iot-dps-cit-hub-1-operationmonitoring",
                             "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
                         }
                     },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_deleteconsumergroup.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_deleteconsumergroup.json
@@ -1,0 +1,13 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "eventHubEndpointName": "events",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "name": "test"
+    },
+    "responses": {
+        "200": {}
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_deleteconsumergroup.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_deleteconsumergroup.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "eventHubEndpointName": "events",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "name": "test"

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_exportdevices.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_exportdevices.json
@@ -1,0 +1,23 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "exportDevicesParameters": {
+            "exportBlobContainerUri": "testBlob",
+            "excludeKeys": true
+        }
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "jobId": "test",
+                "startTimeUtc": "Thu, 15 Jun 2017 19:20:58 GMT",
+                "endTimeUtc": "Thu, 15 Jun 2017 19:20:58 GMT",
+                "type": "unknown",
+                "status": "unknown"
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_exportdevices.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_exportdevices.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "exportDevicesParameters": {
             "exportBlobContainerUri": "testBlob",

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_generateverificationcode.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_generateverificationcode.json
@@ -1,0 +1,26 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "certificateName": "cert",
+        "If-Match": "AAAAAAAADGk="     
+      },
+      "responses": {
+        "200": {
+          "body": {
+              "name": "cert",
+              "properties": {
+                "verificationCode": "##################################",
+                "subject": "CN=andbucdevice1",
+                "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+                "thumbprint": "##############################",
+                "isVerified": false,
+                "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+                "updated": "Thu, 12 Oct 2017 19:26:56 GMT"
+              }
+          }
+        }
+      }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_generateverificationcode.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_generateverificationcode.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "certificateName": "cert",
         "If-Match": "AAAAAAAADGk="     

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_get.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_get.json
@@ -15,17 +15,6 @@
                 "tags": {},
                 "etag": "AAAAAAFD6M4=",
                 "properties": {
-                    "operationsMonitoringProperties": {
-                        "events": {
-                            "None": "None",
-                            "Connections": "None",
-                            "DeviceTelemetry": "None",
-                            "C2DCommands": "None",
-                            "DeviceIdentityOperations": "None",
-                            "FileUploadOperations": "None",
-                            "Routes": "None"
-                        }
-                    },
                     "state": "Active",
                     "provisioningState": "Succeeded",
                     "ipFilterRules": [],
@@ -39,16 +28,6 @@
                                 "1"
                             ],
                             "path": "iot-dps-cit-hub-1",
-                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
-                        },
-                        "operationsMonitoringEvents": {
-                            "retentionTimeInDays": 1,
-                            "partitionCount": 2,
-                            "partitionIds": [
-                                "0",
-                                "1"
-                            ],
-                            "path": "iot-dps-cit-hub-1-operationmonitoring",
                             "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
                         }
                     },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_get.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_get.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_get.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_get.json
@@ -1,0 +1,109 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/testHub",
+                "name": "testHub",
+                "type": "Microsoft.Devices/IotHubs",
+                "location": "centraluseuap",
+                "tags": {},
+                "etag": "AAAAAAFD6M4=",
+                "properties": {
+                    "operationsMonitoringProperties": {
+                        "events": {
+                            "None": "None",
+                            "Connections": "None",
+                            "DeviceTelemetry": "None",
+                            "C2DCommands": "None",
+                            "DeviceIdentityOperations": "None",
+                            "FileUploadOperations": "None",
+                            "Routes": "None"
+                        }
+                    },
+                    "state": "Active",
+                    "provisioningState": "Succeeded",
+                    "ipFilterRules": [],
+                    "hostName": "iot-dps-cit-hub-1.azure-devices.net",
+                    "eventHubEndpoints": {
+                        "events": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        },
+                        "operationsMonitoringEvents": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1-operationmonitoring",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        }
+                    },
+                    "routing": {
+                        "endpoints": {
+                            "serviceBusQueues": [],
+                            "serviceBusTopics": [],
+                            "eventHubs": [],
+                            "storageContainers": []
+                        },
+                        "routes": [],
+                        "fallbackRoute": {
+                            "source": "DeviceMessages",
+                            "condition": "true",
+                            "endpointNames": [
+                                "events"
+                            ],
+                            "isEnabled": true
+                        }
+                    },
+                    "storageEndpoints": {
+                        "$default": {
+                            "sasTtlAsIso8601": "PT1H",
+                            "connectionString": "",
+                            "containerName": ""
+                        }
+                    },
+                    "messagingEndpoints": {
+                        "fileNotifications": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "enableFileUploadNotifications": false,
+                    "cloudToDevice": {
+                        "maxDeliveryCount": 10,
+                        "defaultTtlAsIso8601": "PT1H",
+                        "feedback": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "features": "None",
+                    "deviceStreams": {
+                        "streamingEndpoints": ["https://streams.azure-devices-int.net:9443"]
+                    }
+                },
+                "sku": {
+                    "name": "S1",
+                    "tier": "Standard",
+                    "capacity": 1
+                }
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getcertificate.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getcertificate.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testhub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "certificateName": "cert"
     },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getcertificate.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getcertificate.json
@@ -1,0 +1,27 @@
+{
+    "parameters": {
+        "resourceName": "testhub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "certificateName": "cert"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "properties": {
+                    "subject": "CN=testdevice1",
+                    "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+                    "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+                    "isVerified": false,
+                    "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+                    "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+                },
+                "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/andbuc-hub/certificates/cert",
+                "name": "cert",
+                "type": "Microsoft.Devices/IotHubs/Certificates",
+                "etag": "AAAAAAExpNs="
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getconsumergroup.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getconsumergroup.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "eventHubEndpointName": "events",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "name": "test"

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getconsumergroup.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getconsumergroup.json
@@ -1,0 +1,23 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "eventHubEndpointName": "events",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "name": "test"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "properties": {
+                    "created": "Thu, 15 Jun 2017 19:20:58 GMT"
+                },
+                "id": "/subscriptions/cmd-sub-1/resourceGroups/cmd-rg-1/providers/Microsoft.Devices/IotHubs/test-hub-2/eventHubEndpoints/events/ConsumerGroups/%24Default",
+                "name": "test",
+                "type": "Microsoft.Devices/IotHubs/EventHubEndpoints/ConsumerGroups",
+                "etag": "AAAAAAFD6M4="
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getjob.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getjob.json
@@ -1,0 +1,20 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "jobId": "test"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "jobId": "test",
+                "startTimeUtc": "Thu, 15 Jun 2017 19:20:58 GMT",
+                "endTimeUtc": "Thu, 15 Jun 2017 19:20:58 GMT",
+                "type": "unknown",
+                "status": "unknown"
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getjob.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getjob.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "jobId": "test"
     },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getkey.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getkey.json
@@ -1,0 +1,19 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "keyName": "iothubowner"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "keyName": "iothubowner",
+                "primaryKey": "2aWPrKloLLdcug12ZHNpA0e07yJmRRmYMXDLpEOTd/Y=",
+                "secondaryKey": "DLyFnDTGMDK0BU2QjT5TCkNBQ4h08mi20vOqWMC7TxU=",
+                "rights": "RegistryWrite, ServiceConnect, DeviceConnect"
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getkey.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getkey.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "keyName": "iothubowner"
     },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getskus.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getskus.json
@@ -1,0 +1,53 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "resourceType": "Microsoft.Devices/IotHubs",
+                        "sku": {
+                            "name": "S1",
+                            "tier": "Standard"
+                        },
+                        "capacity": {
+                            "default": 1,
+                            "scaleType": "Manual"
+                        }
+                    },
+                    {
+                        "resourceType": "Microsoft.Devices/IotHubs",
+                        "sku": {
+                            "name": "S2",
+                            "tier": "Standard"
+                        },
+                        "capacity": {
+                            "minimum": 1,
+                            "maximum": 200,
+                            "default": 1,
+                            "scaleType": "Manual"
+                        }
+                    },
+                    {
+                        "resourceType": "Microsoft.Devices/IotHubs",
+                        "sku": {
+                            "name": "S3",
+                            "tier": "Standard"
+                        },
+                        "capacity": {
+                            "minimum": 1,
+                            "maximum": 10,
+                            "default": 1,
+                            "scaleType": "Manual"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getskus.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_getskus.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_importdevices.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_importdevices.json
@@ -1,0 +1,23 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "importDevicesParameters": {
+            "inputBlobContainerUri": "testBlob",
+            "outputBlobContainerUri": "testBlob"
+        }
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "jobId": "test",
+                "startTimeUtc": "Thu, 15 Jun 2017 19:20:58 GMT",
+                "endTimeUtc": "Thu, 15 Jun 2017 19:20:58 GMT",
+                "type": "unknown",
+                "status": "unknown"
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_importdevices.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_importdevices.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "importDevicesParameters": {
             "inputBlobContainerUri": "testBlob",

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbyrg.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbyrg.json
@@ -1,0 +1,111 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/testHub",
+                        "name": "testHub",
+                        "type": "Microsoft.Devices/IotHubs",
+                        "location": "centraluseuap",
+                        "tags": {},
+                        "etag": "AAAAAAFD6M4=",
+                        "properties": {
+                            "operationsMonitoringProperties": {
+                                "events": {
+                                    "None": "None",
+                                    "Connections": "None",
+                                    "DeviceTelemetry": "None",
+                                    "C2DCommands": "None",
+                                    "DeviceIdentityOperations": "None",
+                                    "FileUploadOperations": "None",
+                                    "Routes": "None"
+                                }
+                            },
+                            "state": "Active",
+                            "provisioningState": "Succeeded",
+                            "ipFilterRules": [],
+                            "hostName": "iot-dps-cit-hub-1.azure-devices.net",
+                            "eventHubEndpoints": {
+                                "events": {
+                                    "retentionTimeInDays": 1,
+                                    "partitionCount": 2,
+                                    "partitionIds": [
+                                        "0",
+                                        "1"
+                                    ],
+                                    "path": "iot-dps-cit-hub-1",
+                                    "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                                },
+                                "operationsMonitoringEvents": {
+                                    "retentionTimeInDays": 1,
+                                    "partitionCount": 2,
+                                    "partitionIds": [
+                                        "0",
+                                        "1"
+                                    ],
+                                    "path": "iot-dps-cit-hub-1-operationmonitoring",
+                                    "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                                }
+                            },
+                            "routing": {
+                                "endpoints": {
+                                    "serviceBusQueues": [],
+                                    "serviceBusTopics": [],
+                                    "eventHubs": [],
+                                    "storageContainers": []
+                                },
+                                "routes": [],
+                                "fallbackRoute": {
+                                    "name": "$fallback",
+                                    "source": "DeviceMessages",
+                                    "condition": "true",
+                                    "endpointNames": [
+                                        "events"
+                                    ],
+                                    "isEnabled": true
+                                }
+                            },
+                            "storageEndpoints": {
+                                "$default": {
+                                    "sasTtlAsIso8601": "PT1H",
+                                    "connectionString": "",
+                                    "containerName": ""
+                                }
+                            },
+                            "messagingEndpoints": {
+                                "fileNotifications": {
+                                    "lockDurationAsIso8601": "PT1M",
+                                    "ttlAsIso8601": "PT1H",
+                                    "maxDeliveryCount": 10
+                                }
+                            },
+                            "enableFileUploadNotifications": false,
+                            "cloudToDevice": {
+                                "maxDeliveryCount": 10,
+                                "defaultTtlAsIso8601": "PT1H",
+                                "feedback": {
+                                    "lockDurationAsIso8601": "PT1M",
+                                    "ttlAsIso8601": "PT1H",
+                                    "maxDeliveryCount": 10
+                                }
+                            },
+                            "features": "None"
+                        },
+                        "sku": {
+                            "name": "S1",
+                            "tier": "Standard",
+                            "capacity": 1
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbyrg.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbyrg.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbyrg.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbyrg.json
@@ -17,17 +17,6 @@
                         "tags": {},
                         "etag": "AAAAAAFD6M4=",
                         "properties": {
-                            "operationsMonitoringProperties": {
-                                "events": {
-                                    "None": "None",
-                                    "Connections": "None",
-                                    "DeviceTelemetry": "None",
-                                    "C2DCommands": "None",
-                                    "DeviceIdentityOperations": "None",
-                                    "FileUploadOperations": "None",
-                                    "Routes": "None"
-                                }
-                            },
                             "state": "Active",
                             "provisioningState": "Succeeded",
                             "ipFilterRules": [],
@@ -41,16 +30,6 @@
                                         "1"
                                     ],
                                     "path": "iot-dps-cit-hub-1",
-                                    "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
-                                },
-                                "operationsMonitoringEvents": {
-                                    "retentionTimeInDays": 1,
-                                    "partitionCount": 2,
-                                    "partitionIds": [
-                                        "0",
-                                        "1"
-                                    ],
-                                    "path": "iot-dps-cit-hub-1-operationmonitoring",
                                     "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
                                 }
                             },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbysubscription.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbysubscription.json
@@ -1,7 +1,7 @@
 {
     "parameters": {
         "resourceName": "testHub",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbysubscription.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbysubscription.json
@@ -1,0 +1,110 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/testHub",
+                        "name": "testHub",
+                        "type": "Microsoft.Devices/IotHubs",
+                        "location": "centraluseuap",
+                        "tags": {},
+                        "etag": "AAAAAAFD6M4=",
+                        "properties": {
+                            "operationsMonitoringProperties": {
+                                "events": {
+                                    "None": "None",
+                                    "Connections": "None",
+                                    "DeviceTelemetry": "None",
+                                    "C2DCommands": "None",
+                                    "DeviceIdentityOperations": "None",
+                                    "FileUploadOperations": "None",
+                                    "Routes": "None"
+                                }
+                            },
+                            "state": "Active",
+                            "provisioningState": "Succeeded",
+                            "ipFilterRules": [],
+                            "hostName": "iot-dps-cit-hub-1.azure-devices.net",
+                            "eventHubEndpoints": {
+                                "events": {
+                                    "retentionTimeInDays": 1,
+                                    "partitionCount": 2,
+                                    "partitionIds": [
+                                        "0",
+                                        "1"
+                                    ],
+                                    "path": "iot-dps-cit-hub-1",
+                                    "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                                },
+                                "operationsMonitoringEvents": {
+                                    "retentionTimeInDays": 1,
+                                    "partitionCount": 2,
+                                    "partitionIds": [
+                                        "0",
+                                        "1"
+                                    ],
+                                    "path": "iot-dps-cit-hub-1-operationmonitoring",
+                                    "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                                }
+                            },
+                            "routing": {
+                                "endpoints": {
+                                    "serviceBusQueues": [],
+                                    "serviceBusTopics": [],
+                                    "eventHubs": [],
+                                    "storageContainers": []
+                                },
+                                "routes": [],
+                                "fallbackRoute": {
+                                    "name": "$fallback",
+                                    "source": "DeviceMessages",
+                                    "condition": "true",
+                                    "endpointNames": [
+                                        "events"
+                                    ],
+                                    "isEnabled": true
+                                }
+                            },
+                            "storageEndpoints": {
+                                "$default": {
+                                    "sasTtlAsIso8601": "PT1H",
+                                    "connectionString": "",
+                                    "containerName": ""
+                                }
+                            },
+                            "messagingEndpoints": {
+                                "fileNotifications": {
+                                    "lockDurationAsIso8601": "PT1M",
+                                    "ttlAsIso8601": "PT1H",
+                                    "maxDeliveryCount": 10
+                                }
+                            },
+                            "enableFileUploadNotifications": false,
+                            "cloudToDevice": {
+                                "maxDeliveryCount": 10,
+                                "defaultTtlAsIso8601": "PT1H",
+                                "feedback": {
+                                    "lockDurationAsIso8601": "PT1M",
+                                    "ttlAsIso8601": "PT1H",
+                                    "maxDeliveryCount": 10
+                                }
+                            },
+                            "features": "None"
+                        },
+                        "sku": {
+                            "name": "S1",
+                            "tier": "Standard",
+                            "capacity": 1
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbysubscription.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listbysubscription.json
@@ -16,17 +16,6 @@
                         "tags": {},
                         "etag": "AAAAAAFD6M4=",
                         "properties": {
-                            "operationsMonitoringProperties": {
-                                "events": {
-                                    "None": "None",
-                                    "Connections": "None",
-                                    "DeviceTelemetry": "None",
-                                    "C2DCommands": "None",
-                                    "DeviceIdentityOperations": "None",
-                                    "FileUploadOperations": "None",
-                                    "Routes": "None"
-                                }
-                            },
                             "state": "Active",
                             "provisioningState": "Succeeded",
                             "ipFilterRules": [],
@@ -40,16 +29,6 @@
                                         "1"
                                     ],
                                     "path": "iot-dps-cit-hub-1",
-                                    "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
-                                },
-                                "operationsMonitoringEvents": {
-                                    "retentionTimeInDays": 1,
-                                    "partitionCount": 2,
-                                    "partitionIds": [
-                                        "0",
-                                        "1"
-                                    ],
-                                    "path": "iot-dps-cit-hub-1-operationmonitoring",
                                     "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
                                 }
                             },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listcertificates.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listcertificates.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testhub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listcertificates.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listcertificates.json
@@ -1,0 +1,30 @@
+{
+    "parameters": {
+        "resourceName": "testhub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "properties": {
+                            "subject": "CN=testdevice1",
+                            "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+                            "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+                            "isVerified": false,
+                            "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+                            "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+                        },
+                        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/andbuc-hub/certificates/cert",
+                        "name": "cert",
+                        "type": "Microsoft.Devices/IotHubs/Certificates",
+                        "etag": "AAAAAAExpNs="
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listehgroups.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listehgroups.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "eventHubEndpointName": "events",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listehgroups.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listehgroups.json
@@ -1,0 +1,26 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "eventHubEndpointName": "events",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "properties": {
+                            "created": "Thu, 15 Jun 2017 19:20:58 GMT"
+                        },
+                        "id": "/subscriptions/cmd-sub-1/resourceGroups/cmd-rg-1/providers/Microsoft.Devices/IotHubs/test-hub-2/eventHubEndpoints/events/ConsumerGroups/%24Default",
+                        "name": "$Default",
+                        "type": "Microsoft.Devices/IotHubs/EventHubEndpoints/ConsumerGroups",
+                        "etag": "AAAAAAFD6M4="
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listjobs.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listjobs.json
@@ -1,0 +1,23 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "jobId": "test",
+                        "startTimeUtc": "Thu, 15 Jun 2017 19:20:58 GMT",
+                        "endTimeUtc": "Thu, 15 Jun 2017 19:20:58 GMT",
+                        "type": "unknown",
+                        "status": "unknown"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listjobs.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listjobs.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listkeys.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listkeys.json
@@ -1,0 +1,46 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "keyName": "iothubowner",
+                        "primaryKey": "2aWPrKloLLdcug12ZHNpA0e07yJmRRmYMXDLpEOTd/Y=",
+                        "secondaryKey": "DLyFnDTGMDK0BU2QjT5TCkNBQ4h08mi20vOqWMC7TxU=",
+                        "rights": "RegistryWrite, ServiceConnect, DeviceConnect"
+                    },
+                    {
+                        "keyName": "service",
+                        "primaryKey": "DinqxWW+s814W2Pc3dLxleelksqSYGy8Jfymt8J7a4c=",
+                        "secondaryKey": "5G8KgJ9Wx2T0f6HRIn25TgYcFmJnBSivawNaHssiP9Y=",
+                        "rights": "ServiceConnect"
+                    },
+                    {
+                        "keyName": "device",
+                        "primaryKey": "o/9gPc0oD8LY/r2lRurgl9U/sKFcL2c/tmFLKAiz+e0=",
+                        "secondaryKey": "YOeBMHnYP95vH+ykR8OeapnhS6W8raMsXOdNFwqg4lg=",
+                        "rights": "DeviceConnect"
+                    },
+                    {
+                        "keyName": "registryRead",
+                        "primaryKey": "h2d4mPxy6jPCWX6mO+katV9QPNJivzt4aFq0iGVc1A8=",
+                        "secondaryKey": "3TdcalZNTB7BZHl88LGsG1Z5T6+ElEODunrs1vylwGg=",
+                        "rights": "RegistryRead"
+                    },
+                    {
+                        "keyName": "registryReadWrite",
+                        "primaryKey": "tyNRcaI38fXL+gQTjCmrVZGTP4YFF7uACk7pppWLWzY=",
+                        "secondaryKey": "6P6DXOp0W3HO5/IotzcPS1kx7PHiOdesaND07Im5cYI=",
+                        "rights": "RegistryWrite"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listkeys.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_listkeys.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_operations.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_operations.json
@@ -1,6 +1,6 @@
 {
     "parameters": {
-        "api-version": "2018-12-01-preview"
+        "api-version": "2019-03-12"
       },
       "responses": {
         "200": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_operations.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_operations.json
@@ -1,0 +1,328 @@
+{
+    "parameters": {
+        "api-version": "2018-12-01-preview"
+      },
+      "responses": {
+        "200": {
+          "body": {
+                "value": [
+                    {
+                        "name": "Microsoft.Devices/register/action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Register Resource Provider",
+                            "description": "Register the subscription for the IotHub resource provider and enables the creation of IotHub resources"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/IotHubs/diagnosticSettings/read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get Diagnostic Setting",
+                            "description": "Gets the diagnostic setting for the resource"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/IotHubs/diagnosticSettings/write",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Set Diagnostic Setting",
+                            "description": "Creates or updates the diagnostic setting for the resource"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/IotHubs/metricDefinitions/read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Read IotHub service metric definitions",
+                            "description": "Gets the available metrics for the IotHub service"
+                        }                       
+                    },
+                    {
+                        "name": "Microsoft.Devices/IotHubs/logDefinitions/read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Read IotHub service log definitions",
+                            "description": "Gets the available log definitions for the IotHub Service"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/operations/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get All ResourceProvider Operations",
+                            "description": "Get All ResourceProvider Operations"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/checkNameAvailability/Action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Check If IotHub name is available",
+                            "description": "Check If IotHub name is available"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/usages/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get Subscription Usages",
+                            "description": "Get subscription usage details for this provider."
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get IotHub(s)",
+                            "description": "Gets the IotHub resource(s)"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/Write",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Create or update IotHub Resource",
+                            "description": "Create or update IotHub Resource"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/Delete",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Delete IotHub Resource",
+                            "description": "Delete IotHub Resource"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/iotHubStats/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get IotHub Statistics",
+                            "description": "Get IotHub Statistics"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/skus/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get valid IotHub Skus",
+                            "description": "Get valid IotHub Skus"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/listkeys/Action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get all IotHub Keys",
+                            "description": "Get all IotHub Keys"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/iotHubKeys/listkeys/Action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get IotHub Key for the given name",
+                            "description": "Get IotHub Key for the given name"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/eventHubEndpoints/consumerGroups/Write",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Create EventHub Consumer Group",
+                            "description": "Create EventHub Consumer Group"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/eventHubEndpoints/consumerGroups/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get EventHub Consumer Group(s)",
+                            "description": "Get EventHub Consumer Group(s)"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/eventHubEndpoints/consumerGroups/Delete",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Delete EventHub Consumer Group",
+                            "description": "Delete EventHub Consumer Group"
+                        }
+                    },
+                    {
+                       "name": "Microsoft.Devices/iotHubs/exportDevices/Action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Export Devices",
+                            "description": "Export Devices"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/importDevices/Action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Import Devices",
+                            "description": "Import Devices"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/jobs/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get the Job(s) on IotHub",
+                            "description": "Get Job(s) details submitted on given IotHub"
+                       }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/quotaMetrics/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get Quota Metrics",
+                            "description": "Get Quota Metrics"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/routing/routes/$testall/Action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Routing Rule Test All",
+                            "description": "Test a message against all existing Routes"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/routing/routes/$testnew/Action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Routing Rule Test Route",
+                            "description": "Test a message against a provided test Route"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/iotHubs/routingEndpointsHealth/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get Endpoint Health",
+                            "description": "Gets the health of all routing Endpoints for an IotHub"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/ProvisioningServices/diagnosticSettings/read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Get Diagnostic Setting",
+                            "description": "Gets the diagnostic setting for the resource"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/ProvisioningServices/diagnosticSettings/write",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Set Diagnostic Setting",
+                            "description": "Creates or updates the diagnostic setting for the resource"
+                        }                    
+                    },
+                    {
+                        "name": "Microsoft.Devices/ProvisioningServices/metricDefinitions/read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Read DPS service metric definitions",
+                            "description": "Gets the available metrics for the DPS service"
+                        }                     
+                    },
+                    {
+                        "name": "Microsoft.Devices/ProvisioningServices/logDefinitions/read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "IotHubs",
+                            "operation": "Read DPS service log definitions",
+                            "description": "Gets the available log definitions for the DPS Service"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/checkProvisioningServiceNameAvailability/Action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "ProvisioningServives",
+                            "operation": "Check If Provisioning Service name is available",
+                            "description": "Check If Provisioning Service name is available"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/provisioningServices/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "ProvisioningServices",
+                            "operation": "Get Provisioning Service resource" ,
+                            "description": "Get Provisioning Service resource"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/provisioningServices/Write",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "ProvisioningServices",
+                            "operation": "Create Provisioning Service resource",
+                            "description": "Create Provisioning Service resource"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/provisioningServices/Delete",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "ProvisioningServices",
+                            "operation": "Delete Provisioning Service resource",
+                            "description": "Delete Provisioning Service resource"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/provisioningServices/skus/Read",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "ProvisioningServices",
+                            "operation": "Delete Provisioning Service resource",
+                            "description": "Delete Provisioning Service resource"
+                        }
+                    },
+                    {
+                        "name": "Microsoft.Devices/provisioningServices/listkeys/Action",
+                        "display": {
+                            "provider": "Microsoft Devices",
+                            "resource": "ProvisioningServices",
+                            "operation": "get security related metadata",
+                            "description": "get security related metadata"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_patch.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_patch.json
@@ -24,17 +24,6 @@
                 },
                 "etag": "AAAAAAFD6M4=",
                 "properties": {
-                    "operationsMonitoringProperties": {
-                        "events": {
-                            "None": "None",
-                            "Connections": "None",
-                            "DeviceTelemetry": "None",
-                            "C2DCommands": "None",
-                            "DeviceIdentityOperations": "None",
-                            "FileUploadOperations": "None",
-                            "Routes": "None"
-                        }
-                    },
                     "state": "Active",
                     "provisioningState": "Succeeded",
                     "ipFilterRules": [],
@@ -48,16 +37,6 @@
                                 "1"
                             ],
                             "path": "iot-dps-cit-hub-1",
-                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
-                        },
-                        "operationsMonitoringEvents": {
-                            "retentionTimeInDays": 1,
-                            "partitionCount": 2,
-                            "partitionIds": [
-                                "0",
-                                "1"
-                            ],
-                            "path": "iot-dps-cit-hub-1-operationmonitoring",
                             "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
                         }
                     },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_patch.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_patch.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "myHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
         "location": "East US",
         "type": "Microsoft.Devices/IotHubs",

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_patch.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_patch.json
@@ -1,0 +1,116 @@
+{
+    "parameters": {
+        "resourceName": "myHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "location": "East US",
+        "type": "Microsoft.Devices/IotHubs",
+        "IotHubTags": {
+            "tags": {
+                "foo": "bar"
+            }
+        }
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "id": "/subscriptions/ae24ff83-d2ca-4fc8-9717-05dae4bba489/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/testHub",
+                "name": "testHub",
+                "type": "Microsoft.Devices/IotHubs",
+                "location": "centraluseuap",
+                "tags": {
+                    "foo" : "bar"
+                },
+                "etag": "AAAAAAFD6M4=",
+                "properties": {
+                    "operationsMonitoringProperties": {
+                        "events": {
+                            "None": "None",
+                            "Connections": "None",
+                            "DeviceTelemetry": "None",
+                            "C2DCommands": "None",
+                            "DeviceIdentityOperations": "None",
+                            "FileUploadOperations": "None",
+                            "Routes": "None"
+                        }
+                    },
+                    "state": "Active",
+                    "provisioningState": "Succeeded",
+                    "ipFilterRules": [],
+                    "hostName": "iot-dps-cit-hub-1.azure-devices.net",
+                    "eventHubEndpoints": {
+                        "events": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        },
+                        "operationsMonitoringEvents": {
+                            "retentionTimeInDays": 1,
+                            "partitionCount": 2,
+                            "partitionIds": [
+                                "0",
+                                "1"
+                            ],
+                            "path": "iot-dps-cit-hub-1-operationmonitoring",
+                            "endpoint": "sb://iothub-ns-iot-dps-ci-245306-76aca8e13b.servicebus.windows.net/"
+                        }
+                    },
+                    "routing": {
+                        "endpoints": {
+                            "serviceBusQueues": [],
+                            "serviceBusTopics": [],
+                            "eventHubs": [],
+                            "storageContainers": []
+                        },
+                        "routes": [],
+                        "fallbackRoute": {
+                            "name": "$fallback",
+                            "source": "DeviceMessages",
+                            "condition": "true",
+                            "endpointNames": [
+                                "events"
+                            ],
+                            "isEnabled": true
+                        }
+                    },
+                    "storageEndpoints": {
+                        "$default": {
+                            "sasTtlAsIso8601": "PT1H",
+                            "connectionString": "",
+                            "containerName": ""
+                        }
+                    },
+                    "messagingEndpoints": {
+                        "fileNotifications": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "enableFileUploadNotifications": false,
+                    "cloudToDevice": {
+                        "maxDeliveryCount": 10,
+                        "defaultTtlAsIso8601": "PT1H",
+                        "feedback": {
+                            "lockDurationAsIso8601": "PT1M",
+                            "ttlAsIso8601": "PT1H",
+                            "maxDeliveryCount": 10
+                        }
+                    },
+                    "features": "None"
+                },
+                "sku": {
+                    "name": "S1",
+                    "tier": "Standard",
+                    "capacity": 1
+                }
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_quotametrics.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_quotametrics.json
@@ -1,0 +1,26 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "name": "TotalMessages",
+                        "currentValue": 0,
+                        "maxValue": 400000
+                    },
+                    {
+                        "name": "TotalDeviceCount",
+                        "currentValue": 0,
+                        "maxValue": 500000
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_quotametrics.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_quotametrics.json
@@ -2,7 +2,7 @@
     "parameters": {
         "resourceName": "testHub",
         "resourceGroupName": "myResourceGroup",
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_routingendpointhealth.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_routingendpointhealth.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "iotHubName": "testHub",
+    "resourceGroupName": "myResourceGroup",
+    "api-version": "2018-12-01-preview",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "endpointId": "id1",
+            "healthStatus": "healthy"
+          },
+          {
+            "endpointId": "id2",
+            "healthStatus": "unknown"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_routingendpointhealth.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_routingendpointhealth.json
@@ -2,7 +2,7 @@
   "parameters": {
     "iotHubName": "testHub",
     "resourceGroupName": "myResourceGroup",
-    "api-version": "2018-12-01-preview",
+    "api-version": "2019-03-12",
     "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
   },
   "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_stats.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_stats.json
@@ -1,0 +1,17 @@
+{
+    "parameters": {
+        "resourceName": "testHub",
+        "resourceGroupName": "myResourceGroup",
+        "api-version": "2018-04-01",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "totalDeviceCount": 0,
+                "enabledDeviceCount": 0,
+                "disabledDeviceCount": 0
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_testallroutes.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_testallroutes.json
@@ -2,7 +2,7 @@
   "parameters": {
     "iotHubName": "testHub",
     "resourceGroupName": "myResourceGroup",
-    "api-version": "2018-12-01-preview",
+    "api-version": "2019-03-12",
     "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
     "input": {
       "routingSource": "DeviceMessages",

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_testallroutes.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_testallroutes.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "iotHubName": "testHub",
+    "resourceGroupName": "myResourceGroup",
+    "api-version": "2018-12-01-preview",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+    "input": {
+      "routingSource": "DeviceMessages",
+      "message": {
+        "body": "Body of message",
+        "appProperties": "App Properties",
+        "systemProperties": "System Properties"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "routes": [
+          {
+            "properties": {
+                "name": "Routeid",
+                "source": "DeviceMessages",
+                "endpointNames": ["id1"],
+                "isEnabled": true
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_testnewroute.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_testnewroute.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "iotHubName": "testHub",
+    "resourceGroupName": "myResourceGroup",
+    "api-version": "2018-12-01-preview",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+    "input": {
+      "message": {
+        "body": "Body of message",
+        "appProperties": "App Properties",
+        "systemProperties": "System Properties"
+      },
+      "route": {
+        "name": "Routeid",
+        "source": "DeviceMessages",
+        "endpointNames": [
+          "id1"
+        ],
+        "isEnabled": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "result": "false",
+        "details": {
+            "compilationErrors": [
+                {
+                    "message": "string response",
+                    "severity": "error",
+                    "location": {
+                        "start": {
+                            "line": 12,
+                            "column": 12
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 24
+                        }
+                    }
+                }
+            ]
+        }
+      }
+    }
+  }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_testnewroute.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_testnewroute.json
@@ -2,7 +2,7 @@
   "parameters": {
     "iotHubName": "testHub",
     "resourceGroupName": "myResourceGroup",
-    "api-version": "2018-12-01-preview",
+    "api-version": "2019-03-12",
     "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
     "input": {
       "message": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_usages.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_usages.json
@@ -1,0 +1,25 @@
+{
+    "parameters": {
+        "api-version": "2018-12-01-preview",
+        "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+    },
+    "responses": {
+        "200": {
+            "body": {
+                "value": [
+                    {
+                        "id" : "/subscription/91d12660-3dec-467a-be2a-213b5544ddc0/providers/Microsoft.Devices/usages/freeHubCount",
+                        "type": "/subscription/91d12660-3dec-467a-be2a-213b5544ddc0/providers/Microsoft.Devices/usages",
+                        "unit": "count",
+                        "currentValue": 1,
+                        "limit": 1,
+                        "name": {
+                            "value": "FreeHubCount",
+                            "localizedValue": "Free Hub Count"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_usages.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/examples/iothub_usages.json
@@ -1,6 +1,6 @@
 {
     "parameters": {
-        "api-version": "2018-12-01-preview",
+        "api-version": "2019-03-12",
         "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
     },
     "responses": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/iothub.json
@@ -1920,7 +1920,7 @@
           "readOnly": true
         },
         "eventHubEndpoints": {
-          "description": "The Event Hub-compatible endpoint properties. The possible keys to this dictionary are events and operationsMonitoringEvents. Both of these keys have to be present in the dictionary while making create or update calls for the IoT hub.",
+          "description": "The Event Hub-compatible endpoint properties. The only possible keys to this dictionary is events. This key has to be present in the dictionary while making create or update calls for the IoT hub.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/EventHubProperties"
@@ -1953,9 +1953,6 @@
         "comments": {
           "description": "IoT hub comments.",
           "type": "string"
-        },
-        "operationsMonitoringProperties": {
-          "$ref": "#/definitions/OperationsMonitoringProperties"
         },
         "deviceStreams": {
           "description": "The device streams properties of iothub.",
@@ -2130,29 +2127,6 @@
         }
       }
     },
-    "OperationsMonitoringProperties": {
-      "description": "The operations monitoring properties for the IoT hub. The possible keys to the dictionary are Connections, DeviceTelemetry, C2DCommands, DeviceIdentityOperations, FileUploadOperations, Routes, D2CTwinOperations, C2DTwinOperations, TwinQueries, JobsOperations, DirectMethods.",
-      "type": "object",
-      "properties": {
-        "events": {
-          "type": "object",
-          "additionalProperties": {
-            "enum": [
-              "None",
-              "Error",
-              "Information",
-              "Error, Information"
-            ],
-            "description": "The operations monitoring level.",
-            "type": "string",
-            "x-ms-enum": {
-              "name": "OperationMonitoringLevel",
-              "modelAsString": true
-            }
-          }
-        }
-      }
-    },
     "IpFilterRule": {
       "description": "The IP filter rules for the IoT hub.",
       "type": "object",
@@ -2270,7 +2244,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, operationsMonitoringEvents, fileNotifications, $default. Endpoint names must be unique across endpoint types. The name need not be the same as the actual queue name.",
+          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, fileNotifications, $default. Endpoint names must be unique across endpoint types. The name need not be the same as the actual queue name.",
           "type": "string",
           "pattern": "^[A-Za-z0-9-._]{1,64}$"
         },
@@ -2297,7 +2271,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, operationsMonitoringEvents, fileNotifications, $default. Endpoint names must be unique across endpoint types.  The name need not be the same as the actual topic name.",
+          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, fileNotifications, $default. Endpoint names must be unique across endpoint types.  The name need not be the same as the actual topic name.",
           "type": "string",
           "pattern": "^[A-Za-z0-9-._]{1,64}$"
         },
@@ -2324,7 +2298,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, operationsMonitoringEvents, fileNotifications, $default. Endpoint names must be unique across endpoint types.",
+          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, fileNotifications, $default. Endpoint names must be unique across endpoint types.",
           "type": "string",
           "pattern": "^[A-Za-z0-9-._]{1,64}$"
         },
@@ -2351,7 +2325,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, operationsMonitoringEvents, fileNotifications, $default. Endpoint names must be unique across endpoint types.",
+          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, fileNotifications, $default. Endpoint names must be unique across endpoint types.",
           "type": "string",
           "pattern": "^[A-Za-z0-9-._]{1,64}$"
         },

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/iothub.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2018-12-01-preview",
+    "version": "2019-03-12",
     "title": "iotHubClient",
     "description": "Use this API to manage the IoT hubs in your Azure subscription.",
     "x-ms-code-generation-settings": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2019-03-12/iothub.json
@@ -1,0 +1,3411 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-12-01-preview",
+    "title": "iotHubClient",
+    "description": "Use this API to manage the IoT hubs in your Azure subscription.",
+    "x-ms-code-generation-settings": {
+      "header": "MICROSOFT_MIT_NO_VERSION"
+    }
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/providers/Microsoft.Devices/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/iothub_operations.json"
+          }
+        },
+        "operationId": "Operations_List",
+        "description": "Lists all of the available IoT Hub REST API operations.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get the non-security related metadata of an IoT hub",
+        "description": "Get the non-security related metadata of an IoT hub.",
+        "operationId": "IotHubResource_Get",
+        "x-ms-examples": {
+          "IotHubResource_Get": {
+            "$ref": "./examples/iothub_get.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The body contains all the non-security properties of the IoT hub. Security-related properties are set to null.",
+            "schema": {
+              "$ref": "#/definitions/IotHubDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "PUT"
+        ],
+        "summary": "Create or update the metadata of an IoT hub.",
+        "description": "Create or update the metadata of an Iot hub. The usual pattern to modify a property is to retrieve the IoT hub metadata and security metadata, and then combine them with the modified values in a new body to update the IoT hub.",
+        "operationId": "IotHubResource_CreateOrUpdate",
+        "x-ms-examples": {
+          "IotHubResource_CreateOrUpdate": {
+            "$ref": "./examples/iothub_createOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "name": "iotHubDescription",
+            "in": "body",
+            "description": "The IoT hub metadata and security metadata.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/IotHubDescription"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "ETag of the IoT Hub. Do not specify for creating a brand new IoT Hub. Required to update an existing IoT Hub."
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "This is a long running operation. The operation returns a 201 if the validation is complete. The response includes an Azure-AsyncOperation header that contains a status URL. Clients are expected to poll the status URL for the status of the operation. If successful, the operation returns HTTP status code of 201 (OK).",
+            "schema": {
+              "$ref": "#/definitions/IotHubDescription"
+            }
+          },
+          "200": {
+            "description": "This is returned as a response to the status polling request for the create or update operation. The body contains the resource representation that indicates a transitional provisioning state.",
+            "schema": {
+              "$ref": "#/definitions/IotHubDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "patch": {
+        "tags": [
+          "PATCH"
+        ],
+        "summary": "Update an existing IoT Hubs tags.",
+        "description": "Update an existing IoT Hub tags. to update other fields use the CreateOrUpdate method",
+        "x-ms-long-running-operation": true,
+        "operationId": "IotHubResource_Update",
+        "x-ms-examples": {
+          "IotHubResource_Update": {
+            "$ref": "./examples/iothub_patch.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Resource group identifier."
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Name of iot hub to update."
+          },
+          {
+            "name": "IotHubTags",
+            "in": "body",
+            "required": true,
+            "description": "Updated tag information to set into the iot hub instance.",
+            "schema": {
+              "$ref": "#/definitions/TagsResource"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Iot Hub was successfully updated",
+            "schema": {
+              "$ref": "#/definitions/IotHubDescription"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "delete": {
+        "tags": [
+          "DELETE"
+        ],
+        "summary": "Delete an IoT hub",
+        "description": "Delete an IoT hub.",
+        "operationId": "IotHubResource_Delete",
+        "x-ms-examples": {
+          "IotHubResource_Delete": {
+            "$ref": "./examples/iothub_delete.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The Iot Hub resource provider always returns a 202 Accepted status code with valid Location and Retry-After headers. The resource provider also sets the Azure-AsyncOperation header with a URL that points to the operation resource for this operation. Subsequent GET attempts on the resource after a DELETE operation return a resource representation that indicates a transitional provisioning state (such as Terminating). To retrieve the status of the operation, a client can either poll the URL returned in the Location header after the Retry-After interval, get the IoT Hub service status directly, or query the operation resource.",
+            "schema": {
+              "$ref": "#/definitions/IotHubDescription"
+            }
+          },
+          "200": {
+            "description": "This is returned as a response to the status polling request for the delete operation. The body contains the resource representation that indicates a transitional provisioning state.",
+            "schema": {
+              "$ref": "#/definitions/IotHubDescription"
+            }
+          },
+          "204": {
+            "description": "Once the long running delete operation completes successfully, a 204 No Content status code is returned when the status polling request finds the Iot hub metadata in the service and the status of the delete operation is set to a completed state."
+          },
+          "404": {
+            "description": "After the long running delete operation completes successfully, a 404 Not Found is returned when the status polling request no longer finds the Iot hub metadata in the service.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Devices/IotHubs": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get all the IoT hubs in a subscription",
+        "description": "Get all the IoT hubs in a subscription.",
+        "operationId": "IotHubResource_ListBySubscription",
+        "x-ms-examples": {
+          "IotHubResource_ListBySubscription": {
+            "$ref": "./examples/iothub_listbysubscription.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The body contains a JSON-serialized array of the metadata from all the IoT hubs in the subscription.",
+            "schema": {
+              "$ref": "#/definitions/IotHubDescriptionListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get all the IoT hubs in a resource group",
+        "description": "Get all the IoT hubs in a resource group.",
+        "operationId": "IotHubResource_ListByResourceGroup",
+        "x-ms-examples": {
+          "IotHubResource_ListByResourceGroup": {
+            "$ref": "./examples/iothub_listbyrg.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The body contains a JSON-serialized array of the metadata from all the IoT hubs in the resource group.",
+            "schema": {
+              "$ref": "#/definitions/IotHubDescriptionListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/IotHubStats": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get the statistics from an IoT hub",
+        "description": "Get the statistics from an IoT hub.",
+        "operationId": "IotHubResource_GetStats",
+        "x-ms-examples": {
+          "IotHubResource_GetStats": {
+            "$ref": "./examples/iothub_stats.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The body contains JSON-serialized statistics from the identity registry in the IoT hub.",
+            "schema": {
+              "$ref": "#/definitions/RegistryStatistics"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/skus": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get the list of valid SKUs for an IoT hub",
+        "description": "Get the list of valid SKUs for an IoT hub.",
+        "operationId": "IotHubResource_GetValidSkus",
+        "x-ms-examples": {
+          "IotHubResource_GetValidSkus": {
+            "$ref": "./examples/iothub_getskus.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The body contains a JSON-serialized array of the valid SKUs for this IoT hub.",
+            "schema": {
+              "$ref": "#/definitions/IotHubSkuDescriptionListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/eventHubEndpoints/{eventHubEndpointName}/ConsumerGroups": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get a list of the consumer groups in the Event Hub-compatible device-to-cloud endpoint in an IoT hub",
+        "description": "Get a list of the consumer groups in the Event Hub-compatible device-to-cloud endpoint in an IoT hub.",
+        "operationId": "IotHubResource_ListEventHubConsumerGroups",
+        "x-ms-examples": {
+          "IotHubResource_ListEventHubConsumerGroups": {
+            "$ref": "./examples/iothub_listehgroups.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "name": "eventHubEndpointName",
+            "in": "path",
+            "description": "The name of the Event Hub-compatible endpoint.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The body contains a JSON-serialized list of the consumer groups in the Event Hub-compatible endpoint in this IoT hub",
+            "schema": {
+              "$ref": "#/definitions/EventHubConsumerGroupsListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/eventHubEndpoints/{eventHubEndpointName}/ConsumerGroups/{name}": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get a consumer group from the Event Hub-compatible device-to-cloud endpoint for an IoT hub",
+        "description": "Get a consumer group from the Event Hub-compatible device-to-cloud endpoint for an IoT hub.",
+        "operationId": "IotHubResource_GetEventHubConsumerGroup",
+        "x-ms-examples": {
+          "IotHubResource_ListEventHubConsumerGroups": {
+            "$ref": "./examples/iothub_getconsumergroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "name": "eventHubEndpointName",
+            "in": "path",
+            "description": "The name of the Event Hub-compatible endpoint in the IoT hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the consumer group to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The body contains a JSON-serialized consumer group.",
+            "schema": {
+              "$ref": "#/definitions/EventHubConsumerGroupInfo"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "PUT"
+        ],
+        "summary": "Add a consumer group to an Event Hub-compatible endpoint in an IoT hub",
+        "description": "Add a consumer group to an Event Hub-compatible endpoint in an IoT hub.",
+        "operationId": "IotHubResource_CreateEventHubConsumerGroup",
+        "x-ms-examples": {
+          "IotHubResource_CreateEventHubConsumerGroup": {
+            "$ref": "./examples/iothub_createconsumergroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "name": "eventHubEndpointName",
+            "in": "path",
+            "description": "The name of the Event Hub-compatible endpoint in the IoT hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the consumer group to add.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation.",
+            "schema": {
+              "$ref": "#/definitions/EventHubConsumerGroupInfo"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "DELETE"
+        ],
+        "summary": "Delete a consumer group from an Event Hub-compatible endpoint in an IoT hub",
+        "description": "Delete a consumer group from an Event Hub-compatible endpoint in an IoT hub.",
+        "operationId": "IotHubResource_DeleteEventHubConsumerGroup",
+        "x-ms-examples": {
+          "IotHubResource_DeleteEventHubConsumerGroup": {
+            "$ref": "./examples/iothub_deleteconsumergroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "name": "eventHubEndpointName",
+            "in": "path",
+            "description": "The name of the Event Hub-compatible endpoint in the IoT hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the consumer group to delete.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation."
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/jobs": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get a list of all the jobs in an IoT hub. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry",
+        "description": "Get a list of all the jobs in an IoT hub. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry.",
+        "operationId": "IotHubResource_ListJobs",
+        "x-ms-examples": {
+          "IotHubResource_ListJobs": {
+            "$ref": "./examples/iothub_listjobs.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The response contains a JSON-serialized array of all the jobs in the IoT hub.",
+            "schema": {
+              "$ref": "#/definitions/JobResponseListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/jobs/{jobId}": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get the details of a job from an IoT hub. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry",
+        "description": "Get the details of a job from an IoT hub. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry.",
+        "operationId": "IotHubResource_GetJob",
+        "x-ms-examples": {
+          "IotHubResource_GetJob": {
+            "$ref": "./examples/iothub_getjob.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "description": "The job identifier.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The response contains a JSON-serialized description of the job in the IoT hub.",
+            "schema": {
+              "$ref": "#/definitions/JobResponse"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/quotaMetrics": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get the quota metrics for an IoT hub",
+        "description": "Get the quota metrics for an IoT hub.",
+        "operationId": "IotHubResource_GetQuotaMetrics",
+        "x-ms-examples": {
+          "IotHubResource_GetQuotaMetrics": {
+            "$ref": "./examples/iothub_quotametrics.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The response contains a JSON-serialized array of the quota metrics for the IoT hub.",
+            "schema": {
+              "$ref": "#/definitions/IotHubQuotaMetricInfoListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{iotHubName}/routingEndpointsHealth": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "operationId": "IotHubResource_GetEndpointHealth",
+        "summary": "Get the health for routing endpoints",
+        "description": "Get the health for routing endpoints.",
+        "x-ms-examples": {
+          "IotHubResource_GetEndpointHealth": {
+            "$ref": "./examples/iothub_routingendpointhealth.json"
+          }
+        },
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "iotHubName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/EndpointHealthDataListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Devices/checkNameAvailability": {
+      "post": {
+        "tags": [
+          "POST"
+        ],
+        "summary": "Check if an IoT hub name is available",
+        "description": "Check if an IoT hub name is available.",
+        "operationId": "IotHubResource_CheckNameAvailability",
+        "x-ms-examples": {
+          "IotHubResource_CheckNameAvailability": {
+            "$ref": "./examples/checkNameAvailability.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "operationInputs",
+            "in": "body",
+            "description": "Set the name parameter in the OperationInputs structure to the name of the IoT hub to check.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OperationInputs"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The body contains a JSON-serialized response that specifies whether the IoT hub name is available. If the name is not available, the body contains the reason.",
+            "schema": {
+              "$ref": "#/definitions/IotHubNameAvailabilityInfo"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Devices/usages": {
+      "get": {
+        "tags": [
+          "GET"
+        ],
+        "summary": "Get the number of iot hubs in the subscription",
+        "description": "Get the number of free and paid iot hubs in the subscription",
+        "operationId": "ResourceProviderCommon_GetSubscriptionQuota",
+        "x-ms-examples": {
+          "ResourceProviderCommon_GetSubscriptionQuota": {
+            "$ref": "./examples/iothub_usages.json"
+          }
+        },
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/UserSubscriptionQuotaListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{iotHubName}/routing/routes/$testall": {
+      "post": {
+        "tags": [
+          "POST"
+        ],
+        "operationId": "IotHubResource_TestAllRoutes",
+        "summary": "Test all routes",
+        "description": "Test all routes configured in this Iot Hub",
+        "x-ms-examples": {
+          "IotHubResource_TestAllRoutes": {
+            "$ref": "./examples/iothub_testallroutes.json"
+          }
+        },
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "input",
+            "description": "Input for testing all routes",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TestAllRoutesInput"
+            }
+          },
+          {
+            "name": "iotHubName",
+            "description": "IotHub to be tested",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "description": "resource group which Iot Hub belongs to",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/TestAllRoutesResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{iotHubName}/routing/routes/$testnew": {
+      "post": {
+        "tags": [
+          "POST"
+        ],
+        "operationId": "IotHubResource_TestRoute",
+        "summary": "Test the new route",
+        "description": "Test the new route for this Iot Hub",
+        "x-ms-examples": {
+          "IotHubResource_TestRoute": {
+            "$ref": "./examples/iothub_testnewroute.json"
+          }
+        },
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "input",
+            "description": "Route that needs to be tested",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TestRouteInput"
+            }
+          },
+          {
+            "name": "iotHubName",
+            "description": "IotHub to be tested",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "resourceGroupName",
+            "description": "resource group which Iot Hub belongs to",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/TestRouteResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/listkeys": {
+      "post": {
+        "tags": [
+          "POST"
+        ],
+        "summary": "Get the security metadata for an IoT hub. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security",
+        "description": "Get the security metadata for an IoT hub. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security.",
+        "operationId": "IotHubResource_ListKeys",
+        "x-ms-examples": {
+          "IotHubResource_ListKeys": {
+            "$ref": "./examples/iothub_listkeys.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The body contains a JSON-serialized array of shared access policies, including keys, that you can use to access the IoT hub endpoints.",
+            "schema": {
+              "$ref": "#/definitions/SharedAccessSignatureAuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/IotHubKeys/{keyName}/listkeys": {
+      "post": {
+        "tags": [
+          "POST"
+        ],
+        "summary": "Get a shared access policy by name from an IoT hub. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security",
+        "description": "Get a shared access policy by name from an IoT hub. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security.",
+        "operationId": "IotHubResource_GetKeysForKeyName",
+        "x-ms-examples": {
+          "IotHubResource_GetKeysForKeyName": {
+            "$ref": "./examples/iothub_getkey.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "name": "keyName",
+            "in": "path",
+            "description": "The name of the shared access policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This is a synchronous operation. The body contains a JSON-serialized shared access policy, including keys, that you can use to access one or more IoT hub endpoints.",
+            "schema": {
+              "$ref": "#/definitions/SharedAccessSignatureAuthorizationRule"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/exportDevices": {
+      "post": {
+        "tags": [
+          "POST"
+        ],
+        "summary": "Exports all the device identities in the IoT hub identity registry to an Azure Storage blob container. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities",
+        "description": "Exports all the device identities in the IoT hub identity registry to an Azure Storage blob container. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities.",
+        "operationId": "IotHubResource_ExportDevices",
+        "x-ms-examples": {
+          "IotHubResource_ExportDevices": {
+            "$ref": "./examples/iothub_exportdevices.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "name": "exportDevicesParameters",
+            "in": "body",
+            "description": "The parameters that specify the export devices operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExportDevicesRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/JobResponse"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/importDevices": {
+      "post": {
+        "tags": [
+          "POST"
+        ],
+        "summary": "Import, update, or delete device identities in the IoT hub identity registry from a blob. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities",
+        "description": "Import, update, or delete device identities in the IoT hub identity registry from a blob. For more information, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities.",
+        "operationId": "IotHubResource_ImportDevices",
+        "x-ms-examples": {
+          "IotHubResource_ImportDevices": {
+            "$ref": "./examples/iothub_importdevices.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "name": "importDevicesParameters",
+            "in": "body",
+            "description": "The parameters that specify the import devices operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ImportDevicesRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/JobResponse"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/certificates": {
+      "get": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Get the certificate list.",
+        "description": "Returns the list of certificates.",
+        "operationId": "Certificates_ListByIotHub",
+        "x-ms-examples": {
+          "Certificates_ListByIotHub": {
+            "$ref": "./examples/iothub_listcertificates.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The body contains all the certificate list.",
+            "schema": {
+              "$ref": "#/definitions/CertificateListDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/certificates/{certificateName}": {
+      "get": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Get the certificate.",
+        "description": "Returns the certificate.",
+        "operationId": "Certificates_Get",
+        "x-ms-examples": {
+          "Certificates_Get": {
+            "$ref": "./examples/iothub_getcertificate.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "$ref": "#/parameters/certificateName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The body contains the certificate.",
+            "schema": {
+              "$ref": "#/definitions/CertificateDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Upload the certificate to the IoT hub.",
+        "description": "Adds new or replaces existing certificate.",
+        "operationId": "Certificates_CreateOrUpdate",
+        "x-ms-examples": {
+          "Certificates_CreateOrUpdate": {
+            "$ref": "./examples/iothub_certificatescreateorupdate.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "$ref": "#/parameters/certificateName"
+          },
+          {
+            "name": "certificateDescription",
+            "in": "body",
+            "description": "The certificate body.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CertificateBodyDescription"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "ETag of the Certificate. Do not specify for creating a brand new certificate. Required to update an existing certificate."
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "If certificate didn't exist creation was successful, the operation returns HTTP status code of 201 (OK).",
+            "schema": {
+              "$ref": "#/definitions/CertificateDescription"
+            }
+          },
+          "200": {
+            "description": "If certificate already exist and update was successful, the operation returns HTTP status code of 201 (OK).",
+            "schema": {
+              "$ref": "#/definitions/CertificateDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Delete an X509 certificate.",
+        "description": "Deletes an existing X509 certificate or does nothing if it does not exist.",
+        "operationId": "Certificates_Delete",
+        "x-ms-examples": {
+          "Certificates_Delete": {
+            "$ref": "./examples/iothub_certificatesdelete.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "$ref": "#/parameters/certificateName"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "ETag of the Certificate."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Certificate has been deleted."
+          },
+          "204": {
+            "description": "Certificate does not exist."
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/certificates/{certificateName}/generateVerificationCode": {
+      "post": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Generate verification code for proof of possession flow.",
+        "description": "Generates verification code for proof of possession flow. The verification code will be used to generate a leaf certificate.",
+        "operationId": "Certificates_GenerateVerificationCode",
+        "x-ms-examples": {
+          "Certificates_GenerateVerificationCode": {
+            "$ref": "./examples/iothub_generateverificationcode.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "$ref": "#/parameters/certificateName"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "ETag of the Certificate."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The body contains the certificate.",
+            "schema": {
+              "$ref": "#/definitions/CertificateWithNonceDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}/certificates/{certificateName}/verify": {
+      "post": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Verify certificate's private key possession.",
+        "description": "Verifies the certificate's private key possession by providing the leaf cert issued by the verifying pre uploaded certificate.",
+        "operationId": "Certificates_Verify",
+        "x-ms-examples": {
+          "Certificates_Verify": {
+            "$ref": "./examples/iothub_certverify.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/resourceName"
+          },
+          {
+            "$ref": "#/parameters/certificateName"
+          },
+          {
+            "name": "certificateVerificationBody",
+            "in": "body",
+            "description": "The name of the certificate",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CertificateVerificationDescription"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "ETag of the Certificate."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The body contains the certificate.",
+            "schema": {
+              "$ref": "#/definitions/CertificateDescription"
+            }
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "CertificateVerificationDescription": {
+      "description": "The JSON-serialized leaf certificate",
+      "type": "object",
+      "properties": {
+        "certificate": {
+          "description": "base-64 representation of X509 certificate .cer file or just .pem file content.",
+          "type": "string"
+        }
+      }
+    },
+    "CertificateListDescription": {
+      "description": "The JSON-serialized array of Certificate objects.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The array of Certificate objects.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CertificateDescription"
+          }
+        }
+      }
+    },
+    "CertificateBodyDescription": {
+       "description": "The JSON-serialized X509 Certificate.",
+       "type": "object",
+       "properties": {
+         "certificate": {
+           "description": "base-64 representation of the X509 leaf certificate .cer file or just .pem file content.",
+           "type": "string"
+         }
+       }
+     },
+    "CertificateDescription": {
+      "description": "The X509 Certificate.",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CertificateProperties"
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource identifier."
+        },
+        "name": {
+          "description": "The name of the certificate.",
+          "type": "string",
+          "readOnly": true
+        },
+        "etag": {
+          "description": "The entity tag.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource type."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "CertificateWithNonceDescription": {
+      "description": "The X509 Certificate.",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CertificatePropertiesWithNonce"
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource identifier."
+        },
+        "name": {
+          "description": "The name of the certificate.",
+          "type": "string",
+          "readOnly": true
+        },
+        "etag": {
+          "description": "The entity tag.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource type."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "SharedAccessSignatureAuthorizationRule": {
+      "description": "The properties of an IoT hub shared access policy.",
+      "type": "object",
+      "properties": {
+        "keyName": {
+          "description": "The name of the shared access policy.",
+          "type": "string"
+        },
+        "primaryKey": {
+          "description": "The primary key.",
+          "type": "string"
+        },
+        "secondaryKey": {
+          "description": "The secondary key.",
+          "type": "string"
+        },
+        "rights": {
+          "description": "The permissions assigned to the shared access policy.",
+          "enum": [
+            "RegistryRead",
+            "RegistryWrite",
+            "ServiceConnect",
+            "DeviceConnect",
+            "RegistryRead, RegistryWrite",
+            "RegistryRead, ServiceConnect",
+            "RegistryRead, DeviceConnect",
+            "RegistryWrite, ServiceConnect",
+            "RegistryWrite, DeviceConnect",
+            "ServiceConnect, DeviceConnect",
+            "RegistryRead, RegistryWrite, ServiceConnect",
+            "RegistryRead, RegistryWrite, DeviceConnect",
+            "RegistryRead, ServiceConnect, DeviceConnect",
+            "RegistryWrite, ServiceConnect, DeviceConnect",
+            "RegistryRead, RegistryWrite, ServiceConnect, DeviceConnect"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AccessRights",
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "keyName",
+        "rights"
+      ]
+    },
+    "CertificateProperties": {
+      "description": "The description of an X509 CA Certificate.",
+      "type": "object",
+      "properties": {
+        "subject": {
+          "description": "The certificate's subject name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "expiry": {
+          "description": "The certificate's expiration date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123",
+          "readOnly": true
+        },
+        "thumbprint": {
+          "description": "The certificate's thumbprint.",
+          "type": "string",
+          "readOnly": true
+        },
+        "isVerified": {
+          "description": "Determines whether certificate has been verified.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "created": {
+          "description": "The certificate's create date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123",
+          "readOnly": true
+        },
+        "updated": {
+          "description": "The certificate's last update date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123",
+          "readOnly": true
+        },
+        "certificate": {
+          "description": "The certificate content",
+          "type": "string"
+        }
+      }
+    },
+    "CertificatePropertiesWithNonce": {
+      "description": "The description of an X509 CA Certificate including the challenge nonce issued for the Proof-Of-Possession flow.",
+      "type": "object",
+      "properties": {
+        "subject": {
+          "description": "The certificate's subject name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "expiry": {
+          "description": "The certificate's expiration date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123",
+          "readOnly": true
+        },
+        "thumbprint": {
+          "description": "The certificate's thumbprint.",
+          "type": "string",
+          "readOnly": true
+        },
+        "isVerified": {
+          "description": "Determines whether certificate has been verified.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "created": {
+          "description": "The certificate's create date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123",
+          "readOnly": true
+        },
+        "updated": {
+          "description": "The certificate's last update date and time.",
+          "type": "string",
+          "format": "date-time-rfc1123",
+          "readOnly": true
+        },
+        "verificationCode": {
+          "description": "The certificate's verification code that will be used for proof of possession.",
+          "type": "string",
+          "readOnly": true
+        },
+        "certificate": {
+          "description": "The certificate content",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IotHubProperties": {
+      "description": "The properties of an IoT hub.",
+      "type": "object",
+      "properties": {
+        "authorizationPolicies": {
+          "description": "The shared access policies you can use to secure a connection to the IoT hub.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SharedAccessSignatureAuthorizationRule"
+          }
+        },
+        "ipFilterRules": {
+          "description": "The IP filter rules.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IpFilterRule"
+          }
+        },
+        "provisioningState": {
+          "description": "The provisioning state.",
+          "type": "string",
+          "readOnly": true
+        },
+        "state": {
+          "description": "The hub state.",
+          "type": "string",
+          "readOnly": true
+        },
+        "hostName": {
+          "description": "The name of the host.",
+          "type": "string",
+          "readOnly": true
+        },
+        "eventHubEndpoints": {
+          "description": "The Event Hub-compatible endpoint properties. The possible keys to this dictionary are events and operationsMonitoringEvents. Both of these keys have to be present in the dictionary while making create or update calls for the IoT hub.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/EventHubProperties"
+          }
+        },
+        "routing": {
+          "$ref": "#/definitions/RoutingProperties"
+        },
+        "storageEndpoints": {
+          "description": "The list of Azure Storage endpoints where you can upload files. Currently you can configure only one Azure Storage account and that MUST have its key as $default. Specifying more than one storage account causes an error to be thrown. Not specifying a value for this property when the enableFileUploadNotifications property is set to True, causes an error to be thrown.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StorageEndpointProperties"
+          }
+        },
+        "messagingEndpoints": {
+          "description": "The messaging endpoint properties for the file upload notification queue.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MessagingEndpointProperties"
+          }
+        },
+        "enableFileUploadNotifications": {
+          "description": "If True, file upload notifications are enabled.",
+          "type": "boolean"
+        },
+        "cloudToDevice": {
+          "$ref": "#/definitions/CloudToDeviceProperties"
+        },
+        "comments": {
+          "description": "IoT hub comments.",
+          "type": "string"
+        },
+        "operationsMonitoringProperties": {
+          "$ref": "#/definitions/OperationsMonitoringProperties"
+        },
+        "deviceStreams": {
+          "description": "The device streams properties of iothub.",
+          "type": "object",
+          "properties": {
+            "streamingEndpoints": {
+              "description": "List of Device Streams Endpoints.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "features": {
+          "description": "The capabilities and features enabled for the IoT hub.",
+          "enum": [
+            "None",
+            "DeviceManagement"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "Capabilities",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "IotHubSkuInfo": {
+      "description": "Information about the SKU of the IoT hub.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the SKU.",
+          "enum": [
+            "F1",
+            "S1",
+            "S2",
+            "S3",
+            "B1",
+            "B2",
+            "B3"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "IotHubSku",
+            "modelAsString": true
+          }
+        },
+        "tier": {
+          "description": "The billing tier for the IoT hub.",
+          "enum": [
+            "Free",
+            "Standard",
+            "Basic"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IotHubSkuTier",
+            "modelAsString": false
+          }
+        },
+        "capacity": {
+          "format": "int64",
+          "description": "The number of provisioned IoT Hub units. See: https://docs.microsoft.com/azure/azure-subscription-service-limits#iot-hub-limits.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "EventHubProperties": {
+      "description": "The properties of the provisioned Event Hub-compatible endpoint used by the IoT hub.",
+      "type": "object",
+      "properties": {
+        "retentionTimeInDays": {
+          "format": "int64",
+          "description": "The retention time for device-to-cloud messages in days. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#device-to-cloud-messages",
+          "type": "integer"
+        },
+        "partitionCount": {
+          "format": "int32",
+          "description": "The number of partitions for receiving device-to-cloud messages in the Event Hub-compatible endpoint. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#device-to-cloud-messages.",
+          "type": "integer"
+        },
+        "partitionIds": {
+          "description": "The partition ids in the Event Hub-compatible endpoint.",
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "path": {
+          "description": "The Event Hub-compatible name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "endpoint": {
+          "description": "The Event Hub-compatible endpoint.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "StorageEndpointProperties": {
+      "description": "The properties of the Azure Storage endpoint for file upload.",
+      "type": "object",
+      "properties": {
+        "sasTtlAsIso8601": {
+          "description": "The period of time for which the SAS URI generated by IoT Hub for file upload is valid. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload#file-upload-notification-configuration-options.",
+          "type": "string",
+          "format": "duration"
+        },
+        "connectionString": {
+          "description": "The connection string for the Azure Storage account to which files are uploaded.",
+          "type": "string"
+        },
+        "containerName": {
+          "description": "The name of the root container where you upload files. The container need not exist but should be creatable using the connectionString specified.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "connectionString",
+        "containerName"
+      ]
+    },
+    "MessagingEndpointProperties": {
+      "description": "The properties of the messaging endpoints used by this IoT hub.",
+      "type": "object",
+      "properties": {
+        "lockDurationAsIso8601": {
+          "description": "The lock duration. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload.",
+          "type": "string",
+          "format": "duration"
+        },
+        "ttlAsIso8601": {
+          "description": "The period of time for which a message is available to consume before it is expired by the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload.",
+          "type": "string",
+          "format": "duration"
+        },
+        "maxDeliveryCount": {
+          "description": "The number of times the IoT hub attempts to deliver a message. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload.",
+          "format": "int32",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      }
+    },
+    "CloudToDeviceProperties": {
+      "description": "The IoT hub cloud-to-device messaging properties.",
+      "type": "object",
+      "properties": {
+        "maxDeliveryCount": {
+          "description": "The max delivery count for cloud-to-device messages in the device queue. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages.",
+          "format": "int32",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "defaultTtlAsIso8601": {
+          "description": "The default time to live for cloud-to-device messages in the device queue. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages.",
+          "type": "string",
+          "format": "duration"
+        },
+        "feedback": {
+          "$ref": "#/definitions/FeedbackProperties"
+        }
+      }
+    },
+    "OperationsMonitoringProperties": {
+      "description": "The operations monitoring properties for the IoT hub. The possible keys to the dictionary are Connections, DeviceTelemetry, C2DCommands, DeviceIdentityOperations, FileUploadOperations, Routes, D2CTwinOperations, C2DTwinOperations, TwinQueries, JobsOperations, DirectMethods.",
+      "type": "object",
+      "properties": {
+        "events": {
+          "type": "object",
+          "additionalProperties": {
+            "enum": [
+              "None",
+              "Error",
+              "Information",
+              "Error, Information"
+            ],
+            "description": "The operations monitoring level.",
+            "type": "string",
+            "x-ms-enum": {
+              "name": "OperationMonitoringLevel",
+              "modelAsString": true
+            }
+          }
+        }
+      }
+    },
+    "IpFilterRule": {
+      "description": "The IP filter rules for the IoT hub.",
+      "type": "object",
+      "properties": {
+        "filterName": {
+          "description": "The name of the IP filter rule.",
+          "type": "string"
+        },
+        "action": {
+          "description": "The desired action for requests captured by this rule.",
+          "enum": [
+            "Accept",
+            "Reject"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "IpFilterActionType",
+            "modelAsString": false
+          }
+        },
+        "ipMask": {
+          "description": "A string that contains the IP address range in CIDR notation for the rule.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "filterName",
+        "action",
+        "ipMask"
+      ]
+    },
+    "FeedbackProperties": {
+      "description": "The properties of the feedback queue for cloud-to-device messages.",
+      "type": "object",
+      "properties": {
+        "lockDurationAsIso8601": {
+          "description": "The lock duration for the feedback queue. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages.",
+          "type": "string",
+          "format": "duration"
+        },
+        "ttlAsIso8601": {
+          "description": "The period of time for which a message is available to consume before it is expired by the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages.",
+          "type": "string",
+          "format": "duration"
+        },
+        "maxDeliveryCount": {
+          "description": "The number of times the IoT hub attempts to deliver a message on the feedback queue. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging#cloud-to-device-messages.",
+          "format": "int32",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      }
+    },
+    "RoutingProperties": {
+      "description": "The routing related properties of the IoT hub. See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging",
+      "type": "object",
+      "properties": {
+        "endpoints": {
+          "$ref": "#/definitions/RoutingEndpoints"
+        },
+        "routes": {
+          "description": "The list of user-provided routing rules that the IoT hub uses to route messages to built-in and custom endpoints. A maximum of 100 routing rules are allowed for paid hubs and a maximum of 5 routing rules are allowed for free hubs.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RouteProperties"
+          }
+        },
+        "fallbackRoute": {
+          "description": "The properties of the route that is used as a fall-back route when none of the conditions specified in the 'routes' section are met. This is an optional parameter. When this property is not set, the messages which do not meet any of the conditions specified in the 'routes' section get routed to the built-in eventhub endpoint.",
+          "$ref": "#/definitions/FallbackRouteProperties"
+        }
+      }
+    },
+    "RoutingEndpoints": {
+      "description": "The properties related to the custom endpoints to which your IoT hub routes messages based on the routing rules. A maximum of 10 custom endpoints are allowed across all endpoint types for paid hubs and only 1 custom endpoint is allowed across all endpoint types for free hubs.",
+      "type": "object",
+      "properties": {
+        "serviceBusQueues": {
+          "description": "The list of Service Bus queue endpoints that IoT hub routes the messages to, based on the routing rules.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RoutingServiceBusQueueEndpointProperties"
+          }
+        },
+        "serviceBusTopics": {
+          "description": "The list of Service Bus topic endpoints that the IoT hub routes the messages to, based on the routing rules.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RoutingServiceBusTopicEndpointProperties"
+          }
+        },
+        "eventHubs": {
+          "description": "The list of Event Hubs endpoints that IoT hub routes messages to, based on the routing rules. This list does not include the built-in Event Hubs endpoint.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RoutingEventHubProperties"
+          }
+        },
+        "storageContainers": {
+          "description": "The list of storage container endpoints that IoT hub routes messages to, based on the routing rules.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RoutingStorageContainerProperties"
+          }
+        }
+      }
+    },
+    "RoutingServiceBusQueueEndpointProperties": {
+      "description": "The properties related to service bus queue endpoint types.",
+      "type": "object",
+      "properties": {
+        "connectionString": {
+          "description": "The connection string of the service bus queue endpoint.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, operationsMonitoringEvents, fileNotifications, $default. Endpoint names must be unique across endpoint types. The name need not be the same as the actual queue name.",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9-._]{1,64}$"
+        },
+        "subscriptionId": {
+          "description": "The subscription identifier of the service bus queue endpoint.",
+          "type": "string"
+        },
+        "resourceGroup": {
+          "description": "The name of the resource group of the service bus queue endpoint.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "connectionString"
+      ]
+    },
+    "RoutingServiceBusTopicEndpointProperties": {
+      "description": "The properties related to service bus topic endpoint types.",
+      "type": "object",
+      "properties": {
+        "connectionString": {
+          "description": "The connection string of the service bus topic endpoint.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, operationsMonitoringEvents, fileNotifications, $default. Endpoint names must be unique across endpoint types.  The name need not be the same as the actual topic name.",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9-._]{1,64}$"
+        },
+        "subscriptionId": {
+          "description": "The subscription identifier of the service bus topic endpoint.",
+          "type": "string"
+        },
+        "resourceGroup": {
+          "description": "The name of the resource group of the service bus topic endpoint.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "connectionString"
+      ]
+    },
+    "RoutingEventHubProperties": {
+      "description": "The properties related to an event hub endpoint.",
+      "type": "object",
+      "properties": {
+        "connectionString": {
+          "description": "The connection string of the event hub endpoint. ",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, operationsMonitoringEvents, fileNotifications, $default. Endpoint names must be unique across endpoint types.",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9-._]{1,64}$"
+        },
+        "subscriptionId": {
+          "description": "The subscription identifier of the event hub endpoint.",
+          "type": "string"
+        },
+        "resourceGroup": {
+          "description": "The name of the resource group of the event hub endpoint.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "connectionString"
+      ]
+    },
+    "RoutingStorageContainerProperties": {
+      "description": "The properties related to a storage container endpoint.",
+      "type": "object",
+      "properties": {
+        "connectionString": {
+          "description": "The connection string of the storage account.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name that identifies this endpoint. The name can only include alphanumeric characters, periods, underscores, hyphens and has a maximum length of 64 characters. The following names are reserved:  events, operationsMonitoringEvents, fileNotifications, $default. Endpoint names must be unique across endpoint types.",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9-._]{1,64}$"
+        },
+        "subscriptionId": {
+          "description": "The subscription identifier of the storage account.",
+          "type": "string"
+        },
+        "resourceGroup": {
+          "description": "The name of the resource group of the storage account.",
+          "type": "string"
+        },
+        "containerName": {
+          "description": "The name of storage container in the storage account.",
+          "type": "string"
+        },
+        "fileNameFormat": {
+          "description": "File name format for the blob. Default format is {iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}. All parameters are mandatory but can be reordered.",
+          "type": "string"
+        },
+        "batchFrequencyInSeconds": {
+          "description": "Time interval at which blobs are written to storage. Value should be between 60 and 720 seconds. Default value is 300 seconds.",
+          "format": "int32",
+          "type": "integer",
+          "maximum": 720,
+          "minimum": 60
+        },
+        "maxChunkSizeInBytes": {
+          "description": "Maximum number of bytes for each blob written to storage. Value should be between 10485760(10MB) and 524288000(500MB). Default value is 314572800(300MB).",
+          "format": "int32",
+          "type": "integer",
+          "maximum": 524288000,
+          "minimum": 10485760
+        },
+        "encoding": {
+          "description": "Encoding that is used to serialize messages to blobs. Supported values are 'avro', 'avrodeflate', and 'JSON'. Default value is 'avro'.",
+          "type": "string",
+          "enum": [
+            "Avro",
+            "AvroDeflate",
+            "JSON"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "connectionString",
+        "containerName"
+      ]
+    },
+    "RouteProperties": {
+      "description": "The properties of a routing rule that your IoT hub uses to route messages to endpoints.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the route. The name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters, and must be unique.",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9-._]{1,64}$"
+        },
+        "source": {
+          "description": "The source that the routing rule is to be applied to, such as DeviceMessages.",
+          "enum": [
+            "Invalid",
+            "DeviceMessages",
+            "TwinChangeEvents",
+            "DeviceLifecycleEvents",
+            "DeviceJobLifecycleEvents"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RoutingSource",
+            "modelAsString": true
+          }
+        },
+        "condition": {
+          "description": "The condition that is evaluated to apply the routing rule. If no condition is provided, it evaluates to true by default. For grammar, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language",
+          "type": "string"
+        },
+        "endpointNames": {
+          "description": "The list of endpoints to which messages that satisfy the condition are routed. Currently only one endpoint is allowed.",
+          "minItems": 1,
+          "maxItems": 1,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "isEnabled": {
+          "description": "Used to specify whether a route is enabled.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "endpointNames",
+        "source",
+        "isEnabled"
+      ]
+    },
+    "FallbackRouteProperties": {
+      "description": "The properties of the fallback route. IoT Hub uses these properties when it routes messages to the fallback endpoint.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the route. The name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters, and must be unique.",
+          "type": "string"
+        },
+        "source": {
+          "description": "The source to which the routing rule is to be applied to. For example, DeviceMessages",
+          "enum": [
+            "DeviceMessages"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RoutingSource",
+            "modelAsString": true
+          }
+        },
+        "condition": {
+          "description": "The condition which is evaluated in order to apply the fallback route. If the condition is not provided it will evaluate to true by default. For grammar, See: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language",
+          "type": "string"
+        },
+        "endpointNames": {
+          "description": "The list of endpoints to which the messages that satisfy the condition are routed to. Currently only 1 endpoint is allowed.",
+          "minItems": 1,
+          "maxItems": 1,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "isEnabled": {
+          "description": "Used to specify whether the fallback route is enabled.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "endpointNames",
+        "source",
+        "isEnabled"
+      ]
+    },
+    "IotHubDescription": {
+      "description": "The description of the IoT hub.",
+      "type": "object",
+      "properties": {
+        "etag": {
+          "description": "The Etag field is *not* required. If it is provided in the response body, it must also be provided as a header per the normal ETag convention.",
+          "type": "string"
+        },
+        "properties": {
+          "description": "IotHub properties",
+          "$ref": "#/definitions/IotHubProperties"
+        },
+        "sku": {
+          "description": "IotHub SKU info",
+          "$ref": "#/definitions/IotHubSkuInfo"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "required": [
+        "sku"
+      ]
+    },
+    "Resource": {
+      "description": "The common properties of an Azure resource.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource identifier."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource name.",
+          "pattern": "^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{2,49}[a-zA-Z0-9]$"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource type."
+        },
+        "location": {
+          "type": "string",
+          "description": "The resource location."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The resource tags."
+        }
+      },
+      "x-ms-azure-resource": true,
+      "required": [
+        "location"
+      ]
+    },
+    "SharedAccessSignatureAuthorizationRuleListResult": {
+      "description": "The list of shared access policies with a next link.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The list of shared access policies.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SharedAccessSignatureAuthorizationRule"
+          }
+        },
+        "nextLink": {
+          "description": "The next link.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "OperationListResult": {
+      "description": "Result of the request to list IoT Hub operations. It contains a list of operations and a URL link to get the next set of results.",
+      "properties": {
+        "value": {
+          "description": "List of IoT Hub operations supported by the Microsoft.Devices resource provider.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "URL to get the next set of operation list results if there are any."
+        }
+      }
+    },
+    "Operation": {
+      "description": "IoT Hub REST API operation",
+      "type": "object",
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Operation name: {provider}/{resource}/{read | write | action | delete}"
+        },
+        "display": {
+          "description": "The object that represents the operation.",
+          "properties": {
+            "provider": {
+              "readOnly": true,
+              "type": "string",
+              "description": "Service provider: Microsoft Devices"
+            },
+            "resource": {
+              "readOnly": true,
+              "type": "string",
+              "description": "Resource Type: IotHubs"
+            },
+            "operation": {
+              "readOnly": true,
+              "type": "string",
+              "description": "Name of the operation"
+            },
+            "description": {
+              "readOnly": true,
+              "type": "string",
+              "description": "Description of the operation"
+            }
+          }
+        }
+      }
+    },
+    "ErrorDetails": {
+      "description": "Error details.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The error code.",
+          "type": "string",
+          "readOnly": true
+        },
+        "httpStatusCode": {
+          "description": "The HTTP status code.",
+          "type": "string",
+          "readOnly": true
+        },
+        "message": {
+          "description": "The error message.",
+          "type": "string",
+          "readOnly": true
+        },
+        "details": {
+          "description": "The error details.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IotHubQuotaMetricInfoListResult": {
+      "description": "The JSON-serialized array of IotHubQuotaMetricInfo objects with a next link.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The array of quota metrics objects.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IotHubQuotaMetricInfo"
+          }
+        },
+        "nextLink": {
+          "description": "The next link.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "EndpointHealthDataListResult": {
+      "description": "The JSON-serialized array of EndpointHealthData objects with a next link.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "JSON-serialized array of Endpoint health data",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EndpointHealthData"
+          }
+        },
+        "nextLink": {
+          "description": "Link to more results",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "EndpointHealthData": {
+      "description": "The health data for an endpoint",
+      "type": "object",
+      "properties": {
+        "endpointId": {
+          "description": "Id of the endpoint",
+          "type": "string"
+        },
+        "healthStatus": {
+          "description": "Health statuses have following meanings. The 'healthy' status shows that the endpoint is accepting messages as expected. The 'unhealthy' status shows that the endpoint is not accepting messages as expected and IoT Hub is retrying to send data to this endpoint. The status of an unhealthy endpoint will be updated to healthy when IoT Hub has established an eventually consistent state of health. The 'dead' status shows that the endpoint is not accepting messages, after IoT Hub retried sending messages for the retrial period. See IoT Hub metrics to identify errors and monitor issues with endpoints. The 'unknown' status shows that the IoT Hub has not established a connection with the endpoint. No messages have been delivered to or rejected from this endpoint",
+          "enum": [
+            "unknown",
+            "healthy",
+            "unhealthy",
+            "dead"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "EndpointHealthStatus",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "RegistryStatistics": {
+      "description": "Identity registry statistics.",
+      "type": "object",
+      "properties": {
+        "totalDeviceCount": {
+          "format": "int64",
+          "description": "The total count of devices in the identity registry.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "enabledDeviceCount": {
+          "format": "int64",
+          "description": "The count of enabled devices in the identity registry.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "disabledDeviceCount": {
+          "format": "int64",
+          "description": "The count of disabled devices in the identity registry.",
+          "type": "integer",
+          "readOnly": true
+        }
+      }
+    },
+    "JobResponseListResult": {
+      "description": "The JSON-serialized array of JobResponse objects with a next link.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The array of JobResponse objects.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JobResponse"
+          }
+        },
+        "nextLink": {
+          "description": "The next link.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IotHubSkuDescription": {
+      "description": "SKU properties.",
+      "type": "object",
+      "properties": {
+        "resourceType": {
+          "description": "The type of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "sku": {
+          "description": "The type of the resource.",
+          "$ref": "#/definitions/IotHubSkuInfo"
+        },
+        "capacity": {
+          "description": "IotHub capacity",
+          "$ref": "#/definitions/IotHubCapacity"
+        }
+      },
+      "required": [
+        "sku",
+        "capacity"
+      ]
+    },
+    "TagsResource": {
+      "properties": {
+        "tags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "description": "A container holding only the Tags for a resource, allowing the user to update the tags on an IoT Hub instance."
+    },
+    "IotHubCapacity": {
+      "description": "IoT Hub capacity information.",
+      "type": "object",
+      "properties": {
+        "minimum": {
+          "format": "int64",
+          "description": "The minimum number of units.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1,
+          "readOnly": true
+        },
+        "maximum": {
+          "format": "int64",
+          "description": "The maximum number of units.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "default": {
+          "format": "int64",
+          "description": "The default number of units.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "scaleType": {
+          "description": "The type of the scaling enabled.",
+          "enum": [
+            "Automatic",
+            "Manual",
+            "None"
+          ],
+          "readOnly": true,
+          "type": "string",
+          "x-ms-enum": {
+            "name": "IotHubScaleType",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "EventHubConsumerGroupsListResult": {
+      "description": "The JSON-serialized array of Event Hub-compatible consumer group names with a next link.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of consumer groups objects",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EventHubConsumerGroupInfo"
+          }
+        },
+        "nextLink": {
+          "description": "The next link.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "EventHubConsumerGroupInfo": {
+      "description": "The properties of the EventHubConsumerGroupInfo object.",
+      "x-ms-azure-resource": true,
+      "type": "object",
+      "properties": {
+        "properties": {
+          "description": "The tags.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "The Event Hub-compatible consumer group identifier.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "The Event Hub-compatible consumer group name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "the resource type.",
+          "type": "string",
+          "readOnly": true
+        },
+        "etag": {
+          "description": "The etag.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IotHubSkuDescriptionListResult": {
+      "description": "The JSON-serialized array of IotHubSkuDescription objects with a next link.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The array of IotHubSkuDescription.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IotHubSkuDescription"
+          }
+        },
+        "nextLink": {
+          "description": "The next link.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "JobResponse": {
+      "description": "The properties of the Job Response object.",
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "description": "The job identifier.",
+          "type": "string",
+          "readOnly": true
+        },
+        "startTimeUtc": {
+          "format": "date-time-rfc1123",
+          "description": "The start time of the job.",
+          "type": "string",
+          "readOnly": true
+        },
+        "endTimeUtc": {
+          "format": "date-time-rfc1123",
+          "description": "The time the job stopped processing.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "The type of the job.",
+          "enum": [
+            "unknown",
+            "export",
+            "import",
+            "backup",
+            "readDeviceProperties",
+            "writeDeviceProperties",
+            "updateDeviceConfiguration",
+            "rebootDevice",
+            "factoryResetDevice",
+            "firmwareUpdate"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "JobType",
+            "modelAsString": true
+          }
+        },
+        "status": {
+          "description": "The status of the job.",
+          "enum": [
+            "unknown",
+            "enqueued",
+            "running",
+            "completed",
+            "failed",
+            "cancelled"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "JobStatus",
+            "modelAsString": false
+          }
+        },
+        "failureReason": {
+          "description": "If status == failed, this string containing the reason for the failure.",
+          "type": "string",
+          "readOnly": true
+        },
+        "statusMessage": {
+          "description": "The status message for the job.",
+          "type": "string",
+          "readOnly": true
+        },
+        "parentJobId": {
+          "description": "The job identifier of the parent job, if any.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IotHubDescriptionListResult": {
+      "description": "The JSON-serialized array of IotHubDescription objects with a next link.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The array of IotHubDescription objects.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IotHubDescription"
+          }
+        },
+        "nextLink": {
+          "description": "The next link.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IotHubQuotaMetricInfo": {
+      "description": "Quota metrics properties.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the quota metric.",
+          "type": "string",
+          "readOnly": true
+        },
+        "currentValue": {
+          "format": "int64",
+          "description": "The current value for the quota metric.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "maxValue": {
+          "format": "int64",
+          "description": "The maximum value of the quota metric.",
+          "type": "integer",
+          "readOnly": true
+        }
+      }
+    },
+    "OperationInputs": {
+      "description": "Input values.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the IoT hub to check.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "IotHubNameAvailabilityInfo": {
+      "description": "The properties indicating whether a given IoT hub name is available.",
+      "type": "object",
+      "properties": {
+        "nameAvailable": {
+          "description": "The value which indicates whether the provided name is available.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "reason": {
+          "description": "The reason for unavailability.",
+          "enum": [
+            "Invalid",
+            "AlreadyExists"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IotHubNameUnavailabilityReason",
+            "modelAsString": false
+          }
+        },
+        "message": {
+          "description": "The detailed reason message.",
+          "type": "string"
+        }
+      }
+    },
+    "UserSubscriptionQuotaListResult": {
+      "type": "object",
+      "description": "Json-serialized array of User subscription quota response",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserSubscriptionQuota"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "UserSubscriptionQuota": {
+      "description": "User subscription quota response",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "IotHub type id",
+          "type": "string"
+        },
+        "type": {
+          "description": "Response type",
+          "type": "string"
+        },
+        "unit": {
+          "description": "Unit of IotHub type",
+          "type": "string"
+        },
+        "currentValue": {
+          "description": "Current number of IotHub type",
+          "format": "int32",
+          "type": "integer"
+        },
+        "limit": {
+          "description": "Numerical limit on IotHub type",
+          "format": "int32",
+          "type": "integer"
+        },
+        "name": {
+          "description": "IotHub type",
+          "$ref": "#/definitions/Name"
+        }
+      }
+    },
+    "Name": {
+      "description": "Name of Iot Hub type",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "IotHub type",
+          "type": "string"
+        },
+        "localizedValue": {
+          "description": "Localized value of name",
+          "type": "string"
+        }
+      }
+    },
+    "TestAllRoutesInput": {
+      "description": "Input for testing all routes",
+      "type": "object",
+      "properties": {
+        "routingSource": {
+          "description": "Routing source",
+          "enum": [
+            "Invalid",
+            "DeviceMessages",
+            "TwinChangeEvents",
+            "DeviceLifecycleEvents",
+            "DeviceJobLifecycleEvents"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RoutingSource",
+            "modelAsString": true
+          }
+        },
+        "message": {
+          "description": "Routing message",
+          "$ref": "#/definitions/RoutingMessage"
+        },
+        "twin": {
+          "description": "Routing Twin Reference",
+          "$ref": "#/definitions/RoutingTwin"
+        }
+      }
+    },
+    "RoutingTwin": {
+      "description": "Twin reference input parameter. This is an optional parameter",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "description": "Twin Tags",
+          "type": "object"
+        },
+        "properties": {
+          "properties": {
+            "desired" : {
+              "description": "Twin desired properties",
+              "type": "object"
+            },
+            "reported" : {
+              "description": "Twin desired properties",
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    "RoutingMessage": {
+      "description": "Routing message",
+      "type": "object",
+      "properties": {
+        "body": {
+          "description": "Body of routing message",
+          "type": "string"
+        },
+        "appProperties": {
+          "description": "App properties",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "systemProperties": {
+          "description": "System properties",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TestAllRoutesResult": {
+      "description": "Result of testing all routes",
+      "type": "object",
+      "properties": {
+        "routes": {
+          "description": "JSON-serialized array of matched routes",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MatchedRoute"
+          }
+        }
+      }
+    },
+    "MatchedRoute": {
+      "description": "Routes that matched",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "description": "Properties of routes that matched",
+          "$ref": "#/definitions/RouteProperties"
+        }
+      }
+    },
+    "TestRouteInput": {
+      "required": [
+        "route"
+      ],
+      "description": "Input for testing route",
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "Routing message",
+          "$ref": "#/definitions/RoutingMessage"
+        },
+        "route": {
+          "description": "Route properties",
+          "$ref": "#/definitions/RouteProperties"
+        },
+        "twin": {
+          "description": "Routing Twin Reference",
+          "$ref": "#/definitions/RoutingTwin"
+        }
+      }
+    },
+    "TestRouteResult": {
+      "description": "Result of testing one route",
+      "type": "object",
+      "properties": {
+        "result": {
+          "description": "Result of testing route",
+          "enum": [
+            "undefined",
+            "false",
+            "true"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "TestResultStatus",
+            "modelAsString": true
+          }
+        },
+        "details": {
+          "description": "Detailed result of testing route",
+          "$ref": "#/definitions/TestRouteResultDetails"
+        }
+      }
+    },
+    "TestRouteResultDetails": {
+      "description": "Detailed result of testing a route",
+      "type": "object",
+      "properties": {
+        "compilationErrors": {
+          "description": "JSON-serialized list of route compilation errors",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RouteCompilationError"
+          }
+        }
+      }
+    },
+    "RouteCompilationError": {
+      "description": "Compilation error when evaluating route",
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "Route error message",
+          "type": "string"
+        },
+        "severity": {
+          "description": "Severity of the route error",
+          "enum": [
+            "error",
+            "warning"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RouteErrorSeverity",
+            "modelAsString": true
+          }
+        },
+        "location": {
+          "description": "Location where the route error happened",
+          "$ref": "#/definitions/RouteErrorRange"
+        }
+      }
+    },
+    "RouteErrorRange": {
+      "description": "Range of route errors",
+      "type": "object",
+      "properties": {
+        "start": {
+          "description": "Start where the route error happened",
+          "$ref": "#/definitions/RouteErrorPosition"
+        },
+        "end": {
+          "description": "End where the route error happened",
+          "$ref": "#/definitions/RouteErrorPosition"
+        }
+      }
+    },
+    "RouteErrorPosition": {
+      "description": "Position where the route error happened",
+      "type": "object",
+      "properties": {
+        "line": {
+          "description": "Line where the route error happened",
+          "format": "int32",
+          "type": "integer"
+        },
+        "column": {
+          "description": "Column where the route error happened",
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "ExportDevicesRequest": {
+      "description": "Use to provide parameters when requesting an export of all devices in the IoT hub.",
+      "type": "object",
+      "properties": {
+        "exportBlobContainerUri": {
+          "description": "The export blob container URI.",
+          "type": "string"
+        },
+        "excludeKeys": {
+          "description": "The value indicating whether keys should be excluded during export.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "exportBlobContainerUri",
+        "excludeKeys"
+      ]
+    },
+    "ImportDevicesRequest": {
+      "description": "Use to provide parameters when requesting an import of all devices in the hub.",
+      "type": "object",
+      "properties": {
+        "inputBlobContainerUri": {
+          "description": "The input blob container URI.",
+          "type": "string"
+        },
+        "outputBlobContainerUri": {
+          "description": "The output blob container URI.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "inputBlobContainerUri",
+        "outputBlobContainerUri"
+      ]
+    }
+  },
+  "parameters": {
+    "subscriptionId": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "The subscription identifier.",
+      "required": true,
+      "type": "string"
+    },
+    "api-version": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The version of the API.",
+      "required": true,
+      "type": "string"
+    },
+    "resourceGroupName": {
+      "name": "resourceGroupName",
+      "description": "The name of the resource group that contains the IoT hub.",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "resourceName": {
+      "name": "resourceName",
+      "in": "path",
+      "description": "The name of the IoT hub.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "certificateName": {
+      "name": "certificateName",
+      "in": "path",
+      "description": "The name of the certificate",
+      "required": true,
+      "type": "string",
+      "pattern": "^[A-Za-z0-9-._]{1,64}$",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/iothub/resource-manager/readme.md
+++ b/specification/iothub/resource-manager/readme.md
@@ -4,10 +4,10 @@
 
 This is the AutoRest configuration file for IotHub.
 
-
-
 ---
+
 ## Getting Started
+
 To build the SDK for IotHub, simply [Install AutoRest](https://aka.ms/autorest/install) and in this folder, run:
 
 > `autorest`
@@ -15,20 +15,29 @@ To build the SDK for IotHub, simply [Install AutoRest](https://aka.ms/autorest/i
 To see additional help and options, run:
 
 > `autorest --help`
+
 ---
 
 ## Configuration
 
-
-
 ### Basic Information
+
 These are the global settings for the IotHub API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2018-12-preview
+tag: package-2019-03
 ```
 
+
+### Tag: package-2019-03
+
+These settings apply only when `--tag=package-2019-03` is specified on the command line.
+
+```yaml $(tag) == 'package-2019-03'
+input-file:
+  - Microsoft.Devices/stable/2019-03-12/iothub.json
+```
 ### Tag: package-2018-12-preview
 
 These settings apply only when `--tag=package-2018-12-preview` is specified on the command line.
@@ -84,8 +93,8 @@ input-file:
 ```
 
 ---
-# Code Generation
 
+# Code Generation
 
 ## Swagger to SDK
 
@@ -103,7 +112,6 @@ swagger-to-sdk:
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_iot_hub']
 ```
-
 
 ## C#
 


### PR DESCRIPTION
If you are a MSFT employee you can view your [work branch via this link](https://portal.azure-devex-tools.com/app/branch/jlian/azure-rest-api-specs/dev-iothub-Microsoft.Devices-2019-03-12-try-again).

### Some context

We (IoT Hub team) have been preparing for the deprecation of the [operations monitoring feature](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-operations-monitoring) since [October 2017](https://azure.microsoft.com/en-us/blog/monitor-your-azure-iot-solutions-with-azure-monitor-and-azure-resource-health/). 

With this PR, we are removing OperationsMonitoring properties from our swagger. This is a breaking change, hence the new api-version. 


### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.

