### PR TITLE
fix: applicationinsights delete examples

### DIFF
--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/componentAnnotations_API.json
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/componentAnnotations_API.json
@@ -154,8 +154,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The annotation that was successfully deleted.",
-            "schema": {}
+            "description": "The annotation that was successfully deleted."
           }
         },
         "x-ms-examples": {

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/componentWorkItemConfigs_API.json
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/componentWorkItemConfigs_API.json
@@ -172,8 +172,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The work item configuration that was successfully deleted.",
-            "schema": {}
+            "description": "The work item configuration that was successfully deleted."
           }
         },
         "x-ms-examples": {

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/examples/AnnotationsDelete.json
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/examples/AnnotationsDelete.json
@@ -7,8 +7,6 @@
     "annotationId": "bb820f1b-3110-4a8b-ba2c-8c1129d7eb6a"
   },
   "responses": {
-    "200": {
-      "body": {}
-    }
+    "200": {}
   }
 }

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/examples/WorkItemConfigDelete.json
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/examples/WorkItemConfigDelete.json
@@ -7,8 +7,6 @@
     "workItemConfigId": "Visual Studio Team Services"
   },
   "responses": {
-    "200": {
-      "body": {}
-    }
+    "200": {}
   }
 }


### PR DESCRIPTION

Empty schema object was passing the empty string body in examples.