### PR TITLE
Move dataplane packages - batch3

### DIFF
--- a/specification/batch/data-plane/readme.typescript.md
+++ b/specification/batch/data-plane/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/batch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/batch"
+  output-folder: "$(typescript-sdks-folder)/sdk/batch/batch"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-anomalydetector"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-anomalydetector"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-anomalydetector"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/AutoSuggest/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/AutoSuggest/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-autosuggest"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-autosuggest"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-autosuggest"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/ComputerVision/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/ComputerVision/readme.typescript.md
@@ -12,7 +12,7 @@ directive:
     $ = $.replace( /mode, url/g, "url, mode" );
 typescript:
   package-name: "@azure/cognitiveservices-computervision"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-computervision"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-computervision"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/ContentModerator/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/ContentModerator/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-contentmoderator"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-contentmoderator"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-contentmoderator"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/CustomImageSearch/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/CustomImageSearch/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-customimagesearch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-customimagesearch"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-customimagesearch"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/CustomVision/Prediction/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/CustomVision/Prediction/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-customvision-prediction"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-customvision-prediction"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-customvision-prediction"
   override-client-name: PredictionAPIClient
   azure-arm: false
   generate-metadata: true

--- a/specification/cognitiveservices/data-plane/CustomVision/Training/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/CustomVision/Training/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-customvision-training"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-customvision-training"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-customvision-training"
   override-client-name: TrainingAPIClient
   azure-arm: false
   generate-metadata: true

--- a/specification/cognitiveservices/data-plane/CustomWebSearch/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/CustomWebSearch/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-customsearch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-customsearch"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-customsearch"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/EntitySearch/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/EntitySearch/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-entitysearch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-entitysearch"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-entitysearch"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/Face/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/Face/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-face"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-face"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-face"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/ImageSearch/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/ImageSearch/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-imagesearch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-imagesearch"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-imagesearch"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/LUIS/Authoring/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/LUIS/Authoring/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-luis-authoring"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-luis-authoring"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-luis-authoring"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/LUIS/Runtime/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/LUIS/Runtime/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-luis-runtime"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-luis-runtime"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-luis-runtime"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/LocalSearch/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/LocalSearch/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-localsearch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-localsearch"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-localsearch"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/NewsSearch/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/NewsSearch/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-newssearch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-newssearch"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-newssearch"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/QnAMaker/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/QnAMaker/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-qnamaker"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-qnamaker"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-qnamaker"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/SpellCheck/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/SpellCheck/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-spellcheck"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-spellcheck"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-spellcheck"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/TextAnalytics/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/TextAnalytics/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-textanalytics"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-textanalytics"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-textanalytics"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/VideoSearch/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/VideoSearch/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-videosearch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-videosearch"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-videosearch"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/VisualSearch/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/VisualSearch/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-visualsearch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-visualsearch"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-visualsearch"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/cognitiveservices/data-plane/WebSearch/readme.typescript.md
+++ b/specification/cognitiveservices/data-plane/WebSearch/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/cognitiveservices-websearch"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/cognitiveservices-websearch"
+  output-folder: "$(typescript-sdks-folder)/sdk/cognitiveservices/cognitiveservices-websearch"
   azure-arm: false
   generate-metadata: true
 ```

--- a/specification/eventgrid/data-plane/readme.typescript.md
+++ b/specification/eventgrid/data-plane/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/eventgrid"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/eventgrid"
+  output-folder: "$(typescript-sdks-folder)/sdk/eventgrid/eventgrid"
   generate-metadata: true
 ```

--- a/specification/graphrbac/data-plane/readme.typescript.md
+++ b/specification/graphrbac/data-plane/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/graph"
-  output-folder: "$(typescript-sdks-folder)/sdk/graph/graph"
+  output-folder: "$(typescript-sdks-folder)/sdk/graphrbac/graph"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/graphrbac/data-plane/readme.typescript.md
+++ b/specification/graphrbac/data-plane/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/graph"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/graph"
+  output-folder: "$(typescript-sdks-folder)/sdk/graph/graph"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```

--- a/specification/operationalinsights/data-plane/readme.typescript.md
+++ b/specification/operationalinsights/data-plane/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to the root directory of you
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/loganalytics"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/loganalytics"
+  output-folder: "$(typescript-sdks-folder)/sdk/loganalytics/loganalytics"
   override-client-name: LogAnalyticsClient
   generate-metadata: true
 ```

--- a/specification/operationalinsights/data-plane/readme.typescript.md
+++ b/specification/operationalinsights/data-plane/readme.typescript.md
@@ -6,7 +6,7 @@ Please also specify `--typescript-sdks-folder=<path to the root directory of you
 ``` yaml $(typescript)
 typescript:
   package-name: "@azure/loganalytics"
-  output-folder: "$(typescript-sdks-folder)/sdk/loganalytics/loganalytics"
+  output-folder: "$(typescript-sdks-folder)/sdk/operationalinsights/loganalytics"
   override-client-name: LogAnalyticsClient
   generate-metadata: true
 ```

--- a/specification/servicefabric/data-plane/readme.typescript.md
+++ b/specification/servicefabric/data-plane/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: false
   package-name: "@azure/servicefabric"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/servicefabric"
+  output-folder: "$(typescript-sdks-folder)/sdk/servicefabric/servicefabric"
   override-client-name: ServiceFabricClient
   generate-metadata: true
 ```

--- a/specification/storage/data-plane/readme.typescript.md
+++ b/specification/storage/data-plane/readme.typescript.md
@@ -7,6 +7,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/storage-datalake"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/storage-datalake"
+  output-folder: "$(typescript-sdks-folder)/sdk/storage/storage-datalake"
   generate-metadata: true
 ```


### PR DESCRIPTION
The path update is in reference to the github PR Azure/azure-sdk-for-js#2240
Please review Azure/azure-sdk-for-js#2240 as well
Moving following dataplane packages from packages@Azure and putting them under an `sdk` directory:
![image](https://user-images.githubusercontent.com/8968058/56073605-03954780-5d5c-11e9-9e0e-2739f6cd48ce.png)

Please tag the required reviewers:
@salameer @daschult @kpajdzik @Azure/azure-sdk-eng
