### PR TITLE
chore: Cleanup package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@azure/rest-api-specs-scripts": "^0.3.9",
     "@ts-common/commonmark-to-markdown": "^1.2.0",
     "@ts-common/fs": "0.2.0",
+    "@ts-common/iterator": "^0.3.6",
     "@types/js-yaml": "^3.12.1",
     "@types/mocha": "^5.2.6",
     "cspell": "^4.0.12",
@@ -21,6 +22,7 @@
     "json-schema-ref-parser": "^6.1.0",
     "mocha": "*",
     "ts-node": "^8.1.0",
+    "tslib": "^1.10.0",
     "typescript": "^3.4.4"
   },
   "homepage": "https://github.com/azure/azure-rest-api-specs",

--- a/package.json
+++ b/package.json
@@ -11,30 +11,17 @@
   "license": "MIT",
   "devDependencies": {
     "@azure/avocado": "^0.4.1",
-    "@azure/oad": "^0.6.3",
     "@azure/rest-api-specs-scripts": "^0.3.9",
-    "@microsoft.azure/async-io": "^2.0.21",
-    "@microsoft.azure/literate": "^1.0.25",
-    "@microsoft.azure/polyfill": "^1.0.19",
-    "@octokit/rest": "^16.25.0",
     "@ts-common/commonmark-to-markdown": "^1.2.0",
     "@ts-common/fs": "0.2.0",
-    "@types/fs-extra": "^5.0.5",
     "@types/js-yaml": "^3.12.1",
     "@types/mocha": "^5.2.6",
-    "@types/request": "^2.48.1",
     "cspell": "^4.0.12",
-    "fs-extra": "^7.0.1",
-    "glob": "^7.1.3",
     "js-yaml": "^3.13.1",
     "json-schema-ref-parser": "^6.1.0",
     "mocha": "*",
-    "oav": "^0.18.1",
-    "request": "^2.88.0",
-    "request-promise-native": "^1.0.7",
     "ts-node": "^8.1.0",
-    "typescript": "^3.4.4",
-    "z-schema": "^4.0.2"
+    "typescript": "^3.4.4"
   },
   "homepage": "https://github.com/azure/azure-rest-api-specs",
   "repository": {
@@ -47,7 +34,6 @@
   "scripts": {
     "test": "tsc && mocha -t 500000 --reporter min",
     "spellcheck": "cspell \"specification/**/*.json\"",
-    "oav": "oav",
     "tsc": "tsc",
     "multiapi": "ts-node ./scripts/multiapi.ts"
   }


### PR DESCRIPTION
Few weren't used since logic was moved to azure-rest-api-scripts repos. A couple missing for the mutliapi.ts script that isn't referenced right now.