### PR TITLE
Add AllowBlobPublicAccess and MinimumTLSVersion to storage account property

### DIFF
--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountCreate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountCreate.json
@@ -29,8 +29,10 @@
         "name": "sto4445",
         "properties": {
           "isHnsEnabled": true,
+          "allowBlobPublicAccess": false,
           "azureFilesAadIntegration": true,
           "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "minimumTLSVersion": "TLS1_2",
           "primaryEndpoints": {
             "web": "https://sto4445.web.core.windows.net/",
             "dfs": "https://sto4445.dfs.core.windows.net/",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountGetProperties.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountGetProperties.json
@@ -20,8 +20,10 @@
             "canFailover": true
           },
           "isHnsEnabled": true,
+          "allowBlobPublicAccess": false,
           "azureFilesAadIntegration": true,
           "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "minimumTLSVersion": "TLS1_2",
           "networkAcls": {
             "bypass": "AzureServices",
             "defaultAction": "Allow",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountList.json
@@ -15,8 +15,10 @@
             "name": "sto1125",
             "properties": {
               "isHnsEnabled": true,
+              "allowBlobPublicAccess": false,
               "azureFilesAadIntegration": true,
               "creationTime": "2017-05-24T13:28:53.4540398Z",
+              "minimumTLSVersion": "TLS1_2",
               "primaryEndpoints": {
                 "web": "https://sto1125.web.core.windows.net/",
                 "dfs": "https://sto1125.dfs.core.windows.net/",
@@ -53,7 +55,9 @@
             "location": "eastus2euap",
             "name": "sto3699",
             "properties": {
+              "allowBlobPublicAccess": false,
               "creationTime": "2017-05-24T10:06:30.6093014Z",
+              "minimumTLSVersion": "TLS1_2",
               "primaryEndpoints": {
                 "blob": "https://sto3699.blob.core.windows.net/",
                 "file": "https://sto3699.file.core.windows.net/",
@@ -88,7 +92,9 @@
             "location": "eastus2euap",
             "name": "sto6637",
             "properties": {
+              "allowBlobPublicAccess": false,
               "creationTime": "2017-05-24T10:09:39.5625175Z",
+              "minimumTLSVersion": "TLS1_2",
               "primaryEndpoints": {
                 "blob": "https://sto6637.blob.core.windows.net/",
                 "file": "https://sto6637.file.core.windows.net/",
@@ -118,7 +124,9 @@
             "location": "eastus2euap",
             "name": "sto834",
             "properties": {
+              "allowBlobPublicAccess": false,
               "creationTime": "2017-05-24T13:28:20.8686541Z",
+              "minimumTLSVersion": "TLS1_2",
               "primaryEndpoints": {
                 "blob": "https://sto834.blob.core.windows.net/",
                 "file": "https://sto834.file.core.windows.net/",
@@ -153,7 +161,9 @@
             "location": "eastus2euap",
             "name": "sto9174",
             "properties": {
+              "allowBlobPublicAccess": false,
               "creationTime": "2017-05-24T09:46:19.6556989Z",
+              "minimumTLSVersion": "TLS1_2",
               "primaryEndpoints": {
                 "blob": "https://sto9174.blob.core.windows.net/",
                 "file": "https://sto9174.file.core.windows.net/",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountListByResourceGroup.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountListByResourceGroup.json
@@ -15,8 +15,10 @@
             "name": "sto4036",
             "properties": {
               "isHnsEnabled": true,
+              "allowBlobPublicAccess": false,
               "azureFilesAadIntegration": true,
               "creationTime": "2017-05-24T13:24:47.818801Z",
+              "minimumTLSVersion": "TLS1_2",
               "primaryEndpoints": {
                 "web": "https://sto4036.web.core.windows.net/",
                 "dfs": "https://sto4036.dfs.core.windows.net/",
@@ -48,7 +50,9 @@
             "location": "eastus2euap",
             "name": "sto4452",
             "properties": {
+              "allowBlobPublicAccess": false,
               "creationTime": "2017-05-24T13:24:15.7068366Z",
+              "minimumTLSVersion": "TLS1_2",
               "primaryEndpoints": {
                 "blob": "https://sto4452.blob.core.windows.net/",
                 "file": "https://sto4452.file.core.windows.net/",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountUpdate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/examples/StorageAccountUpdate.json
@@ -22,8 +22,10 @@
         "name": "sto8596",
         "properties": {
           "isHnsEnabled": true,
+          "allowBlobPublicAccess": false,
           "azureFilesAadIntegration": true,
           "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "minimumTLSVersion": "TLS1_2",
           "networkAcls": {
             "bypass": "AzureServices",
             "defaultAction": "Allow",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/storage.json
@@ -1628,6 +1628,24 @@
           "x-ms-client-name": "FailoverInProgress",
           "description": "If the failover is in progress, the value will be true, otherwise, it will be null.",
           "readOnly": true
+        },
+        "minimumTLSVersion": {
+          "type": "string",
+          "description": "TLS version control on storage account in customer configuration, TLS v1.2 by default.",
+          "enum": [
+            "TLS1_0",
+            "TLS1_1",
+            "TLS1_2"
+          ],
+          "x-ms-enum": {
+            "name": "MinimumTLSVersion",
+            "modelAsString": true
+          }
+        },
+        "allowBlobPublicAccess": {
+          "type": "boolean",
+          "x-ms-client-name": "AllowBlobPublicAccess",
+          "description": "Public access to a container is enabled if the value is true."
         }
       },
       "description": "Properties of the storage account."


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
