### PR TITLE
nextLink in azsadmin

### DIFF
--- a/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Offer/MetricDefinitions.json
+++ b/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Offer/MetricDefinitions.json
@@ -10,7 +10,7 @@
     "200": {
       "body": {
         "value": [],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Offer/Metrics.json
+++ b/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Offer/Metrics.json
@@ -10,7 +10,7 @@
     "200": {
       "body": {
         "value": [],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Plan/MetricDefinitions.json
+++ b/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Plan/MetricDefinitions.json
@@ -10,7 +10,7 @@
     "200": {
       "body": {
         "value": [],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Plan/Metrics.json
+++ b/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Plan/Metrics.json
@@ -10,7 +10,7 @@
     "200": {
       "body": {
         "value": [],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Quota/Create.json
+++ b/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Quota/Create.json
@@ -13,7 +13,7 @@
     "200": {
       "body": {
         "value": [],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Quota/Delete.json
+++ b/specification/azsadmin/resource-manager/subscriptions/Microsoft.Subscriptions.Admin/preview/2015-11-01/examples/Quota/Delete.json
@@ -13,7 +13,7 @@
     "200": {
       "body": {
         "value": [],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/update/Microsoft.Update.Admin/preview/2016-05-01/examples/Operations/List.json
+++ b/specification/azsadmin/resource-manager/update/Microsoft.Update.Admin/preview/2016-05-01/examples/Operations/List.json
@@ -13,7 +13,7 @@
     "200": {
       "body": {
         "value": [],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/update/Microsoft.Update.Admin/preview/2016-05-01/examples/UpdateRuns/List.json
+++ b/specification/azsadmin/resource-manager/update/Microsoft.Update.Admin/preview/2016-05-01/examples/UpdateRuns/List.json
@@ -396,7 +396,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/update/Microsoft.Update.Admin/preview/2016-05-01/examples/Updates/List.json
+++ b/specification/azsadmin/resource-manager/update/Microsoft.Update.Admin/preview/2016-05-01/examples/Updates/List.json
@@ -32,7 +32,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
