### PR TITLE
[HDInsight] Fix syntax error in description of subDomainSuffix parameter

### DIFF
--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/stable/2018-06-01-preview/applications.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/stable/2018-06-01-preview/applications.json
@@ -253,7 +253,7 @@
         },
         "subDomainSuffix": {
           "type": "string",
-          "description": "The subDomainSuffix of the application and can not greater than 3 characters."
+          "description": "The subDomainSuffix of the application."
         },
         "disableGatewayAuth": {
           "type": "boolean",


### PR DESCRIPTION
This PR is related to previous PR [[HDInsight] Fix specs not support subdomainsuffix parameter](https://github.com/Azure/azure-rest-api-specs/pull/6150) which has been merged.

In previous PR there is a syntax error in the description of subDomainSuffix parameter, this PR fixed it.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
