### PR TITLE
update readme.TS for arm-commerce and applicationinsights-query path

### DIFF
--- a/specification/applicationinsights/data-plane/readme.typescript.md
+++ b/specification/applicationinsights/data-plane/readme.typescript.md
@@ -9,6 +9,6 @@ directive:
     remove-operation: Events_GetOdataMetadata
 typescript:
   package-name: "@azure/applicationinsights-query"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/applicationinsights-query"
+  output-folder: "$(typescript-sdks-folder)/sdk/applicationinsights/applicationinsights-query"
   generate-metadata: true
 ```

--- a/specification/commerce/resource-manager/readme.typescript.md
+++ b/specification/commerce/resource-manager/readme.typescript.md
@@ -7,7 +7,7 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 typescript:
   azure-arm: true
   package-name: "@azure/arm-commerce"
-  output-folder: "$(typescript-sdks-folder)/packages/@azure/arm-commerce"
+  output-folder: "$(typescript-sdks-folder)/sdk/commerce/arm-commerce"
   payload-flattening-threshold: 2
   generate-metadata: true
 ```


### PR DESCRIPTION
The path update is in reference to the github PR Azure/azure-sdk-for-js#2293
Please review Azure/azure-sdk-for-js#2293 as well
Moving following packages for arm-* from packages@Azure and putting them under an `sdk` directory:
- arm-commerce
- applicationinsights-query

@salameer @daschult @kpajdzik @Azure/azure-sdk-eng
