### PR TITLE
updated arm-apimanagement path in readmeTS

### DIFF
--- a/specification/apimanagement/resource-manager/readme.typescript.md
+++ b/specification/apimanagement/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-apimanagement"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-apimanagement"
+  output-folder: "$(typescript-sdks-folder)/sdk/apimanagement/arm-apimanagement"
   generate-metadata: true
 ```


### PR DESCRIPTION
The path update is in reference to the github issue Azure/azure-sdk-for-js#2122
Please review Azure/azure-sdk-for-js#2122 as well

@salameer @daschult @kpajdzik @Azure/azure-sdk-eng
