### PR TITLE
Update sku, offer and publisher for Debian

### DIFF
--- a/arm-compute/quickstart-templates/aliases.json
+++ b/arm-compute/quickstart-templates/aliases.json
@@ -24,9 +24,9 @@
             "version":"latest"
           },
           "Debian":{
-            "publisher":"credativ",
-            "offer":"Debian",
-            "sku":"9",
+            "publisher":"Debian",
+            "offer":"debian-10",
+            "sku":"10",
             "version":"latest"
           },
           "openSUSE-Leap": {


### PR DESCRIPTION
Debian has released Debian 10, Codename Buster. Azure Images for Buster have been moved to new publisher named "Debian" as per discussion with @szarkos.

Signed-off-by: Martin Zobel-Helas <zobel@debian.org>