### PR TITLE
[Cogs OCR] Remove optional `mode` parameter from CognitiveService OCR preview API for GA preparation

### DIFF
--- a/specification/cognitiveservices/data-plane/ComputerVision/stable/v2.0/Ocr.json
+++ b/specification/cognitiveservices/data-plane/ComputerVision/stable/v2.0/Ocr.json
@@ -118,9 +118,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/ImageUrl"
-          },
-          {
-            "$ref": "#/parameters/TextRecognitionMode"
           }
         ],
         "consumes": [
@@ -241,9 +238,6 @@
         "parameters": [
           {
             "$ref": "#/parameters/ImageStream"
-          },
-          {
-            "$ref": "#/parameters/TextRecognitionMode"
           }
         ],
         "consumes": [

--- a/specification/cognitiveservices/data-plane/ComputerVision/stable/v2.0/examples/SuccessfulBatchReadFileWithStream.json
+++ b/specification/cognitiveservices/data-plane/ComputerVision/stable/v2.0/examples/SuccessfulBatchReadFileWithStream.json
@@ -2,7 +2,6 @@
   "parameters": {
     "Endpoint": "{Endpoint}",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "mode": "Printed",
     "Image": "{binary}"
   },
   "responses": {

--- a/specification/cognitiveservices/data-plane/ComputerVision/stable/v2.0/examples/SuccessfulBatchReadFileWithUrl.json
+++ b/specification/cognitiveservices/data-plane/ComputerVision/stable/v2.0/examples/SuccessfulBatchReadFileWithUrl.json
@@ -2,7 +2,6 @@
   "parameters": {
     "Endpoint": "{Endpoint}",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "mode": "Printed",
     "ImageUrl": "{url}"
   },
   "responses": {


### PR DESCRIPTION
Now `read/core/asyncBatchAnalyze` API is in public preview state. It will be GA soon.

In our public preview version, we have an optional parameter `Mode`. In GA, this parameter is not necessary anymore, because we introduce auto mode detection for better user experience.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
