### PR TITLE
typo: vmwarecloudsimple

### DIFF
--- a/specification/vmwarecloudsimple/resource-manager/Microsoft.VMwareCloudSimple/stable/2019-04-01/vmwarecloudsimple.json
+++ b/specification/vmwarecloudsimple/resource-manager/Microsoft.VMwareCloudSimple/stable/2019-04-01/vmwarecloudsimple.json
@@ -147,7 +147,7 @@
     },
     "/subscriptions/{subscriptionId}/providers/Microsoft.VMwareCloudSimple/dedicatedCloudServices": {
       "get": {
-        "description": "Returns list of dedicated cloud service within within subscription",
+        "description": "Returns list of dedicated cloud services within a subscription",
         "consumes": [
           "application/json"
         ],


### PR DESCRIPTION

- Double word "within"