### PR TITLE
ExpressRouteCircuit: Use SubResource instead of creating new definition for RouteFilter reference

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/expressRouteCircuit.json
@@ -1533,7 +1533,7 @@
           "description": "The Microsoft peering configuration."
         },
         "routeFilter": {
-          "$ref": "./routeFilter.json#/definitions/RouteFilter",
+          "$ref": "./network.json#/definitions/SubResource",
           "description": "The reference of the RouteFilter resource."
         },
         "state": {
@@ -1575,15 +1575,6 @@
         }
       },
       "description": "Contains stats associated with the peering."
-    },
-    "RouteFilterReference": {
-      "properties": {
-        "id": {
-          "type":"string",
-          "description": "Corresponding route filter Id."
-        }
-      },
-      "description": "Reference to a route filter."
     },
     "ExpressRouteCircuitPeeringPropertiesFormat": {
       "properties": {
@@ -1653,7 +1644,7 @@
           "description": "Gets whether the provider or the customer last modified the peering."
         },
         "routeFilter": {
-          "$ref": "#/definitions/RouteFilterReference",
+          "$ref": "./network.json#/definitions/SubResource",
           "description": "The reference of the RouteFilter resource."
         },
         "ipv6PeeringConfig": {


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
