### PR TITLE
Blueprints API update for excludedPrincipals and whoIsBlueprint

### DIFF
--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/assignmentOperation.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/assignmentOperation.json
@@ -290,7 +290,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "description": "The scope of the resource. Valid scope is: subscription (format: '/subscriptions/{subscriptionId}').",
+      "description": "The scope of the resource. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'). For blueprint assignments management group scope is reserved for future use.",
       "x-ms-parameter-location": "method",
       "x-ms-skip-url-encoding": true
     },

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/assignmentOperation.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/assignmentOperation.json
@@ -290,7 +290,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "description": "The scope of the resource. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}').",
+      "description": "The scope of the resource. Valid scope is: subscription (format: '/subscriptions/{subscriptionId}').",
       "x-ms-parameter-location": "method",
       "x-ms-skip-url-encoding": true
     },

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
@@ -579,7 +579,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "description": "The scope of the resource. Valid scope is: subscription (format: '/subscriptions/{subscriptionId}').",
+      "description": "The scope of the resource. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'). For blueprint assignments management group scope is reserved for future use.",
       "x-ms-parameter-location": "method",
       "x-ms-skip-url-encoding": true
     },

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
@@ -141,7 +141,7 @@
         }
       },
       "post": {
-        "operationId": "WhoIsBlueprint",
+        "operationId": "Assignments_WhoIsBlueprint",
         "description": "Get Blueprints service SPN objectId",
         "x-ms-examples": {
           "WhoIsBlueprint_Action": {
@@ -314,7 +314,7 @@
         },
         "excludedPrincipals": {
           "type": "array",
-          "description": "List of AAD principals excluded from blueprint locks. Up to 5 principals permitted.",
+          "description": "List of AAD principals excluded from blueprint locks. Up to 5 principals are permitted.",
           "items": {
             "type": "string"
           }
@@ -552,11 +552,11 @@
       }
     },
     "WhoIsBlueprintContract":{
-      "description": "AAD object Id of the Azure Blueprints service principal in the tenant.",
+      "description": "Response schema for querying the Azure Blueprints service principal in the tenant.",
       "properties": {
         "objectId": {
           "type": "string",
-          "description": "Identifier."
+          "description": "AAD object Id of the Azure Blueprints service principal in the tenant."
         }
       }
     }

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
@@ -139,6 +139,24 @@
             "description": "No Content"
           }
         }
+      },
+      "post": {
+        "operationId": "WhoIsBlueprint",
+        "description": "Get Blueprints service SPN objectId",
+        "x-ms-examples": {
+          "Assignment_Delete": {
+            "$ref": "./examples/WhoIsBlueprint_Action.json"
+          }
+        },
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Blueprints service SPN objectId",
+            "schema":{
+              "$ref": "#/definitions/WhoIsBlueprintContract"
+            }
+          }
+        }
       }
     },
     "/{scope}/providers/Microsoft.Blueprint/blueprintAssignments": {
@@ -292,6 +310,13 @@
           "x-ms-enum": {
             "name": "AssignmentLockMode",
             "modelAsString": true
+          }
+        },
+        "excludedPrincipals": {
+          "type": "array",
+          "description": "List of up to 5 service principal GUIDs.",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -523,6 +548,15 @@
           "type": "string",
           "readOnly": true,
           "description": "Last modified time of this blueprint definition."
+        }
+      }
+    },
+    "WhoIsBlueprintContract":{
+      "description": "ObjectID of the Blueprints service SPN",
+      "properties": {
+        "objectId": {
+          "type": "string",
+          "description": "Identifier."
         }
       }
     }

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
@@ -150,7 +150,17 @@
             "$ref": "./examples/WhoIsBlueprint_Action.json"
           }
         },
-        "parameters": [],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ScopeParameter"
+          },
+          {
+            "$ref": "#/parameters/AssignmentNameParameter"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Blueprints service SPN objectId",

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
@@ -139,7 +139,9 @@
             "description": "No Content"
           }
         }
-      },
+      }
+    },
+    "/{scope}/providers/Microsoft.Blueprint/blueprintAssignments/{assignmentName}/WhoIsBlueprint": {
       "post": {
         "operationId": "Assignments_WhoIsBlueprint",
         "description": "Get Blueprints service SPN objectId",

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
@@ -144,7 +144,7 @@
         "operationId": "WhoIsBlueprint",
         "description": "Get Blueprints service SPN objectId",
         "x-ms-examples": {
-          "Assignment_Delete": {
+          "WhoIsBlueprint_Action": {
             "$ref": "./examples/WhoIsBlueprint_Action.json"
           }
         },
@@ -314,7 +314,7 @@
         },
         "excludedPrincipals": {
           "type": "array",
-          "description": "List of up to 5 service principal GUIDs.",
+          "description": "List of AAD principals excluded from blueprint locks. Up to 5 principals permitted.",
           "items": {
             "type": "string"
           }
@@ -552,7 +552,7 @@
       }
     },
     "WhoIsBlueprintContract":{
-      "description": "ObjectID of the Blueprints service SPN",
+      "description": "AAD object Id of the Azure Blueprints service principal in the tenant.",
       "properties": {
         "objectId": {
           "type": "string",

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintAssignment.json
@@ -579,7 +579,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "description": "The scope of the resource. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}').",
+      "description": "The scope of the resource. Valid scope is: subscription (format: '/subscriptions/{subscriptionId}').",
       "x-ms-parameter-location": "method",
       "x-ms-skip-url-encoding": true
     },

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
@@ -817,7 +817,7 @@
         },
         "targetScope": {
           "type": "string",
-          "description": "The scope where this blueprint definition can be assigned. Management group is reserved for future use.",
+          "description": "The scope where this blueprint definition can be assigned.",
           "enum": [
             "subscription",
             "managementGroup"

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
@@ -550,22 +550,22 @@
         "description": "Get an artifact for a published blueprint definition.",
         "x-ms-examples": {
           "Sub-ARMTemplateArtifact": {
-            "$ref": "./examples/subscriptionBPDef/ARMTemplateArtifact_Get.json"
+            "$ref": "./examples/subscriptionBPDef/SealedARMTemplateArtifact_Get.json"
           },
           "Sub-PolicyAssignmentArtifact": {
-            "$ref": "./examples/subscriptionBPDef/PolicyAssignmentArtifact_Get.json"
+            "$ref": "./examples/subscriptionBPDef/SealedPolicyAssignmentArtifact_Get.json"
           },
           "Sub-RoleAssignmentArtifact": {
-            "$ref": "./examples/subscriptionBPDef/RoleAssignmentArtifact_Get.json"
+            "$ref": "./examples/subscriptionBPDef/SealedRoleAssignmentArtifact_Get.json"
           },
           "MG-ARMTemplateArtifact": {
-            "$ref": "./examples/managementGroupBPDef/ARMTemplateArtifact_Get.json"
+            "$ref": "./examples/managementGroupBPDef/SealedARMTemplateArtifact_Get.json"
           },
           "MG-PolicyAssignmentArtifact": {
-            "$ref": "./examples/managementGroupBPDef/PolicyAssignmentArtifact_Get.json"
+            "$ref": "./examples/managementGroupBPDef/SealedPolicyAssignmentArtifact_Get.json"
           },
           "MG-RoleAssignmentArtifact": {
-            "$ref": "./examples/managementGroupBPDef/RoleAssignmentArtifact_Get.json"
+            "$ref": "./examples/managementGroupBPDef/SealedRoleAssignmentArtifact_Get.json"
           }
         },
         "parameters": [

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
@@ -824,7 +824,17 @@
           ],
           "x-ms-enum": {
             "name": "BlueprintTargetScope",
-            "modelAsString": true
+            "modelAsString": false,
+            "values": [
+              {
+                  "value": "subscription",
+                  "description": "The blueprint targets a subscription during blueprint assignment."
+              },
+              {
+                  "value": "managementGroup",
+                  "description": "The blueprint targets a management group during blueprint assignment. This is reserved for future use."
+              }
+            ]
           }
         },
         "parameters": {

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
@@ -1352,7 +1352,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "description": "The scope of the resource. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}').",
+      "description": "The scope of the resource. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'). For blueprint assignments management group scope is reserved for future use.",
       "x-ms-parameter-location": "method",
       "x-ms-skip-url-encoding": true
     },

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/blueprintDefinition.json
@@ -817,7 +817,7 @@
         },
         "targetScope": {
           "type": "string",
-          "description": "The scope where this blueprint definition can be assigned.",
+          "description": "The scope where this blueprint definition can be assigned. Management group is reserved for future use.",
           "enum": [
             "subscription",
             "managementGroup"

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/examples/WhoIsBlueprint_Action.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/examples/WhoIsBlueprint_Action.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2018-11-01-preview",
+    "scope": "subscriptions/f8df94f2-2f5a-4f4a-bcaf-1bb992fb564b",
+    "assignmentName": "assignSimpleBlueprint"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectId" : "00000000-0000-0000-0000-000000000000"
+      }
+    }
+  }
+}

--- a/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/examples/WhoIsBlueprint_Action.json
+++ b/specification/blueprint/resource-manager/Microsoft.Blueprint/preview/2018-11-01-preview/examples/WhoIsBlueprint_Action.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2018-11-01-preview",
-    "scope": "subscriptions/f8df94f2-2f5a-4f4a-bcaf-1bb992fb564b",
+    "scope": "subscriptions/{subscriptionId}",
     "assignmentName": "assignSimpleBlueprint"
   },
   "responses": {

--- a/specification/blueprint/resource-manager/readme.md
+++ b/specification/blueprint/resource-manager/readme.md
@@ -60,7 +60,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-node
+  - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python
 ```
 

--- a/specification/blueprint/resource-manager/readme.md
+++ b/specification/blueprint/resource-manager/readme.md
@@ -82,32 +82,7 @@ csharp:
 
 ## Python
 
-These settings apply only when `--python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
-
-``` yaml $(python)
-python-mode: create
-python:
-  azure-arm: true
-  license-header: MICROSOFT_MIT_NO_VERSION
-  payload-flattening-threshold: 2
-  namespace: azure.mgmt.blueprint
-  package-name: azure-mgmt-blueprint
-  title: BlueprintManagementClient
-  description: The Blueprint Client.
-  clear-output-folder: true
-```
-``` yaml $(python) && $(python-mode) == 'update'
-python:
-  no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-blueprint/azure/mgmt/blueprint
-```
-``` yaml $(python) && $(python-mode) == 'create'
-python:
-  basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-blueprint
-```
+See configuration in [readme.python.md](./readme.python.md)
 
 ## Go
 

--- a/specification/blueprint/resource-manager/readme.python.md
+++ b/specification/blueprint/resource-manager/readme.python.md
@@ -1,0 +1,28 @@
+## Python
+
+These settings apply only when `--python` is specified on the command line.
+Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
+Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
+
+``` yaml $(python)
+python-mode: create
+python:
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  payload-flattening-threshold: 2
+  namespace: azure.mgmt.blueprint
+  package-name: azure-mgmt-blueprint
+  title: BlueprintManagementClient
+  description: The Blueprint Client.
+  clear-output-folder: true
+```
+``` yaml $(python) && $(python-mode) == 'update'
+python:
+  no-namespace-folders: true
+  output-folder: $(python-sdks-folder)/azure-mgmt-blueprint/azure/mgmt/blueprint
+```
+``` yaml $(python) && $(python-mode) == 'create'
+python:
+  basic-setup-py: true
+  output-folder: $(python-sdks-folder)/azure-mgmt-blueprint
+```

--- a/specification/blueprint/resource-manager/readme.typescript.md
+++ b/specification/blueprint/resource-manager/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   azure-arm: true
-  package-name: "@azure/azure-mgmt-blueprint"
+  package-name: "@azure/arm-blueprint"
   output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-blueprint"
   generate-metadata: true
 ```

--- a/specification/blueprint/resource-manager/readme.typescript.md
+++ b/specification/blueprint/resource-manager/readme.typescript.md
@@ -1,0 +1,12 @@
+## TypeScript
+
+These settings apply only when `--typescript` is specified on the command line.
+Please also specify `--typescript-sdks-folder=<path to root folder of your azure-sdk-for-js clone>`.
+
+``` yaml $(typescript)
+typescript:
+  azure-arm: true
+  package-name: "@azure/azure-mgmt-blueprint"
+  output-folder: "$(typescript-sdks-folder)/packages/@azure/azure-mgmt-blueprint"
+  generate-metadata: true
+```

--- a/specification/blueprint/resource-manager/readme.typescript.md
+++ b/specification/blueprint/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/azure-mgmt-blueprint"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/azure-mgmt-blueprint"
+  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-blueprint"
   generate-metadata: true
 ```


### PR DESCRIPTION
This PR includes two updates to Blueprints API specification:
1)  Add a property to AssignmentLockSettings called excludedPrincipals.
2)  Add a support for Post operation called WhoIsBlueprints. 

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
