### PR TITLE
Move arm in bulk1

### DIFF
--- a/specification/automation/resource-manager/readme.typescript.md
+++ b/specification/automation/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-automation"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-automation"
+  output-folder: "$(typescript-sdks-folder)/sdk/automation/arm-automation"
   generate-metadata: true
 ```

--- a/specification/azurestack/resource-manager/readme.typescript.md
+++ b/specification/azurestack/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-azurestack"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-azurestack"
+  output-folder: "$(typescript-sdks-folder)/sdk/azurestack/arm-azurestack"
   generate-metadata: true
 ```

--- a/specification/batch/resource-manager/readme.typescript.md
+++ b/specification/batch/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-batch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-batch"
+  output-folder: "$(typescript-sdks-folder)/sdk/batch/arm-batch"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/batchai/resource-manager/readme.typescript.md
+++ b/specification/batchai/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-batchai"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-batchai"
+  output-folder: "$(typescript-sdks-folder)/sdk/batchai/arm-batchai"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/billing/resource-manager/readme.typescript.md
+++ b/specification/billing/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-billing"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-billing"
+  output-folder: "$(typescript-sdks-folder)/sdk/billing/arm-billing"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/cdn/resource-manager/readme.typescript.md
+++ b/specification/cdn/resource-manager/readme.typescript.md
@@ -9,6 +9,6 @@ typescript:
   license-header: MICROSOFT_MIT_NO_VERSION
   payload-flattening-threshold: 2
   package-name: "@azure/arm-cdn"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-cdn"
+  output-folder: "$(typescript-sdks-folder)/sdk/cdn/arm-cdn"
   generate-metadata: true
 ```

--- a/specification/consumption/resource-manager/readme.typescript.md
+++ b/specification/consumption/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-consumption"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-consumption"
+  output-folder: "$(typescript-sdks-folder)/sdk/consumption/arm-consumption"
   generate-metadata: true
 ```

--- a/specification/containerinstance/resource-manager/readme.typescript.md
+++ b/specification/containerinstance/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-containerinstance"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-containerinstance"
+  output-folder: "$(typescript-sdks-folder)/containerinstance/arm-containerinstance"
   generate-metadata: true
 ```

--- a/specification/customer-insights/resource-manager/readme.typescript.md
+++ b/specification/customer-insights/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-customerinsights"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-customerinsights"
+  output-folder: "$(typescript-sdks-folder)/sdk/customer-insights/arm-customerinsights"
   generate-metadata: true
 ```

--- a/specification/databox/resource-manager/readme.typescript.md
+++ b/specification/databox/resource-manager/readme.typescript.md
@@ -9,6 +9,6 @@ typescript:
   license-header: MICROSOFT_MIT_NO_VERSION
   payload-flattening-threshold: 2
   package-name: "@azure/arm-databox"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-databox"
+  output-folder: "$(typescript-sdks-folder)/sdk/databox/arm-databox"
   generate-metadata: true
 ```

--- a/specification/databricks/resource-manager/readme.typescript.md
+++ b/specification/databricks/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-databricks"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-databricks"
+  output-folder: "$(typescript-sdks-folder)/sdk/databricks/arm-databricks"
   generate-metadata: true
 ```

--- a/specification/datacatalog/resource-manager/readme.typescript.md
+++ b/specification/datacatalog/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-datacatalog"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-datacatalog"
+  output-folder: "$(typescript-sdks-folder)/sdk/datacatalog/arm-datacatalog"
   generate-metadata: true
 ```

--- a/specification/datafactory/resource-manager/readme.typescript.md
+++ b/specification/datafactory/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-datafactory"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-datafactory"
+  output-folder: "$(typescript-sdks-folder)/sdk/datafactory/arm-datafactory"
   generate-metadata: true
 ```

--- a/specification/deploymentmanager/resource-manager/readme.typescript.md
+++ b/specification/deploymentmanager/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-deploymentmanager"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-deploymentmanager"
+  output-folder: "$(typescript-sdks-folder)/sdk/deploymentmanager/arm-deploymentmanager"
   generate-metadata: true
 ```

--- a/specification/deviceprovisioningservices/resource-manager/readme.typescript.md
+++ b/specification/deviceprovisioningservices/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-deviceprovisioningservices"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-deviceprovisioningservices"
+  output-folder: "$(typescript-sdks-folder)/sdk/deviceprovisioningservices/arm-deviceprovisioningservices"
   generate-metadata: true
 ```

--- a/specification/devspaces/resource-manager/readme.typescript.md
+++ b/specification/devspaces/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-devspaces"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-devspaces"
+  output-folder: "$(typescript-sdks-folder)/sdk/devspaces/arm-devspaces"
   generate-metadata: true
 ```

--- a/specification/devtestlabs/resource-manager/readme.typescript.md
+++ b/specification/devtestlabs/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-devtestlabs"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-devtestlabs"
+  output-folder: "$(typescript-sdks-folder)/sdk/devtestlabs/arm-devtestlabs"
   generate-metadata: true
 ```

--- a/specification/dns/resource-manager/readme.typescript.md
+++ b/specification/dns/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-dns"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-dns"
+  output-folder: "$(typescript-sdks-folder)/sdk/dns/arm-dns"
   generate-metadata: true
 ```

--- a/specification/domainservices/resource-manager/readme.typescript.md
+++ b/specification/domainservices/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-domainservices"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-domainservices"
+  output-folder: "$(typescript-sdks-folder)/sdk/domainservices/arm-domainservices"
   override-client-name: DomainservicesManagementClient
   generate-metadata: true
 ```

--- a/specification/edgegateway/resource-manager/readme.typescript.md
+++ b/specification/edgegateway/resource-manager/readme.typescript.md
@@ -9,6 +9,6 @@ typescript:
   license-header: MICROSOFT_MIT_NO_VERSION
   payload-flattening-threshold: 2
   package-name: "@azure/arm-edgegateway"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-edgegateway"
+  output-folder: "$(typescript-sdks-folder)/sdk/edgegateway/arm-edgegateway"
   generate-metadata: true
 ```

--- a/specification/eventgrid/resource-manager/readme.typescript.md
+++ b/specification/eventgrid/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-eventgrid"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-eventgrid"
+  output-folder: "$(typescript-sdks-folder)/sdk/eventgrid/arm-eventgrid"
   generate-metadata: true
 ```

--- a/specification/eventhub/resource-manager/readme.typescript.md
+++ b/specification/eventhub/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-eventhub"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-eventhub"
+  output-folder: "$(typescript-sdks-folder)/sdk/eventhub/arm-eventhub"
   generate-metadata: true
 ```

--- a/specification/frontdoor/resource-manager/readme.typescript.md
+++ b/specification/frontdoor/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-frontdoor"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-frontdoor"
+  output-folder: "$(typescript-sdks-folder)/sdk/frontdoor/arm-frontdoor"
   generate-metadata: true
 ```

--- a/specification/resources/resource-manager/readme.typescript.md
+++ b/specification/resources/resource-manager/readme.typescript.md
@@ -20,7 +20,7 @@ batch:
 ```yaml $(typescript) && $(package-features)
 typescript:
   package-name: "@azure/arm-features"
-  output-folder: "$(typescript-sdks-folder)/sdk/resources/arm-features"
+  output-folder: "$(typescript-sdks-folder)/sdk/features/arm-features"
 ```
 
 ```yaml $(typescript) && $(package-locks)

--- a/specification/resources/resource-manager/readme.typescript.md
+++ b/specification/resources/resource-manager/readme.typescript.md
@@ -20,7 +20,7 @@ batch:
 ```yaml $(typescript) && $(package-features)
 typescript:
   package-name: "@azure/arm-features"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-features"
+  output-folder: "$(typescript-sdks-folder)/sdk/resources/arm-features"
 ```
 
 ```yaml $(typescript) && $(package-locks)


### PR DESCRIPTION
The path update is in reference to the github PR Azure/azure-sdk-for-js#2194
Please review Azure/azure-sdk-for-js#2194 as well
Moving following packages for arm-* from packages@Azure and putting them under an `sdk` directory:
- arm-automation
- arm-azurestack
- arm-batch
- arm-batchai
- arm-billing
- arm-cdn
- arm-consumption
- arm-containerinstance
- arm-customerinsights
- arm-databox
- arm-databricks
- arm-datacatalog
- arm-datafactory
- arm-deploymentmanager
- arm-deviceprovisioningservices
- arm-devspaces
- arm-devtestlabs
- arm-dns
- arm-domainservices
- arm-edgegateway
- arm-eventgrid
- arm-eventhub
- arm-features
- arm-frontdoor

@salameer @daschult @kpajdzik @Azure/azure-sdk-eng