### PR TITLE
fix: Casing for Microsoft.Kusto enums in examples

### DIFF
--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersCheckNameAvailability.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersCheckNameAvailability.json
@@ -5,7 +5,7 @@
     "location": "wus",
     "clusterName": {
       "name": "kuskusprod",
-      "type": "Microsoft.Kusto/Clusters"
+      "type": "Microsoft.Kusto/clusters"
     }
   },
   "responses": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersCreateOrUpdate.json
@@ -16,9 +16,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersGet.json
@@ -8,9 +8,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersList.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersList.json
@@ -8,9 +8,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
             "name": "KustoClusterRPTest4",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
             "location": "westus",
             "properties": {
@@ -23,9 +23,9 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest3",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest3",
             "name": "KustoClusterRPTest3",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
             "location": "westus",
             "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersListByResourceGroup.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersListByResourceGroup.json
@@ -9,9 +9,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
             "name": "KustoClusterRPTest4",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
             "location": "westus",
             "properties": {
@@ -24,9 +24,9 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest3",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest3",
             "name": "KustoClusterRPTest3",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
             "location": "westus",
             "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoClustersUpdate.json
@@ -11,9 +11,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesCheckNameAvailability.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesCheckNameAvailability.json
@@ -6,7 +6,7 @@
     "clusterName": "kustoProd",
     "databaseName": {
       "name": "kuskus",
-      "type": "Microsoft.Kusto/Clusters/Databases"
+      "type": "Microsoft.Kusto/clusters/databases"
     }
   },
   "responses": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesCreateOrUpdate.json
@@ -15,7 +15,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesCreateOrUpdate.json
@@ -17,7 +17,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesGet.json
@@ -11,7 +11,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesGet.json
@@ -9,7 +9,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesListByCluster.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesListByCluster.json
@@ -10,7 +10,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
             "type": "Microsoft.Kusto/clusters/databases",
             "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
@@ -21,7 +21,7 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
             "type": "Microsoft.Kusto/clusters/databases",
             "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesListByCluster.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesListByCluster.json
@@ -12,7 +12,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
             "location": "westus",
             "properties": {
@@ -23,7 +23,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
             "location": "westus",
             "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesUpdate.json
@@ -15,7 +15,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoDatabasesUpdate.json
@@ -17,7 +17,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsCreateOrUpdate.json
@@ -17,7 +17,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsCreateOrUpdate.json
@@ -19,7 +19,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",
         "properties": {
           "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns1/eventhubs/eventhubTest1",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsGet.json
@@ -12,7 +12,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",
         "properties": {
           "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns1/eventhubs/eventhubTest1",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsGet.json
@@ -10,7 +10,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsListByDatabase.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsListByDatabase.json
@@ -11,7 +11,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
             "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",
@@ -21,7 +21,7 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
             "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsListByDatabase.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsListByDatabase.json
@@ -13,7 +13,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",
             "properties": {
               "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns1/eventhubs/eventhubTest1",
@@ -23,7 +23,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",
             "properties": {
               "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns2/eventhubs/eventhubTest2",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsUpdate.json
@@ -17,7 +17,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2017-09-07-privatepreview/examples/KustoEventHubConnectionsUpdate.json
@@ -19,7 +19,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",
         "properties": {
           "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns1/eventhubs/eventhubTest1",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersCheckNameAvailability.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersCheckNameAvailability.json
@@ -5,7 +5,7 @@
     "location": "wus",
     "clusterName": {
       "name": "kuskusprod",
-      "type": "Microsoft.Kusto/Clusters"
+      "type": "Microsoft.Kusto/clusters"
     }
   },
   "responses": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersCreateOrUpdate.json
@@ -16,9 +16,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersGet.json
@@ -8,9 +8,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersList.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersList.json
@@ -8,9 +8,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
             "name": "KustoClusterRPTest4",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
             "location": "westus",
             "properties": {
@@ -23,9 +23,9 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest3",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest3",
             "name": "KustoClusterRPTest3",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
             "location": "westus",
             "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersListByResourceGroup.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersListByResourceGroup.json
@@ -9,9 +9,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
             "name": "KustoClusterRPTest4",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
             "location": "westus",
             "properties": {
@@ -24,9 +24,9 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest3",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest3",
             "name": "KustoClusterRPTest3",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
             "location": "westus",
             "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoClustersUpdate.json
@@ -11,9 +11,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "etag": "W/\"datetime'2017-12-06T12%3A05%3A57.2528942Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesCheckNameAvailability.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesCheckNameAvailability.json
@@ -6,7 +6,7 @@
     "clusterName": "kustoProd",
     "databaseName": {
       "name": "kuskus",
-      "type": "Microsoft.Kusto/Clusters/Databases"
+      "type": "Microsoft.Kusto/clusters/databases"
     }
   },
   "responses": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesCreateOrUpdate.json
@@ -15,7 +15,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesCreateOrUpdate.json
@@ -17,7 +17,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesGet.json
@@ -11,7 +11,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesGet.json
@@ -9,7 +9,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesListByCluster.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesListByCluster.json
@@ -10,7 +10,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
             "type": "Microsoft.Kusto/clusters/databases",
             "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
@@ -21,7 +21,7 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
             "type": "Microsoft.Kusto/clusters/databases",
             "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesListByCluster.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesListByCluster.json
@@ -12,7 +12,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
             "location": "westus",
             "properties": {
@@ -23,7 +23,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
             "location": "westus",
             "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesUpdate.json
@@ -15,7 +15,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoDatabasesUpdate.json
@@ -17,7 +17,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "etag": "W/\"datetime'2017-12-05T15%3A28%3A05.732611Z'\"",
         "location": "westus",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsCreateOrUpdate.json
@@ -17,7 +17,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsCreateOrUpdate.json
@@ -19,7 +19,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",
         "properties": {
           "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns1/eventhubs/eventhubTest1",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsGet.json
@@ -12,7 +12,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",
         "properties": {
           "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns1/eventhubs/eventhubTest1",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsGet.json
@@ -10,7 +10,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsListByDatabase.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsListByDatabase.json
@@ -11,7 +11,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
             "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",
@@ -21,7 +21,7 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
             "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsListByDatabase.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsListByDatabase.json
@@ -13,7 +13,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",
             "properties": {
               "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns1/eventhubs/eventhubTest1",
@@ -23,7 +23,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",
             "properties": {
               "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns2/eventhubs/eventhubTest2",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsUpdate.json
@@ -17,7 +17,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/preview/2018-09-07-preview/examples/KustoEventHubConnectionsUpdate.json
@@ -19,7 +19,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",
         "properties": {
           "eventHubResourceId": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.EventHub/namespaces/eventhubTestns1/eventhubs/eventhubTest1",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersCreateOrUpdate.json
@@ -16,9 +16,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded"
@@ -32,9 +32,9 @@
     },
     "201": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded"

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersGet.json
@@ -8,9 +8,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded"

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersList.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersList.json
@@ -8,9 +8,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
             "name": "KustoClusterRPTest4",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded"
@@ -22,9 +22,9 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest3",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest3",
             "name": "KustoClusterRPTest3",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded"

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersListByResourceGroup.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersListByResourceGroup.json
@@ -9,9 +9,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
             "name": "KustoClusterRPTest4",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded"
@@ -23,9 +23,9 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest3",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest3",
             "name": "KustoClusterRPTest3",
-            "type": "Microsoft.Kusto/Clusters",
+            "type": "Microsoft.Kusto/clusters",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded"

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoClustersUpdate.json
@@ -11,9 +11,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded"
@@ -27,9 +27,9 @@
     },
     "201": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4",
         "name": "KustoClusterRPTest4",
-        "type": "Microsoft.Kusto/Clusters",
+        "type": "Microsoft.Kusto/clusters",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded"

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsCreateOrUpdate.json
@@ -18,7 +18,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
         "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",
@@ -31,7 +31,7 @@
     },
     "201": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
         "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsCreateOrUpdate.json
@@ -20,7 +20,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
-        "type": "Microsoft.Kusto/Clusters/Databases/DataConnections",
+        "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",
         "kind": "EventHub",
         "properties": {
@@ -33,7 +33,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
-        "type": "Microsoft.Kusto/Clusters/Databases/DataConnections",
+        "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",
         "kind": "EventHub",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsGet.json
@@ -10,7 +10,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
         "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsGet.json
@@ -12,7 +12,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
-        "type": "Microsoft.Kusto/Clusters/Databases/DataConnections",
+        "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",
         "kind": "EventHub",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsListByDatabase.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsListByDatabase.json
@@ -11,7 +11,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/KustoDataConnection8",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/KustoDataConnection8",
             "name": "KustoClusterRPTest4/KustoDatabase8/KustoDataConnection8",
             "type": "Microsoft.Kusto/clusters/databases/DataConnections",
             "location": "westus",
@@ -22,7 +22,7 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9/DataConnections/KustoDataConnection9",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase9/DataConnections/KustoDataConnection9",
             "name": "KustoClusterRPTest4/KustoDatabase9/KustoDataConnection9",
             "type": "Microsoft.Kusto/clusters/databases/DataConnections",
             "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsListByDatabase.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsListByDatabase.json
@@ -13,7 +13,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/KustoDataConnection8",
             "name": "KustoClusterRPTest4/KustoDatabase8/KustoDataConnection8",
-            "type": "Microsoft.Kusto/Clusters/Databases/DataConnections",
+            "type": "Microsoft.Kusto/clusters/databases/DataConnections",
             "location": "westus",
             "kind": "EventHub",
             "properties": {
@@ -24,7 +24,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9/DataConnections/KustoDataConnection9",
             "name": "KustoClusterRPTest4/KustoDatabase9/KustoDataConnection9",
-            "type": "Microsoft.Kusto/Clusters/Databases/DataConnections",
+            "type": "Microsoft.Kusto/clusters/databases/DataConnections",
             "location": "westus",
             "kind": "EventHub",
             "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsUpdate.json
@@ -18,7 +18,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
         "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",
@@ -31,7 +31,7 @@
     },
     "201": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
         "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDataConnectionsUpdate.json
@@ -20,7 +20,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
-        "type": "Microsoft.Kusto/Clusters/Databases/DataConnections",
+        "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",
         "kind": "EventHub",
         "properties": {
@@ -33,7 +33,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8/DataConnections/DataConnections8",
         "name": "KustoClusterRPTest4/KustoDatabase8/DataConnections8",
-        "type": "Microsoft.Kusto/Clusters/Databases/DataConnections",
+        "type": "Microsoft.Kusto/clusters/databases/DataConnections",
         "location": "westus",
         "kind": "EventHub",
         "properties": {

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesCreateOrUpdate.json
@@ -17,7 +17,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",
         "properties": {
           "softDeletePeriod": "P1D",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesCreateOrUpdate.json
@@ -15,7 +15,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesGet.json
@@ -9,7 +9,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesGet.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesGet.json
@@ -11,7 +11,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",
         "properties": {
           "softDeletePeriod": "P1D",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesListByCluster.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesListByCluster.json
@@ -12,7 +12,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",
             "properties": {
               "softDeletePeriod": "P1D",
@@ -22,7 +22,7 @@
           {
             "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
-            "type": "Microsoft.Kusto/Clusters/Databases",
+            "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",
             "properties": {
               "softDeletePeriod": "P1D",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesListByCluster.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesListByCluster.json
@@ -10,7 +10,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
             "name": "KustoClusterRPTest4/KustoDatabase8",
             "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",
@@ -20,7 +20,7 @@
             }
           },
           {
-            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase9",
             "name": "KustoClusterRPTest4/KustoDatabase9",
             "type": "Microsoft.Kusto/clusters/databases",
             "location": "westus",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesUpdate.json
@@ -17,7 +17,7 @@
       "body": {
         "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
-        "type": "Microsoft.Kusto/Clusters/Databases",
+        "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",
         "properties": {
           "softDeletePeriod": "P1D",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2019-01-21/examples/KustoDatabasesUpdate.json
@@ -15,7 +15,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/Clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789098/resourceGroups/kustorptest/providers/Microsoft.Kusto/clusters/KustoClusterRPTest4/Databases/KustoDatabase8",
         "name": "KustoClusterRPTest4/KustoDatabase8",
         "type": "Microsoft.Kusto/clusters/databases",
         "location": "westus",


### PR DESCRIPTION
Casing for the 2 enums was flagged by oav