### PR TITLE
fix: apimanagment model validation

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementCreateProperty.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementCreateProperty.json
@@ -35,17 +35,19 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/properties/testprop2",
-      "type": "Microsoft.ApiManagement/service/properties",
-      "name": "testprop2",
-      "properties": {
-        "displayName": "prop3name",
-        "value": "propValue",
-        "tags": [
-          "foo",
-          "bar"
-        ],
-        "secret": true
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/properties/testprop2",
+        "type": "Microsoft.ApiManagement/service/properties",
+        "name": "testprop2",
+        "properties": {
+          "displayName": "prop3name",
+          "value": "propValue",
+          "tags": [
+            "foo",
+            "bar"
+          ],
+          "secret": true
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementCreateServiceWithSystemCertificates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementCreateServiceWithSystemCertificates.json
@@ -71,91 +71,95 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "tag1": "value1",
-        "tag2": "value2",
-        "tag3": "value3"
-      },
-      "location": "Central US",
-      "etag": "AAAAAADauqg=",
-      "properties": {
-        "publisherEmail": "apim@autorestsdk.com",
-        "publisherName": "autorestsdk",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2018-02-19T16:42:47.362368Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "gatewayRegionalUrl": "https://apimService1-centralus-01.regional.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.69.153.91"
-        ],
-        "virtualNetworkType": "None",
-        "certificates": [
-          {
-            "storeName": "CertificateAuthority",
-            "certificate": {
-              "expiry": "2035-12-31T23:00:00-08:00",
-              "thumbprint": "8E989652XXXXXXXXXXXXXXXDB3A2",
-              "subject": "CN=*.msitesting.net"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2",
+          "tag3": "value3"
+        },
+        "location": "Central US",
+        "etag": "AAAAAADauqg=",
+        "properties": {
+          "publisherEmail": "apim@autorestsdk.com",
+          "publisherName": "autorestsdk",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2018-02-19T16:42:47.362368Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "gatewayRegionalUrl": "https://apimService1-centralus-01.regional.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.69.153.91"
+          ],
+          "virtualNetworkType": "None",
+          "certificates": [
+            {
+              "storeName": "CertificateAuthority",
+              "certificate": {
+                "expiry": "2035-12-31T23:00:00-08:00",
+                "thumbprint": "8E989652XXXXXXXXXXXXXXXDB3A2",
+                "subject": "CN=*.msitesting.net"
+              }
             }
-          }
-        ]
-      },
-      "sku": {
-        "name": "Basic",
-        "capacity": 1
+          ]
+        },
+        "sku": {
+          "name": "Basic",
+          "capacity": 1
+        }
       }
     },
     "202": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "tag1": "value1",
-        "tag2": "value2",
-        "tag3": "value3"
-      },
-      "location": "Central US",
-      "etag": "AAAAAADauqg=",
-      "properties": {
-        "publisherEmail": "apim@autorestsdk.com",
-        "publisherName": "autorestsdk",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2018-02-19T16:42:47.362368Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "gatewayRegionalUrl": "https://apimService1-centralus-01.regional.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.69.153.91"
-        ],
-        "virtualNetworkType": "None",
-        "certificates": [
-          {
-            "storeName": "CertificateAuthority",
-            "certificate": {
-              "expiry": "2035-12-31T23:00:00-08:00",
-              "thumbprint": "8E989652XXXXXXXXXXXXXXXDB3A2",
-              "subject": "CN=*.msitesting.net"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2",
+          "tag3": "value3"
+        },
+        "location": "Central US",
+        "etag": "AAAAAADauqg=",
+        "properties": {
+          "publisherEmail": "apim@autorestsdk.com",
+          "publisherName": "autorestsdk",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2018-02-19T16:42:47.362368Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "gatewayRegionalUrl": "https://apimService1-centralus-01.regional.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.69.153.91"
+          ],
+          "virtualNetworkType": "None",
+          "certificates": [
+            {
+              "storeName": "CertificateAuthority",
+              "certificate": {
+                "expiry": "2035-12-31T23:00:00-08:00",
+                "thumbprint": "8E989652XXXXXXXXXXXXXXXDB3A2",
+                "subject": "CN=*.msitesting.net"
+              }
             }
-          }
-        ]
-      },
-      "sku": {
-        "name": "Basic",
-        "capacity": 1
+          ]
+        },
+        "sku": {
+          "name": "Basic",
+          "capacity": 1
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementCreateSubscription.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementCreateSubscription.json
@@ -31,17 +31,19 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/subscriptions/testsub",
-      "type": "Microsoft.ApiManagement/service/subscriptions",
-      "name": "testsub",
-      "properties": {
-        "ownerId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/users/57127d485157a511ace86ae7",
-        "scope": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/products/5600b59475ff190048060002",
-        "displayName": "testsub",
-        "state": "submitted",
-        "createdDate": "2017-06-02T23:34:03.1055076Z",
-        "primaryKey": "06c34e1a9d394412b292e0611e73d417",
-        "secondaryKey": "1e756a7705364c529e8d1760190f47b3"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/subscriptions/testsub",
+        "type": "Microsoft.ApiManagement/service/subscriptions",
+        "name": "testsub",
+        "properties": {
+          "ownerId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/users/57127d485157a511ace86ae7",
+          "scope": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/products/5600b59475ff190048060002",
+          "displayName": "testsub",
+          "state": "submitted",
+          "createdDate": "2017-06-02T23:34:03.1055076Z",
+          "primaryKey": "06c34e1a9d394412b292e0611e73d417",
+          "secondaryKey": "1e756a7705364c529e8d1760190f47b3"
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementUpdateServiceDisableTls10.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementUpdateServiceDisableTls10.json
@@ -48,42 +48,44 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "Owner": "sasolank",
-        "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
-        "Reserved": "",
-        "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
-        "Pool": "Manual",
-        "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
-      },
-      "location": "West US",
-      "etag": "AAAAAAAYRPs=",
-      "properties": {
-        "publisherEmail": "admin@live.com",
-        "publisherName": "Contoso",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.86.176.232"
-        ],
-        "customProperties": {
-          "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "Owner": "sasolank",
+          "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
+          "Reserved": "",
+          "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
+          "Pool": "Manual",
+          "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
         },
-        "virtualNetworkType": "None"
-      },
-      "sku": {
-        "name": "Standard",
-        "capacity": 1
+        "location": "West US",
+        "etag": "AAAAAAAYRPs=",
+        "properties": {
+          "publisherEmail": "admin@live.com",
+          "publisherName": "Contoso",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.86.176.232"
+          ],
+          "customProperties": {
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+          },
+          "virtualNetworkType": "None"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementUpdateServicePublisherDetails.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementUpdateServicePublisherDetails.json
@@ -47,42 +47,44 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "Owner": "sasolank",
-        "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
-        "Reserved": "",
-        "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
-        "Pool": "Manual",
-        "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
-      },
-      "location": "West US",
-      "etag": "AAAAAAAYRPs=",
-      "properties": {
-        "publisherEmail": "foobar@live.com",
-        "publisherName": "Contoso Vnext",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.86.176.232"
-        ],
-        "customProperties": {
-          "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "Owner": "sasolank",
+          "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
+          "Reserved": "",
+          "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
+          "Pool": "Manual",
+          "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
         },
-        "virtualNetworkType": "None"
-      },
-      "sku": {
-        "name": "Standard",
-        "capacity": 1
+        "location": "West US",
+        "etag": "AAAAAAAYRPs=",
+        "properties": {
+          "publisherEmail": "foobar@live.com",
+          "publisherName": "Contoso Vnext",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.86.176.232"
+          ],
+          "customProperties": {
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+          },
+          "virtualNetworkType": "None"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementCreateProperty.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementCreateProperty.json
@@ -35,17 +35,19 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/properties/testprop2",
-      "type": "Microsoft.ApiManagement/service/properties",
-      "name": "testprop2",
-      "properties": {
-        "displayName": "prop3name",
-        "value": "propValue",
-        "tags": [
-          "foo",
-          "bar"
-        ],
-        "secret": true
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/properties/testprop2",
+        "type": "Microsoft.ApiManagement/service/properties",
+        "name": "testprop2",
+        "properties": {
+          "displayName": "prop3name",
+          "value": "propValue",
+          "tags": [
+            "foo",
+            "bar"
+          ],
+          "secret": true
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementCreateSubscription.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementCreateSubscription.json
@@ -31,17 +31,19 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/subscriptions/testsub",
-      "type": "Microsoft.ApiManagement/service/subscriptions",
-      "name": "testsub",
-      "properties": {
-        "userId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/users/57127d485157a511ace86ae7",
-        "productId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/products/5600b59475ff190048060002",
-        "displayName": "testsub",
-        "state": "submitted",
-        "createdDate": "2017-06-02T23:34:03.1055076Z",
-        "primaryKey": "06c34e1a9d394412b292e0611e73d417",
-        "secondaryKey": "1e756a7705364c529e8d1760190f47b3"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/subscriptions/testsub",
+        "type": "Microsoft.ApiManagement/service/subscriptions",
+        "name": "testsub",
+        "properties": {
+          "userId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/users/57127d485157a511ace86ae7",
+          "productId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/products/5600b59475ff190048060002",
+          "displayName": "testsub",
+          "state": "submitted",
+          "createdDate": "2017-06-02T23:34:03.1055076Z",
+          "primaryKey": "06c34e1a9d394412b292e0611e73d417",
+          "secondaryKey": "1e756a7705364c529e8d1760190f47b3"
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementUpdateServiceDisableTls10.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementUpdateServiceDisableTls10.json
@@ -48,42 +48,44 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "Owner": "sasolank",
-        "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
-        "Reserved": "",
-        "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
-        "Pool": "Manual",
-        "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
-      },
-      "location": "West US",
-      "etag": "AAAAAAAYRPs=",
-      "properties": {
-        "publisherEmail": "admin@live.com",
-        "publisherName": "Contoso",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "staticIps": [
-          "40.86.176.232"
-        ],
-        "customProperties": {
-          "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "Owner": "sasolank",
+          "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
+          "Reserved": "",
+          "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
+          "Pool": "Manual",
+          "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
         },
-        "virtualNetworkType": "None"
-      },
-      "sku": {
-        "name": "Standard",
-        "capacity": 1
+        "location": "West US",
+        "etag": "AAAAAAAYRPs=",
+        "properties": {
+          "publisherEmail": "admin@live.com",
+          "publisherName": "Contoso",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "staticIps": [
+            "40.86.176.232"
+          ],
+          "customProperties": {
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+          },
+          "virtualNetworkType": "None"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementUpdateServicePublisherDetails.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementUpdateServicePublisherDetails.json
@@ -47,42 +47,44 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "Owner": "sasolank",
-        "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
-        "Reserved": "",
-        "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
-        "Pool": "Manual",
-        "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
-      },
-      "location": "West US",
-      "etag": "AAAAAAAYRPs=",
-      "properties": {
-        "publisherEmail": "foobar@live.com",
-        "publisherName": "Contoso Vnext",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "staticIps": [
-          "40.86.176.232"
-        ],
-        "customProperties": {
-          "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "Owner": "sasolank",
+          "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
+          "Reserved": "",
+          "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
+          "Pool": "Manual",
+          "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
         },
-        "virtualNetworkType": "None"
-      },
-      "sku": {
-        "name": "Standard",
-        "capacity": 1
+        "location": "West US",
+        "etag": "AAAAAAAYRPs=",
+        "properties": {
+          "publisherEmail": "foobar@live.com",
+          "publisherName": "Contoso Vnext",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "staticIps": [
+            "40.86.176.232"
+          ],
+          "customProperties": {
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+          },
+          "virtualNetworkType": "None"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementCreateProperty.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementCreateProperty.json
@@ -35,17 +35,19 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/properties/testprop2",
-      "type": "Microsoft.ApiManagement/service/properties",
-      "name": "testprop2",
-      "properties": {
-        "displayName": "prop3name",
-        "value": "propValue",
-        "tags": [
-          "foo",
-          "bar"
-        ],
-        "secret": true
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/properties/testprop2",
+        "type": "Microsoft.ApiManagement/service/properties",
+        "name": "testprop2",
+        "properties": {
+          "displayName": "prop3name",
+          "value": "propValue",
+          "tags": [
+            "foo",
+            "bar"
+          ],
+          "secret": true
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementCreateServiceWithSystemCertificates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementCreateServiceWithSystemCertificates.json
@@ -71,91 +71,95 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "tag1": "value1",
-        "tag2": "value2",
-        "tag3": "value3"
-      },
-      "location": "Central US",
-      "etag": "AAAAAADauqg=",
-      "properties": {
-        "publisherEmail": "apim@autorestsdk.com",
-        "publisherName": "autorestsdk",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2018-02-19T16:42:47.362368Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "gatewayRegionalUrl": "https://apimService1-centralus-01.regional.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.69.153.91"
-        ],
-        "virtualNetworkType": "None",
-        "certificates": [
-          {
-            "storeName": "CertificateAuthority",
-            "certificate": {
-              "expiry": "2035-12-31T23:00:00-08:00",
-              "thumbprint": "8E989652XXXXXXXXXXXXXXXDB3A2",
-              "subject": "CN=*.msitesting.net"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2",
+          "tag3": "value3"
+        },
+        "location": "Central US",
+        "etag": "AAAAAADauqg=",
+        "properties": {
+          "publisherEmail": "apim@autorestsdk.com",
+          "publisherName": "autorestsdk",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2018-02-19T16:42:47.362368Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "gatewayRegionalUrl": "https://apimService1-centralus-01.regional.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.69.153.91"
+          ],
+          "virtualNetworkType": "None",
+          "certificates": [
+            {
+              "storeName": "CertificateAuthority",
+              "certificate": {
+                "expiry": "2035-12-31T23:00:00-08:00",
+                "thumbprint": "8E989652XXXXXXXXXXXXXXXDB3A2",
+                "subject": "CN=*.msitesting.net"
+              }
             }
-          }
-        ]
-      },
-      "sku": {
-        "name": "Basic",
-        "capacity": 1
+          ]
+        },
+        "sku": {
+          "name": "Basic",
+          "capacity": 1
+        }
       }
     },
     "202": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "tag1": "value1",
-        "tag2": "value2",
-        "tag3": "value3"
-      },
-      "location": "Central US",
-      "etag": "AAAAAADauqg=",
-      "properties": {
-        "publisherEmail": "apim@autorestsdk.com",
-        "publisherName": "autorestsdk",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2018-02-19T16:42:47.362368Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "gatewayRegionalUrl": "https://apimService1-centralus-01.regional.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.69.153.91"
-        ],
-        "virtualNetworkType": "None",
-        "certificates": [
-          {
-            "storeName": "CertificateAuthority",
-            "certificate": {
-              "expiry": "2035-12-31T23:00:00-08:00",
-              "thumbprint": "8E989652XXXXXXXXXXXXXXXDB3A2",
-              "subject": "CN=*.msitesting.net"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2",
+          "tag3": "value3"
+        },
+        "location": "Central US",
+        "etag": "AAAAAADauqg=",
+        "properties": {
+          "publisherEmail": "apim@autorestsdk.com",
+          "publisherName": "autorestsdk",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2018-02-19T16:42:47.362368Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "gatewayRegionalUrl": "https://apimService1-centralus-01.regional.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.69.153.91"
+          ],
+          "virtualNetworkType": "None",
+          "certificates": [
+            {
+              "storeName": "CertificateAuthority",
+              "certificate": {
+                "expiry": "2035-12-31T23:00:00-08:00",
+                "thumbprint": "8E989652XXXXXXXXXXXXXXXDB3A2",
+                "subject": "CN=*.msitesting.net"
+              }
             }
-          }
-        ]
-      },
-      "sku": {
-        "name": "Basic",
-        "capacity": 1
+          ]
+        },
+        "sku": {
+          "name": "Basic",
+          "capacity": 1
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementCreateSubscription.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementCreateSubscription.json
@@ -31,17 +31,19 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/subscriptions/testsub",
-      "type": "Microsoft.ApiManagement/service/subscriptions",
-      "name": "testsub",
-      "properties": {
-        "userId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/users/57127d485157a511ace86ae7",
-        "productId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/products/5600b59475ff190048060002",
-        "displayName": "testsub",
-        "state": "submitted",
-        "createdDate": "2017-06-02T23:34:03.1055076Z",
-        "primaryKey": "06c34e1a9d394412b292e0611e73d417",
-        "secondaryKey": "1e756a7705364c529e8d1760190f47b3"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/subscriptions/testsub",
+        "type": "Microsoft.ApiManagement/service/subscriptions",
+        "name": "testsub",
+        "properties": {
+          "userId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/users/57127d485157a511ace86ae7",
+          "productId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/products/5600b59475ff190048060002",
+          "displayName": "testsub",
+          "state": "submitted",
+          "createdDate": "2017-06-02T23:34:03.1055076Z",
+          "primaryKey": "06c34e1a9d394412b292e0611e73d417",
+          "secondaryKey": "1e756a7705364c529e8d1760190f47b3"
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementUpdateServiceDisableTls10.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementUpdateServiceDisableTls10.json
@@ -48,42 +48,44 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "Owner": "sasolank",
-        "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
-        "Reserved": "",
-        "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
-        "Pool": "Manual",
-        "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
-      },
-      "location": "West US",
-      "etag": "AAAAAAAYRPs=",
-      "properties": {
-        "publisherEmail": "admin@live.com",
-        "publisherName": "Contoso",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.86.176.232"
-        ],
-        "customProperties": {
-          "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "Owner": "sasolank",
+          "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
+          "Reserved": "",
+          "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
+          "Pool": "Manual",
+          "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
         },
-        "virtualNetworkType": "None"
-      },
-      "sku": {
-        "name": "Standard",
-        "capacity": 1
+        "location": "West US",
+        "etag": "AAAAAAAYRPs=",
+        "properties": {
+          "publisherEmail": "admin@live.com",
+          "publisherName": "Contoso",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.86.176.232"
+          ],
+          "customProperties": {
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+          },
+          "virtualNetworkType": "None"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementUpdateServicePublisherDetails.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementUpdateServicePublisherDetails.json
@@ -47,42 +47,44 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "Owner": "sasolank",
-        "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
-        "Reserved": "",
-        "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
-        "Pool": "Manual",
-        "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
-      },
-      "location": "West US",
-      "etag": "AAAAAAAYRPs=",
-      "properties": {
-        "publisherEmail": "foobar@live.com",
-        "publisherName": "Contoso Vnext",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.86.176.232"
-        ],
-        "customProperties": {
-          "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "Owner": "sasolank",
+          "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
+          "Reserved": "",
+          "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
+          "Pool": "Manual",
+          "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
         },
-        "virtualNetworkType": "None"
-      },
-      "sku": {
-        "name": "Standard",
-        "capacity": 1
+        "location": "West US",
+        "etag": "AAAAAAAYRPs=",
+        "properties": {
+          "publisherEmail": "foobar@live.com",
+          "publisherName": "Contoso Vnext",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.86.176.232"
+          ],
+          "customProperties": {
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+          },
+          "virtualNetworkType": "None"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementCreateProperty.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementCreateProperty.json
@@ -35,17 +35,19 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/properties/testprop2",
-      "type": "Microsoft.ApiManagement/service/properties",
-      "name": "testprop2",
-      "properties": {
-        "displayName": "prop3name",
-        "value": "propValue",
-        "tags": [
-          "foo",
-          "bar"
-        ],
-        "secret": true
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/properties/testprop2",
+        "type": "Microsoft.ApiManagement/service/properties",
+        "name": "testprop2",
+        "properties": {
+          "displayName": "prop3name",
+          "value": "propValue",
+          "tags": [
+            "foo",
+            "bar"
+          ],
+          "secret": true
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementCreateSubscription.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementCreateSubscription.json
@@ -31,17 +31,19 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/subscriptions/testsub",
-      "type": "Microsoft.ApiManagement/service/subscriptions",
-      "name": "testsub",
-      "properties": {
-        "ownerId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/users/57127d485157a511ace86ae7",
-        "scope": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/products/5600b59475ff190048060002",
-        "displayName": "testsub",
-        "state": "submitted",
-        "createdDate": "2017-06-02T23:34:03.1055076Z",
-        "primaryKey": "06c34e1a9d394412b292e0611e73d417",
-        "secondaryKey": "1e756a7705364c529e8d1760190f47b3"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/subscriptions/testsub",
+        "type": "Microsoft.ApiManagement/service/subscriptions",
+        "name": "testsub",
+        "properties": {
+          "ownerId": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/users/57127d485157a511ace86ae7",
+          "scope": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/products/5600b59475ff190048060002",
+          "displayName": "testsub",
+          "state": "submitted",
+          "createdDate": "2017-06-02T23:34:03.1055076Z",
+          "primaryKey": "06c34e1a9d394412b292e0611e73d417",
+          "secondaryKey": "1e756a7705364c529e8d1760190f47b3"
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementUpdateServiceDisableTls10.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementUpdateServiceDisableTls10.json
@@ -48,42 +48,44 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "Owner": "sasolank",
-        "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
-        "Reserved": "",
-        "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
-        "Pool": "Manual",
-        "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
-      },
-      "location": "West US",
-      "etag": "AAAAAAAYRPs=",
-      "properties": {
-        "publisherEmail": "admin@live.com",
-        "publisherName": "Contoso",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.86.176.232"
-        ],
-        "customProperties": {
-          "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "Owner": "sasolank",
+          "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
+          "Reserved": "",
+          "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
+          "Pool": "Manual",
+          "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
         },
-        "virtualNetworkType": "None"
-      },
-      "sku": {
-        "name": "Standard",
-        "capacity": 1
+        "location": "West US",
+        "etag": "AAAAAAAYRPs=",
+        "properties": {
+          "publisherEmail": "admin@live.com",
+          "publisherName": "Contoso",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.86.176.232"
+          ],
+          "customProperties": {
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+          },
+          "virtualNetworkType": "None"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementUpdateServicePublisherDetails.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementUpdateServicePublisherDetails.json
@@ -47,42 +47,44 @@
       }
     },
     "200": {
-      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
-      "name": "apimService1",
-      "type": "Microsoft.ApiManagement/service",
-      "tags": {
-        "Owner": "sasolank",
-        "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
-        "Reserved": "",
-        "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
-        "Pool": "Manual",
-        "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
-      },
-      "location": "West US",
-      "etag": "AAAAAAAYRPs=",
-      "properties": {
-        "publisherEmail": "foobar@live.com",
-        "publisherName": "Contoso Vnext",
-        "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-        "provisioningState": "Succeeded",
-        "targetProvisioningState": "",
-        "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
-        "gatewayUrl": "https://apimService1.azure-api.net",
-        "portalUrl": "https://apimService1.portal.azure-api.net",
-        "managementApiUrl": "https://apimService1.management.azure-api.net",
-        "scmUrl": "https://apimService1.scm.azure-api.net",
-        "hostnameConfigurations": [],
-        "publicIPAddresses": [
-          "40.86.176.232"
-        ],
-        "customProperties": {
-          "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "Owner": "sasolank",
+          "UID": "4f5025fe-0669-4e2e-8320-5199466e5eb3",
+          "Reserved": "",
+          "TestExpiration": "Thu, 29 Jun 2017 18:50:40 GMT",
+          "Pool": "Manual",
+          "TestSuiteExpiration": "Thu, 29 Jun 2017 18:51:46 GMT"
         },
-        "virtualNetworkType": "None"
-      },
-      "sku": {
-        "name": "Standard",
-        "capacity": 1
+        "location": "West US",
+        "etag": "AAAAAAAYRPs=",
+        "properties": {
+          "publisherEmail": "foobar@live.com",
+          "publisherName": "Contoso Vnext",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2017-06-29T17:50:42.3191122Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "portalUrl": "https://apimService1.portal.azure-api.net",
+          "managementApiUrl": "https://apimService1.management.azure-api.net",
+          "scmUrl": "https://apimService1.scm.azure-api.net",
+          "hostnameConfigurations": [],
+          "publicIPAddresses": [
+            "40.86.176.232"
+          ],
+          "customProperties": {
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False"
+          },
+          "virtualNetworkType": "None"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
       }
     }
   }


### PR DESCRIPTION

- Add missing "body" in response
Didn't add "body" for some "202" with no schemas, but maybe they should be empty.