### PR TITLE
[Azure Search] Introduce the minimumPrecision parameter for Entity recognition skill

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceCreateOrUpdateSkillset.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceCreateOrUpdateSkillset.json
@@ -15,6 +15,7 @@
 						"organization"
 					],
 					"defaultLanguageCode": "en",
+					"minimumPrecision": 0.7,
 					"inputs": [
 						{
 							"name": "text",
@@ -112,7 +113,8 @@
 						"categories": [
 							"organization"
 						],
-						"defaultLanguageCode": "en"
+						"defaultLanguageCode": "en",
+						"minimumPrecision": 0.7
 					},
 					{
 						"@odata.type": "#Microsoft.Skills.Text.LanguageDetectionSkill",
@@ -205,7 +207,8 @@
 						"categories": [
 							"organization"
 						],
-						"defaultLanguageCode": "en"
+						"defaultLanguageCode": "en",
+						"minimumPrecision": 0.7
 					},
 					{
 						"@odata.type": "#Microsoft.Skills.Text.LanguageDetectionSkill",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceCreateSkillset.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceCreateSkillset.json
@@ -15,6 +15,7 @@
 						"organization"
 					],
 					"defaultLanguageCode": "en",
+					"minimumPrecision": 0.7,
 					"inputs": [
 						{
 							"name": "text",
@@ -112,7 +113,8 @@
 						"categories": [
 							"organization"
 						],
-						"defaultLanguageCode": "en"
+						"defaultLanguageCode": "en",
+						"minimumPrecision": 0.7
 					},
 					{
 						"@odata.type": "#Microsoft.Skills.Text.LanguageDetectionSkill",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceGetSkillset.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceGetSkillset.json
@@ -30,7 +30,8 @@
 						"categories": [
 							"organization"
 						],
-						"defaultLanguageCode": "en"
+						"defaultLanguageCode": "en",
+						"minimumPrecision": 0.7
 					},
 					{
 						"@odata.type": "#Microsoft.Skills.Text.LanguageDetectionSkill",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceListSkillsets.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceListSkillsets.json
@@ -31,7 +31,8 @@
                 "categories": [
                   "organization"
                 ],
-                "defaultLanguageCode": "en"
+                "defaultLanguageCode": "en",
+					      "minimumPrecision": 0.7
               },
               {
                 "@odata.type": "#Microsoft.Skills.Text.LanguageDetectionSkill",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceListSkillsets.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/examples/SearchServiceListSkillsets.json
@@ -32,7 +32,7 @@
                   "organization"
                 ],
                 "defaultLanguageCode": "en",
-					      "minimumPrecision": 0.7
+                "minimumPrecision": 0.7
               },
               {
                 "@odata.type": "#Microsoft.Skills.Text.LanguageDetectionSkill",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/preview/2017-11-11-preview/searchservice.json
@@ -4738,7 +4738,13 @@
         "includeTypelessEntities": {
           "type": "boolean",
           "x-nullable": true,
-          "description": "Determines whether or not to include entities which are well known but don't conform to a type. If this configuration is not set (default), set to null or set to false, entities which don't have a type will not be surfaced."
+          "description": "Determines whether or not to include entities which are well known but don't conform to a pre-defined type. If this configuration is not set (default), set to null or set to false, entities which don't conform to one of the pre-defined types will not be surfaced."
+        },
+        "minimumPrecision": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": true,
+          "description": "A value between 0 and 1 that be used to only include entities whose confidence score is greater than the value specified. If not set (default), or if explicitly set to null, all entities will be included."
         }
       },
       "externalDocs": {


### PR DESCRIPTION
`minimumPrecision` was already exposed by the REST API, but it was reserved.
Soon (next couple of weeks), that parameter will be used to filter out low confidence entities.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
