### PR TITLE
next link in alerts management

### DIFF
--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-05-05-preview/examples/SmartGroups_List.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-05-05-preview/examples/SmartGroups_List.json
@@ -6,7 +6,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": nulls,
+        "nextLink": null,
         "value": [
           {
             "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-05-05-preview/examples/SmartGroups_List.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-05-05-preview/examples/SmartGroups_List.json
@@ -6,7 +6,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": nulls,
         "value": [
           {
             "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-11-02-privatepreview/examples/SmartGroups_List.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-11-02-privatepreview/examples/SmartGroups_List.json
@@ -6,7 +6,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": null,
         "value": [
           {
             "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-03-01-preview/examples/SmartGroups_List.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-03-01-preview/examples/SmartGroups_List.json
@@ -6,7 +6,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": null,
         "value": [
           {
             "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/examples/SmartGroups_List.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/examples/SmartGroups_List.json
@@ -6,7 +6,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": null,
         "value": [
           {
             "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2018-05-05/examples/SmartGroups_List.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2018-05-05/examples/SmartGroups_List.json
@@ -6,7 +6,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": null,
         "value": [
           {
             "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/examples/SmartDetectorAlertRule_List.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/examples/SmartDetectorAlertRule_List.json
@@ -7,7 +7,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": null,
         "value": [
           {
             "id": "/subscriptions/b368ca2f-e298-46b7-b0ab-012281956afa/resourceGroups/MyAlertRules/providers/microsoft.alertsManagement/smartDetectorAlertRules/MyAlertRule",

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/examples/SmartDetectorAlertRule_ListByResourceGroup.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/examples/SmartDetectorAlertRule_ListByResourceGroup.json
@@ -7,7 +7,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": null,
         "value": [
           {
             "id": "/subscriptions/b368ca2f-e298-46b7-b0ab-012281956afa/resourceGroups/MyAlertRules/providers/microsoft.alertsManagement/smartDetectorAlertRules/MyAlertRule",

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/examples/SmartGroups_List.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/examples/SmartGroups_List.json
@@ -6,7 +6,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": null,
         "value": [
           {
             "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-06-01/examples/SmartDetectorAlertRule_List.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-06-01/examples/SmartDetectorAlertRule_List.json
@@ -7,7 +7,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": null,
         "value": [
           {
             "id": "/subscriptions/b368ca2f-e298-46b7-b0ab-012281956afa/resourceGroups/MyAlertRules/providers/microsoft.alertsManagement/smartDetectorAlertRules/MyAlertRule",

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-06-01/examples/SmartDetectorAlertRule_ListByResourceGroup.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-06-01/examples/SmartDetectorAlertRule_ListByResourceGroup.json
@@ -7,7 +7,7 @@
   "responses": {
     "200": {
       "body": {
-        "nextLink": "",
+        "nextLink": null,
         "value": [
           {
             "id": "/subscriptions/b368ca2f-e298-46b7-b0ab-012281956afa/resourceGroups/MyAlertRules/providers/microsoft.alertsManagement/smartDetectorAlertRules/MyAlertRule",


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
