### PR TITLE
fixing stos.proj parameter

### DIFF
--- a/scripts/stostools/stos.proj
+++ b/scripts/stostools/stos.proj
@@ -17,7 +17,7 @@
         <StartNetSdkCodeGeneration
                 GitHubPRNumber="$(githubprnumber)" 
                     GitHubCommitId="$(githubcommitid)"
-                    GithubRepositoryUrl="$(giturl)"
+                    RestSpecRepositoryUrl ="$(giturl)"
                     TriggerComment="$(triggercomment)"
                     DebugMode="$(debugmode)"
         >


### PR DESCRIPTION
Updating a required task parameter name from GithubRepositoryUrl to RestSpecRepositoryUrl to reflect the task 