### PR TITLE
fix: reservations\resource-manager\Microsoft.Capacity

### DIFF
--- a/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-04-01/reservations.json
+++ b/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-04-01/reservations.json
@@ -94,7 +94,7 @@
     "/providers/Microsoft.Capacity/calculatePrice" : {
       "post" : {
         "summary" : "Calculate price for a `ReservationOrder`.",
-        "description" : "Calculate price for placing a `ReservationOrder`\n",
+        "description" : "Calculate price for placing a `ReservationOrder`.",
         "operationId" : "ReservationOrder_Calculate",
         "x-ms-examples" : {
           "Purchase" : {
@@ -159,7 +159,7 @@
     "/providers/Microsoft.Capacity/reservationOrders/{reservationOrderId}" : {
       "put" : {
         "summary" : "Purchase `ReservationOrder`",
-        "description" : "Purchase `ReservationOrder` and create resource under the specificed URI\n",
+        "description" : "Purchase `ReservationOrder` and create resource under the specified URI.",
         "operationId" : "ReservationOrder_Purchase",
         "x-ms-examples" : {
           "Purchase" : {
@@ -233,7 +233,7 @@
     "/providers/Microsoft.Capacity/reservationOrders/{reservationOrderId}/split" : {
       "post" : {
         "summary" : "Split the `Reservation`.",
-        "description" : "Split a `Reservation` into two `Reservation`s with specified quantity distribution.\n",
+        "description" : "Split a `Reservation` into two `Reservation`s with specified quantity distribution.",
         "operationId" : "Reservation_Split",
         "x-ms-examples" : {
           "Split" : {
@@ -422,7 +422,7 @@
     "/providers/Microsoft.Capacity/reservationOrders/{reservationOrderId}/reservations/{reservationId}/revisions" : {
       "get" : {
         "summary" : "Get `Reservation` revisions.",
-        "description" : "List of all the revisions for the `Reservation`.\n",
+        "description" : "List of all the revisions for the `Reservation`.",
         "operationId" : "Reservation_ListRevisions",
         "x-ms-examples" : {
           "ReservationRevisions" : {


### PR DESCRIPTION

- Remove trailing newline in description
- specificed -> specified