### PR TITLE
apimanagement: flattening `document` to a proper object

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/definitions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/definitions.json
@@ -4246,7 +4246,8 @@
           "description": "Must be a valid a media type used in a Content-Type header as defined in the RFC 2616. Media type of the schema document (e.g. application/json, application/xml). </br> - `Swagger` Schema use `application/vnd.ms-azure-apim.swagger.definitions+json` </br> - `WSDL` Schema use `application/vnd.ms-azure-apim.xsd+xml` </br> - `OpenApi` Schema use `application/vnd.oai.openapi.components+json` </br> - `WADL Schema` use `application/vnd.ms-azure-apim.wadl.grammars+xml`. "
         },
         "document": {
-          "type": "object",
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/SchemaDocumentProperties",
           "description": "Properties of the Schema Document."
         }
       },


### PR DESCRIPTION
This PR fixes a regression in the API Management version 2019-01-01 where the field was a concrete type in the previous API version (2018-01-01), but now returns a dictionary, which makes this field less usable:

https://github.com/Azure/azure-sdk-for-go/blob/v29.0.0/services/apimanagement/mgmt/2018-01-01/apimanagement/models.go#L8710

https://github.com/Azure/azure-sdk-for-go/blob/v29.0.0/services/apimanagement/mgmt/2019-01-01/apimanagement/models.go#L9269

---

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).