### PR TITLE
Correcting the limits ofr FileUploadLimitInMb for WAF

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
@@ -2115,10 +2115,7 @@
         "fileUploadLimitInMb": {
           "type": "integer",
           "format": "int32",
-          "maximum": 500,
-          "exclusiveMaximum": false,
-          "minimum": 0,
-          "exclusiveMinimum": false,
+          "minimum" : 1,
           "description": "Maximum file upload size in Mb for WAF."
         },
         "exclusions": {


### PR DESCRIPTION
The Swagger was enforcing the following range
**0 <= FileUploadLimitInMb <= 100** 
But, We have increased the FileUploadLimitinMb to 750Mb for v2 Gateways. To ensure Swagger doesnt invalidate requests the upper cap has been removed.  We don't enforce the upper limit so as to ensure that the swagger works for v1 and v2 Application Gateways. Also, the minimum FileUploadLimitInMb should be 1 Mb.