### PR TITLE
Swagger has to just enforce a positive fileUploadLimitInMb, It doesnt have to check the upper Limit.

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
@@ -2115,8 +2115,6 @@
         "fileUploadLimitInMb": {
           "type": "integer",
           "format": "int32",
-          "maximum": 500,
-          "exclusiveMaximum": false,
           "minimum": 0,
           "exclusiveMinimum": false,
           "description": "Maximum file upload size in Mb for WAF."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
@@ -2115,6 +2115,8 @@
         "fileUploadLimitInMb": {
           "type": "integer",
           "format": "int32",
+          "maximum": 500,
+          "exclusiveMaximum": false,
           "minimum": 0,
           "exclusiveMinimum": false,
           "description": "Maximum file upload size in Mb for WAF."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/applicationGateway.json
@@ -2132,8 +2132,6 @@
         "fileUploadLimitInMb": {
           "type": "integer",
           "format": "int32",
-          "maximum": 500,
-          "exclusiveMaximum": false,
           "minimum": 0,
           "exclusiveMinimum": false,
           "description": "Maximum file upload size in Mb for WAF."


### PR DESCRIPTION
Swagger was enforcing the following limit
0 <= fileUploadLimitInMb <= 100

Now we update the max value to 750 Mb for AppGW-v2. The Max validation will happen at the NRP.
Swagger has to just enforce a non-negative FileUploadLimit.