### PR TITLE
Updating output location for KeyVault DataPlane

### DIFF
--- a/specification/keyvault/data-plane/readme.python.md
+++ b/specification/keyvault/data-plane/readme.python.md
@@ -32,7 +32,7 @@ These settings apply only when `--tag=package-7.0 --python` is specified on the 
 ``` yaml $(tag) == 'package-7.0' && $(python)
 python:
   namespace: azure.keyvault.v7_0
-  output-folder: $(python-sdks-folder)/azure-keyvault/azure/keyvault/v7_0
+  output-folder: $(python-sdks-folder)/keyvault/azure-keyvault/azure/keyvault/v7_0
 ```
 
 ### Tag: package-2016-10 and python
@@ -42,5 +42,5 @@ These settings apply only when `--tag=package-2016-10 --python` is specified on 
 ``` yaml $(tag) == 'package-2016-10' && $(python)
 python:
   namespace: azure.keyvault.v2016_10_01
-  output-folder: $(python-sdks-folder)/azure-keyvault/azure/keyvault/v2016_10_01
+  output-folder: $(python-sdks-folder)/keyvault/azure-keyvault/azure/keyvault/v2016_10_01
 ```


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).

Needed to merge master into the autorest branch before submitting this PR. Otherwise the swagger_to_sdk config wouldn't be updated, which would cause the files to generate to the wrong location.