### PR TITLE
chore: Remove Travis-CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Repo Status](http://img.shields.io/travis/Azure/azure-rest-api-specs/master.svg?style=flat-square&label=repo-status)](https://travis-ci.org/Azure/azure-rest-api-specs)
-
 # Azure REST API Specifications
 
 ## Description


### PR DESCRIPTION
Wasn't sure if the Azure DevOps badge should be added, but that could be done separately