### PR TITLE
chore: Sort custom-words.txt

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1,5 +1,6 @@
 AADDS
 aadiam
+AATP
 abcxyz
 ABFS
 Accel
@@ -44,6 +45,7 @@ amlcompute
 amortizedcost
 analysisservices
 AND'ed
+Annotatable
 anomalydetector
 anomalyfinder
 APAC
@@ -208,6 +210,7 @@ canadaeast
 canceldelete
 cancelpipelinerun
 canonicalized
+Carbonite
 catenate
 catenated
 caverphone
@@ -243,6 +246,7 @@ Cloneability
 Cloneable
 closedlist
 closedlists
+Cloudamize
 cloudapp
 cloudsimple
 clustermonitoring
@@ -278,6 +282,7 @@ contosomedia
 cooldown
 Corda
 coreml
+Corent
 Cortana
 cosmosdb
 costcenter
@@ -633,6 +638,7 @@ isordered
 issqlcompression
 istransitioning
 isusernameavailable
+ISVs
 items
 ITSM
 janedoe
@@ -690,6 +696,7 @@ LDAP
 ldaps
 ldom
 leavingpool
+LEDs
 libtrust
 lifecycle
 lifetimejobstats
@@ -763,6 +770,7 @@ maxresults
 mbaldwin
 Mbps
 MCAS
+MDATP
 mediaservices
 Mesos
 messagingplan
@@ -1350,6 +1358,7 @@ translatortext
 trendingtopics
 triggeredwebjobs
 triggerruns
+Turbonomic
 Txns
 Typeless
 UEBA
@@ -1514,17 +1523,8 @@ Xero
 XSMB
 YYMMDD
 Zabbix
+Zerto
 Zilla
 ziplist
 Zoho
 zset
-Annotatable
-ISVs
-Cloudamize
-Turbonomic
-Zerto
-Corent
-Carbonite
-AATP
-MDATP
-LEDs


### PR DESCRIPTION

Alpha isn't required, but avoids merge conflicts what putting them at the end causes.