### PR TITLE
Add PATCH to Azure Firewall supported operations

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/azureFirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/azureFirewall.json
@@ -192,6 +192,58 @@
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation"
         }
+      },
+      "patch": {
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "operationId": "AzureFirewalls_UpdateTags",
+        "description": "Updates tags for an Azure Firewall resource.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure Firewall."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            },
+            "description": "Parameters supplied to the create or update Azure Firewall operation."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update successful. The operation returns the resulting AzureFirewall resource.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Azure Firewall Tags": {
+            "$ref": "./examples/AzureFirewallUpdateTags.json"
+          }
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/azureFirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/azureFirewall.json
@@ -242,8 +242,7 @@
           "Update Azure Firewall Tags": {
             "$ref": "./examples/AzureFirewallUpdateTags.json"
           }
-        },
-        "x-ms-long-running-operation": true
+        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/AzureFirewallUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/AzureFirewallUpdateTags.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2019-06-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "azfwtest",
+    "firewallName": "fw1",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "fw1",
+        "id": "/subscriptions/subid/resourceGroups/azfwtest/providers/Microsoft.Network/azureFirewalls/fw1",
+        "type": "Microsoft.Network/azureFirewalls",
+        "location": "brazilsouth",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "threatIntelMode": "Alert"
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/AzureFirewallUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/AzureFirewallUpdateTags.json
@@ -3,7 +3,7 @@
     "api-version": "2019-06-01",
     "subscriptionId": "subid",
     "resourceGroupName": "azfwtest",
-    "firewallName": "fw1",
+    "azureFirewallName": "fw1",
     "parameters": {
       "tags": {
         "tag1": "value1",


### PR DESCRIPTION
We are adding PATCH to the list of supported operations for Azure Firewall.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
