### PR TITLE
fixed nextLink in servicefabric

### DIFF
--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2017-07-01-preview/examples/ClusterListOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2017-07-01-preview/examples/ClusterListOperation_example.json
@@ -197,7 +197,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ApplicationListOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ApplicationListOperation_example.json
@@ -33,7 +33,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ApplicationTypeNameListOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ApplicationTypeNameListOperation_example.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ApplicationTypeVersionListOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ApplicationTypeVersionListOperation_example.json
@@ -25,7 +25,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ClusterListByResourceGroupOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ClusterListByResourceGroupOperation_example.json
@@ -241,7 +241,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ClusterListOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ClusterListOperation_example.json
@@ -240,7 +240,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ServiceListOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2019-03-01-preview/examples/ServiceListOperation_example.json
@@ -36,7 +36,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/stable/2018-02-01/examples/ClusterListByResourceGroupOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/stable/2018-02-01/examples/ClusterListByResourceGroupOperation_example.json
@@ -239,7 +239,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/stable/2018-02-01/examples/ClusterListOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/stable/2018-02-01/examples/ClusterListOperation_example.json
@@ -238,7 +238,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
