### PR TITLE
Revert not support formats xml-link and rawxml-link

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimanagement.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimanagement.json
@@ -490,9 +490,7 @@
       "description": "Policy Export Format.",
       "enum": [
         "xml",
-        "xml-link",
-        "rawxml",
-        "rawxml-link"
+        "rawxml"
       ],
       "x-ms-enum": {
         "name": "PolicyExportFormat",
@@ -503,16 +501,8 @@
             "description": "The contents are inline and Content type is an XML document."
           },
           {
-            "value": "xml-link",
-            "description": "The policy XML document is exported to a storage blob with SAS key valid for 5 minutes."
-          },
-          {
             "value": "rawxml",
             "description": "The contents are inline and Content type is a non XML encoded policy document."
-          },
-          {
-            "value": "rawxml-link",
-            "description": "The policy document is not XML encoded is exported to a storage blob with SAS Key valid for 5 minutes."
           }
         ]
       },

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimapis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimapis.json
@@ -1266,9 +1266,6 @@
             "$ref": "./apimanagement.json#/parameters/PolicyIdParameter"
           },
           {
-            "$ref": "./apimanagement.json#/parameters/PolicyExportFormat"
-          },
-          {
             "$ref": "./apimanagement.json#/parameters/ApiVersionParameter"
           },
           {
@@ -1316,6 +1313,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/OperationIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/PolicyExportFormat"
           },
           {
             "$ref": "./apimanagement.json#/parameters/PolicyIdParameter"


### PR DESCRIPTION
### Latest improvements:
- Incorrectly published the not supported export formats in the PR 
https://github.com/Azure/azure-rest-api-specs/pull/5732
Reverting those.

- Also the PolicyExportFormat should be on the `GET` resource and not the `HEAD` resource under 
/apis/{apiId}/operations/{operationId}
 
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
