### PR TITLE
Add missing read-only property "loadBalancerFrontendIpConfiguration" to publicIpPrefix

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixCreateCustomizedValues.json
@@ -8,6 +8,7 @@
       "1"
     ],
     "parameters": {
+      "location": "westus",
       "properties": {
         "publicIPAddressVersion": "IPv4",
         "prefixLength": 30
@@ -22,14 +23,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -41,14 +46,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixCreateDefaults.json
@@ -4,18 +4,30 @@
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "publicIpPrefixName": "test-ipprefix",
-    "parameters": {}
+    "parameters": {
+      "location": "westus",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "prefixLength": 30
+      }
+    }
   },
   "responses": {
     "200": {
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -27,11 +39,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixGet.json
@@ -10,9 +10,11 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
           "prefixLength": 30,
           "ipPrefix": "192.168.254.2/30",
@@ -22,6 +24,9 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
             }
           ]
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixList.json
@@ -11,9 +11,11 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "40.85.154.2/30",
@@ -24,17 +26,26 @@
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix03",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/ipprefix03",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 31,
-              "ipPrefix": "40.85.153.2/31"
+              "ipPrefix": "40.85.153.2/31",
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixListAll.json
@@ -10,31 +10,64 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "41.85.154.247/30",
+              "ipTags": [],
               "publicIPAddresses": [
                 {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix01",
             "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/publicIPPrefixes/ipprefix01",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "ipPrefix": "40.85.154.247/30",
               "publicIPAddressVersion": "IPv4",
-              "prefixLength": 30
+              "prefixLength": 30,
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
+          },
+          {
+            "name": "pfx",
+            "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/publicIPPrefixes/pfx",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+            "type": "Microsoft.Network/publicIPPrefixes",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
+              "ipPrefix": "25.101.84.16/30",
+              "publicIPAddressVersion": "IPv4",
+              "prefixLength": 30,
+              "ipTags": [],
+              "loadBalancerFrontendIpConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/loadBalancers/lb-pfx/frontendIPConfigurations/ipconfig1"
+              }
+            },
+            "sku": {
+              "name": "Standard"
+            }
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/PublicIpPrefixUpdateTags.json
@@ -16,15 +16,22 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "ipPrefix": "40.85.154.247/30",
+          "prefixLength": 30,
+          "ipTags": []
         },
         "tags": {
           "tag1": "value1",
           "tag2": "value2"
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/publicIpPrefix.json
@@ -372,6 +372,11 @@
           },
           "description": "The list of all referenced PublicIPAddresses"
         },
+        "loadBalancerFrontendIpConfiguration": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to load balancer frontend IP configuration associated with the public IP prefix."
+        },
         "resourceGuid": {
           "type": "string",
           "description": "The resource GUID property of the public IP prefix resource."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixCreateCustomizedValues.json
@@ -8,6 +8,7 @@
       "1"
     ],
     "parameters": {
+      "location": "westus",
       "properties": {
         "publicIPAddressVersion": "IPv4",
         "prefixLength": 30
@@ -22,14 +23,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -41,14 +46,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixCreateDefaults.json
@@ -4,18 +4,30 @@
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "publicIpPrefixName": "test-ipprefix",
-    "parameters": {}
+    "parameters": {
+      "location": "westus",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "prefixLength": 30
+      }
+    }
   },
   "responses": {
     "200": {
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -27,11 +39,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixGet.json
@@ -10,9 +10,11 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
           "prefixLength": 30,
           "ipPrefix": "192.168.254.2/30",
@@ -22,6 +24,9 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
             }
           ]
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixList.json
@@ -11,9 +11,11 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "40.85.154.2/30",
@@ -24,17 +26,26 @@
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix03",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/ipprefix03",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 31,
-              "ipPrefix": "40.85.153.2/31"
+              "ipPrefix": "40.85.153.2/31",
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixListAll.json
@@ -10,31 +10,64 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "41.85.154.247/30",
+              "ipTags": [],
               "publicIPAddresses": [
                 {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix01",
             "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/publicIPPrefixes/ipprefix01",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "ipPrefix": "40.85.154.247/30",
               "publicIPAddressVersion": "IPv4",
-              "prefixLength": 30
+              "prefixLength": 30,
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
+          },
+          {
+            "name": "pfx",
+            "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/publicIPPrefixes/pfx",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+            "type": "Microsoft.Network/publicIPPrefixes",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
+              "ipPrefix": "25.101.84.16/30",
+              "publicIPAddressVersion": "IPv4",
+              "prefixLength": 30,
+              "ipTags": [],
+              "loadBalancerFrontendIpConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/loadBalancers/lb-pfx/frontendIPConfigurations/ipconfig1"
+              }
+            },
+            "sku": {
+              "name": "Standard"
+            }
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/PublicIpPrefixUpdateTags.json
@@ -16,15 +16,22 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "ipPrefix": "40.85.154.247/30",
+          "prefixLength": 30,
+          "ipTags": []
         },
         "tags": {
           "tag1": "value1",
           "tag2": "value2"
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/publicIpPrefix.json
@@ -372,6 +372,11 @@
           },
           "description": "The list of all referenced PublicIPAddresses"
         },
+        "loadBalancerFrontendIpConfiguration": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to load balancer frontend IP configuration associated with the public IP prefix."
+        },
         "resourceGuid": {
           "type": "string",
           "description": "The resource GUID property of the public IP prefix resource."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixCreateCustomizedValues.json
@@ -8,6 +8,7 @@
       "1"
     ],
     "parameters": {
+      "location": "westus",
       "properties": {
         "publicIPAddressVersion": "IPv4",
         "prefixLength": 30
@@ -22,14 +23,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -41,14 +46,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixCreateDefaults.json
@@ -4,18 +4,30 @@
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "publicIpPrefixName": "test-ipprefix",
-    "parameters": {}
+    "parameters": {
+      "location": "westus",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "prefixLength": 30
+      }
+    }
   },
   "responses": {
     "200": {
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -27,11 +39,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixGet.json
@@ -10,9 +10,11 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
           "prefixLength": 30,
           "ipPrefix": "192.168.254.2/30",
@@ -22,6 +24,9 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
             }
           ]
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixList.json
@@ -11,9 +11,11 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "40.85.154.2/30",
@@ -24,17 +26,26 @@
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix03",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/ipprefix03",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 31,
-              "ipPrefix": "40.85.153.2/31"
+              "ipPrefix": "40.85.153.2/31",
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixListAll.json
@@ -10,31 +10,64 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "41.85.154.247/30",
+              "ipTags": [],
               "publicIPAddresses": [
                 {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix01",
             "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/publicIPPrefixes/ipprefix01",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "ipPrefix": "40.85.154.247/30",
               "publicIPAddressVersion": "IPv4",
-              "prefixLength": 30
+              "prefixLength": 30,
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
+          },
+          {
+            "name": "pfx",
+            "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/publicIPPrefixes/pfx",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+            "type": "Microsoft.Network/publicIPPrefixes",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
+              "ipPrefix": "25.101.84.16/30",
+              "publicIPAddressVersion": "IPv4",
+              "prefixLength": 30,
+              "ipTags": [],
+              "loadBalancerFrontendIpConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/loadBalancers/lb-pfx/frontendIPConfigurations/ipconfig1"
+              }
+            },
+            "sku": {
+              "name": "Standard"
+            }
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/PublicIpPrefixUpdateTags.json
@@ -16,15 +16,22 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "ipPrefix": "40.85.154.247/30",
+          "prefixLength": 30,
+          "ipTags": []
         },
         "tags": {
           "tag1": "value1",
           "tag2": "value2"
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/publicIpPrefix.json
@@ -372,6 +372,11 @@
           },
           "description": "The list of all referenced PublicIPAddresses"
         },
+        "loadBalancerFrontendIpConfiguration": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to load balancer frontend IP configuration associated with the public IP prefix."
+        },
         "resourceGuid": {
           "type": "string",
           "description": "The resource GUID property of the public IP prefix resource."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixCreateCustomizedValues.json
@@ -8,6 +8,7 @@
       "1"
     ],
     "parameters": {
+      "location": "westus",
       "properties": {
         "publicIPAddressVersion": "IPv4",
         "prefixLength": 30
@@ -22,14 +23,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -41,14 +46,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixCreateDefaults.json
@@ -4,18 +4,30 @@
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "publicIpPrefixName": "test-ipprefix",
-    "parameters": {}
+    "parameters": {
+      "location": "westus",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "prefixLength": 30
+      }
+    }
   },
   "responses": {
     "200": {
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -27,11 +39,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixGet.json
@@ -10,9 +10,11 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
           "prefixLength": 30,
           "ipPrefix": "192.168.254.2/30",
@@ -22,6 +24,9 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
             }
           ]
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixList.json
@@ -11,9 +11,11 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "40.85.154.2/30",
@@ -24,17 +26,26 @@
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix03",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/ipprefix03",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 31,
-              "ipPrefix": "40.85.153.2/31"
+              "ipPrefix": "40.85.153.2/31",
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixListAll.json
@@ -10,31 +10,64 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "41.85.154.247/30",
+              "ipTags": [],
               "publicIPAddresses": [
                 {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix01",
             "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/publicIPPrefixes/ipprefix01",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "ipPrefix": "40.85.154.247/30",
               "publicIPAddressVersion": "IPv4",
-              "prefixLength": 30
+              "prefixLength": 30,
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
+          },
+          {
+            "name": "pfx",
+            "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/publicIPPrefixes/pfx",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+            "type": "Microsoft.Network/publicIPPrefixes",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
+              "ipPrefix": "25.101.84.16/30",
+              "publicIPAddressVersion": "IPv4",
+              "prefixLength": 30,
+              "ipTags": [],
+              "loadBalancerFrontendIpConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/loadBalancers/lb-pfx/frontendIPConfigurations/ipconfig1"
+              }
+            },
+            "sku": {
+              "name": "Standard"
+            }
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/PublicIpPrefixUpdateTags.json
@@ -16,15 +16,22 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "ipPrefix": "40.85.154.247/30",
+          "prefixLength": 30,
+          "ipTags": []
         },
         "tags": {
           "tag1": "value1",
           "tag2": "value2"
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/publicIpPrefix.json
@@ -372,6 +372,11 @@
           },
           "description": "The list of all referenced PublicIPAddresses"
         },
+        "loadBalancerFrontendIpConfiguration": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to load balancer frontend IP configuration associated with the public IP prefix."
+        },
         "resourceGuid": {
           "type": "string",
           "description": "The resource GUID property of the public IP prefix resource."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixCreateCustomizedValues.json
@@ -8,6 +8,7 @@
       "1"
     ],
     "parameters": {
+      "location": "westus",
       "properties": {
         "publicIPAddressVersion": "IPv4",
         "prefixLength": 30
@@ -22,14 +23,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -41,14 +46,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixCreateDefaults.json
@@ -4,18 +4,30 @@
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "publicIpPrefixName": "test-ipprefix",
-    "parameters": {}
+    "parameters": {
+      "location": "westus",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "prefixLength": 30
+      }
+    }
   },
   "responses": {
     "200": {
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -27,11 +39,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixGet.json
@@ -10,9 +10,11 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
           "prefixLength": 30,
           "ipPrefix": "192.168.254.2/30",
@@ -22,6 +24,9 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
             }
           ]
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixList.json
@@ -11,9 +11,11 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "40.85.154.2/30",
@@ -24,17 +26,26 @@
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix03",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/ipprefix03",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 31,
-              "ipPrefix": "40.85.153.2/31"
+              "ipPrefix": "40.85.153.2/31",
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixListAll.json
@@ -10,31 +10,64 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "41.85.154.247/30",
+              "ipTags": [],
               "publicIPAddresses": [
                 {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix01",
             "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/publicIPPrefixes/ipprefix01",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "ipPrefix": "40.85.154.247/30",
               "publicIPAddressVersion": "IPv4",
-              "prefixLength": 30
+              "prefixLength": 30,
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
+          },
+          {
+            "name": "pfx",
+            "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/publicIPPrefixes/pfx",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+            "type": "Microsoft.Network/publicIPPrefixes",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
+              "ipPrefix": "25.101.84.16/30",
+              "publicIPAddressVersion": "IPv4",
+              "prefixLength": 30,
+              "ipTags": [],
+              "loadBalancerFrontendIpConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/loadBalancers/lb-pfx/frontendIPConfigurations/ipconfig1"
+              }
+            },
+            "sku": {
+              "name": "Standard"
+            }
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/PublicIpPrefixUpdateTags.json
@@ -16,15 +16,22 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "ipPrefix": "40.85.154.247/30",
+          "prefixLength": 30,
+          "ipTags": []
         },
         "tags": {
           "tag1": "value1",
           "tag2": "value2"
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/publicIpPrefix.json
@@ -372,6 +372,11 @@
           },
           "description": "The list of all referenced PublicIPAddresses"
         },
+        "loadBalancerFrontendIpConfiguration": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to load balancer frontend IP configuration associated with the public IP prefix."
+        },
         "resourceGuid": {
           "type": "string",
           "description": "The resource GUID property of the public IP prefix resource."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixCreateCustomizedValues.json
@@ -8,6 +8,7 @@
       "1"
     ],
     "parameters": {
+      "location": "westus",
       "properties": {
         "publicIPAddressVersion": "IPv4",
         "prefixLength": 30
@@ -22,14 +23,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -41,14 +46,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixCreateDefaults.json
@@ -4,18 +4,30 @@
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "publicIpPrefixName": "test-ipprefix",
-    "parameters": {}
+    "parameters": {
+      "location": "westus",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "prefixLength": 30
+      }
+    }
   },
   "responses": {
     "200": {
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -27,11 +39,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixGet.json
@@ -10,9 +10,11 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
           "prefixLength": 30,
           "ipPrefix": "192.168.254.2/30",
@@ -22,6 +24,9 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
             }
           ]
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixList.json
@@ -11,9 +11,11 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "40.85.154.2/30",
@@ -24,17 +26,26 @@
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix03",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/ipprefix03",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 31,
-              "ipPrefix": "40.85.153.2/31"
+              "ipPrefix": "40.85.153.2/31",
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixListAll.json
@@ -10,31 +10,64 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "41.85.154.247/30",
+              "ipTags": [],
               "publicIPAddresses": [
                 {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix01",
             "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/publicIPPrefixes/ipprefix01",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "ipPrefix": "40.85.154.247/30",
               "publicIPAddressVersion": "IPv4",
-              "prefixLength": 30
+              "prefixLength": 30,
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
+          },
+          {
+            "name": "pfx",
+            "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/publicIPPrefixes/pfx",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+            "type": "Microsoft.Network/publicIPPrefixes",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
+              "ipPrefix": "25.101.84.16/30",
+              "publicIPAddressVersion": "IPv4",
+              "prefixLength": 30,
+              "ipTags": [],
+              "loadBalancerFrontendIpConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/loadBalancers/lb-pfx/frontendIPConfigurations/ipconfig1"
+              }
+            },
+            "sku": {
+              "name": "Standard"
+            }
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/PublicIpPrefixUpdateTags.json
@@ -16,15 +16,22 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "ipPrefix": "40.85.154.247/30",
+          "prefixLength": 30,
+          "ipTags": []
         },
         "tags": {
           "tag1": "value1",
           "tag2": "value2"
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/publicIpPrefix.json
@@ -339,7 +339,7 @@
           }
         }
       },
-      "description": "SKU of a public IP prefix"
+      "description": "SKU of a public IP prefix."
     },
     "PublicIPPrefixPropertiesFormat": {
       "properties": {
@@ -361,14 +361,19 @@
         },
         "ipPrefix": {
           "type": "string",
-          "description": "The allocated Prefix"
+          "description": "The allocated Prefix."
         },
         "publicIPAddresses": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ReferencedPublicIpAddress"
           },
-          "description": "The list of all referenced PublicIPAddresses"
+          "description": "The list of all referenced PublicIPAddresses."
+        },
+        "loadBalancerFrontendIpConfiguration": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to load balancer frontend IP configuration associated with the public IP prefix."
         },
         "resourceGuid": {
           "type": "string",
@@ -431,7 +436,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "The PublicIPAddress Reference"
+          "description": "The PublicIPAddress Reference."
         }
       },
       "description": "Reference to a public IP address."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixCreateCustomizedValues.json
@@ -8,6 +8,7 @@
       "1"
     ],
     "parameters": {
+      "location": "westus",
       "properties": {
         "publicIPAddressVersion": "IPv4",
         "prefixLength": 30
@@ -22,14 +23,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -41,14 +46,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixCreateDefaults.json
@@ -19,11 +19,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -35,11 +39,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixGet.json
@@ -10,9 +10,11 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
           "prefixLength": 30,
           "ipPrefix": "192.168.254.2/30",
@@ -22,6 +24,9 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
             }
           ]
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixList.json
@@ -11,9 +11,11 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "40.85.154.2/30",
@@ -24,17 +26,26 @@
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix03",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/ipprefix03",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 31,
-              "ipPrefix": "40.85.153.2/31"
+              "ipPrefix": "40.85.153.2/31",
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixListAll.json
@@ -10,31 +10,64 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "41.85.154.247/30",
+              "ipTags": [],
               "publicIPAddresses": [
                 {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix01",
             "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/publicIPPrefixes/ipprefix01",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "ipPrefix": "40.85.154.247/30",
               "publicIPAddressVersion": "IPv4",
-              "prefixLength": 30
+              "prefixLength": 30,
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
+          },
+          {
+            "name": "pfx",
+            "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/publicIPPrefixes/pfx",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+            "type": "Microsoft.Network/publicIPPrefixes",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
+              "ipPrefix": "25.101.84.16/30",
+              "publicIPAddressVersion": "IPv4",
+              "prefixLength": 30,
+              "ipTags": [],
+              "loadBalancerFrontendIpConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/loadBalancers/lb-pfx/frontendIPConfigurations/ipconfig1"
+              }
+            },
+            "sku": {
+              "name": "Standard"
+            }
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/PublicIpPrefixUpdateTags.json
@@ -16,15 +16,22 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "ipPrefix": "40.85.154.247/30",
+          "prefixLength": 30,
+          "ipTags": []
         },
         "tags": {
           "tag1": "value1",
           "tag2": "value2"
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/publicIpPrefix.json
@@ -370,6 +370,11 @@
           },
           "description": "The list of all referenced PublicIPAddresses."
         },
+        "loadBalancerFrontendIpConfiguration": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to load balancer frontend IP configuration associated with the public IP prefix."
+        },
         "resourceGuid": {
           "type": "string",
           "description": "The resource GUID property of the public IP prefix resource."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixCreateCustomizedValues.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixCreateCustomizedValues.json
@@ -23,14 +23,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -42,14 +46,18 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "zones": [
           "1"
         ],
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixCreateDefaults.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixCreateDefaults.json
@@ -5,6 +5,10 @@
     "resourceGroupName": "rg1",
     "publicIpPrefixName": "test-ipprefix",
     "parameters": {
+      "location": "westus",
+      "properties": {
+        "prefixLength": 30
+      },
       "sku": {
         "name": "Standard"
       }
@@ -15,11 +19,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"
@@ -31,11 +39,15 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "prefixLength": 30,
+          "ipPrefix": "192.168.254.2/30",
+          "ipTags": []
         },
         "sku": {
           "name": "Standard"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixGet.json
@@ -10,9 +10,11 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
           "prefixLength": 30,
           "ipPrefix": "192.168.254.2/30",
@@ -22,6 +24,9 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
             }
           ]
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixList.json
@@ -11,9 +11,11 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "40.85.154.2/30",
@@ -24,17 +26,26 @@
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix03",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/ipprefix03",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 31,
-              "ipPrefix": "40.85.153.2/31"
+              "ipPrefix": "40.85.153.2/31",
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixListAll.json
@@ -10,31 +10,64 @@
           {
             "name": "test-ipprefix",
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "publicIPAddressVersion": "IPv4",
               "prefixLength": 30,
               "ipPrefix": "41.85.154.247/30",
+              "ipTags": [],
               "publicIPAddresses": [
                 {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/PublicIpAddress1"
                 }
               ]
             },
+            "sku": {
+              "name": "Standard"
+            },
             "type": "Microsoft.Network/publicIPPrefixes"
           },
           {
             "name": "ipprefix01",
             "id": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/publicIPPrefixes/ipprefix01",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
             "location": "westus",
             "properties": {
               "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
               "ipPrefix": "40.85.154.247/30",
               "publicIPAddressVersion": "IPv4",
-              "prefixLength": 30
+              "prefixLength": 30,
+              "ipTags": []
+            },
+            "sku": {
+              "name": "Standard"
             },
             "type": "Microsoft.Network/publicIPPrefixes"
+          },
+          {
+            "name": "pfx",
+            "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/publicIPPrefixes/pfx",
+            "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+            "type": "Microsoft.Network/publicIPPrefixes",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "resourceGuid": "00000000-0000-0000-0000-00000000",
+              "ipPrefix": "25.101.84.16/30",
+              "publicIPAddressVersion": "IPv4",
+              "prefixLength": 30,
+              "ipTags": [],
+              "loadBalancerFrontendIpConfiguration": {
+                "id": "/subscriptions/subid/resourceGroups/rg3/providers/Microsoft.Network/loadBalancers/lb-pfx/frontendIPConfigurations/ipconfig1"
+              }
+            },
+            "sku": {
+              "name": "Standard"
+            }
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/PublicIpPrefixUpdateTags.json
@@ -16,15 +16,22 @@
       "body": {
         "name": "test-ipprefix",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/test-ipprefix",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "westus",
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "publicIPAddressVersion": "IPv4",
-          "prefixLength": 30
+          "ipPrefix": "40.85.154.247/30",
+          "prefixLength": 30,
+          "ipTags": []
         },
         "tags": {
           "tag1": "value1",
           "tag2": "value2"
+        },
+        "sku": {
+          "name": "Standard"
         },
         "type": "Microsoft.Network/publicIPPrefixes"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/publicIpPrefix.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/publicIpPrefix.json
@@ -370,6 +370,11 @@
           },
           "description": "The list of all referenced PublicIPAddresses."
         },
+        "loadBalancerFrontendIpConfiguration": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to load balancer frontend IP configuration associated with the public IP prefix."
+        },
         "resourceGuid": {
           "type": "string",
           "description": "The resource GUID property of the public IP prefix resource."


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-rest-api-specs/issues/6506

* Add missing read-only property "loadBalancerFrontendIpConfiguration" to publicIpPrefix
* Fix examples for publicIpPrefix

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
