### PR TITLE
Add way to override the service url example

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimapis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimapis.json
@@ -255,7 +255,7 @@
             "$ref": "./examples/ApiManagementCreateApiWithOpenIdConnect.json"
           },
           "ApiManagementCreateApiUsingImportOverrideServiceUrl": {
-            "$ref": "./examples/ApiManagementCreateApiWithOpenIdConnect.json"
+            "$ref": "./examples/ApiManagementCreateApiUsingImportOverrideServiceUrl.json"
           }
         },
         "parameters": [

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimapis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimapis.json
@@ -253,6 +253,9 @@
           },
           "ApiManagementCreateApiWithOpenIdConnect": {
             "$ref": "./examples/ApiManagementCreateApiWithOpenIdConnect.json"
+          },
+          "ApiManagementCreateApiUsingImportOverrideServiceUrl": {
+            "$ref": "./examples/ApiManagementCreateApiWithOpenIdConnect.json"
           }
         },
         "parameters": [

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementCreateApiOperation.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementCreateApiOperation.json
@@ -7,7 +7,6 @@
     "apiId": "PetStoreTemplate2",
     "operationId": "newoperations",
     "parameters": {
-      "name": "newoperation",
       "properties": {
         "displayName": "createUser2",
         "method": "POST",

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementCreateApiUsingImportOverrideServiceUrl.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementCreateApiUsingImportOverrideServiceUrl.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "serviceName": "apimService1",
+    "resourceGroupName": "rg1",
+    "api-version": "2019-01-01",
+    "subscriptionId": "subid",
+    "apiId": "apidocs",
+    "parameters": {
+      "properties": {
+        "format": "swagger-link",
+        "value": "http://apimpimportviaurl.azurewebsites.net/api/apidocs/",
+        "path": "petstoreapi123",
+        "serviceUrl": "http://petstore.swagger.wordnik.com/api"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/apidocs",
+        "type": "Microsoft.ApiManagement/service/apis",
+        "name": "apidocs",
+        "properties": {
+          "displayName": "Swagger Sample App",
+          "apiRevision": "1",
+          "description": "This is a sample server Petstore server.  You can find out more about Swagger \n    at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.  For this sample,\n    you can use the api key \"special-key\" to test the authorization filters",
+          "serviceUrl": "http://petstore.swagger.wordnik.com/api",
+          "path": "petstoreapi123",
+          "protocols": [
+            "https"
+          ],
+          "subscriptionKeyParameterNames": {
+            "header": "Ocp-Apim-Subscription-Key",
+            "query": "subscription-key"
+          },
+          "isCurrent": true
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/apidocs?api-version=2019-01-01&asyncId=5c730e343244df1b9cb56e85&asyncCode=201"
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/apis/apidocs",
+        "type": "Microsoft.ApiManagement/service/apis",
+        "name": "apidocs",
+        "properties": {
+          "displayName": "Swagger Sample App",
+          "apiRevision": "1",
+          "description": "This is a sample server Petstore server.  You can find out more about Swagger \n    at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.  For this sample,\n    you can use the api key \"special-key\" to test the authorization filters",
+          "serviceUrl": "http://petstore.swagger.wordnik.com/api",
+          "path": "petstoreapi123",
+          "protocols": [
+            "https"
+          ],
+          "subscriptionKeyParameterNames": {
+            "header": "Ocp-Apim-Subscription-Key",
+            "query": "subscription-key"
+          },
+          "isCurrent": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
Added example on how to override the ServiceUrl when doing the API Import
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
