### PR TITLE
Support single role restore for Azure Stack infrastructure backup

### DIFF
--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/Backups.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/Backups.json
@@ -275,6 +275,10 @@
     "RestoreOptions": {
       "description": "Properties for restore options.",
       "properties": {
+        "RoleName": {
+          "description": "The Azure Stack role name for restore, use \"-\" for infrastructure role",
+          "type": "string"
+        },
         "decryptionCertBase64": {
           "description": "The certificate file raw data in Base64 string. This should be the .pfx file with the private key.",
           "type": "string"

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/Backups.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/Backups.json
@@ -99,6 +99,9 @@
         "x-ms-examples": {
           "Restore a backup.": {
             "$ref": "./examples/Backups/Restore.json"
+          },
+          "Restore a single role from backup.": {
+            "$ref": "./examples/Backups/SingleRepoRestore.json"
           }
         },
         "description": "Restore a backup.",

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/Backups.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/Backups.json
@@ -275,8 +275,8 @@
     "RestoreOptions": {
       "description": "Properties for restore options.",
       "properties": {
-        "RoleName": {
-          "description": "The Azure Stack role name for restore, use \"-\" for infrastructure role",
+        "roleName": {
+          "description": "The Azure Stack role name for restore, use \"-\" for all infrastructure role",
           "type": "string"
         },
         "decryptionCertBase64": {

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/Backups.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/Backups.json
@@ -276,7 +276,7 @@
       "description": "Properties for restore options.",
       "properties": {
         "roleName": {
-          "description": "The Azure Stack role name for restore, use \"-\" for all infrastructure role",
+          "description": "The Azure Stack role name for restore, set it to empty for all infrastructure role",
           "type": "string"
         },
         "decryptionCertBase64": {

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/Restore.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/Restore.json
@@ -5,7 +5,6 @@
     "location": "local",
     "backup": "64e8625a-8dc0-49df-a195-932901b4be81",
     "restoreOptions": {
-      "roleName": "-",
       "decryptionCertBase64": "decryptionCert",
       "decryptionCertPassword": "decryptionCertPassword"
     },

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/Restore.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/Restore.json
@@ -5,7 +5,7 @@
     "location": "local",
     "backup": "64e8625a-8dc0-49df-a195-932901b4be81",
     "restoreOptions": {
-      "RoleName": "-",
+      "roleName": "-",
       "decryptionCertBase64": "decryptionCert",
       "decryptionCertPassword": "decryptionCertPassword"
     },

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/Restore.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/Restore.json
@@ -5,6 +5,7 @@
     "location": "local",
     "backup": "64e8625a-8dc0-49df-a195-932901b4be81",
     "restoreOptions": {
+      "RoleName": "-",
       "decryptionCertBase64": "decryptionCert",
       "decryptionCertPassword": "decryptionCertPassword"
     },

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/SingleRepoRestore.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/SingleRepoRestore.json
@@ -1,0 +1,19 @@
+{
+    "parameters": {
+      "subscriptionId": "11111111-2222-3333-4444-555555555555",
+      "resourceGroupName": "System.local",
+      "location": "local",
+      "backup": "64e8625a-8dc0-49df-a195-932901b4be81",
+      "restoreOptions": {
+        "roleName": "fakerp",
+        "decryptionCertBase64": "decryptionCert",
+        "decryptionCertPassword": "decryptionCertPassword"
+      },
+      "api-version": "2018-09-01"
+    },
+    "responses": {
+      "200": {},
+      "202": {}
+    }
+  }
+  


### PR DESCRIPTION
Previous api only support restore all infrastructure role, add an option to support single role restore.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
