### PR TITLE
CosmosDB add Availability Zone option for locations

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/cosmos-db.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/cosmos-db.json
@@ -3096,6 +3096,10 @@
           "format": "int32",
           "type": "integer",
           "minimum": 0
+        },
+        "isZoneRedundant": {
+          "type": "boolean",
+          "description": "Flag to indicate whether or not this region is an AvailabilityZone region"
         }
       }
     },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMax.json
@@ -21,11 +21,13 @@
         "locations": [
           {
             "failoverPriority": 0,
-            "locationName": "southcentralus"
+            "locationName": "southcentralus",
+            "isAvailabilityZone": false
           },
           {
             "failoverPriority": 1,
-            "locationName": "eastus"
+            "locationName": "eastus",
+            "isAvailabilityZone": false
           }
         ],
         "consistencyPolicy": {
@@ -60,7 +62,8 @@
               "id": "ddb1-southcentralus",
               "locationName": "South Central US",
               "provisioningState": "Initializing",
-              "failoverPriority": 0
+              "failoverPriority": 0,
+              "isAvailabilityZone": false
             }
           ],
           "readLocations": [
@@ -68,13 +71,15 @@
               "id": "ddb1-southcentralus",
               "locationName": "South Central US",
               "provisioningState": "Initializing",
-              "failoverPriority": 0
+              "failoverPriority": 0,
+              "isAvailabilityZone": false
             },
             {
               "id": "ddb1-eastus",
               "locationName": "East US",
               "provisioningState": "Initializing",
-              "failoverPriority": 1
+              "failoverPriority": 1,
+              "isAvailabilityZone": false
             }
           ],
           "failoverPolicies": [

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMax.json
@@ -22,12 +22,12 @@
           {
             "failoverPriority": 0,
             "locationName": "southcentralus",
-            "isAvailabilityZone": false
+            "isZoneRedundant": false
           },
           {
             "failoverPriority": 1,
             "locationName": "eastus",
-            "isAvailabilityZone": false
+            "isZoneRedundant": false
           }
         ],
         "consistencyPolicy": {
@@ -63,7 +63,7 @@
               "locationName": "South Central US",
               "provisioningState": "Initializing",
               "failoverPriority": 0,
-              "isAvailabilityZone": false
+              "isZoneRedundant": false
             }
           ],
           "readLocations": [
@@ -72,14 +72,14 @@
               "locationName": "South Central US",
               "provisioningState": "Initializing",
               "failoverPriority": 0,
-              "isAvailabilityZone": false
+              "isZoneRedundant": false
             },
             {
               "id": "ddb1-eastus",
               "locationName": "East US",
               "provisioningState": "Initializing",
               "failoverPriority": 1,
-              "isAvailabilityZone": false
+              "isZoneRedundant": false
             }
           ],
           "failoverPolicies": [

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMin.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMin.json
@@ -11,7 +11,8 @@
         "locations": [
           {
             "failoverPriority": 0,
-            "locationName": "southcentralus"
+            "locationName": "southcentralus",
+            "isAvailabilityZone": false
           }
         ]
       }
@@ -40,7 +41,8 @@
               "id": "ddb1-southcentralus",
               "locationName": "South Central US",
               "provisioningState": "Initializing",
-              "failoverPriority": 0
+              "failoverPriority": 0,
+              "isAvailabilityZone": false
             }
           ],
           "readLocations": [
@@ -48,7 +50,8 @@
               "id": "ddb1-southcentralus",
               "locationName": "South Central US",
               "provisioningState": "Initializing",
-              "failoverPriority": 0
+              "failoverPriority": 0,
+              "isAvailabilityZone": false
             }
           ],
           "failoverPolicies": [

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMin.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2015-04-08/examples/CosmosDBDatabaseAccountCreateMin.json
@@ -12,7 +12,7 @@
           {
             "failoverPriority": 0,
             "locationName": "southcentralus",
-            "isAvailabilityZone": false
+            "isZoneRedundant": false
           }
         ]
       }
@@ -42,7 +42,7 @@
               "locationName": "South Central US",
               "provisioningState": "Initializing",
               "failoverPriority": 0,
-              "isAvailabilityZone": false
+              "isZoneRedundant": false
             }
           ],
           "readLocations": [
@@ -51,7 +51,7 @@
               "locationName": "South Central US",
               "provisioningState": "Initializing",
               "failoverPriority": 0,
-              "isAvailabilityZone": false
+              "isZoneRedundant": false
             }
           ],
           "failoverPolicies": [


### PR DESCRIPTION
This change allows users to specify if a location is zone redundant when creating or updating a CosmosDB account.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
