### PR TITLE
Revert "set a default api version"

### DIFF
--- a/specification/containerregistry/resource-manager/readme.md
+++ b/specification/containerregistry/resource-manager/readme.md
@@ -159,7 +159,7 @@ swagger-to-sdk:
     autorest_options:
       use: "@microsoft.azure/autorest.python@4.0.70"
     after_scripts:
-      - python ./scripts/multiapi_init_gen.py azure-mgmt-containerregistry --default-api-version=2017-10-01
+      - python ./scripts/multiapi_init_gen.py azure-mgmt-containerregistry
       - python ./scripts/trim_aio.py ./sdk/containerregistry/azure-mgmt-containerregistry
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#6588

This is no longer needed as the `2019-05-01` api-version is now available in all regions and we want it published.