### PR TITLE
[Azure Search] Add indexer limits to IndexerExecutionInfo

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceGetIndexerStatus.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceGetIndexerStatus.json
@@ -57,7 +57,12 @@
                         "initialTrackingState": null,
                         "finalTrackingState": null
                     }
-                ]
+                ],
+                "limits": {
+                    "maxRunTime": "22:00:00",
+                    "maxDocumentExtractionSize": 256000000,
+                    "maxDocumentContentCharactersToExtract": 4000000
+                }
             }
         }
     }

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -3889,6 +3889,11 @@
             "$ref": "#/definitions/IndexerExecutionResult"
           },
           "description": "History of the recent indexer executions, sorted in reverse chronological order."
+        },
+        "limits" : {
+          "$ref": "#/definitions/IndexerLimits",
+          "readOnly": true,
+          "description": "The execution limits for the indexer."
         }
       },
       "description": "Represents the current status and execution history of an indexer."
@@ -3905,6 +3910,28 @@
       },
       "x-nullable": false,
       "description": "Represents the overall indexer status."
+    },
+    "IndexerLimits": {
+      "properties": {
+        "maxRunTime": {
+          "type": "string",
+          "format": "duration",
+          "readOnly": true,
+          "description": "The maximum duration that the indexer is permitted to run for one execution."
+        },
+        "maxDocumentExtractionSize": {
+          "type": "number",
+          "format": "int64",
+          "readOnly": true,
+          "description": "The maximum size of a document which will be considered valid for indexing."
+        },
+        "maxDocumentContentCharactersToExtract": {
+          "type": "number",
+          "format": "int64",
+          "readOnly": true,
+          "description": "The maximum number of characters that will be extracted from a document picked up for indexing."
+        }
+      }
     },
     "Field": {
       "properties": {

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -3923,7 +3923,7 @@
           "type": "number",
           "format": "int64",
           "readOnly": true,
-          "description": "The maximum size of a document which will be considered valid for indexing."
+          "description": "The maximum size of a document, in bytes, which will be considered valid for indexing."
         },
         "maxDocumentContentCharactersToExtract": {
           "type": "number",


### PR DESCRIPTION
Add to swagger and examples for the IndexerExecutionInfo model, IndexerLimits which is something the REST API started exposing a while back.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
