### PR TITLE
new tag in alerts management

### DIFF
--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-11-02-privatepreview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-11-02-privatepreview/AlertsManagement.json
@@ -582,7 +582,7 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.AlertsManagement/actionRules/{actionRuleName}": {
       "get": {
         "summary": "Get action rule by name",
-        "operationId": "ActionRules_GetByName",
+        "operationId": "ActionRules_Get",
         "description": "Get a specific action rule",
         "parameters": [
           {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-11-02-privatepreview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-11-02-privatepreview/AlertsManagement.json
@@ -582,7 +582,7 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.AlertsManagement/actionRules/{actionRuleName}": {
       "get": {
         "summary": "Get action rule by name",
-        "operationId": "ActionRules_Get",
+        "operationId": "ActionRules_GetByName",
         "description": "Get a specific action rule",
         "parameters": [
           {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
@@ -757,7 +757,7 @@
       },
       "put": {
         "summary": "Create/update an action rule",
-        "operationId": "ActionRules_CreateUpdate",
+        "operationId": "ActionRules_CreateOrUpdate",
         "description": "Creates/Updates a specific action rule",
         "parameters": [
           {
@@ -1312,7 +1312,8 @@
       "x-ms-enum": {
         "name": "identifier",
         "modelAsString": true
-      }
+      },
+      "x-ms-parameter-location": "method"
     }
   },
   "definitions": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
@@ -709,7 +709,7 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AlertsManagement/actionRules/{actionRuleName}": {
       "get": {
         "summary": "Get action rule by name",
-        "operationId": "ActionRules_Get",
+        "operationId": "ActionRules_GetByName",
         "description": "Get a specific action rule",
         "parameters": [
           {
@@ -757,7 +757,7 @@
       },
       "put": {
         "summary": "Create/update an action rule",
-        "operationId": "ActionRules_CreateOrUpdate",
+        "operationId": "ActionRules_CreateUpdate",
         "description": "Creates/Updates a specific action rule",
         "parameters": [
           {
@@ -1442,7 +1442,10 @@
           },
           "description": "Resource tags"
         }
-      }
+      },
+      "required": [
+        "location"
+      ]
     },
     "alert": {
       "description": "An alert created in alert management service.",

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
@@ -1420,33 +1420,6 @@
         }
       }
     },
-    "ManagedResource": {
-      "description": "An azure managed resource object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Resource"
-        }
-      ],
-      "properties": {
-        "location": {
-          "type": "string",
-          "description": "Resource location",
-          "x-ms-mutability": [
-            "create",
-            "read"
-          ]
-        },
-        "tags": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Resource tags"
-        }
-      },
-      "required": [
-        "location"
-      ]
-    },
     "alert": {
       "description": "An alert created in alert management service.",
       "allOf": [
@@ -2160,15 +2133,32 @@
       "description": "Action rule object containing target scope, conditions and suppression logic",
       "allOf": [
         {
-          "$ref": "#/definitions/ManagedResource"
+          "$ref": "#/definitions/Resource"
         }
       ],
       "properties": {
         "properties": {
           "description": "action rule properties",
           "$ref": "#/definitions/ActionRuleProperties"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location",
+          "x-ms-mutability": [
+            "create",
+            "read"
+          ]
+        },
+        "tags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
         }
-      }
+      },
+      "required": [
+        "location"
+      ]
     },
     "ActionRuleProperties": {
       "description": "Action rule properties defining scope, conditions, suppression logic for action rule",

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
@@ -1420,6 +1420,30 @@
         }
       }
     },
+    "ManagedResource": {
+      "description": "An azure managed resource object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Resource location",
+          "x-ms-mutability": [
+            "create",
+            "read"
+          ]
+        },
+        "tags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      }
+    },
     "alert": {
       "description": "An alert created in alert management service.",
       "allOf": [
@@ -2133,32 +2157,15 @@
       "description": "Action rule object containing target scope, conditions and suppression logic",
       "allOf": [
         {
-          "$ref": "#/definitions/Resource"
+          "$ref": "#/definitions/ManagedResource"
         }
       ],
       "properties": {
         "properties": {
           "description": "action rule properties",
           "$ref": "#/definitions/ActionRuleProperties"
-        },
-        "location": {
-          "type": "string",
-          "description": "Resource location",
-          "x-ms-mutability": [
-            "create",
-            "read"
-          ]
-        },
-        "tags": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Resource tags"
         }
-      },
-      "required": [
-        "location"
-      ]
+      }
     },
     "ActionRuleProperties": {
       "description": "Action rule properties defining scope, conditions, suppression logic for action rule",

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
@@ -709,7 +709,7 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AlertsManagement/actionRules/{actionRuleName}": {
       "get": {
         "summary": "Get action rule by name",
-        "operationId": "ActionRules_GetByName",
+        "operationId": "ActionRules_Get",
         "description": "Get a specific action rule",
         "parameters": [
           {

--- a/specification/alertsmanagement/resource-manager/readme.md
+++ b/specification/alertsmanagement/resource-manager/readme.md
@@ -28,7 +28,17 @@ These are the global settings for the AlertManagement API.
 title: AlertsManagementClient
 description: AlertsManagement Client
 openapi-type: arm
-tag: package-2019-03
+tag: package-2019-06-preview
+```
+
+### Tag: package-2019-06-preview
+
+These settings apply only when `--tag=package-2019-06-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2019-06-preview'
+input-file:
+  - Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
+  - Microsoft.AlertsManagement/stable/2019-06-01/SmartDetectorAlertRulesApi.json
 ```
 
 
@@ -40,6 +50,7 @@ These settings apply only when `--tag=package-2019-06` is specified on the comma
 input-file:
   - Microsoft.AlertsManagement/stable/2019-06-01/SmartDetectorAlertRulesApi.json
 ```
+
 ### Tag: package-2019-03
 
 These settings apply only when `--tag=package-2019-03` is specified on the command line.
@@ -49,6 +60,7 @@ input-file:
   - Microsoft.AlertsManagement/stable/2019-03-01/AlertsManagement.json
   - Microsoft.AlertsManagement/stable/2019-03-01/SmartDetectorAlertRulesApi.json
 ```
+
 ### Tag: package-preview-2019-05
 
 These settings apply only when `--tag=package-preview-2019-05` is specified on the command line.

--- a/specification/alertsmanagement/resource-manager/readme.md
+++ b/specification/alertsmanagement/resource-manager/readme.md
@@ -24,6 +24,19 @@ To see additional help and options, run:
 
 These are the global settings for the AlertManagement API.
 
+## Suppression
+``` yaml
+directive:
+  - suppress: R3025
+    reason: The rule applied incorrectly to base class.
+    where:
+      - $.definitions.ManagedResource
+  - suppress: R3026
+    reason: The rule applied incorrectly to base class.
+    where:
+      - $.definitions.ManagedResource
+```
+
 ``` yaml
 title: AlertsManagementClient
 description: AlertsManagement Client


### PR DESCRIPTION
This is a tag for **alertsmanagement** to accommodate new single api release that should include **2019-05-05-preview** API and also **2019-06-01** which includes **SmartDetectorAlertRulesApi.json** that is not included in preview.