### PR TITLE
Move arm in bulk2

### DIFF
--- a/specification/azure-kusto/resource-manager/readme.typescript.md
+++ b/specification/azure-kusto/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-kusto"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-kusto"
+  output-folder: "$(typescript-sdks-folder)sdk/kusto/arm-kusto"
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/resource-manager/readme.typescript.md
+++ b/specification/cognitiveservices/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-cognitiveservices"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-cognitiveservices"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/arm-cognitiveservices"
   generate-metadata: true
 ```

--- a/specification/compute/resource-manager/readme.typescript.md
+++ b/specification/compute/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-compute"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-compute"
+  output-folder: "$(typescript-sdks-folder)/sdk/compute/arm-compute"
   generate-metadata: true
 ```

--- a/specification/containerregistry/resource-manager/readme.typescript.md
+++ b/specification/containerregistry/resource-manager/readme.typescript.md
@@ -10,6 +10,6 @@ input-file:
 typescript:
   azure-arm: true
   package-name: "@azure/arm-containerregistry"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-containerregistry"
+  output-folder: "$(typescript-sdks-folder)/sdk/containerregistry/arm-containerregistry"
   generate-metadata: true
 ```

--- a/specification/containerservice/resource-manager/readme.typescript.md
+++ b/specification/containerservice/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-containerservice"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-containerservice"
+  output-folder: "$(typescript-sdks-folder)/sdk/containerservice/arm-containerservice"
   generate-metadata: true
 ```

--- a/specification/cosmos-db/resource-manager/readme.typescript.md
+++ b/specification/cosmos-db/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-cosmosdb"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-cosmosdb"
+  output-folder: "$(typescript-sdks-folder)/sdk/cosmosdb/arm-cosmosdb"
   override-client-name: CosmosDBManagementClient
   generate-metadata: true
 ```

--- a/specification/hanaonazure/resource-manager/readme.typescript.md
+++ b/specification/hanaonazure/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-hanaonazure"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-hanaonazure"
+  output-folder: "$(typescript-sdks-folder)/sdk/hanaonazure/arm-hanaonazure"
   generate-metadata: true
 ```

--- a/specification/hdinsight/resource-manager/readme.typescript.md
+++ b/specification/hdinsight/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-hdinsight"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-hdinsight"
+  output-folder: "$(typescript-sdks-folder)/sdk/hdinsight/arm-hdinsight"
   generate-metadata: true
 ```

--- a/specification/iotcentral/resource-manager/readme.typescript.md
+++ b/specification/iotcentral/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-iotcentral"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-iotcentral"
+  output-folder: "$(typescript-sdks-folder)/sdk/iotcentral/arm-iotcentral"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/iothub/resource-manager/readme.typescript.md
+++ b/specification/iothub/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-iothub"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-iothub"
+  output-folder: "$(typescript-sdks-folder)/sdk/iothub/arm-iothub"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/iotspaces/resource-manager/readme.typescript.md
+++ b/specification/iotspaces/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-iotspaces"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-iotspaces"
+  output-folder: "$(typescript-sdks-folder)/sdk/iotspaces/arm-iotspaces"
   generate-metadata: true
 ```

--- a/specification/labservices/resource-manager/readme.typescript.md
+++ b/specification/labservices/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-labservices"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-labservices"
+  output-folder: "$(typescript-sdks-folder)/sdk/labservices/arm-labservices"
   generate-metadata: true
 ```

--- a/specification/logic/resource-manager/readme.typescript.md
+++ b/specification/logic/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-logic"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-logic"
+  output-folder: "$(typescript-sdks-folder)/sdk/logic/arm-logic"
   generate-metadata: true
 ```

--- a/specification/machinelearning/resource-manager/readme.typescript.md
+++ b/specification/machinelearning/resource-manager/readme.typescript.md
@@ -13,7 +13,7 @@ batch:
     output-folder: $(typescript-sdks-folder)/packages/@azure/arm-commitmentplans
   - package-webservices: true
     package-name: "@azure/arm-webservices"
-    output-folder: $(typescript-sdks-folder)/packages/@azure/arm-webservices
+    output-folder: $(typescript-sdks-folder)/sdk/webservices/arm-webservices
   - package-workspaces: true
     package-name: "@azure/arm-workspaces"
     output-folder: $(typescript-sdks-folder)/packages/@azure/arm-workspaces

--- a/specification/machinelearning/resource-manager/readme.typescript.md
+++ b/specification/machinelearning/resource-manager/readme.typescript.md
@@ -10,11 +10,11 @@ typescript:
 batch:
   - package-commitmentPlans: true
     package-name: "@azure/arm-commitmentplans"
-    output-folder: $(typescript-sdks-folder)/packages/@azure/arm-commitmentplans
+    output-folder: $(typescript-sdks-folder)/sdk/machinelearning/arm-commitmentplans
   - package-webservices: true
     package-name: "@azure/arm-webservices"
-    output-folder: $(typescript-sdks-folder)/sdk/webservices/arm-webservices
+    output-folder: $(typescript-sdks-folder)/sdk/machinelearning/arm-webservices
   - package-workspaces: true
     package-name: "@azure/arm-workspaces"
-    output-folder: $(typescript-sdks-folder)/sdk/workspaces/arm-workspaces
+    output-folder: $(typescript-sdks-folder)/sdk/machinelearning/arm-workspaces
 ```

--- a/specification/machinelearning/resource-manager/readme.typescript.md
+++ b/specification/machinelearning/resource-manager/readme.typescript.md
@@ -16,5 +16,5 @@ batch:
     output-folder: $(typescript-sdks-folder)/sdk/webservices/arm-webservices
   - package-workspaces: true
     package-name: "@azure/arm-workspaces"
-    output-folder: $(typescript-sdks-folder)/packages/@azure/arm-workspaces
+    output-folder: $(typescript-sdks-folder)/sdk/workspaces/arm-workspaces
 ```

--- a/specification/machinelearningcompute/resource-manager/readme.typescript.md
+++ b/specification/machinelearningcompute/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-machinelearningcompute"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-machinelearningcompute"
+  output-folder: "$(typescript-sdks-folder)/sdk/machinelearningcompute/arm-machinelearningcompute"
   generate-metadata: true
 ```

--- a/specification/machinelearningexperimentation/resource-manager/readme.typescript.md
+++ b/specification/machinelearningexperimentation/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-machinelearningexperimentation"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-machinelearningexperimentation"
+  output-folder: "$(typescript-sdks-folder)/sdk/machinelearningexperimentation/arm-machinelearningexperimentation"
   generate-metadata: true
 ```

--- a/specification/machinelearningservices/resource-manager/readme.typescript.md
+++ b/specification/machinelearningservices/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-machinelearningservices"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-machinelearningservices"
+  output-folder: "$(typescript-sdks-folder)/sdk/machinelearningservices/arm-machinelearningservices"
   generate-metadata: true
 ```

--- a/specification/managementgroups/resource-manager/readme.typescript.md
+++ b/specification/managementgroups/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-managementgroups"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-managementgroups"
+  output-folder: "$(typescript-sdks-folder)/sdk/managementgroups/arm-managementgroups"
   generate-metadata: true
 ```

--- a/specification/managementpartner/resource-manager/readme.typescript.md
+++ b/specification/managementpartner/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-managementpartner"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-managementpartner"
+  output-folder: "$(typescript-sdks-folder)/sdk/managementpartner/arm-managementpartner"
   generate-metadata: true
 ```

--- a/specification/maps/resource-manager/readme.typescript.md
+++ b/specification/maps/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-maps"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-maps"
+  output-folder: "$(typescript-sdks-folder)/sdk/maps/arm-maps"
   generate-metadata: true
 ```

--- a/specification/mariadb/resource-manager/readme.typescript.md
+++ b/specification/mariadb/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-mariadb"
-  output-folder: "$(typescript-sdks-folder)/sdk/arm-mariadb/arm-mariadb"
+  output-folder: "$(typescript-sdks-folder)/sdk/mariadb/arm-mariadb"
   generate-metadata: true
 ```

--- a/specification/mariadb/resource-manager/readme.typescript.md
+++ b/specification/mariadb/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-mariadb"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-mariadb"
+  output-folder: "$(typescript-sdks-folder)/sdk/arm-mariadb/arm-mariadb"
   generate-metadata: true
 ```

--- a/specification/marketplaceordering/resource-manager/readme.typescript.md
+++ b/specification/marketplaceordering/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-marketplaceordering"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-marketplaceordering"
+  output-folder: "$(typescript-sdks-folder)/sdk/marketplaceordering/arm-marketplaceordering"
   generate-metadata: true
 ```

--- a/specification/mediaservices/resource-manager/readme.typescript.md
+++ b/specification/mediaservices/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-mediaservices"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-mediaservices"
+  output-folder: "$(typescript-sdks-folder)/sdk/mediaservices/arm-mediaservices"
   generate-metadata: true
 ```

--- a/specification/migrate/resource-manager/readme.typescript.md
+++ b/specification/migrate/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-migrate"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-migrate"
+  output-folder: "$(typescript-sdks-folder)/sdk/migrate/arm-migrate"
   generate-metadata: true
 ```

--- a/specification/mixedreality/resource-manager/readme.typescript.md
+++ b/specification/mixedreality/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-mixedreality"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-mixedreality"
+  output-folder: "$(typescript-sdks-folder)/sdk/mixedreality/arm-mixedreality"
   generate-metadata: true
 ```

--- a/specification/monitor/resource-manager/readme.typescript.md
+++ b/specification/monitor/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-monitor"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-monitor"
+  output-folder: "$(typescript-sdks-folder)/sdk/monitor/arm-monitor"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/msi/resource-manager/readme.typescript.md
+++ b/specification/msi/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-msi"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-msi"
+  output-folder: "$(typescript-sdks-folder)/sdk/msi/arm-msi"
   generate-metadata: true
 ```

--- a/specification/mysql/resource-manager/readme.typescript.md
+++ b/specification/mysql/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-mysql"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-mysql"
+  output-folder: "$(typescript-sdks-folder)/sdk/mysql/arm-mysql"
   generate-metadata: true
 ```

--- a/specification/netapp/resource-manager/readme.typescript.md
+++ b/specification/netapp/resource-manager/readme.typescript.md
@@ -8,6 +8,6 @@ typescript:
   azure-arm: true
   package-name: "@azure/arm-netapp"
   payload-flattening-threshold: 2
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-netapp"
+  output-folder: "$(typescript-sdks-folder)/sdk/netapp/arm-netapp"
   generate-metadata: true
 ```

--- a/specification/network/resource-manager/readme.typescript.md
+++ b/specification/network/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-network"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-network"
+  output-folder: "$(typescript-sdks-folder)/sdk/network/arm-network"
   generate-metadata: true
 ```

--- a/specification/notificationhubs/resource-manager/readme.typescript.md
+++ b/specification/notificationhubs/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-notificationhubs"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-notificationhubs"
+  output-folder: "$(typescript-sdks-folder)/sdk/notificationhubs/arm-notificationhubs"
   generate-metadata: true
 ```

--- a/specification/operationalinsights/resource-manager/readme.typescript.md
+++ b/specification/operationalinsights/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-operationalinsights"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-operationalinsights"
+  output-folder: "$(typescript-sdks-folder)/sdk/operationalinsights/arm-operationalinsights"
   override-client-name: OperationalInsightsManagementClient
   generate-metadata: true
 ```

--- a/specification/operationsmanagement/resource-manager/readme.typescript.md
+++ b/specification/operationsmanagement/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-operations"
-  output-folder: "$(typescript-sdks-folder)/sdk/operations/arm-operations"
+  output-folder: "$(typescript-sdks-folder)/sdk/operationsmanagement/arm-operations"
   generate-metadata: true
 ```

--- a/specification/operationsmanagement/resource-manager/readme.typescript.md
+++ b/specification/operationsmanagement/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-operations"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-operations"
+  output-folder: "$(typescript-sdks-folder)/sdk/operations/arm-operations"
   generate-metadata: true
 ```

--- a/specification/policyinsights/resource-manager/readme.typescript.md
+++ b/specification/policyinsights/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-policyinsights"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-policyinsights"
+  output-folder: "$(typescript-sdks-folder)/sdk/policyinsights/arm-policyinsights"
   generate-metadata: true
 ```

--- a/specification/postgresql/resource-manager/readme.typescript.md
+++ b/specification/postgresql/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-postgresql"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-postgresql"
+  output-folder: "$(typescript-sdks-folder)/sdk/postgresql/arm-postgresql"
   generate-metadata: true
 ```

--- a/specification/powerbidedicated/resource-manager/readme.typescript.md
+++ b/specification/powerbidedicated/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-powerbidedicated"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-powerbidedicated"
+  output-folder: "$(typescript-sdks-folder)/sdk/powerbidedicated/arm-powerbidedicated"
   generate-metadata: true
 ```

--- a/specification/powerbiembedded/resource-manager/readme.typescript.md
+++ b/specification/powerbiembedded/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-powerbiembedded"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-powerbiembedded"
+  output-folder: "$(typescript-sdks-folder)/sdk/powerbiembedded/arm-powerbiembedded"
   generate-metadata: true
 ```

--- a/specification/privatedns/resource-manager/readme.typescript.md
+++ b/specification/privatedns/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-privatedns"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-privatedns"
+  output-folder: "$(typescript-sdks-folder)/sdk/privatedns/arm-privatedns"
   generate-metadata: true
 ```

--- a/specification/recoveryservices/resource-manager/readme.typescript.md
+++ b/specification/recoveryservices/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-recoveryservices"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-recoveryservices"
+  output-folder: "$(typescript-sdks-folder)/sdk/recoveryservices/arm-recoveryservices"
   generate-metadata: true
 ```

--- a/specification/recoveryservicesbackup/resource-manager/readme.typescript.md
+++ b/specification/recoveryservicesbackup/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-recoveryservicesbackup"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-recoveryservicesbackup"
+  output-folder: "$(typescript-sdks-folder)/sdk/recoveryservicesbackup/arm-recoveryservicesbackup"
   generate-metadata: true
 ```

--- a/specification/recoveryservicessiterecovery/resource-manager/readme.typescript.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-recoveryservices-siterecovery"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-recoveryservices-siterecovery"
+  output-folder: "$(typescript-sdks-folder)/sdk/recoveryservices-siterecovery/arm-recoveryservices-siterecovery"
   generate-metadata: true
 ```

--- a/specification/recoveryservicessiterecovery/resource-manager/readme.typescript.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-recoveryservices-siterecovery"
-  output-folder: "$(typescript-sdks-folder)/sdk/recoveryservices-siterecovery/arm-recoveryservices-siterecovery"
+  output-folder: "$(typescript-sdks-folder)/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery"
   generate-metadata: true
 ```

--- a/specification/redis/resource-manager/readme.typescript.md
+++ b/specification/redis/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-rediscache"
-  output-folder: "$(typescript-sdks-folder)/sdk/rediscache/arm-rediscache"
+  output-folder: "$(typescript-sdks-folder)/sdk/redis/arm-rediscache"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/redis/resource-manager/readme.typescript.md
+++ b/specification/redis/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-rediscache"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-rediscache"
+  output-folder: "$(typescript-sdks-folder)/sdk/rediscache/arm-rediscache"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/relay/resource-manager/readme.typescript.md
+++ b/specification/relay/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-relay"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-relay"
+  output-folder: "$(typescript-sdks-folder)/sdk/relay/arm-relay"
   generate-metadata: true
 ```

--- a/specification/reservations/resource-manager/readme.typescript.md
+++ b/specification/reservations/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-reservations"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-reservations"
+  output-folder: "$(typescript-sdks-folder)/sdk/reservations/arm-reservations"
   generate-metadata: true
 ```

--- a/specification/resourcegraph/resource-manager/readme.typescript.md
+++ b/specification/resourcegraph/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-resourcegraph"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-resourcegraph"
+  output-folder: "$(typescript-sdks-folder)/sdk/resourcegraph/arm-resourcegraph"
   generate-metadata: true
 ```

--- a/specification/resourcehealth/resource-manager/readme.typescript.md
+++ b/specification/resourcehealth/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-resourcehealth"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-resourcehealth"
+  output-folder: "$(typescript-sdks-folder)/sdk/resourcehealth/arm-resourcehealth"
   generate-metadata: true
 ```

--- a/specification/resources/resource-manager/readme.typescript.md
+++ b/specification/resources/resource-manager/readme.typescript.md
@@ -32,7 +32,7 @@ typescript:
 ```yaml $(typescript) && $(package-policy)
 typescript:
   package-name: "@azure/arm-policy"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-policy"
+  output-folder: "$(typescript-sdks-folder)/sdk/policy/arm-policy"
 ```
 
 ```yaml $(typescript) && $(package-resources)

--- a/specification/resources/resource-manager/readme.typescript.md
+++ b/specification/resources/resource-manager/readme.typescript.md
@@ -44,7 +44,7 @@ typescript:
 ```yaml $(typescript) && $(package-links)
 typescript:
   package-name: "@azure/arm-links"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-links"
+  output-folder: "$(typescript-sdks-folder)/sdk/links/arm-links"
 ```
 
 ```yaml $(typescript) && $(package-managedapplications)

--- a/specification/resources/resource-manager/readme.typescript.md
+++ b/specification/resources/resource-manager/readme.typescript.md
@@ -38,7 +38,7 @@ typescript:
 ```yaml $(typescript) && $(package-resources)
 typescript:
   package-name: "@azure/arm-resources"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-resources"
+  output-folder: "$(typescript-sdks-folder)/sdk/resources/arm-resources"
 ```
 
 ```yaml $(typescript) && $(package-links)

--- a/specification/resources/resource-manager/readme.typescript.md
+++ b/specification/resources/resource-manager/readme.typescript.md
@@ -26,7 +26,7 @@ typescript:
 ```yaml $(typescript) && $(package-locks)
 typescript:
   package-name: "@azure/arm-locks"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-locks"
+  output-folder: "$(typescript-sdks-folder)/sdk/locks/arm-locks"
 ```
 
 ```yaml $(typescript) && $(package-policy)

--- a/specification/resources/resource-manager/readme.typescript.md
+++ b/specification/resources/resource-manager/readme.typescript.md
@@ -50,5 +50,5 @@ typescript:
 ```yaml $(typescript) && $(package-managedapplications)
 typescript:
   package-name: "@azure/arm-managedapplications"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-managedapplications"
+  output-folder: "$(typescript-sdks-folder)/sdk/managedapplications/arm-managedapplications"
 ```

--- a/specification/search/resource-manager/readme.typescript.md
+++ b/specification/search/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-search"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-search"
+  output-folder: "$(typescript-sdks-folder)/sdk/search/arm-search"
   generate-metadata: true
 ```

--- a/specification/security/resource-manager/readme.typescript.md
+++ b/specification/security/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-security"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-security"
+  output-folder: "$(typescript-sdks-folder)/sdk/security/arm-security"
   generate-metadata: true
 ```

--- a/specification/service-map/resource-manager/readme.typescript.md
+++ b/specification/service-map/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-servicemap"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-servicemap"
+  output-folder: "$(typescript-sdks-folder)/sdk/servicemap/arm-servicemap"
   override-client-name: ServicemapManagementClient
   generate-metadata: true
 ```

--- a/specification/service-map/resource-manager/readme.typescript.md
+++ b/specification/service-map/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-servicemap"
-  output-folder: "$(typescript-sdks-folder)/sdk/servicemap/arm-servicemap"
+  output-folder: "$(typescript-sdks-folder)/sdk/service-map/arm-servicemap"
   override-client-name: ServicemapManagementClient
   generate-metadata: true
 ```

--- a/specification/servicebus/resource-manager/readme.typescript.md
+++ b/specification/servicebus/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-servicebus"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-servicebus"
+  output-folder: "$(typescript-sdks-folder)/sdk/servicebus/arm-servicebus"
   generate-metadata: true
 ```

--- a/specification/signalr/resource-manager/readme.typescript.md
+++ b/specification/signalr/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-signalr"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-signalr"
+  output-folder: "$(typescript-sdks-folder)/sdk/signalr/arm-signalr"
   generate-metadata: true
 ```

--- a/specification/sql/resource-manager/readme.typescript.md
+++ b/specification/sql/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-sql"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-sql"
+  output-folder: "$(typescript-sdks-folder)/sdk/sql/arm-sql"
   generate-metadata: true
 ```

--- a/specification/sqlvirtualmachine/resource-manager/readme.typescript.md
+++ b/specification/sqlvirtualmachine/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-sqlvirtualmachine"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-sqlvirtualmachine"
+  output-folder: "$(typescript-sdks-folder)/sdk/sqlvirtualmachine/arm-sqlvirtualmachine"
   generate-metadata: true
 ```

--- a/specification/storSimple1200Series/resource-manager/readme.typescript.md
+++ b/specification/storSimple1200Series/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-storsimple1200series"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-storsimple1200series"
+  output-folder: "$(typescript-sdks-folder)/sdk/storsimple1200series/arm-storsimple1200series"
   generate-metadata: true
 ```

--- a/specification/storage/resource-manager/readme.typescript.md
+++ b/specification/storage/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-storage"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-storage"
+  output-folder: "$(typescript-sdks-folder)/sdk/storage/arm-storage"
   payload-flattening-threshold: 2
   override-client-name: StorageManagementClient
   generate-metadata: true

--- a/specification/storageimportexport/resource-manager/readme.typescript.md
+++ b/specification/storageimportexport/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-storageimportexport"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-storageimportexport"
+  output-folder: "$(typescript-sdks-folder)/sdk/storageimportexport/arm-storageimportexport"
   override-client-name: StorageImportExportManagementClient
   generate-metadata: true
 ```

--- a/specification/storagesync/resource-manager/readme.typescript.md
+++ b/specification/storagesync/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-storagesync"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-storagesync"
+  output-folder: "$(typescript-sdks-folder)/sdk/storagesync/arm-storagesync"
   generate-metadata: true
 ```

--- a/specification/storsimple8000series/resource-manager/readme.typescript.md
+++ b/specification/storsimple8000series/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-storsimple8000series"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-storsimple8000series"
+  output-folder: "$(typescript-sdks-folder)/sdk/storsimple8000series/arm-storsimple8000series"
   generate-metadata: true
 ```

--- a/specification/streamanalytics/resource-manager/readme.typescript.md
+++ b/specification/streamanalytics/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-streamanalytics"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-streamanalytics"
+  output-folder: "$(typescript-sdks-folder)/sdk/streamanalytics/arm-streamanalytics"
   generate-metadata: true
 ```

--- a/specification/subscription/resource-manager/readme.typescript.md
+++ b/specification/subscription/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-subscriptions"
-  output-folder: "$(typescript-sdks-folder)/sdk/subscriptions/arm-subscriptions"
+  output-folder: "$(typescript-sdks-folder)/sdk/subscription/arm-subscriptions"
   generate-metadata: true
 ```

--- a/specification/subscription/resource-manager/readme.typescript.md
+++ b/specification/subscription/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-subscriptions"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-subscriptions"
+  output-folder: "$(typescript-sdks-folder)/sdk/subscriptions/arm-subscriptions"
   generate-metadata: true
 ```

--- a/specification/timeseriesinsights/resource-manager/readme.typescript.md
+++ b/specification/timeseriesinsights/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-timeseriesinsights"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-timeseriesinsights"
+  output-folder: "$(typescript-sdks-folder)/sdk/timeseriesinsights/arm-timeseriesinsights"
   generate-metadata: true
 ```

--- a/specification/trafficmanager/resource-manager/readme.typescript.md
+++ b/specification/trafficmanager/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-trafficmanager"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-trafficmanager"
+  output-folder: "$(typescript-sdks-folder)/sdk/trafficmanager/arm-trafficmanager"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/visualstudio/resource-manager/readme.typescript.md
+++ b/specification/visualstudio/resource-manager/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-visualstudio"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-visualstudio"
+  output-folder: "$(typescript-sdks-folder)/sdk/visualstudio/arm-visualstudio"
   generate-metadata: true
 ```


### PR DESCRIPTION
The path update is in reference to the github PR Azure/azure-sdk-for-js#2229
Please review Azure/azure-sdk-for-js#2229 as well
Moving following packages for arm-* from packages@Azure and putting them under an `sdk` directory:
- arm-compute- arm-cognitive services
- arm-cosmosdb
- arm-hanaonazure
- arm-hdinsight
- arm-iotcentral
- arm-iothub
- arm-iotspaces
- arm-kusto
- arm-labservices
- arm-links
- arm-locks
- arm-logic
- arm-machinelearningcompute
- arm-machinelearningexperimentation
- arm-machinelearningservices
- arm-managedapplications
- arm-managementgroups
- arm-managementpartner
- arm-maps
- arm-mariadb
- arm-marketplaceordering
- arm-mediaservices
- arm-migrate
- arm-mixedreality
- arm-monitor
- arm-msi
- arm-mysql
- arm-netapp
- arm-network
- arm-notificationhubs
- arm-operationalinsights
- arm-operations
- arm-policy
- arm-policyinsights
- arm-postgresql
- arm-powerbidedicated
- arm-powerbiembedded
- arm-privatedns
- arm-recoveryservices
- arm-recoveryservices-siterecovery
- arm-recoveryservicesbackup
- arm-rediscache
- arm-relay
- arm-reservations
- arm-resourcegraph
- arm-resourcehealth
- arm-resources
- arm-search
- arm-security
- arm-servicebus
- arm-servicefabricmesh
- arm-servicemap
- arm-signalr
- arm-sql
- arm-sqlvirtualmachine
- arm-storage
- arm-storageimportexport
- arm-storagesync
- arm-storsimple1200series
- arm-storsimple8000series
- arm-streamanalytics
- arm-subscriptions
- arm-timeseriesinsights
- arm-trafficmanager
- arm-visualstudio
- arm-webservices
- arm-workspaces

@salameer @daschult @kpajdzik @Azure/azure-sdk-eng