### PR TITLE
Add unreferenced examples for service endpoint policy to VirtualNetwork specs

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
@@ -51,7 +51,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],
@@ -96,7 +95,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/virtualNetwork.json
@@ -181,7 +181,8 @@
         "x-ms-examples": {
           "Create virtual network": { "$ref": "./examples/VirtualNetworkCreate.json" },
           "Create virtual network with subnet": { "$ref": "./examples/VirtualNetworkCreateSubnet.json" },
-          "Create virtual network with service endpoints": { "$ref": "./examples/VirtualNetworkCreateServiceEndpoints.json" }
+          "Create virtual network with service endpoints": { "$ref": "./examples/VirtualNetworkCreateServiceEndpoints.json" },
+          "Create virtual network with service endpoints and service endpoint policy": { "$ref": "./examples/VirtualNetworkCreateServiceEndpointPolicy.json" }
         }
       },
       "patch": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
@@ -51,7 +51,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],
@@ -96,7 +95,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/virtualNetwork.json
@@ -185,6 +185,7 @@
           "Create virtual network with subnet": { "$ref": "./examples/VirtualNetworkCreateSubnet.json" },
           "Create virtual network with subnet containing address prefixes": { "$ref": "./examples/VirtualNetworkCreateSubnetWithAddressPrefixes.json" },
           "Create virtual network with service endpoints": { "$ref": "./examples/VirtualNetworkCreateServiceEndpoints.json" },
+          "Create virtual network with service endpoints and service endpoint policy": { "$ref": "./examples/VirtualNetworkCreateServiceEndpointPolicy.json" },
           "Create virtual network with delegated subnets": { "$ref": "./examples/VirtualNetworkCreateSubnetWithDelegation.json" }
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
@@ -51,7 +51,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],
@@ -96,7 +95,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/virtualNetwork.json
@@ -185,6 +185,7 @@
           "Create virtual network with subnet": { "$ref": "./examples/VirtualNetworkCreateSubnet.json" },
           "Create virtual network with subnet containing address prefixes": { "$ref": "./examples/VirtualNetworkCreateSubnetWithAddressPrefixes.json" },
           "Create virtual network with service endpoints": { "$ref": "./examples/VirtualNetworkCreateServiceEndpoints.json" },
+          "Create virtual network with service endpoints and service endpoint policy": { "$ref": "./examples/VirtualNetworkCreateServiceEndpointPolicy.json" },
           "Create virtual network with delegated subnets": { "$ref": "./examples/VirtualNetworkCreateSubnetWithDelegation.json" }
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
@@ -51,7 +51,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],
@@ -96,7 +95,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/virtualNetwork.json
@@ -185,6 +185,7 @@
           "Create virtual network with subnet": { "$ref": "./examples/VirtualNetworkCreateSubnet.json" },
           "Create virtual network with subnet containing address prefixes": { "$ref": "./examples/VirtualNetworkCreateSubnetWithAddressPrefixes.json" },
           "Create virtual network with service endpoints": { "$ref": "./examples/VirtualNetworkCreateServiceEndpoints.json" },
+          "Create virtual network with service endpoints and service endpoint policy": { "$ref": "./examples/VirtualNetworkCreateServiceEndpointPolicy.json" },
           "Create virtual network with delegated subnets": { "$ref": "./examples/VirtualNetworkCreateSubnetWithDelegation.json" }
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/VirtualNetworkCreateServiceEndpointPolicy.json
@@ -51,7 +51,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],
@@ -96,7 +95,6 @@
             {
               "name": "test-1",
               "id": "/subscriptions/subid/resourceGroups/vnetTest/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/test-1",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
               "properties": {
                 "addressPrefix": "10.0.0.0/16",
                 "ipConfigurations": [],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/virtualNetwork.json
@@ -185,6 +185,7 @@
           "Create virtual network with subnet": { "$ref": "./examples/VirtualNetworkCreateSubnet.json" },
           "Create virtual network with subnet containing address prefixes": { "$ref": "./examples/VirtualNetworkCreateSubnetWithAddressPrefixes.json" },
           "Create virtual network with service endpoints": { "$ref": "./examples/VirtualNetworkCreateServiceEndpoints.json" },
+          "Create virtual network with service endpoints and service endpoint policy": { "$ref": "./examples/VirtualNetworkCreateServiceEndpointPolicy.json" },
           "Create virtual network with delegated subnets": { "$ref": "./examples/VirtualNetworkCreateSubnetWithDelegation.json" }
         }
       },


### PR DESCRIPTION
Missed some unreferenced examples in previous PR

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
