### PR TITLE
Add type field to child resources. Fix routefilter reference. Add ipv6peering property

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/ExpressRouteCircuitAuthorizationGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/ExpressRouteCircuitAuthorizationGet.json
@@ -15,7 +15,8 @@
             "provisioningState": "Succeeded",
             "authorizationKey": "authKey",
             "authorizationUseStatus": "Available"
-         }
+         },
+         "type": "Microsoft.Network/expressRouteCircuits/authorizations"
       }
    }
 }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/ExpressRouteCircuitConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/ExpressRouteCircuitConnectionGet.json
@@ -24,7 +24,8 @@
           "addressPrefix": "10.0.0.0/24",
           "circuitConnectionStatus": "Connected",
           "provisioningState":"Succeeded"
-        }
+        },
+        "type": "Microsoft.Network/expressRouteCircuits/peerings/connections"
       }
     }
   }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/ExpressRouteCircuitPeeringGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/ExpressRouteCircuitPeeringGet.json
@@ -48,8 +48,12 @@
                         "legacyMode": 0,
                         "routingRegistryName": "ARIN"
                     }
+                },
+                "routeFilter": {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/routeFilters/filterName"
                 }
-            }
+            },
+            "type": "Microsoft.Network/expressRouteCircuits/peerings"
         }
     }
 }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/expressRouteCircuit.json
@@ -1441,6 +1441,11 @@
           "readOnly": true,
           "type": "string",
           "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Type of the resource."
         }
       },
       "allOf": [
@@ -1571,6 +1576,15 @@
       },
       "description": "Contains stats associated with the peering."
     },
+    "RouteFilterReference": {
+      "properties": {
+        "id": {
+          "type":"string",
+          "description": "Corresponding route filter Id."
+        }
+      },
+      "description": "Reference to a route filter."
+    },
     "ExpressRouteCircuitPeeringPropertiesFormat": {
       "properties": {
         "peeringType": {
@@ -1639,7 +1653,7 @@
           "description": "Gets whether the provider or the customer last modified the peering."
         },
         "routeFilter": {
-          "$ref": "./routeFilter.json#/definitions/RouteFilter",
+          "$ref": "#/definitions/RouteFilterReference",
           "description": "The reference of the RouteFilter resource."
         },
         "ipv6PeeringConfig": {
@@ -1683,6 +1697,11 @@
           "readOnly": true,
           "type": "string",
           "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Type of the resource."
         }
       },
       "allOf": [
@@ -1778,6 +1797,11 @@
           "readOnly": true,
           "type": "string",
           "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Type of the resource."
         }
       },
       "allOf": [
@@ -1852,6 +1876,11 @@
           "readOnly": true,
           "type": "string",
           "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Type of the resource."
         }
       },
       "allOf": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/routeFilter.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/routeFilter.json
@@ -687,6 +687,13 @@
                     },
                     "description": "A collection of references to express route circuit peerings."
                 },
+                "ipv6Peerings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "./expressRouteCircuit.json#/definitions/ExpressRouteCircuitPeering"
+                    },
+                    "description": "A collection of references to express route circuit ipv6 peerings."
+                },
                 "provisioningState": {
                     "type": "string",
                     "readOnly": true,


### PR DESCRIPTION
Added type field in child resources.
Fixed Routefilter reference.
Added ipv6peering field that was missing in the specs.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [X] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
