### PR TITLE
Output location updates to align with PR#5395 in azure-sdk-for-python

### DIFF
--- a/specification/managementgroups/resource-manager/readme.md
+++ b/specification/managementgroups/resource-manager/readme.md
@@ -109,12 +109,12 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-managementgroups/azure/mgmt/managementgroups
+  output-folder: $(python-sdks-folder)/managementgroups/azure-mgmt-managementgroups/azure/mgmt/managementgroups
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-managementgroups
+  output-folder: $(python-sdks-folder)/managementgroups/azure-mgmt-managementgroups
 ```
 
 ## Go

--- a/specification/mariadb/resource-manager/readme.md
+++ b/specification/mariadb/resource-manager/readme.md
@@ -104,12 +104,12 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-rdbms/azure/mgmt/rdbms/mariadb
+  output-folder: $(python-sdks-folder)/rdbms/azure-mgmt-rdbms/azure/mgmt/rdbms/mariadb
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-rdbms
+  output-folder: $(python-sdks-folder)/rdbms/azure-mgmt-rdbms
 ```
 
 ## Go

--- a/specification/marketplaceordering/resource-manager/readme.md
+++ b/specification/marketplaceordering/resource-manager/readme.md
@@ -118,12 +118,12 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-marketplaceordering/azure/mgmt/marketplaceordering
+  output-folder: $(python-sdks-folder)/marketplaceordering/azure-mgmt-marketplaceordering/azure/mgmt/marketplaceordering
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-marketplaceordering
+  output-folder: $(python-sdks-folder)/marketplaceordering/azure-mgmt-marketplaceordering
 ```
 
 Workaround invalid date-time returned by the server.

--- a/specification/mysql/resource-manager/readme.md
+++ b/specification/mysql/resource-manager/readme.md
@@ -113,12 +113,12 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-rdbms/azure/mgmt/rdbms/mysql
+  output-folder: $(python-sdks-folder)/rdbms/azure-mgmt-rdbms/azure/mgmt/rdbms/mysql
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-rdbms
+  output-folder: $(python-sdks-folder)/rdbms/azure-mgmt-rdbms
 ```
 
 ## Go

--- a/specification/netapp/resource-manager/readme.python.md
+++ b/specification/netapp/resource-manager/readme.python.md
@@ -19,11 +19,11 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-netapp/azure/mgmt/netapp
+  output-folder: $(python-sdks-folder)/netapp/azure-mgmt-netapp/azure/mgmt/netapp
 ```
 
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-netapp
+  output-folder: $(python-sdks-folder)/netapp/azure-mgmt-netapp
 ```

--- a/specification/notificationhubs/resource-manager/readme.md
+++ b/specification/notificationhubs/resource-manager/readme.md
@@ -129,12 +129,12 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-notificationhubs/azure/mgmt/notificationhubs
+  output-folder: $(python-sdks-folder)/notificationhubs/azure-mgmt-notificationhubs/azure/mgmt/notificationhubs
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-notificationhubs
+  output-folder: $(python-sdks-folder)/notificationhubs/azure-mgmt-notificationhubs
 ```
 
 ## Go

--- a/specification/postgresql/resource-manager/readme.md
+++ b/specification/postgresql/resource-manager/readme.md
@@ -103,12 +103,12 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-rdbms/azure/mgmt/rdbms/postgresql
+  output-folder: $(python-sdks-folder)/rdbms/azure-mgmt-rdbms/azure/mgmt/rdbms/postgresql
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-rdbms
+  output-folder: $(python-sdks-folder)/rdbms/azure-mgmt-rdbms
 ```
 
 ## Go

--- a/specification/powerbiembedded/resource-manager/readme.md
+++ b/specification/powerbiembedded/resource-manager/readme.md
@@ -96,12 +96,12 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-powerbiembedded/azure/mgmt/powerbiembedded
+  output-folder: $(python-sdks-folder)/powerbiembedded/azure-mgmt-powerbiembedded/azure/mgmt/powerbiembedded
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-powerbiembedded
+  output-folder: $(python-sdks-folder)/powerbiembedded/azure-mgmt-powerbiembedded
 ```
 
 ## Go

--- a/specification/privatedns/resource-manager/readme.python.md
+++ b/specification/privatedns/resource-manager/readme.python.md
@@ -18,10 +18,10 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/privatedns/azure-mgmt-privatedns/azure/mgmt/privatedns
+  output-folder: $(python-sdks-folder)/network/azure-mgmt-privatedns/azure/mgmt/privatedns
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/privatedns/azure-mgmt-privatedns
+  output-folder: $(python-sdks-folder)/network/azure-mgmt-privatedns
 ```

--- a/specification/privatedns/resource-manager/readme.python.md
+++ b/specification/privatedns/resource-manager/readme.python.md
@@ -18,10 +18,10 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-privatedns/azure/mgmt/privatedns
+  output-folder: $(python-sdks-folder)/privatedns/azure-mgmt-privatedns/azure/mgmt/privatedns
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-privatedns
+  output-folder: $(python-sdks-folder)/privatedns/azure-mgmt-privatedns
 ```


### PR DESCRIPTION
[Origin PR for changes](https://github.com/Azure/azure-sdk-for-python/pull/5395)

This PR will update the output location for swagger.

@lmazuel I noticed that `mariadb`, `postgressql`, and `mysql` all output to the same target location. I am assuming this is because this same package gets used for. That said, I am naming the service folder `rdbms`, given that it stretches across all 3.

Files I'm talking about: 
* specification/mariadb/resource-manager/readme.md
* specification/mysql/resource-manager/readme.md
* specification/postgresql/resource-manager/readme.md

@lmazuel for approval + double check.