### PR TITLE
[Hub Generated] Review request for Microsoft.Insights to add version stable/2018-09-01

### DIFF
--- a/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-09-01/baseline_API.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-09-01/baseline_API.json
@@ -75,7 +75,7 @@
               "name": "$filter",
               "in": "query",
               "type": "string",
-              "description": "The **$filter** is used to describe a set of dimensions with their concrete values which produce a specific metric�s time series, in which a baseline is requested for.",
+              "description": "The **$filter** is used to describe a set of dimensions with their concrete values which produce a specific metric's time series, in which a baseline is requested for.",
               "required": false
             }
           ],

--- a/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-09-01/baseline_API.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-09-01/baseline_API.json
@@ -98,6 +98,71 @@
             "Get Metric for metadata": { "$ref": "./examples/GetBaselineMetadata.json" }
           }
         }
+      },
+      "/{resourceUri}/providers/microsoft.insights/baseline": {
+        "get": {
+          "tags": [
+            "Baseline"
+          ],
+          "operationId": "MetricBaseline_Get",
+          "description": "**Gets the baseline values for a resource**.",
+          "parameters": [
+            {
+              "$ref": "#/parameters/ExtendedResourceUriParameter"
+            },
+            {
+              "$ref": "#/parameters/MetricNamesParameter"
+            },
+            {
+              "$ref": "#/parameters/MetricNameParameter"
+            },
+            {
+              "$ref": "#/parameters/TimespanParameter"
+            },
+            {
+              "$ref": "#/parameters/IntervalParameter"
+            },
+            {
+              "$ref": "#/parameters/AggregationParameter"
+            },
+            {
+              "$ref": "#/parameters/SensitivitiesParameter"
+            },
+            {
+              "$ref": "#/parameters/BaselineResultTypeParameter"
+            },
+            {
+              "$ref": "#/parameters/ApiVersionParameter"
+            },
+            {
+              "$ref": "#/parameters/MetricNamespaceParameter"
+            },
+            {
+              "name": "$filter",
+              "in": "query",
+              "type": "string",
+              "description": "The **$filter** is used to describe a set of dimensions with their concrete values which produce a specific metric�s time series, in which a baseline is requested for.",
+              "required": false
+            }
+          ],
+          "responses": {
+            "default": {
+              "description": "Error response describing why the operation failed.",
+              "schema": {
+                "$ref": "#/definitions/ErrorResponse"
+              }
+            },
+            "200": {
+              "description": "Successful request to get the list of metric values.",
+              "schema": {
+                "$ref": "#/definitions/BaselineResponse"
+              }
+            }
+          },
+          "x-ms-examples": {
+            "Get Metric for data": { "$ref": "./examples/GetBaseline.json" }
+          }
+        }
       }
     },
     "definitions": {
@@ -281,6 +346,14 @@
         "type": "string",
         "format": "duration",
         "description": "The interval (i.e. timegrain) of the query.",
+        "x-ms-parameter-location": "method"
+      },
+      "MetricNamesParameter": {
+        "name": "metricnames",
+        "in": "query",
+        "required": false,
+        "type": "string",
+        "description": "The names of the metrics (comma separated) to retrieve.",
         "x-ms-parameter-location": "method"
       },
       "AggregationParameter": {

--- a/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-09-01/baseline_API.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-09-01/baseline_API.json
@@ -104,7 +104,7 @@
           "tags": [
             "Baseline"
           ],
-          "operationId": "MetricBaseline_Get",
+          "operationId": "Baseline_Get",
           "description": "**Gets the baseline values for a resource**.",
           "parameters": [
             {
@@ -112,9 +112,6 @@
             },
             {
               "$ref": "#/parameters/MetricNamesParameter"
-            },
-            {
-              "$ref": "#/parameters/MetricNameParameter"
             },
             {
               "$ref": "#/parameters/TimespanParameter"

--- a/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-09-01/baseline_API.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/stable/2018-09-01/baseline_API.json
@@ -138,7 +138,7 @@
               "name": "$filter",
               "in": "query",
               "type": "string",
-              "description": "The **$filter** is used to describe a set of dimensions with their concrete values which produce a specific metric�s time series, in which a baseline is requested for.",
+              "description": "The **$filter** is used to describe a set of dimensions with their concrete values which produce a specific metric's time series, in which a baseline is requested for.",
               "required": false
             }
           ],


### PR DESCRIPTION
If you are a MSFT employee you can view your [work branch via this link](https://portal.azure-devex-tools.com/app/branch/asafst/azure-rest-api-specs/dev-monitor-Microsoft.Insights-2018-09-01...master).

This PR adds support for calling the baseline API without the need to pass the metric name in the URL, but instead passing it in the query parameters (to be consistant with metrics API and the new metricBaselines API)

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.

