### PR TITLE
Add elevateAccess to Microsoft.Authorization

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2015-07-01/authorization-ElevateAccessCalls.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2015-07-01/authorization-ElevateAccessCalls.json
@@ -39,7 +39,7 @@
         "tags": [
           "ElevateAccess"
         ],
-        "operationId": "ElevateAccess_Post",
+        "operationId": "GlobalAdministrator_ElevateAccess",
         "description": "Elevates access for a Global Administrator.",
         "parameters": [
           {

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2015-07-01/authorization-ElevateAccessCalls.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2015-07-01/authorization-ElevateAccessCalls.json
@@ -1,0 +1,71 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "AuthorizationManagementClient",
+    "version": "2015-07-01",
+    "description": "Role based access control provides you a way to apply granular level policy administration down to individual resources or resource groups. These operations enable you to manage role definitions and role assignments. A role definition describes the set of actions that can be performed on resources. A role assignment grants access to Azure Active Directory users."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/providers/Microsoft.Authorization/elevateAccess": {
+      "post": {
+        "tags": [
+          "ElevateAccess"
+        ],
+        "operationId": "ElevateAccess_Post",
+        "description": "Elevates access for a Global Administrator.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an HttpResponseMessage with HttpStatusCode 200."
+          }
+        },
+        "x-ms-examples": {
+          "GetConfigurations": {
+            "$ref": "./examples/ElevateAccess.json"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The API version to use for this operation."
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2015-07-01/examples/ElevateAccess.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2015-07-01/examples/ElevateAccess.json
@@ -1,0 +1,9 @@
+{
+  "parameters": {
+    "api-version": "2015-07-01"
+  },
+  "responses": {
+    "200": {
+    }
+  }
+}

--- a/specification/authorization/resource-manager/readme.md
+++ b/specification/authorization/resource-manager/readme.md
@@ -73,7 +73,9 @@ These settings apply only when `--tag=package-2015-07-01-preview` is specified o
 
 ``` yaml $(tag) == 'package-2015-07-01-preview'
 input-file:
+- Microsoft.Authorization/preview/2015-06-01/authorization-ClassicAdminCalls.json
 - Microsoft.Authorization/preview/2015-07-01/authorization.json
+- Microsoft.Authorization/preview/2015-07-01/authorization-ElevateAccessCalls.json
 ```
 
 ### Tag: package-2017-10-01-preview-only
@@ -122,6 +124,7 @@ These settings apply only when `--tag=package-2017-10-01-preview` is specified o
 input-file:
 - Microsoft.Authorization/preview/2015-06-01/authorization-ClassicAdminCalls.json
 - Microsoft.Authorization/preview/2015-07-01/authorization.json
+- Microsoft.Authorization/preview/2015-07-01/authorization-ElevateAccessCalls.json
 - Microsoft.Authorization/preview/2017-10-01-preview/authorization-RACalls.json
 ```
 
@@ -132,6 +135,7 @@ These settings apply only when `--tag=package-2018-01-01-preview` is specified o
 ``` yaml $(tag) == 'package-2018-01-01-preview'
 input-file:
 - Microsoft.Authorization/preview/2015-06-01/authorization-ClassicAdminCalls.json
+- Microsoft.Authorization/preview/2015-07-01/authorization-ElevateAccessCalls.json
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-ProviderOperationsCalls.json
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-RoleAssignmentsCalls.json
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-RoleDefinitionsCalls.json
@@ -144,6 +148,7 @@ These settings apply only when `--tag=package-2018-07-01-preview` is specified o
 ``` yaml $(tag) == 'package-2018-07-01-preview'
 input-file:
 - Microsoft.Authorization/preview/2015-06-01/authorization-ClassicAdminCalls.json
+- Microsoft.Authorization/preview/2015-07-01/authorization-ElevateAccessCalls.json
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-ProviderOperationsCalls.json
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-RoleAssignmentsCalls.json
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-RoleDefinitionsCalls.json
@@ -157,6 +162,7 @@ These settings apply only when `--tag=package-2018-09-01-preview` is specified o
 ``` yaml $(tag) == 'package-2018-09-01-preview'
 input-file:
 - Microsoft.Authorization/preview/2015-06-01/authorization-ClassicAdminCalls.json
+- Microsoft.Authorization/preview/2015-07-01/authorization-ElevateAccessCalls.json
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-ProviderOperationsCalls.json
 - Microsoft.Authorization/preview/2018-09-01-preview/authorization-RoleAssignmentsCalls.json
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-RoleDefinitionsCalls.json


### PR DESCRIPTION
elevateAccess was only present in an old stable version of
Microsoft.Authorization, which was not used for SDK generation. This
change moves the elevateAccess call to a version that can then be added
to the readme and used for SDK generation.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps. (This doesn't work for me 😢)
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
