### PR TITLE
fix: hdinsight model validation

### DIFF
--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2015-03-01-preview/examples/GetHDInsightCapabilities.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2015-03-01-preview/examples/GetHDInsightCapabilities.json
@@ -6,19 +6,19 @@
   },
   "responses": {
     "200": {
-      "Body": {
+      "body": {
         "versions": {
           "paas": {
             "available": [
               {
                 "friendlyName": "1.6",
                 "displayName": "HdInsight version 1.6.1.0.335536",
-                "isDefault": false
+                "isDefault": "false"
               },
               {
                 "friendlyName": "2.1",
                 "displayName": "Version 2.1.9.406.1221105",
-                "isDefault": false,
+                "isDefault": "false",
                 "componentVersions": {
                   "HDP": "1.3",
                   "Hadoop": "1.2.0"
@@ -27,7 +27,7 @@
               {
                 "friendlyName": "3.0",
                 "displayName": "Version 3.0.6.989.2441725",
-                "isDefault": false,
+                "isDefault": "false",
                 "componentVersions": {
                   "HDP": "2.0",
                   "Hadoop": "2.2.0"
@@ -36,7 +36,7 @@
               {
                 "friendlyName": "3.1",
                 "displayName": "Version 3.1.4.989.2441725",
-                "isDefault": false,
+                "isDefault": "false",
                 "componentVersions": {
                   "HDP": "2.1.7",
                   "Hadoop": "2.4.0",
@@ -46,7 +46,7 @@
               {
                 "friendlyName": "3.2",
                 "displayName": "Version 3.2.7.989.2441725",
-                "isDefault": false,
+                "isDefault": "false",
                 "componentVersions": {
                   "HDP": "2.2",
                   "Hadoop": "2.6.0",
@@ -57,7 +57,7 @@
               {
                 "friendlyName": "3.3",
                 "displayName": "Version 3.3.0.989.2441725",
-                "isDefault": true,
+                "isDefault": "true",
                 "componentVersions": {
                   "HDP": "2.3",
                   "Hadoop": "2.7.0",
@@ -72,7 +72,7 @@
               {
                 "friendlyName": "3.2",
                 "displayName": "Version 3.2.1000.0.8840373",
-                "isDefault": false,
+                "isDefault": "false",
                 "componentVersions": {
                   "HDP": "2.2",
                   "Hadoop": "2.6.0",
@@ -83,7 +83,7 @@
               {
                 "friendlyName": "3.3",
                 "displayName": "Version 3.3.1000.0.9776961",
-                "isDefault": false,
+                "isDefault": "false",
                 "componentVersions": {
                   "HDP": "2.3",
                   "Hadoop": "2.7.0",
@@ -95,7 +95,7 @@
               {
                 "friendlyName": "3.4",
                 "displayName": "Version 3.4.1000.0.9719475",
-                "isDefault": false,
+                "isDefault": "false",
                 "componentVersions": {
                   "HDP": "2.4",
                   "Hadoop": "2.7.1",
@@ -108,7 +108,7 @@
               {
                 "friendlyName": "3.5",
                 "displayName": "Version 3.5.1000.0.9732704",
-                "isDefault": true,
+                "isDefault": "true",
                 "componentVersions": {
                   "HDP": "2.5",
                   "Hadoop": "2.7.3",
@@ -122,7 +122,7 @@
               {
                 "friendlyName": "3.6",
                 "displayName": "Version 3.6.1000.0.9503998",
-                "isDefault": false,
+                "isDefault": "false",
                 "componentVersions": {
                   "HDP": "2.6",
                   "Spark": "2.1.0"
@@ -131,7 +131,7 @@
               {
                 "friendlyName": "99.152",
                 "displayName": "Version 99.152.1000.0.6943836",
-                "isDefault": false
+                "isDefault": "false"
               }
             ]
           }
@@ -184,7 +184,7 @@
             ]
           }
         },
-        "vmsizes": {
+        "vmSizes": {
           "paas": {
             "available": [
               "A5",
@@ -242,7 +242,7 @@
             ]
           }
         },
-        "vmsize_filters": [
+        "vmSize_filters": [
           {
             "FilterMode": "Exclude",
             "Regions": [
@@ -257,10 +257,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A5"
             ]
           },
@@ -280,10 +277,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A5"
             ]
           },
@@ -302,10 +296,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A5"
             ]
           },
@@ -325,10 +316,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A5"
             ]
           },
@@ -347,10 +335,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A5"
             ]
           },
@@ -368,10 +353,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A6"
             ]
           },
@@ -390,10 +372,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A6"
             ]
           },
@@ -413,10 +392,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A6"
             ]
           },
@@ -435,10 +411,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A6"
             ]
           },
@@ -456,10 +429,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A7"
             ]
           },
@@ -478,10 +448,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A7"
             ]
           },
@@ -501,10 +468,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A7"
             ]
           },
@@ -523,10 +487,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "A7"
             ]
           },
@@ -544,10 +505,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "EXTRALARGE"
             ]
           },
@@ -566,10 +524,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "EXTRALARGE"
             ]
           },
@@ -591,10 +546,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "EXTRALARGE"
             ]
           },
@@ -613,10 +565,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "EXTRALARGE"
             ]
           },
@@ -634,10 +583,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "LARGE"
             ]
           },
@@ -656,10 +602,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "LARGE"
             ]
           },
@@ -679,10 +622,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "LARGE"
             ]
           },
@@ -701,10 +641,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "LARGE"
             ]
           },
@@ -722,10 +659,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "MEDIUM"
             ]
           },
@@ -745,10 +679,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "MEDIUM"
             ]
           },
@@ -767,10 +698,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "MEDIUM"
             ]
           },
@@ -788,10 +716,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "SMALL"
             ]
           },
@@ -811,10 +736,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "SMALL"
             ]
           },
@@ -833,10 +755,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "SMALL"
             ]
           },
@@ -855,10 +774,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "SMALL"
             ]
           },
@@ -876,10 +792,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1"
             ]
           },
@@ -899,10 +812,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1"
             ]
           },
@@ -921,10 +831,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1"
             ]
           },
@@ -942,10 +849,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1"
             ]
           },
@@ -965,10 +869,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1"
             ]
           },
@@ -987,10 +888,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1"
             ]
           },
@@ -1008,10 +906,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1_V2"
             ]
           },
@@ -1031,10 +926,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1_V2"
             ]
           },
@@ -1053,10 +945,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1_V2"
             ]
           },
@@ -1075,10 +964,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1_V2"
             ]
           },
@@ -1098,10 +984,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1_V2"
             ]
           },
@@ -1120,10 +1003,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1_V2"
             ]
           },
@@ -1141,10 +1021,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11"
             ]
           },
@@ -1164,10 +1041,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11"
             ]
           },
@@ -1186,10 +1060,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11"
             ]
           },
@@ -1207,10 +1078,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11"
             ]
           },
@@ -1230,10 +1098,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11"
             ]
           },
@@ -1252,10 +1117,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11"
             ]
           },
@@ -1273,10 +1135,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11_V2"
             ]
           },
@@ -1296,10 +1155,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11_V2"
             ]
           },
@@ -1318,10 +1174,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11_V2"
             ]
           },
@@ -1340,10 +1193,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11_V2"
             ]
           },
@@ -1363,10 +1213,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11_V2"
             ]
           },
@@ -1385,10 +1232,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11_V2"
             ]
           },
@@ -1406,10 +1250,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12"
             ]
           },
@@ -1428,10 +1269,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12"
             ]
           },
@@ -1449,10 +1287,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12"
             ]
           },
@@ -1472,10 +1307,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12"
             ]
           },
@@ -1494,10 +1326,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12"
             ]
           },
@@ -1515,10 +1344,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12_V2"
             ]
           },
@@ -1537,10 +1363,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12_V2"
             ]
           },
@@ -1559,10 +1382,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12_V2"
             ]
           },
@@ -1582,10 +1402,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12_V2"
             ]
           },
@@ -1604,10 +1421,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12_V2"
             ]
           },
@@ -1625,10 +1439,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D13"
             ]
           },
@@ -1647,10 +1458,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D13"
             ]
           },
@@ -1668,10 +1476,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D13"
             ]
           },
@@ -1691,10 +1496,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D13"
             ]
           },
@@ -1713,10 +1515,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D13_V2"
             ]
           },
@@ -1735,10 +1534,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D13_V2"
             ]
           },
@@ -1758,10 +1554,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D13_V2"
             ]
           },
@@ -1779,10 +1572,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14"
             ]
           },
@@ -1801,10 +1591,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14"
             ]
           },
@@ -1822,10 +1609,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14"
             ]
           },
@@ -1845,10 +1629,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14"
             ]
           },
@@ -1866,10 +1647,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14_V2"
             ]
           },
@@ -1888,10 +1666,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14_V2"
             ]
           },
@@ -1910,10 +1685,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14_V2"
             ]
           },
@@ -1933,10 +1705,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14_V2"
             ]
           },
@@ -1954,10 +1723,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2"
             ]
           },
@@ -1977,10 +1743,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2"
             ]
           },
@@ -1999,10 +1762,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2"
             ]
           },
@@ -2020,10 +1780,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2"
             ]
           },
@@ -2043,10 +1800,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2"
             ]
           },
@@ -2065,10 +1819,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2"
             ]
           },
@@ -2086,10 +1837,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2_V2"
             ]
           },
@@ -2109,10 +1857,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2_V2"
             ]
           },
@@ -2131,10 +1876,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2_V2"
             ]
           },
@@ -2153,10 +1895,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2_V2"
             ]
           },
@@ -2176,10 +1915,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2_V2"
             ]
           },
@@ -2198,10 +1934,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2_V2"
             ]
           },
@@ -2219,10 +1952,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3"
             ]
           },
@@ -2241,10 +1971,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3"
             ]
           },
@@ -2262,10 +1989,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3"
             ]
           },
@@ -2285,10 +2009,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3"
             ]
           },
@@ -2307,10 +2028,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3"
             ]
           },
@@ -2328,10 +2046,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3_V2"
             ]
           },
@@ -2350,10 +2065,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3_V2"
             ]
           },
@@ -2372,10 +2084,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3_V2"
             ]
           },
@@ -2395,10 +2104,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3_V2"
             ]
           },
@@ -2417,10 +2123,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3_V2"
             ]
           },
@@ -2438,10 +2141,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4"
             ]
           },
@@ -2460,10 +2160,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4"
             ]
           },
@@ -2481,10 +2178,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4"
             ]
           },
@@ -2504,10 +2198,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4"
             ]
           },
@@ -2526,10 +2217,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4"
             ]
           },
@@ -2547,10 +2235,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4_V2"
             ]
           },
@@ -2569,10 +2254,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4_V2"
             ]
           },
@@ -2591,10 +2273,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4_V2"
             ]
           },
@@ -2614,10 +2293,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4_V2"
             ]
           },
@@ -2636,10 +2312,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4_V2"
             ]
           },
@@ -2657,10 +2330,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D5_V2"
             ]
           },
@@ -2679,10 +2349,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D5_V2"
             ]
           },
@@ -2701,10 +2368,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D5_V2"
             ]
           },
@@ -2724,10 +2388,7 @@
               "2.1",
               "3.0"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D5_V2"
             ]
           },
@@ -2746,10 +2407,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D5_V2"
             ]
           },
@@ -2768,10 +2426,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D1_V2"
             ]
           },
@@ -2790,10 +2445,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D11_V2"
             ]
           },
@@ -2812,10 +2464,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12_V2"
             ]
           },
@@ -2834,10 +2483,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D12_V2"
             ]
           },
@@ -2856,10 +2502,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D13_V2"
             ]
           },
@@ -2878,10 +2521,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D13_V2"
             ]
           },
@@ -2900,10 +2540,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14_V2"
             ]
           },
@@ -2922,10 +2559,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D14_V2"
             ]
           },
@@ -2944,10 +2578,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D2_V2"
             ]
           },
@@ -2966,10 +2597,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3_V2"
             ]
           },
@@ -2988,10 +2616,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D3_V2"
             ]
           },
@@ -3010,10 +2635,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4_V2"
             ]
           },
@@ -3032,10 +2654,7 @@
             "ClusterVersions": [
               "*"
             ],
-            "OsType": [
-              "*"
-            ],
-            "VMSizes": [
+            "vmsizes": [
               "STANDARD_D4_V2"
             ]
           }
@@ -3124,8 +2743,6 @@
           "VMSIZES_AUX"
         ],
         "quota": {
-          "cores_used": 72,
-          "max_cores_allowed": 1000,
           "regionalQuotas": [
             {
               "region_name": "Australia East",

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2015-03-01-preview/examples/GetHDInsightUsages.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2015-03-01-preview/examples/GetHDInsightUsages.json
@@ -6,7 +6,7 @@
   },
   "responses": {
     "200": {
-      "Body": {
+      "body": {
         "value": [
           {
             "unit": "Count",

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/stable/2018-06-01-preview/examples/GetHDInsightUsages.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/stable/2018-06-01-preview/examples/GetHDInsightUsages.json
@@ -6,7 +6,7 @@
   },
   "responses": {
     "200": {
-      "Body": {
+      "body": {
         "value": [
           {
             "unit": "Count",


### PR DESCRIPTION
Noticed on a different PR that OAV doesn't parse the examples when "Body" is uppercase. Found this old example was one that was affected.
/cc @sergey-shandar not sure if this is a known issue