### PR TITLE
Adding windowsProfile and maxAgentPools property in the new 2019-04-01 api version

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/examples/ManagedClustersCreate_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/examples/ManagedClustersCreate_Update.json
@@ -31,6 +31,10 @@
             ]
           }
         },
+        "windowsProfile": {
+          "adminUsername": "azureuser",
+          "adminPassword": "replacePassword1234$"
+        },
         "servicePrincipalProfile": {
           "clientId": "clientid",
           "secret": "secret"
@@ -55,6 +59,7 @@
         "type": "Microsoft.ContainerService/ManagedClusters",
         "properties": {
           "provisioningState": "Succeeded",
+          "maxAgentPools": 1,
           "kubernetesVersion": "1.9.6",
           "dnsPrefix": "dnsprefix1",
           "agentPoolProfiles": [
@@ -77,6 +82,9 @@
                 }
               ]
             }
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
           },
           "servicePrincipalProfile": {
             "clientId": "clientid"
@@ -107,6 +115,7 @@
         "type": "Microsoft.ContainerService/ManagedClusters",
         "properties": {
           "provisioningState": "Creating",
+          "maxAgentPools": 1,
           "kubernetesVersion": "1.9.6",
           "dnsPrefix": "dnsprefix1",
           "agentPoolProfiles": [
@@ -129,6 +138,9 @@
                 }
               ]
             }
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
           },
           "servicePrincipalProfile": {
             "clientId": "clientid"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/examples/ManagedClustersGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/examples/ManagedClustersGet.json
@@ -18,6 +18,7 @@
         "type": "Microsoft.ContainerService/ManagedClusters",
         "properties": {
           "provisioningState": "Succeeded",
+          "maxAgentPools": 1,
           "kubernetesVersion": "1.9.6",
           "dnsPrefix": "dnsprefix1",
           "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/examples/ManagedClustersList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/examples/ManagedClustersList.json
@@ -19,6 +19,7 @@
             "properties": {
               "provisioningState": "Succeeded",
               "kubernetesVersion": "1.9.6",
+              "maxAgentPools": 1,
               "dnsPrefix": "dnsprefix1",
               "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
               "agentPoolProfiles": [

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/examples/ManagedClustersListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/examples/ManagedClustersListByResourceGroup.json
@@ -20,6 +20,7 @@
             "properties": {
               "provisioningState": "Succeeded",
               "kubernetesVersion": "1.9.6",
+              "maxAgentPools": 1,
               "dnsPrefix": "dnsprefix1",
               "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
               "agentPoolProfiles": [

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/managedClusters.json
@@ -1527,8 +1527,7 @@
         }
       },
       "required": [
-        "adminUsername",
-        "adminPassword"
+        "adminUsername"
       ],
       "description": "Profile for Windows VMs in the container service cluster."
     },
@@ -1701,6 +1700,12 @@
           "type": "string",
           "description": "The current deployment or provisioning state, which only appears in the response."
         },
+        "maxAgentPools": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int32",
+          "description": "The max number of agent pools for the managed cluster."
+        },
         "kubernetesVersion": {
           "type": "string",
           "description": "Version of Kubernetes specified when creating the managed cluster."
@@ -1724,6 +1729,10 @@
         "linuxProfile": {
           "$ref": "#/definitions/ContainerServiceLinuxProfile",
           "description": "Profile for Linux VMs in the container service cluster."
+        },
+        "windowsProfile": {
+          "$ref": "#/definitions/ContainerServiceWindowsProfile",
+          "description": "Profile for Windows VMs in the container service cluster."
         },
         "servicePrincipalProfile": {
           "$ref": "#/definitions/ManagedClusterServicePrincipalProfile",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-04-01/managedClusters.json
@@ -1513,7 +1513,7 @@
       ],
       "description": "Agent Pool."
     },
-    "ContainerServiceWindowsProfile": {
+    "ManagedClusterWindowsProfile": {
       "properties": {
         "adminUsername": {
           "type": "string",
@@ -1731,7 +1731,7 @@
           "description": "Profile for Linux VMs in the container service cluster."
         },
         "windowsProfile": {
-          "$ref": "#/definitions/ContainerServiceWindowsProfile",
+          "$ref": "#/definitions/ManagedClusterWindowsProfile",
           "description": "Profile for Windows VMs in the container service cluster."
         },
         "servicePrincipalProfile": {

--- a/specification/containerservice/resource-manager/readme.go.md
+++ b/specification/containerservice/resource-manager/readme.go.md
@@ -12,6 +12,7 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
+  - tag: package-2019-04
   - tag: package-2019-02
   - tag: package-2018-09-30-preview
   - tag: package-2018-08-preview
@@ -19,6 +20,16 @@ batch:
   - tag: package-2017-09
   - tag: package-2017-08
   - tag: package-2017-07
+```
+
+### Tag: package-2019-04 and go
+
+These settings apply only when `--package-2019-04 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2019-04' && $(go)
+namespace: containerservice
+output-folder: $(go-sdk-folder)/services/$(namespace)/mgmt/2019-04-01/$(namespace)
 ```
 
 ### Tag: package-2019-02 and go

--- a/specification/containerservice/resource-manager/readme.md
+++ b/specification/containerservice/resource-manager/readme.md
@@ -44,7 +44,10 @@ These settings apply only when `--tag=package-2019-04` is specified on the comma
 
 ```yaml $(tag) == 'package-2019-04'
 input-file:
+  - Microsoft.ContainerService/preview/2018-09-30-preview/openShiftManagedClusters.json
+  - Microsoft.ContainerService/stable/2017-07-01/containerService.json
   - Microsoft.ContainerService/stable/2019-04-01/managedClusters.json
+  - Microsoft.ContainerService/stable/2017-09-30/location.json
 ```
 ### Tag: package-2019-02
 

--- a/specification/containerservice/resource-manager/readme.md
+++ b/specification/containerservice/resource-manager/readme.md
@@ -49,6 +49,7 @@ input-file:
   - Microsoft.ContainerService/stable/2019-04-01/managedClusters.json
   - Microsoft.ContainerService/stable/2017-09-30/location.json
 ```
+
 ### Tag: package-2019-02
 
 These settings apply only when `--tag=package-2019-02` is specified on the command line.
@@ -124,6 +125,15 @@ These settings apply only when `--tag=package-2017-07` is specified on the comma
 ``` yaml $(tag) == 'package-2017-07'
 input-file:
 - Microsoft.ContainerService/stable/2017-07-01/containerService.json
+```
+
+### Tag: package-2019-04-only
+
+These settings apply only when `--tag=package-2019-04-only` is specified on the command line.
+
+``` yaml $(tag) == 'package-2019-04-only'
+input-file:
+- Microsoft.ContainerService/stable/2019-04-01/managedClusters.json
 ```
 
 ### Tag: package-2019-02-only

--- a/specification/containerservice/resource-manager/readme.python.md
+++ b/specification/containerservice/resource-manager/readme.python.md
@@ -18,7 +18,7 @@ Generate all API versions currently shipped for this package
 
 ```yaml $(python) && $(multiapi)
 batch:
-    tag: package-2019-04-only
+  - tag: package-2019-04-only
   - tag: package-2019-02-only
   - tag: package-2018-09-preview-only
   - tag: package-2018-08-preview-only

--- a/specification/containerservice/resource-manager/readme.python.md
+++ b/specification/containerservice/resource-manager/readme.python.md
@@ -18,12 +18,24 @@ Generate all API versions currently shipped for this package
 
 ```yaml $(python) && $(multiapi)
 batch:
+    tag: package-2019-04-only
   - tag: package-2019-02-only
   - tag: package-2018-09-preview-only
   - tag: package-2018-08-preview-only
   - tag: package-2018-03-only
   - tag: package-2017-07-only-extended
 ```
+### Tag: package-2019-04-only and python
+
+These settings apply only when `--tag=package-2019-04-only --python` is specified on the command line.
+Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
+
+``` yaml $(tag) == 'package-2019-04-only' && $(python)
+python:
+  namespace: azure.mgmt.containerservice.v2019_04_01
+  output-folder: $(python-sdks-folder)/azure-mgmt-containerservice/azure/mgmt/containerservice/v2019_04_01
+```
+
 ### Tag: package-2019-02-only and python
 
 These settings apply only when `--tag=package-2019-02-only --python` is specified on the command line.


### PR DESCRIPTION
MaxAgentPools is a read only field. It's purpose is to show whether the current managed cluster is able to support the new multi-agentpool APIs. Old clusters will have the value 1 because they can't add new agent pools. But new clusters will have the value  8 because new agent pools can be added.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
