### PR TITLE
Fix Go SDK for cognitiveservices/anomalydetector

### DIFF
--- a/specification/cognitiveservices/data-plane/AnomalyDetector/readme.go.md
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/readme.go.md
@@ -7,6 +7,15 @@ go:
   license-header: MICROSOFT_APACHE_NO_VERSION
   namespace: anomalydetector
   clear-output-folder: true
+
+directive:
+  # Replace the default client constructor with the one that enables TLS renegotiation.
+  - from: client.go
+    where: $
+    transform: >-
+      return $.
+        replace( /"context"/g, "\"context\"\n\"crypto/tls\"" ).
+        replace( /autorest\.NewClientWithUserAgent\(UserAgent\(\)\)/g, "autorest.NewClientWithOptions(autorest.ClientOptions{UserAgent: UserAgent(), Renegotiation: tls.RenegotiateFreelyAsClient})" )
 ```
 
 ### Go multi-api


### PR DESCRIPTION
This endpoint requires client-side TLS renegotiation to be enabled.
Add a directive to modify the codegen to enable renegotiation.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
