### PR TITLE
Swagger has to only enforce positive fileUploadLimitInMb values

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
@@ -2115,10 +2115,7 @@
         "fileUploadLimitInMb": {
           "type": "integer",
           "format": "int32",
-          "maximum": 500,
-          "exclusiveMaximum": false,
-          "minimum": 0,
-          "exclusiveMinimum": false,
+          "minimum" : 1,
           "description": "Maximum file upload size in Mb for WAF."
         },
         "exclusions": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
@@ -2115,7 +2115,7 @@
         "fileUploadLimitInMb": {
           "type": "integer",
           "format": "int32",
-          "minimum" : 1,
+          "minimum" : 0,
           "description": "Maximum file upload size in Mb for WAF."
         },
         "exclusions": {


### PR DESCRIPTION
The validation for the values should be done by the NRP.