### PR TITLE
[Azure Search] Fix the definition of WebApiSkill

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -4902,7 +4902,7 @@
         "uri"
       ],
       "externalDocs": {
-        "url": "https://docs.microsoft.com/azure/search/cognitive-search-custom-skill-interface"
+        "url": "https://docs.microsoft.com/azure/search/cognitive-search-custom-skill-web-api"
       },
       "description": "A skill that can call a Web API endpoint, allowing you to extend a skillset by having it call your custom code."
     },

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -4899,9 +4899,7 @@
         }
       },
       "required": [
-        "uri",
-        "httpHeaders",
-        "httpMethod"
+        "uri"
       ],
       "externalDocs": {
         "url": "https://docs.microsoft.com/azure/search/cognitive-search-custom-skill-interface"

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -4896,6 +4896,12 @@
           "format": "int32",
           "x-nullable": true,
           "description": "The desired batch size which indicates number of documents."
+        },
+        "degreeOfParallelism": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "The desired number of parallel api calls that can be made to the web api endpoint."
         }
       },
       "required": [

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -4909,15 +4909,11 @@
       "description": "A skill that can call a Web API endpoint, allowing you to extend a skillset by having it call your custom code."
     },
     "WebApiHttpHeaders": {
-      "properties": {
-        "headers": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "A dictionary of http request headers."
-        }
-      }
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "A dictionary of http request headers."
     },
     "SkillsetListResult": {
       "properties": {


### PR DESCRIPTION
1. The previously defined specification of `WebApiSkill` was incorrect.
HttpHeaders is a top level dictionary and not a nested property under `Headers`

2. Also introduce the new `degreeOfParallelism` parameter

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
