### PR TITLE
update readme(ts) for arm-advisor path

### DIFF
--- a/specification/advisor/resource-manager/readme.typescript.md
+++ b/specification/advisor/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-advisor"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-advisor"
+  output-folder: "$(typescript-sdks-folder)/sdk/advisor/arm-advisor"
   generate-metadata: true
 ```


### PR DESCRIPTION
The path update is in reference to the github issue Azure/azure-sdk-for-js#2097
Please review Azure/azure-sdk-for-js#2097 as well

@salameer @daschult @kpajdzik @Azure/azure-sdk-eng