### PR TITLE
Microsoft.HanaOnAzure: Remove readOnly attribute from customer-provided properties in CreateHanaInstance

### DIFF
--- a/specification/hanaonazure/resource-manager/Microsoft.HanaOnAzure/preview/2017-11-03-preview/hanaonazure.json
+++ b/specification/hanaonazure/resource-manager/Microsoft.HanaOnAzure/preview/2017-11-03-preview/hanaonazure.json
@@ -448,7 +448,6 @@
           "description": "Resource type"
         },
         "location": {
-          "readOnly": true,
           "type": "string",
           "description": "Resource location"
         },
@@ -545,7 +544,6 @@
           "description": "Hardware revision of a HANA instance"
         },
         "partnerNodeId": {
-          "readOnly": true,
           "type": "string",
           "description": "ARM ID of another HanaInstance that will share a network with this HanaInstance"
         },

--- a/specification/hanaonazure/resource-manager/Microsoft.HanaOnAzure/preview/2017-11-03-preview/hanaonazure.json
+++ b/specification/hanaonazure/resource-manager/Microsoft.HanaOnAzure/preview/2017-11-03-preview/hanaonazure.json
@@ -662,7 +662,6 @@
     "OSProfile": {
       "properties": {
         "computerName": {
-          "readOnly": true,
           "type": "string",
           "description": "Specifies the host OS name of the HANA instance."
         },
@@ -677,7 +676,6 @@
           "description": "Specifies version of operating system."
         },
         "sshPublicKey": {
-          "readOnly": true,
           "type": "string",
           "description": "Specifies the SSH public key used to access the operating system."
         }
@@ -704,7 +702,6 @@
     "IpAddress": {
       "properties": {
         "ipAddress": {
-          "readOnly": true,
           "type": "string",
           "description": "Specifies the IP address of the network interface."
         }


### PR DESCRIPTION
After completing https://github.com/Azure/azure-rest-api-specs/pull/5945, I discovered I could not update our CLI extension to call the Create HanaInstance API as expected as some properties were marked as read-only in the Swagger. This PR resolves this.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [X] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
