### PR TITLE
[HDInsight] Change accessModes and applicationType from enum to string

### DIFF
--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2015-03-01-preview/applications.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2015-03-01-preview/applications.json
@@ -233,14 +233,7 @@
         "accessModes": {
           "type": "array",
           "items": {
-            "type": "string",
-            "enum": [
-              "WebPage"
-            ],
-            "x-ms-enum": {
-              "name": "ApplicationHttpsEndpointAccessMode",
-              "modelAsString": true
-            }
+            "type": "string"
           },
           "description": "The list of access modes for the application."
         },
@@ -331,15 +324,7 @@
         },
         "applicationType": {
           "type": "string",
-          "description": "The application type.",
-          "enum": [
-            "CustomApplication",
-            "RServer"
-          ],
-          "x-ms-enum": {
-            "name": "ApplicationType",
-            "modelAsString": true
-          }
+          "description": "The application type."
         },
         "applicationState": {
           "readOnly": true,

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/stable/2018-06-01-preview/applications.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/stable/2018-06-01-preview/applications.json
@@ -233,14 +233,7 @@
         "accessModes": {
           "type": "array",
           "items": {
-            "type": "string",
-            "enum": [
-              "WebPage"
-            ],
-            "x-ms-enum": {
-              "name": "ApplicationHttpsEndpointAccessMode",
-              "modelAsString": true
-            }
+            "type": "string"
           },
           "description": "The list of access modes for the application."
         },
@@ -331,15 +324,7 @@
         },
         "applicationType": {
           "type": "string",
-          "description": "The application type.",
-          "enum": [
-            "CustomApplication",
-            "RServer"
-          ],
-          "x-ms-enum": {
-            "name": "ApplicationType",
-            "modelAsString": true
-          }
+          "description": "The application type."
         },
         "applicationState": {
           "readOnly": true,


### PR DESCRIPTION
- Problem: in previous pr #6665  we modify accessModes and applicationType which are under application.json to enum, this will bring breaking change in java sdk. 

- Solution: remove the two enum, change it to string type

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
