### PR TITLE
Remove extra "x-ms-enum"

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/applicationGateway.json
@@ -816,11 +816,7 @@
           "description": "Ssl protocols to be disabled on application gateway.",
           "items": {
             "type": "string",
-            "$ref": "#/definitions/ProtocolsEnum",
-            "x-ms-enum": {
-              "name": "ApplicationGatewaySslProtocol",
-              "modelAsString": true
-            }
+            "$ref": "#/definitions/ProtocolsEnum"
           }
         },
         "policyType": {
@@ -1735,11 +1731,7 @@
         "redirectType": {
           "type": "string",
           "$ref": "#/definitions/RedirectTypeEnum",
-          "description": "Supported http redirection types - Permanent, Temporary, Found, SeeOther.",
-          "x-ms-enum": {
-            "name": "ApplicationGatewayRedirectType",
-            "modelAsString": true
-          }
+          "description": "HTTP redirection type."
         },
         "targetListener": {
           "$ref": "./network.json#/definitions/SubResource",


### PR DESCRIPTION
Removed `x-ms-enum` from properties that didn't have `enum` specified

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
