### PR TITLE
[Network] Remove text like "Possible values are" from props that have enum

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/expressRouteCircuit.json
@@ -1409,7 +1409,7 @@
         },
         "authorizationUseStatus": {
           "type": "string",
-          "description": "AuthorizationUseStatus. Possible values are: 'Available' and 'InUse'.",
+          "description": "The authorization use status.",
           "enum": [
             "Available",
             "InUse"
@@ -1484,7 +1484,7 @@
         },
         "advertisedPublicPrefixesState": {
           "type": "string",
-          "description": "AdvertisedPublicPrefixState of the Peering resource. Possible values are 'NotConfigured', 'Configuring', 'Configured', and 'ValidationNeeded'.",
+          "description": "The advertised public prefix state of the Peering resource.",
           "enum": [
             "NotConfigured",
             "Configuring",
@@ -1533,7 +1533,7 @@
         },
         "state": {
           "type": "string",
-          "description": "The state of peering. Possible values are: 'Disabled' and 'Enabled'",
+          "description": "The state of peering.",
           "enum": [
             "Disabled",
             "Enabled"
@@ -1710,7 +1710,7 @@
     },
     "ExpressRoutePeeringType": {
       "type": "string",
-      "description": "The PeeringType. Possible values are: 'AzurePublicPeering', 'AzurePrivatePeering', and 'MicrosoftPeering'.",
+      "description": "The peering type.",
       "enum": [
         "AzurePublicPeering",
         "AzurePrivatePeering",
@@ -1723,7 +1723,7 @@
     },
     "ExpressRoutePeeringState": {
       "type": "string",
-      "description": "The state of peering. Possible values are: 'Disabled' and 'Enabled'",
+      "description": "The state of peering.",
       "enum": [
         "Disabled",
         "Enabled"
@@ -1885,7 +1885,7 @@
         },
         "tier": {
           "type": "string",
-          "description": "The tier of the SKU. Possible values are 'Standard', 'Premium' or 'Local'.",
+          "description": "The tier of the SKU.",
           "enum": [
             "Standard",
             "Premium",
@@ -1899,7 +1899,7 @@
         },
         "family": {
           "type": "string",
-          "description": "The family of the SKU. Possible values are: 'UnlimitedData' and 'MeteredData'.",
+          "description": "The family of the SKU.",
           "enum": [
             "UnlimitedData",
             "MeteredData"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/loadBalancer.json
@@ -1232,7 +1232,7 @@
         },
         "loadDistribution": {
           "type": "string",
-          "description": "The load distribution policy for this rule. Possible values are 'Default', 'SourceIP', and 'SourceIPProtocol'.",
+          "description": "The load distribution policy for this rule.",
           "enum": [
             "Default",
             "SourceIP",
@@ -1316,7 +1316,7 @@
         },
         "protocol": {
           "type": "string",
-          "description": "The protocol of the end point. Possible values are: 'Http', 'Tcp', or 'Https'. If 'Tcp' is specified, a received ACK is required for the probe to be successful. If 'Http' or 'Https' is specified, a 200 OK response from the specifies URI is required for the probe to be successful.",
+          "description": "The protocol of the end point. If 'Tcp' is specified, a received ACK is required for the probe to be successful. If 'Http' or 'Https' is specified, a 200 OK response from the specifies URI is required for the probe to be successful.",
           "enum": [
             "Http",
             "Tcp",
@@ -1546,7 +1546,7 @@
         },
         "protocol": {
           "type": "string",
-          "description": "The protocol for the outbound rule in load balancer. Possible values are: 'Tcp', 'Udp', and 'All'.",
+          "description": "The protocol for the outbound rule in load balancer.",
           "enum": [
             "Tcp",
             "Udp",
@@ -1802,7 +1802,7 @@
     },
     "TransportProtocol": {
       "type": "string",
-      "description": "The transport protocol for the endpoint. Possible values are 'Udp' or 'Tcp' or 'All'.",
+      "description": "The transport protocol for the endpoint.",
       "enum": [
         "Udp",
         "Tcp",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/network.json
@@ -85,7 +85,7 @@
       "properties": {
         "status": {
           "type": "string",
-          "description": "Status of the Azure async operation. Possible values are: 'InProgress', 'Succeeded', and 'Failed'.",
+          "description": "Status of the Azure async operation.",
           "enum": [
             "InProgress",
             "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/networkInterface.json
@@ -1136,7 +1136,7 @@
         },
         "protocol": {
           "type": "string",
-          "description": "The network protocol this rule applies to. Possible values are: 'Tcp', 'Udp', and 'All'.",
+          "description": "The network protocol this rule applies to.",
           "enum": [
             "Tcp",
             "Udp",
@@ -1250,7 +1250,7 @@
         },
         "source": {
           "type": "string",
-          "description": "Who created the route. Possible values are: 'Unknown', 'User', 'VirtualNetworkGateway', and 'Default'.",
+          "description": "Who created the route.",
           "enum": [
             "Unknown",
             "User",
@@ -1264,7 +1264,7 @@
         },
         "state": {
           "type": "string",
-          "description": "The value of effective route. Possible values are: 'Active' and 'Invalid'.",
+          "description": "The value of effective route.",
           "enum": [
             "Active",
             "Invalid"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/networkSecurityGroup.json
@@ -627,7 +627,7 @@
         },
         "protocol": {
           "type": "string",
-          "description": "Network protocol this rule applies to. Possible values are 'Tcp', 'Udp', 'Icmp', 'Esp', and '*'.",
+          "description": "Network protocol this rule applies to.",
           "enum": [
             "Tcp",
             "Udp",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/networkWatcher.json
@@ -3517,7 +3517,7 @@
             "name": "VerbosityLevel",
             "modelAsString": true
           },
-          "description": "Verbosity level. Accepted values are 'Normal', 'Minimum', 'Full'."
+          "description": "Verbosity level."
         },
         "profiles": {
           "type": "array",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/routeFilter.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/routeFilter.json
@@ -594,7 +594,7 @@
                 },
                 "routeFilterRuleType": {
                     "type": "string",
-                    "description": "The rule type of the rule. Valid value is: 'Community'",
+                    "description": "The rule type of the rule.",
                     "enum": [
                         "Community"
                     ],

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/virtualNetwork.json
@@ -1174,7 +1174,7 @@
         },
         "peeringState": {
           "type": "string",
-          "description": "The status of the virtual network peering. Possible values are 'Initiated', 'Connected', and 'Disconnected'.",
+          "description": "The status of the virtual network peering.",
           "enum": [
             "Initiated",
             "Connected",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/virtualNetworkGateway.json
@@ -1631,7 +1631,7 @@
         },
         "gatewayType": {
           "type": "string",
-          "description": "The type of this virtual network gateway. Possible values are: 'Vpn' and 'ExpressRoute'.",
+          "description": "The type of this virtual network gateway.",
           "enum": [
             "Vpn",
             "ExpressRoute"
@@ -1643,7 +1643,7 @@
         },
         "vpnType": {
           "type": "string",
-          "description": "The type of this virtual network gateway. Possible values are: 'PolicyBased' and 'RouteBased'.",
+          "description": "The type of this virtual network gateway.",
           "enum": [
             "PolicyBased",
             "RouteBased"
@@ -2030,7 +2030,7 @@
       "properties": {
         "processorArchitecture": {
           "type": "string",
-          "description": "VPN client Processor Architecture. Possible values are: 'AMD64' and 'X86'.",
+          "description": "VPN client Processor Architecture.",
           "enum": [
             "Amd64",
             "X86"
@@ -2352,7 +2352,7 @@
     },
     "ConnectionProtocol": {
         "type": "string",
-        "description": "Gateway connection protocol. Possible values are: 'IKEv2', 'IKEv1'.",
+        "description": "Gateway connection protocol.",
         "enum": [
           "IKEv2",
           "IKEv1"


### PR DESCRIPTION
Description text like "Possible values are" is going to be generated by AutoRest so there is no reason to add it in Swagger (plus sometimes list of values in description and enum differ).

Example of [incorrect description](https://github.com/Azure/azure-sdk-for-net/blob/master/src/SDKs/Network/Management.Network/Generated/Models/ExpressRouteCircuitAuthorization.cs#L39) caused by the issue:

```csharp
        /// <param name="authorizationUseStatus">AuthorizationUseStatus.
        /// Possible values are: 'Available' and 'InUse'. Possible values
        /// include: 'Available', 'InUse'</param>
```

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
