### PR TITLE
Changing Apiversion for subscriptions to 2016-06-01, matching the ava…

### DIFF
--- a/profile/2019-03-01-hybrid.json
+++ b/profile/2019-03-01-hybrid.json
@@ -44,17 +44,6 @@
                 "snapshots"
             ]
         },
-        "microsoft.eventhub": {
-            "2018-01-01-preview": [
-                "namespaces",
-                "checkNameAvailability",
-                "sku",
-                "operations"
-            ],
-            "2015-08-01": [
-                "checkNamespaceAvailability"
-            ]
-        },
         "microsoft.insights": {
             "2018-01-01": [
                 "metricDefinitions",
@@ -188,7 +177,7 @@
             "2016-10-01": []
         },
         "microsoft.storage": {
-            "2017-04-17": []
+            "2017-11-09": []
         }
     }
 }

--- a/profile/2019-03-01-hybrid.json
+++ b/profile/2019-03-01-hybrid.json
@@ -100,6 +100,11 @@
             ]
         },
         "microsoft.resources": {
+            "2016-06-01": [
+                "subscriptions",
+                "subscriptions/locations",
+                "tenants"
+            ],
             "2018-05-01": [
                 "deployments",
                 "deployments/operations",
@@ -109,16 +114,13 @@
                 "providers",
                 "resourceGroups",
                 "resources",
-                "subscriptions",
-                "subscriptions/locations",
                 "subscriptions/operationresults",
                 "subscriptions/providers",
                 "subscriptions/resourceGroups",
                 "subscriptions/resourceGroups/resources",
                 "subscriptions/resources",
                 "subscriptions/tagNames",
-                "subscriptions/tagNames/tagValues",
-                "tenants"
+                "subscriptions/tagNames/tagValues"
             ]
         },
         "microsoft.storage": {


### PR DESCRIPTION
…ilable spec

Though we support 2018-05-01 api version for /subscriptions, there are not any spec available. The model is same as that of 2016-01-01, so changing to 2016-06-01

Note that this is not a swagger change

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
