### PR TITLE
fixed next link in customer-insights

### DIFF
--- a/specification/customer-insights/resource-manager/Microsoft.CustomerInsights/stable/2017-01-01/examples/ProfilesListByHub.json
+++ b/specification/customer-insights/resource-manager/Microsoft.CustomerInsights/stable/2017-01-01/examples/ProfilesListByHub.json
@@ -111,7 +111,7 @@
             "type": "Microsoft.CustomerInsights/hubs/profiles"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/customer-insights/resource-manager/Microsoft.CustomerInsights/stable/2017-04-26/examples/ProfilesListByHub.json
+++ b/specification/customer-insights/resource-manager/Microsoft.CustomerInsights/stable/2017-04-26/examples/ProfilesListByHub.json
@@ -111,7 +111,7 @@
             "type": "Microsoft.CustomerInsights/hubs/profiles"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
