### PR TITLE
Make subscription a method parameter

### DIFF
--- a/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/subscriptions.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/subscriptions.json
@@ -215,6 +215,7 @@
     },
     "subscriptionIdParameter": {
       "name": "subscriptionId",
+      "x-ms-parameter-location": "method",
       "in": "path",
       "required": true,
       "type": "string",


### PR DESCRIPTION
Subscription SDK is a special one where all is about subscription. By convention, operations should take subscription as a method parameter and not a client parameter, since the purpose is to act globally.

This was the case until the rename/cancel were added.