### PR TITLE
update readmeTS for arm-appservice path

### DIFF
--- a/specification/web/resource-manager/readme.typescript.md
+++ b/specification/web/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-appservice"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-appservice"
+  output-folder: "$(typescript-sdks-folder)/sdk/appservice/arm-appservice"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```


### PR DESCRIPTION
The path update is in reference to the github issue Azure/azure-sdk-for-js#2130
Please review Azure/azure-sdk-for-js#2130 as well

@salameer @daschult @kpajdzik @Azure/azure-sdk-eng @jhendrixMSFT