### PR TITLE
fix: EnterpriseKnowledge model validation

### DIFF
--- a/specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/examples/CreateEnterpriseKnowledgeGraph.json
+++ b/specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/examples/CreateEnterpriseKnowledgeGraph.json
@@ -15,11 +15,13 @@
   },
   "responses": {
     "201": {
-      "name": "samplename",
-      "type": "sampletype",
-      "id": "someid",
-      "properties": {
-        "provisioningState": "Accepted"
+      "body": {
+        "name": "samplename",
+        "type": "sampletype",
+        "id": "someid",
+        "properties": {
+          "provisioningState": "Creating"
+        }
       }
     }
   }

--- a/specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/examples/GetEnterpriseKnowledgeGraph.json
+++ b/specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/examples/GetEnterpriseKnowledgeGraph.json
@@ -7,11 +7,13 @@
   },
   "responses": {
     "200": {
-      "name": "samplename",
-      "type": "sampletype",
-      "id": "someid",
-      "properties": {
-        "provisioningState": "Succeedded"
+      "body": {
+        "name": "samplename",
+        "type": "sampletype",
+        "id": "someid",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
       }
     }
   }

--- a/specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/examples/UpdateEnterpriseKnowledgeGraph.json
+++ b/specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/examples/UpdateEnterpriseKnowledgeGraph.json
@@ -18,11 +18,13 @@
   },
   "responses": {
     "201": {
-      "name": "samplename",
-      "type": "sampletype",
-      "id": "someid",
-      "properties": {
-        "provisioningState": "Accepted"
+      "body": {
+        "name": "samplename",
+        "type": "sampletype",
+        "id": "someid",
+        "properties": {
+          "provisioningState": "Creating"
+        }
       }
     }
   }


### PR DESCRIPTION
- Add missing "body"
- Succeedded -> Succeeded
- Accepted -> Creating

Still two warnings for missing 200 responses
```
oav validate-example specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/EnterpriseKnowledgeGraphSwagger.json -p
Validating "examples" and "x-ms-examples" in  specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/EnterpriseKnowledgeGraphSwagger.json:

 error : 
operationId: EnterpriseKnowledgeGraph_Create
scenario: Create EnterpriseKnowledgeGraph
source: response
responseCode: '200'
severity: 0
code: RESPONSE_STATUS_CODE_NOT_IN_EXAMPLE
details:
  code: RESPONSE_STATUS_CODE_NOT_IN_EXAMPLE
  id: OAV111
  message: >-
    Following response status codes "200" for operation
    "EnterpriseKnowledgeGraph_Create" were present in the swagger spec, however
    they were not present in x-ms-examples. Please provide them.
  position:
    line: 31
    column: 14
  url: >-
    specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/EnterpriseKnowledgeGraphSwagger.json
  title: >-
    #/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.EnterpriseKnowledgeGraph~1services~1{resourceName}/put
  directives: {}
  level: error

 error : 
operationId: EnterpriseKnowledgeGraph_Update
scenario: Update EnterpriseKnowledgeGraph
source: response
responseCode: '200'
severity: 0
code: RESPONSE_STATUS_CODE_NOT_IN_EXAMPLE
details:
  code: RESPONSE_STATUS_CODE_NOT_IN_EXAMPLE
  id: OAV111
  message: >-
    Following response status codes "200" for operation
    "EnterpriseKnowledgeGraph_Update" were present in the swagger spec, however
    they were not present in x-ms-examples. Please provide them.
  position:
    line: 86
    column: 16
  url: >-
    specification/EnterpriseKnowledgeGraph/resource-manager/Microsoft.EnterpriseKnowledgeGraph/preview/2018-12-03/EnterpriseKnowledgeGraphSwagger.json
  title: >-
    #/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.EnterpriseKnowledgeGraph~1services~1{resourceName}/patch
  directives: {}
```