### PR TITLE
fixing next-link in hybrid data manager

### DIFF
--- a/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/DataServices_ListByDataManager-GET-example-51.json
+++ b/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/DataServices_ListByDataManager-GET-example-51.json
@@ -102,7 +102,7 @@
             "type": "Microsoft.HybridData/dataManagers/dataServices"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/DataStoreTypes_ListByDataManager-GET-example-171.json
+++ b/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/DataStoreTypes_ListByDataManager-GET-example-171.json
@@ -97,7 +97,7 @@
             "type": "Microsoft.HybridData/dataManagers/dataStoreTypes"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/DataStores_ListByDataManager-GET-example-151.json
+++ b/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/DataStores_ListByDataManager-GET-example-151.json
@@ -49,7 +49,7 @@
             "type": "Microsoft.HybridData/dataManagers/dataStores"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/JobDefinitions_ListByDataManager-GET-example-191.json
+++ b/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/JobDefinitions_ListByDataManager-GET-example-191.json
@@ -50,7 +50,7 @@
             "type": "Microsoft.HybridData/dataManagers/dataServices/jobDefinitions"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/JobDefinitions_ListByDataService-GET-example-71.json
+++ b/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/JobDefinitions_ListByDataService-GET-example-71.json
@@ -51,7 +51,7 @@
             "type": "Microsoft.HybridData/dataManagers/dataServices/jobDefinitions"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/Jobs_ListByDataManager-GET-example-201.json
+++ b/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/Jobs_ListByDataManager-GET-example-201.json
@@ -64,7 +64,7 @@
             "type": "Microsoft.HybridData/dataManagers/jobs"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/Jobs_ListByDataService-GET-example-141.json
+++ b/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/Jobs_ListByDataService-GET-example-141.json
@@ -65,7 +65,7 @@
             "type": "Microsoft.HybridData/dataManagers/jobs"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/Jobs_ListByJobDefinition-GET-example-91.json
+++ b/specification/hybriddatamanager/resource-manager/Microsoft.HybridData/stable/2016-06-01/examples/Jobs_ListByJobDefinition-GET-example-91.json
@@ -66,7 +66,7 @@
             "type": "Microsoft.HybridData/dataManagers/jobs"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
