### PR TITLE
Cherry pick: Remove x-ms-pageable from Get Server Variables APIs

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/applicationGateway.json
@@ -452,7 +452,7 @@
         "x-ms-long-running-operation": true
       }
     },
-	"/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableServerVariables": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableServerVariables": {
       "get": {
         "tags": [
           "ApplicationGateways"
@@ -485,13 +485,10 @@
               "$ref": "./network.json#/definitions/Error"
             }
           }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": null
         }
       }
-  },
-	"/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableRequestHeaders": {
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableRequestHeaders": {
      "get": {
         "tags": [
           "ApplicationGateways"
@@ -524,13 +521,10 @@
               "$ref": "./network.json#/definitions/Error"
             }
           }
-        },
-       "x-ms-pageable": {
-          "nextLinkName": null
         }
       }
-  },
-	"/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableResponseHeaders": {
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableResponseHeaders": {
       "get": {
         "tags": [
           "ApplicationGateways"
@@ -563,9 +557,6 @@
               "$ref": "./network.json#/definitions/Error"
             }
           }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": null
         }
       }
     },


### PR DESCRIPTION
Copy changes to new API version from this PR: https://github.com/Azure/azure-rest-api-specs/pull/5439

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
