### PR TITLE
Fix incorrect type of enablePowerBIService property

### DIFF
--- a/specification/analysisservices/resource-manager/Microsoft.AnalysisServices/preview/2017-08-01-beta/analysisservices.json
+++ b/specification/analysisservices/resource-manager/Microsoft.AnalysisServices/preview/2017-08-01-beta/analysisservices.json
@@ -1033,7 +1033,7 @@
           "description": "An array of firewall rules."
         },
         "enablePowerBIService": {
-          "type": "string",
+          "type": "boolean",
           "description": "The indicator of enabling PBI service."
         }
       }

--- a/specification/analysisservices/resource-manager/Microsoft.AnalysisServices/stable/2017-08-01/analysisservices.json
+++ b/specification/analysisservices/resource-manager/Microsoft.AnalysisServices/stable/2017-08-01/analysisservices.json
@@ -1033,7 +1033,7 @@
           "description": "An array of firewall rules."
         },
         "enablePowerBIService": {
-          "type": "string",
+          "type": "boolean",
           "description": "The indicator of enabling PBI service."
         }
       }


### PR DESCRIPTION
The mentioned property is of type string in the documentation but is incorrect. It should be a boolean as that's the type that's returned from the API. Even the example ARM template uses a boolean:
https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-analysis-services-create/azuredeploy.json

Hope this will be fixed fast as it is also incorrect in the Go SDK and blocks me from developing a full featured analysis services server resource for Terraform.