### PR TITLE
[Azure Search] Update output paths for C# codegen

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md
@@ -108,7 +108,7 @@ csharp:
   license-header: MICROSOFT_MIT_NO_VERSION
   namespace: Microsoft.Azure.Search
   clear-output-folder: true
-  output-folder: $(csharp-sdks-folder)/Search/DataPlane/Microsoft.Azure.Search.Data/Generated
+  output-folder: $(csharp-sdks-folder)/search/Microsoft.Azure.Search.Data/src/Generated
 ```
 
 ### Tweak generated code

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/readme.md
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/readme.md
@@ -109,7 +109,7 @@ csharp:
   license-header: MICROSOFT_MIT_NO_VERSION
   namespace: Microsoft.Azure.Search
   clear-output-folder: true
-  output-folder: $(csharp-sdks-folder)/Search/DataPlane/Microsoft.Azure.Search.Service/Generated
+  output-folder: $(csharp-sdks-folder)/search/Microsoft.Azure.Search.Service/src/Generated
 
 directive: 
   # TODO: Remove this workaround once AutoRest fixes the incorrect code generation when using a parameterized host and both client and operation groups paths.

--- a/specification/search/resource-manager/readme.md
+++ b/specification/search/resource-manager/readme.md
@@ -81,7 +81,7 @@ csharp:
   azure-arm: true
   license-header: MICROSOFT_MIT_NO_VERSION
   namespace: Microsoft.Azure.Management.Search
-  output-folder: $(csharp-sdks-folder)/Search/Management/Management.Search/Generated
+  output-folder: $(csharp-sdks-folder)/search/Microsoft.Azure.Management.Search/src/Generated
   clear-output-folder: true
 ```
 


### PR DESCRIPTION
Updating paths for C# code generation to match the new azure-sdk-for-net repo layout.