### PR TITLE
[Resource Graph] result format option added

### DIFF
--- a/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/stable/2019-04-01/resourcegraph.json
+++ b/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/stable/2019-04-01/resourcegraph.json
@@ -170,6 +170,18 @@
           "type": "integer",
           "format": "int32",
           "minimum": 0
+        },
+        "resultFormat": {
+          "description": "Defines in which format query result returned.",
+          "type": "string",
+          "enum": [
+            "table",
+            "objectArray"
+          ],
+          "x-ms-enum": {
+            "name": "ResultFormat",
+            "modelAsString": false
+          }
         }
       }
     },
@@ -255,7 +267,7 @@
         },
         "data": {
           "description": "Query output in tabular format.",
-          "$ref": "#/definitions/Table"
+          "type": "object"
         },
         "facets": {
           "description": "Query facets.",
@@ -358,7 +370,7 @@
       ],
       "discriminator": "resultType"
     },
-    "FacetResult" : {
+    "FacetResult": {
       "x-ms-discriminator-value": "FacetResult",
       "description": "Successfully executed facet containing additional statistics on the response of a query.",
       "type": "object",
@@ -375,7 +387,7 @@
         },
         "data": {
           "description": "A table containing the desired facets. Only present if the facet is valid.",
-          "$ref": "#/definitions/Table"
+          "type": "object"
         }
       },
       "required": [
@@ -389,7 +401,7 @@
         }
       ]
     },
-    "FacetError" : {
+    "FacetError": {
       "x-ms-discriminator-value": "FacetError",
       "description": "A facet whose execution resulted in an error.",
       "type": "object",
@@ -473,7 +485,7 @@
       ]
     },
     "OperationListResult": {
-     "description": "Result of the request to list Resource Graph operations. It contains a list of operations and a URL link to get the next set of results.",
+      "description": "Result of the request to list Resource Graph operations. It contains a list of operations and a URL link to get the next set of results.",
       "properties": {
         "value": {
           "type": "array",
@@ -513,7 +525,7 @@
           }
         },
         "origin": {
-          "type" : "string",
+          "type": "string",
           "description": "The origin of operations."
         }
       }

--- a/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/stable/2019-04-01/resourcegraph.json
+++ b/specification/resourcegraph/resource-manager/Microsoft.ResourceGraph/stable/2019-04-01/resourcegraph.json
@@ -266,8 +266,7 @@
           "type": "string"
         },
         "data": {
-          "description": "Query output in tabular format.",
-          "type": "object"
+          "description": "Query output in tabular format."
         },
         "facets": {
           "description": "Query facets.",
@@ -386,8 +385,7 @@
           "format": "int32"
         },
         "data": {
-          "description": "A table containing the desired facets. Only present if the facet is valid.",
-          "type": "object"
+          "description": "A table containing the desired facets. Only present if the facet is valid."
         }
       },
       "required": [


### PR DESCRIPTION
## Context:
Currently Resource Graph returns response in Table format:
data: { column: [],  rows: [] }
This format is good for portal, but is different from ARM response. 
Customers are doing custom conversion from that format to array format on their side. 
They are asking us to support array format also. For example, Adobe, VM blade were asking for it.
 
We are expanding result format with new option array for objects:
      data: []
 
## Problem:
Currently, the problem is how to achieve it with less overhead for customers.

We were considering options:
**1. New operation** (/Microsoft.ResourcesTopology/listresources **/array** ?api-version=2019-04-01)
PROS: no breaking change
CONS: confusing for customers, hard to add 3rd response type

**2. New property in query result**
If current format is requested:   {"data": {...},   "objects": null}
if new format:                           {"data": null,   "objects": [ ... ]}
PROS: not confusing
CONS: breaking change, require new api-version, hard to add 3rd response type, customers will wait longer for feature

**3. Return Table or Array from existing operation depending on provided value in query param ResultFormat.**
PROS: easy to expand with new response type,  least overheads, customers like it, existing SDK version continues to work.
CONS: new SDK version is required to be published.

As a team we feel option-3 is the best for our customers and with least overheads, and only con is we need to generate new SDK version. _**Existing SDK version continues to work.**_

**Points:**
We agree that it isn’t ideal to make customers modify code after sdk update, but we saw such behavior in many standard libraries.
All considered designs aren’t ideal anyway and have its disadvantages. 

## Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
