### PR TITLE
Add application gateway backendHealthOnDemand operation

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/applicationGateway.json
@@ -452,7 +452,71 @@
         "x-ms-long-running-operation": true
       }
     },
-	"/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableServerVariables": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/backendHealthOnDemand": {
+      "post": {
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "operationId": "ApplicationGateways_BackendHealthOnDemand",
+        "description": "Gets the backend health for given combination of backend pool and http setting of the specified application gateway in a resource group.",
+        "x-ms-examples": {
+          "Test Backend Health": {
+            "$ref": "./examples/ApplicationGatewayBackendHealthTest.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the application gateway."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands BackendAddressPool and BackendHttpSettings referenced in backend health."
+          },
+          {
+            "name": "probeRequest",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayOnDemandProbe"
+            },
+            "description": "Request body for on-demand test probe operation."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayBackendHealthOnDemand"
+            }
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },    
+	  "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableServerVariables": {
       "get": {
         "tags": [
           "ApplicationGateways"
@@ -692,6 +756,65 @@
     }
   },
   "definitions": {
+    "ApplicationGatewayOnDemandProbe": {
+      "properties": {
+        "protocol": {
+          "type": "string",
+          "description": "The protocol used for the probe. Possible values are 'Http' and 'Https'.",
+          "enum": [
+            "Http",
+            "Https"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayProtocol",
+            "modelAsString": true
+          }
+        },
+        "host": {
+          "type": "string",
+          "description": "Host name to send the probe to."
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path of probe. Valid path starts from '/'. Probe is sent to <Protocol>://<host>:<port><path>"
+        },
+        "timeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The probe timeout in seconds. Probe marked as failed if valid response is not received with this timeout period. Acceptable values are from 1 second to 86400 seconds."
+        },
+        "pickHostNameFromBackendHttpSettings": {
+          "type": "boolean",
+          "description": "Whether the host header should be picked from the backend http settings. Default value is false."
+        },
+        "match": {
+          "$ref": "#/definitions/ApplicationGatewayProbeHealthResponseMatch",
+          "description": "Criterion for classifying a healthy probe response."
+        },
+        "backendPoolName": {
+          "type": "string",
+          "description": "Name of backend pool of application gateway to which probe request will be sent."
+        },
+        "backendHttpSettingName": {
+          "type": "string",
+          "description": "Name of backend http setting of application gateway to be used for test probe"
+        }
+      },
+      "description": "Details of on demand test probe request"
+    },
+    "ApplicationGatewayBackendHealthOnDemand": {
+      "properties": {
+        "backendAddressPool": {
+          "$ref": "#/definitions/ApplicationGatewayBackendAddressPool",
+          "description": "Reference of an ApplicationGatewayBackendAddressPool resource."          
+        },
+        "backendHealthHttpSettings": {
+          "$ref": "#/definitions/ApplicationGatewayBackendHealthHttpSettings",
+          "description": "Application gateway BackendHealthHttp settings."          
+        }
+      },
+      "description": "Result of on demand test probe"
+    },
     "ApplicationGatewayBackendHealth": {
       "properties": {
         "backendAddressPools": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/ApplicationGatewayBackendHealthTest.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/ApplicationGatewayBackendHealthTest.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2018-12-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "appgw",
+    "applicationGatewayName": "appgw",
+    "probeRequest": {
+      "protocol": "Http",
+      "pickHostNameFromBackendHttpSettings": true,
+      "path": "/",
+      "timeout": 30,
+      "backendPoolName": "MFAnalyticsPool",
+      "backendHttpSettingName": "MFPoolSettings"      
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "backendAddressPool": {
+          "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendaddressPools/MFAnalyticsPool"
+        },
+        "backendHealthHttpSettings": {
+          "backendHttpSettings": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/MFPoolSettings"
+          },
+          "servers": [
+            {
+              "address": "10.220.1.4",
+              "health": "Up"
+            },
+            {
+              "address": "10.220.1.5",
+              "health": "Up"
+            }
+          ]
+        }
+      }
+    },
+    "202": {}
+  }
+}


### PR DESCRIPTION
Add backendhealthondemand operation for application gateway. It is an additive change, hence can go with existing API version.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
