### PR TITLE
chore: Use Xenial image for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: node_js
 node_js:
   - '10'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
     vmImage: 'Ubuntu 16.04'
   steps:
   - script: 'scripts/install-dotnet.sh'
-    displayName: 'Insall .Net'
+    displayName: 'Install .Net'
   - task: Npm@1
     displayName: 'npm install'
     inputs:

--- a/preproduction-azure-pipelines.yml
+++ b/preproduction-azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
     vmImage: 'Ubuntu 16.04'
   steps:
   - script: 'scripts/install-dotnet.sh'
-    displayName: 'Insall .Net'
+    displayName: 'Install .Net'
   - task: Npm@1
     displayName: 'npm install'
     inputs:

--- a/scripts/install-dotnet.sh
+++ b/scripts/install-dotnet.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# From https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/sdk-2.0.0
+# From https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/sdk-2.0.0
 
-wget -q https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
+wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get install apt-transport-https -y
 sudo apt-get update


### PR DESCRIPTION

.Net install started to fail on 14.04
Pipelines is already using this version