### PR TITLE
[Hub Generated] Review request for Microsoft.PolicyInsights to add version 2018-07-01-preview

### DIFF
--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/preview/2018-07-01-preview/examples/PolicyStates_QueryResourceScopeExpandPolicyEvaluationDetails.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/preview/2018-07-01-preview/examples/PolicyStates_QueryResourceScopeExpandPolicyEvaluationDetails.json
@@ -93,12 +93,12 @@
             "policyEvaluationDetails": {
               "evaluatedExpressions": [
                 {
-                  "result": "False",
-                  "expression": "name",
-                  "path": "name",
-                  "expressionValue": "myDomainName",
-                  "targetValue": "someName",
-                  "operator": "Equals"
+                  "result": "True",
+                  "expression": "tags",
+                  "path": "tags",
+                  "expressionValue": {},
+                  "targetValue": "global-opco",
+                  "operator": "NotContainsKey"
                 }
               ],
               "ifNotExistsDetails": {

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/preview/2018-07-01-preview/policyStates.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/preview/2018-07-01-preview/policyStates.json
@@ -1165,11 +1165,11 @@
         },
         "expressionValue": {
           "description": "Value of the expression.",
-          "type": "object"
+          "type": "string"
         },
         "targetValue": {
           "description": "Target value to be compared with the expression value.",
-          "type": "object"
+          "type": "string"
         },
         "operator": {
           "description": "Operator to compare the expression value and the target value.",

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/preview/2018-07-01-preview/policyStates.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/preview/2018-07-01-preview/policyStates.json
@@ -1165,11 +1165,11 @@
         },
         "expressionValue": {
           "description": "Value of the expression.",
-          "type": "string"
+          "type": "object"
         },
         "targetValue": {
           "description": "Target value to be compared with the expression value.",
-          "type": "string"
+          "type": "object"
         },
         "operator": {
           "description": "Operator to compare the expression value and the target value.",

--- a/specification/policyinsights/resource-manager/readme.md
+++ b/specification/policyinsights/resource-manager/readme.md
@@ -145,6 +145,13 @@ csharp:
   namespace: Microsoft.Azure.Management.PolicyInsights
   output-folder: $(csharp-sdks-folder)/PolicyInsights/Management/Management.PolicyInsights/Generated
   clear-output-folder: true
+directive:
+  - from: swagger-document
+    where: $.definitions.ExpressionEvaluationDetails.properties.expressionValue
+    transform: $.type = "object"
+  - from: swagger-document
+    where: $.definitions.ExpressionEvaluationDetails.properties.targetValue
+    transform: $.type = "object"
 ```
 
 ## Python
@@ -162,6 +169,13 @@ python:
   namespace: azure.mgmt.policyinsights
   package-name: azure-mgmt-policyinsights
   clear-output-folder: true
+directive:
+  - from: swagger-document
+    where: $.definitions.ExpressionEvaluationDetails.properties.expressionValue
+    transform: $.type = "object"
+  - from: swagger-document
+    where: $.definitions.ExpressionEvaluationDetails.properties.targetValue
+    transform: $.type = "object"
 ```
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
@@ -190,6 +204,13 @@ namespace: com.microsoft.azure.management.policyinsights
 license-header: MICROSOFT_MIT_NO_CODEGEN
 payload-flattening-threshold: 1
 output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-policyinsights
+directive:
+  - from: swagger-document
+    where: $.definitions.ExpressionEvaluationDetails.properties.expressionValue
+    transform: $.type = "object"
+  - from: swagger-document
+    where: $.definitions.ExpressionEvaluationDetails.properties.targetValue
+    transform: $.type = "object"
 ```
 
 ### Java multi-api


### PR DESCRIPTION
"expressionValue" and "targetValue" can be any object (defined as JToken in the backend). Following are valid values:
{}
{ "foo": "bar"}
["foo", "bar"]
"foo"

Changed the type to "object" from "string".

If you are a MSFT employee you can view your [work branch via this link](https://portal.azure-devex-tools.com/app/branch/j5lim/azure-rest-api-specs/dev-policyinsights-Microsoft.PolicyInsights-2018-07-01-preview).

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.

