### PR TITLE
update readmeTS for arm-authorization path

### DIFF
--- a/specification/authorization/resource-manager/readme.typescript.md
+++ b/specification/authorization/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-authorization"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-authorization"
+  output-folder: "$(typescript-sdks-folder)/sdk/authorization/arm-authorization"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```


### PR DESCRIPTION
The path update is in reference to the github issue Azure/azure-sdk-for-js#2135
Please review Azure/azure-sdk-for-js#2135 as well

@salameer @daschult @kpajdzik @Azure/azure-sdk-eng