### PR TITLE
[Azure Search] Improving description of searchFields parameter

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/stable/2019-05-06/searchindex.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/stable/2019-05-06/searchindex.json
@@ -221,7 +221,7 @@
             "items": {
               "type": "string"
             },
-            "description": "The list of field names to include in the full-text search.",
+            "description": "The list of field names to which to scope the full-text search. When using fielded search (fieldName:searchExpression) in a full Lucene query, the field names of each fielded search expression take precedence over any field names listed in this parameter.",
             "x-ms-parameter-grouping": {
               "name": "SearchParameters"
             }
@@ -1099,7 +1099,7 @@
         },
         "searchFields": {
           "type": "string",
-          "description": "The comma-separated list of field names to include in the full-text search."
+          "description": "The comma-separated list of field names to which to scope the full-text search. When using fielded search (fieldName:searchExpression) in a full Lucene query, the field names of each fielded search expression take precedence over any field names listed in this parameter."
         },
         "searchMode": {
           "$ref": "#/definitions/SearchMode",
@@ -1161,7 +1161,7 @@
         },
         "searchFields": {
           "type": "string",
-          "description": "The list of comma-separated field names to search for the specified search text. Target fields must be included in the specified suggester."
+          "description": "The comma-separated list of field names to search for the specified search text. Target fields must be included in the specified suggester."
         },
         "select": {
           "type": "string",


### PR DESCRIPTION
This is part of the effort to clarify the relationship between searchFields and fielded search in the full Lucene query syntax. See this issue for context: https://github.com/Azure/azure-sdk-for-net/issues/5019

FYI @HeidiSteen 

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
