### PR TITLE
[AzureSearch] Revert exposing Skill.Name in the swagger spec

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceCreateOrUpdateSkillset.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceCreateOrUpdateSkillset.json
@@ -96,7 +96,6 @@
 				"skills": [
 					{
 						"@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
-						"name": "MyLanguageERSkill",
 						"description": null,
 						"context": null,
 						"inputs": [
@@ -119,7 +118,6 @@
 					},
 					{
 						"@odata.type": "#Microsoft.Skills.Text.LanguageDetectionSkill",
-						"name": "MyLanguageDetectionSkill",
 						"description": null,
 						"context": null,
 						"inputs": [
@@ -137,7 +135,6 @@
 					},
 					{
 						"@odata.type": "#Microsoft.Skills.Text.SplitSkill",
-						"name": "MyLanguageSplitSkill",
 						"description": null,
 						"context": null,
 						"inputs": [
@@ -162,7 +159,6 @@
 					},
 					{
 						"@odata.type": "#Microsoft.Skills.Text.KeyPhraseExtractionSkill",
-						"name": "MyKeyPhraseSkill",
 						"description": null,
 						"context": "/document/pages/*",
 						"inputs": [

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -4548,7 +4548,7 @@
         },
         "name": {
           "type": "string",
-          "description": "The name of the skill which uniquely identifies it within the skillset. A skill with no name defined will be given a default name of its 1-based index in the skills array."
+          "description": "The name of the skill which uniquely identifies the skill within the skillset. Skills with no skill name defined will be given a default name of its index in the skillset array."
         },
         "description": {
           "type": "string",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -4546,10 +4546,6 @@
         "@odata.type": {
           "type": "string"
         },
-        "name": {
-          "type": "string",
-          "description": "The name of the skill which uniquely identifies the skill within the skillset. Skills with no skill name defined will be given a default name of its index in the skillset array."
-        },
         "description": {
           "type": "string",
           "description": "The description of the skill which describes the inputs, outputs, and usage of the skill."


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
