### PR TITLE
API for usages by VM family, Workspace & Compute

### DIFF
--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListUsagesByVMFamilyResult.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListUsagesByVMFamilyResult.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "location": "eastus",
-    "api-version": "2018-05-01"
+    "api-version": "2018-11-19"
   },
   "responses": {
     "200": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListUsagesByVMFamilyResult.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListUsagesByVMFamilyResult.json
@@ -1,0 +1,297 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "location": "eastus",
+    "api-version": "2018-05-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "unit": "Count",
+            "currentValue": 2,
+            "limit": 100,
+            "name": {
+              "value": "Clusters",
+              "localizedValue": "Clusters"
+            },
+            "resourceType": "TotalClusters"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 6,
+            "limit": 24,
+            "name": {
+              "value": "Total Cluster Dedicated Regional vCPUs",
+              "localizedValue": "Total Cluster Dedicated Regional vCPUs"
+            },
+            "resourceType": "TotalDedicatedCores"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 48,
+            "name": {
+              "value": "Standard D Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard D Family Cluster Dedicated vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 24,
+            "name": {
+              "value": "Standard DSv2 Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard DSv2 Family Cluster Dedicated vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 24,
+            "name": {
+              "value": "Standard Dv2 Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard Dv2 Family Cluster Dedicated vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 24,
+            "name": {
+              "value": "Standard FSv2 Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard FSv2 Family Cluster Dedicated vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 6,
+            "limit": 24,
+            "name": {
+              "value": "Standard NC Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard NC Family Cluster Dedicated vCPUs"
+            },
+            "usageBreakdown": [
+              {
+                "unit": "Count",
+                "currentValue": 6,
+                "limit": 24,
+                "name": {
+                  "value": "Workspace1",
+                  "localizedValue": "Workspace1"
+                },
+                "usageBreakdown": [
+                  {
+                    "unit": "Count",
+                    "currentValue": 6,
+                    "limit": 24,
+                    "name": {
+                      "value": "Compute1",
+                      "localizedValue": "Compute1"
+                    },
+                    "resourceType": "Cluster",
+                    "resourceGroupName": "rg"
+                  }
+                ],
+                "resourceType": "Workspace",
+                "resourceGroupName": "rg"
+              }
+            ],
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 0,
+            "name": {
+              "value": "Standard NCv2 Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard NCv2 Family Cluster Dedicated vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 0,
+            "name": {
+              "value": "Standard NCv3 Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard NCv3 Family Cluster Dedicated vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 0,
+            "name": {
+              "value": "Standard ND Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard ND Family Cluster Dedicated vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 0,
+            "name": {
+              "value": "Standard NDv2 Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard NDv2 Family Cluster Dedicated vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 24,
+            "name": {
+              "value": "Standard NV Family Cluster Dedicated vCPUs",
+              "localizedValue": "Standard NV Family Cluster Dedicated vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": 50,
+            "name": {
+              "value": "Total Cluster LowPriority Regional vCPUs",
+              "localizedValue": "Total Cluster Low Priority Regional vCPUs"
+            },
+            "resourceType": "TotalLowPriorityCores"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard D Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard D Family Cluster Low Priority vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard DSv2 Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard DSv2 Family Cluster Low Priority vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard Dv2 Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard Dv2 Family Cluster Low Priority vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard FSv2 Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard FSv2 Family Cluster Low Priority vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard NC Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard NC Family Cluster Low Priority vCPUs"
+            },
+            "usageBreakdown": [
+              {
+                "unit": "Count",
+                "currentValue": 0,
+                "limit": -1,
+                "name": {
+                  "value": "Workspace2",
+                  "localizedValue": "Workspace2"
+                },
+                "usageBreakdown": [
+                  {
+                    "unit": "Count",
+                    "currentValue": 0,
+                    "limit": -1,
+                    "name": {
+                      "value": "Compute2",
+                      "localizedValue": "Compute2"
+                    },
+                    "resourceType": "Cluster",
+                    "resourceGroupName": "rg"
+                  }
+                ],
+                "resourceType": "Workspace",
+                "resourceGroupName": "rg"
+              }
+            ],
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard NCv2 Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard NCv2 Family Cluster Low Priority vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard NCv3 Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard NCv3 Family Cluster Low Priority vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard ND Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard ND Family Cluster Low Priority vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard NDv2 Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard NDv2 Family Cluster Low Priority vCPUs"
+            },
+            "resourceType": "VMFamily"
+          },
+          {
+            "unit": "Count",
+            "currentValue": 0,
+            "limit": -1,
+            "name": {
+              "value": "Standard NV Family Cluster LowPriority vCPUs",
+              "localizedValue": "Standard NV Family Cluster Low Priority vCPUs"
+            },
+            "resourceType": "VMFamily"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListUsagesByVMFamilyResult.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListUsagesByVMFamilyResult.json
@@ -16,7 +16,8 @@
               "value": "Clusters",
               "localizedValue": "Clusters"
             },
-            "resourceType": "TotalClusters"
+            "resourceType": "TotalClusters",
+            "resourceGroupName": "rg"
           },
           {
             "unit": "Count",

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListVMSizesResult.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListVMSizesResult.json
@@ -1,10 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
-    "resourceGroupName": "testrg123",
-    "workspaceName": "workspaces123",
-    "computeName": "compute123",
-    "api-version": "2018-11-19"
+    "api-version": "2018-11-19",
+    "location": "eastus"
   },
   "responses": {
     "200": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListVMSizesResult.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/examples/ListVMSizesResult.json
@@ -1,0 +1,457 @@
+{
+  "parameters": {
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "resourceGroupName": "testrg123",
+    "workspaceName": "workspaces123",
+    "computeName": "compute123",
+    "api-version": "2018-11-19"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "amlCompute": [
+          {
+            "name": "Standard_F2s_v2",
+            "family": "standardFSv2Family",
+            "vCPUs": 2,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 16384,
+            "memoryGB": 4.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_F4s_v2",
+            "family": "standardFSv2Family",
+            "vCPUs": 4,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 32768,
+            "memoryGB": 8.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_F8s_v2",
+            "family": "standardFSv2Family",
+            "vCPUs": 8,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 65536,
+            "memoryGB": 16.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_F16s_v2",
+            "family": "standardFSv2Family",
+            "vCPUs": 16,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 131072,
+            "memoryGB": 32.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_F32s_v2",
+            "family": "standardFSv2Family",
+            "vCPUs": 32,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 262144,
+            "memoryGB": 64.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_F64s_v2",
+            "family": "standardFSv2Family",
+            "vCPUs": 64,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 524288,
+            "memoryGB": 128.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_F72s_v2",
+            "family": "standardFSv2Family",
+            "vCPUs": 72,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 589824,
+            "memoryGB": 144.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_D1_v2",
+            "family": "standardDv2Family",
+            "vCPUs": 1,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 51200,
+            "memoryGB": 3.5,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_D2_v2",
+            "family": "standardDv2Family",
+            "vCPUs": 2,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 102400,
+            "memoryGB": 7.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_D3_v2",
+            "family": "standardDv2Family",
+            "vCPUs": 4,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 204800,
+            "memoryGB": 14.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_D4_v2",
+            "family": "standardDv2Family",
+            "vCPUs": 8,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 409600,
+            "memoryGB": 28.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_D11_v2",
+            "family": "standardDv2Family",
+            "vCPUs": 2,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 102400,
+            "memoryGB": 14.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_D12_v2",
+            "family": "standardDv2Family",
+            "vCPUs": 4,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 204800,
+            "memoryGB": 28.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_D13_v2",
+            "family": "standardDv2Family",
+            "vCPUs": 8,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 409600,
+            "memoryGB": 56.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_D14_v2",
+            "family": "standardDv2Family",
+            "vCPUs": 16,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 819200,
+            "memoryGB": 112.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_DS1_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 1,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 7168,
+            "memoryGB": 3.5,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_DS2_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 2,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 14336,
+            "memoryGB": 7.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_DS3_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 4,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_DS4_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 8,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_DS5_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 16,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_DS11_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 2,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 28672,
+            "memoryGB": 14.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_DS12_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 4,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 57344,
+            "memoryGB": 28.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_DS13_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 8,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 114688,
+            "memoryGB": 56.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_DS14_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 16,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 229376,
+            "memoryGB": 112.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_DS15_v2",
+            "family": "standardDSv2Family",
+            "vCPUs": 20,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 286720,
+            "memoryGB": 140.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_NC6s_v2",
+            "family": "standardNCSv2Family",
+            "vCPUs": 6,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 344064,
+            "memoryGB": 112.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_NC12s_v2",
+            "family": "standardNCSv2Family",
+            "vCPUs": 12,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 688128,
+            "memoryGB": 224.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_NC24rs_v2",
+            "family": "standardNCSv2Family",
+            "vCPUs": 24,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 1376256,
+            "memoryGB": 448.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_NC24s_v2",
+            "family": "standardNCSv2Family",
+            "vCPUs": 24,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 1376256,
+            "memoryGB": 448.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_NC6s_v3",
+            "family": "standardNCSv3Family",
+            "vCPUs": 6,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 344064,
+            "memoryGB": 112.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_NC12s_v3",
+            "family": "standardNCSv3Family",
+            "vCPUs": 12,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 688128,
+            "memoryGB": 224.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_NC24rs_v3",
+            "family": "standardNCSv3Family",
+            "vCPUs": 24,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 1376256,
+            "memoryGB": 448.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_NC24s_v3",
+            "family": "standardNCSv3Family",
+            "vCPUs": 24,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 1376256,
+            "memoryGB": 448.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_NC6",
+            "family": "standardNCFamily",
+            "vCPUs": 6,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 389120,
+            "memoryGB": 56.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_NC12",
+            "family": "standardNCFamily",
+            "vCPUs": 12,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 696320,
+            "memoryGB": 112.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_NC24",
+            "family": "standardNCFamily",
+            "vCPUs": 24,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 1474560,
+            "memoryGB": 224.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_NC24r",
+            "family": "standardNCFamily",
+            "vCPUs": 24,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 1474560,
+            "memoryGB": 224.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_NV6",
+            "family": "standardNVFamily",
+            "vCPUs": 6,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 389120,
+            "memoryGB": 56.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_NV12",
+            "family": "standardNVFamily",
+            "vCPUs": 12,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 696320,
+            "memoryGB": 112.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_NV24",
+            "family": "standardNVFamily",
+            "vCPUs": 24,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 1474560,
+            "memoryGB": 224.0,
+            "lowPriorityCapable": true,
+            "premiumIO": false
+          },
+          {
+            "name": "Standard_ND6s",
+            "family": "standardNDSFamily",
+            "vCPUs": 6,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 344064,
+            "memoryGB": 112.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_ND12s",
+            "family": "standardNDSFamily",
+            "vCPUs": 12,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 688128,
+            "memoryGB": 224.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_ND24rs",
+            "family": "standardNDSFamily",
+            "vCPUs": 24,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 1376256,
+            "memoryGB": 448.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          },
+          {
+            "name": "Standard_ND24s",
+            "family": "standardNDSFamily",
+            "vCPUs": 24,
+            "osVhdSizeMB": 1047552,
+            "maxResourceVolumeMB": 1376256,
+            "memoryGB": 448.0,
+            "lowPriorityCapable": true,
+            "premiumIO": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -1142,40 +1142,7 @@
       "description": "The Usage Names."
     },
     "Usage": {
-      "properties": {
-        "unit": {
-          "readOnly": true,
-          "type": "string",
-          "description": "An enum describing the unit of usage measurement.",
-          "enum": [
-            "Count"
-          ],
-          "x-ms-enum": {
-            "name": "UsageUnit",
-            "modelAsString": true
-          }
-        },
-        "currentValue": {
-          "readOnly": true,
-          "type": "integer",
-          "format": "int64",
-          "description": "The current usage of the resource."
-        },
-        "limit": {
-          "readOnly": true,
-          "type": "integer",
-          "format": "int64",
-          "description": "The maximum permitted usage of the resource."
-        },
-        "name": {
-          "readOnly": true,
-          "$ref": "#/definitions/UsageName",
-          "description": "The name of the type of usage."
-        }
-      },
-      "description": "Describes AML Resource Usage."
-    },
-    "DummyObject": {
+      "type":"object",
       "properties": {
         "unit": {
           "readOnly": true,
@@ -1214,7 +1181,7 @@
       "description": "Describes Batch AI Resource Usage by VM Family, broken down by Workspace and Cluster usage",
       "allOf": [
         {
-          "$ref": "#/definitions/DummyObject"
+          "$ref": "#/definitions/Usage"
         }
       ],
       "properties": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -404,6 +404,47 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/usagesbyvmfamily": {
+      "get": {
+        "tags": [
+          "UsageByVMFamily"
+        ],
+        "operationId": "UsagesByVMFamily_List",
+        "description": "Gets the current usage information in a detailed format as well as limits for Batch AI resources for given subscription, by VM family, workspace and cluster hierarchy.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/APIVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The location for which resource usage is queried.",
+            "pattern": "^[-\\w\\._]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ListUsagesByVMFamilyResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List Usages": {
+            "$ref": "./examples/ListUsagesByVMFamilyResult.json"
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/vmSizes": {
       "get": {
         "tags": [
@@ -1135,6 +1176,44 @@
       },
       "description": "Describes AML Resource Usage."
     },
+    "UsageByVMFamily": {
+      "properties": {
+          "properties": {
+            "x-ms-client-flatten": true,
+            "$ref": "#/definitions/UsageByVMFamilyProperties",
+            "description": "The properties associated with UsageByVMFamily"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/definitions/Usage"
+          }
+        ],
+        "description": "Describes Batch AI Resource Usage by VM Family, broken down by Workspace and Cluster usage"
+    },
+    "UsageByVMFamilyProperties": {
+      "properties": {
+          "resourceGroupName": {
+            "readOnly": true,
+            "type": "string",
+            "description": "The name of the resource group this resource type belongs to"
+          },
+          "resourceType": {
+              "readOnly": true,
+              "type": "string",
+              "description": "The type of the resource, whether its VM family, workspace name, or cluster"
+          },
+          "usageBreakdown": {
+              "readOnly": true,
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/UsageByVMFamily"
+              },
+              "description": "The breakdown of usage by Workspace or Cluster"
+            }
+        },
+        "description": "Properties of UsageByVMFamily definition, an extension of Usage definition"
+    },
     "ListUsagesResult": {
       "properties": {
         "value": {
@@ -1152,6 +1231,24 @@
         }
       },
       "description": "The List Usages operation response."
+    },
+    "ListUsagesByVMFamilyResult": {
+      "properties": {
+        "value": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UsageByVMFamily"
+          },
+          "description": "The list of compute resource usages, by VM family, broken down by Workspace, and Cluster usage."
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URI to fetch the next page of compute resource usage information. Call ListNext() with this to fetch the next page of compute resource usage information."
+        }
+      },
+      "description": "The List UsagesByVMFamily operation response."
     },
     "VirtualMachineSize": {
       "properties": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -439,7 +439,7 @@
           "nextLinkName": "nextLink"
         },
         "x-ms-examples": {
-          "List Usages": {
+          "List Usages By VM Family": {
             "$ref": "./examples/ListUsagesByVMFamilyResult.json"
           }
         }

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -404,7 +404,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/usagesByVMFamily": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/resourceUsagesByVMFamily": {
       "get": {
         "tags": [
           "UsageByVMFamily"

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -476,8 +476,10 @@
             }
           }
         },
-        "x-ms-pageable": {
-          "nextLinkName": null
+        "x-ms-examples": {
+          "List VM Sizes": {
+            "$ref": "./examples/ListVMSizesResult.json"
+          }
         }
       }
     },
@@ -712,7 +714,7 @@
           }
         ],
         "responses": {
-          "202": {
+          "201": {
             "description": "Compute update initiated.",
             "schema": {
               "$ref": "#/definitions/ComputeResource"
@@ -820,9 +822,6 @@
               "$ref": "#/definitions/MachineLearningServiceError"
             }
           }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
         },
         "x-ms-examples": {
           "Get compute nodes information for a compute": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -404,7 +404,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/usagesByVMFamily": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/resourcesByVMFamily": {
       "get": {
         "tags": [
           "UsageByVMFamily"
@@ -1175,12 +1175,61 @@
       },
       "description": "Describes AML Resource Usage."
     },
+    "ResourceUsageName": {
+      "properties": {
+        "value": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        "localizedValue": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The localized name of the resource."
+        }
+      },
+      "description": "The Usage Names."
+    },
+    "ResourceUsage": {
+      "properties": {
+        "unit": {
+          "readOnly": true,
+          "type": "string",
+          "description": "An enum describing the unit of usage measurement.",
+          "enum": [
+            "Count"
+          ],
+          "x-ms-enum": {
+            "name": "UsageUnit",
+            "modelAsString": true
+          }
+        },
+        "currentValue": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int64",
+          "description": "The current usage of the resource."
+        },
+        "limit": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int64",
+          "description": "The maximum permitted usage of the resource."
+        },
+        "name": {
+          "readOnly": true,
+          "$ref": "#/definitions/ResourceUsageName",
+          "description": "The name of the type of usage."
+        }
+      },
+      "description": "Describes AML Resource Usage."
+    },
     "UsageByVMFamily": {
       "type": "object",
       "description": "Describes Batch AI Resource Usage by VM Family, broken down by Workspace and Cluster usage",
       "allOf": [
         {
-          "$ref": "#/definitions/Usage"
+          "$ref": "#/definitions/ResourceUsage"
         }
       ],
       "properties": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -404,7 +404,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/resourceUsagesByVMFamily": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/usagesByVMFamily": {
       "get": {
         "tags": [
           "UsageByVMFamily"
@@ -1176,19 +1176,20 @@
       "description": "Describes AML Resource Usage."
     },
     "UsageByVMFamily": {
+      "type": "object",
+      "description": "Describes Batch AI Resource Usage by VM Family, broken down by Workspace and Cluster usage",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Usage"
+        }
+      ],
       "properties": {
           "properties": {
             "x-ms-client-flatten": true,
             "$ref": "#/definitions/UsageByVMFamilyProperties",
             "description": "The properties associated with UsageByVMFamily"
           }
-        },
-        "allOf": [
-          {
-            "$ref": "#/definitions/Usage"
-          }
-        ],
-        "description": "Describes Batch AI Resource Usage by VM Family, broken down by Workspace and Cluster usage"
+        }
     },
     "UsageByVMFamilyProperties": {
       "properties": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -404,7 +404,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/resourcesByVMFamily": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/usagesByVMFamily": {
       "get": {
         "tags": [
           "UsageByVMFamily"
@@ -1175,22 +1175,7 @@
       },
       "description": "Describes AML Resource Usage."
     },
-    "ResourceUsageName": {
-      "properties": {
-        "value": {
-          "readOnly": true,
-          "type": "string",
-          "description": "The name of the resource."
-        },
-        "localizedValue": {
-          "readOnly": true,
-          "type": "string",
-          "description": "The localized name of the resource."
-        }
-      },
-      "description": "The Usage Names."
-    },
-    "ResourceUsage": {
+    "DummyObject": {
       "properties": {
         "unit": {
           "readOnly": true,
@@ -1218,7 +1203,7 @@
         },
         "name": {
           "readOnly": true,
-          "$ref": "#/definitions/ResourceUsageName",
+          "$ref": "#/definitions/UsageName",
           "description": "The name of the type of usage."
         }
       },
@@ -1229,7 +1214,7 @@
       "description": "Describes Batch AI Resource Usage by VM Family, broken down by Workspace and Cluster usage",
       "allOf": [
         {
-          "$ref": "#/definitions/ResourceUsage"
+          "$ref": "#/definitions/DummyObject"
         }
       ],
       "properties": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -404,7 +404,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/usagesbyvmfamily": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/usagesByVMFamily": {
       "get": {
         "tags": [
           "UsageByVMFamily"
@@ -1245,7 +1245,7 @@
         "nextLink": {
           "readOnly": true,
           "type": "string",
-          "description": "The URI to fetch the next page of compute resource usage information. Call ListNext() with this to fetch the next page of compute resource usage information."
+          "description": "The URI to fetch the next page of compute resource usage information."
         }
       },
       "description": "The List UsagesByVMFamily operation response."

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -714,7 +714,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "Compute update initiated.",
             "schema": {
               "$ref": "#/definitions/ComputeResource"

--- a/specification/machinelearningservices/resource-manager/readme.go.md
+++ b/specification/machinelearningservices/resource-manager/readme.go.md
@@ -13,7 +13,17 @@ go:
 
 ```yaml $(go) && $(multiapi)
 batch:
+  - tag: package-2018-03-preview
   - tag: package-2018-11-19
+```
+
+### Tag: package-2018-03-preview and go
+
+These settings apply only when `--tag=package-2018-03-preview --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+```yaml $(tag)=='package-2018-03-preview' && $(go)
+output-folder: $(go-sdk-folder)/services/preview/machinelearning/mgmt/2018-03-01-preview/$(namespace)
 ```
 
 ### Tag: package-2018-11-19 and go

--- a/specification/machinelearningservices/resource-manager/readme.go.md
+++ b/specification/machinelearningservices/resource-manager/readme.go.md
@@ -32,5 +32,5 @@ These settings apply only when `--tag=package-2018-11-19 --go` is specified on t
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ```yaml $(tag)=='package-2018-11-19' && $(go)
-output-folder: $(go-sdk-folder)/services/preview/machinelearning/mgmt/2018-11-19/$(namespace)
+output-folder: $(go-sdk-folder)/services/machinelearning/mgmt/2018-11-19/$(namespace)
 ```

--- a/specification/machinelearningservices/resource-manager/readme.go.md
+++ b/specification/machinelearningservices/resource-manager/readme.go.md
@@ -13,14 +13,14 @@ go:
 
 ```yaml $(go) && $(multiapi)
 batch:
-  - tag: package-2018-03-preview
+  - tag: package-2018-11-19
 ```
 
-### Tag: package-2018-03-preview and go
+### Tag: package-2018-11-19 and go
 
-These settings apply only when `--tag=package-2018-03-preview --go` is specified on the command line.
+These settings apply only when `--tag=package-2018-11-19 --go` is specified on the command line.
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
-```yaml $(tag)=='package-2018-03-preview' && $(go)
-output-folder: $(go-sdk-folder)/services/preview/machinelearning/mgmt/2018-03-01-preview/$(namespace)
+```yaml $(tag)=='package-2018-11-19' && $(go)
+output-folder: $(go-sdk-folder)/services/preview/machinelearning/mgmt/2018-11-19/$(namespace)
 ```

--- a/specification/machinelearningservices/resource-manager/readme.md
+++ b/specification/machinelearningservices/resource-manager/readme.md
@@ -29,6 +29,14 @@ openapi-type: arm
 tag: package-2018-11-19
 ```
 
+### Tag: package-2018-03-preview
+
+These settings apply only when `--tag=package-2018-03-preview` is specified on the command line.
+
+``` yaml $(tag) == 'package-2018-03-preview'
+input-file:
+- Microsoft.MachineLearningServices/preview/2018-03-01-preview/machineLearningServices.json
+```
 
 ### Tag: package-2018-11-19
 
@@ -136,5 +144,3 @@ java:
 regenerate-manager: true
 generate-interface: true
 ```
-
-

--- a/specification/machinelearningservices/resource-manager/readme.md
+++ b/specification/machinelearningservices/resource-manager/readme.md
@@ -36,7 +36,7 @@ These settings apply only when `--tag=package-2018-11-19` is specified on the co
 
 ``` yaml $(tag) == 'package-2018-11-19'
 input-file:
-- Microsoft.MachineLearningServices/preview/2018-11-19/machineLearningServices.json
+- Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
 ```
 
 ---

--- a/specification/machinelearningservices/resource-manager/readme.md
+++ b/specification/machinelearningservices/resource-manager/readme.md
@@ -26,17 +26,17 @@ These are the global settings for the Machine Learning Services API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2018-03-preview
+tag: package-2018-11-19
 ```
 
 
-### Tag: package-2018-03-preview
+### Tag: package-2018-11-19
 
-These settings apply only when `--tag=package-2018-03-preview` is specified on the command line.
+These settings apply only when `--tag=package-2018-11-19` is specified on the command line.
 
-``` yaml $(tag) == 'package-2018-03-preview'
+``` yaml $(tag) == 'package-2018-11-19'
 input-file:
-- Microsoft.MachineLearningServices/preview/2018-03-01-preview/machineLearningServices.json
+- Microsoft.MachineLearningServices/preview/2018-11-19/machineLearningServices.json
 ```
 
 ---
@@ -121,15 +121,15 @@ output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-machinelearning/ser
 
 ``` yaml $(java) && $(multiapi)
 batch:
-  - tag: package-2018-03-preview
+  - tag: package-2018-11-19
 ```
 
-### Tag: package-2018-03-preview and java
+### Tag: package-2018-11-19 and java
 
-These settings apply only when `--tag=package-2018-03-preview --java` is specified on the command line.
+These settings apply only when `--tag=package-2018-11-19 --java` is specified on the command line.
 Please also specify `--azure-libraries-for-java=<path to the root directory of your azure-sdk-for-java clone>`.
 
-``` yaml $(tag) == 'package-2018-03-preview' && $(java) && $(multiapi)
+``` yaml $(tag) == 'package-2018-11-19' && $(java) && $(multiapi)
 java:
   namespace: com.microsoft.azure.management.machinelearningservices.v2018_03_01_preview
   output-folder: $(azure-libraries-for-java-folder)/machinelearningservices/resource-manager/v2018_03_01_preview


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).

## New Usage API with detailed breakdown of usage by VM Family, Workspace and Compute
- Added a new API usagesbyvmfamily
- Added a new defintion UsageByVMFamily extending an existing Usage definition, with some new properties
- Added new example for the API

## Validation
{ message: 'Semantically validating  specification\\machinelearningservices\\resource-manager\\Microsoft.MachineLearningServices\\stable\\2018-11-19\\machineLearningServices.json:\n',
  level: '\u001b[32minfo\u001b[39m' }
{ message: 'No Errors were found.',
  level: '\u001b[32minfo\u001b[39m' }