### PR TITLE
fixed next link in backup

### DIFF
--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/List.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Backups/List.json
@@ -83,7 +83,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Operations/List.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/preview/2018-09-01/examples/Operations/List.json
@@ -45,7 +45,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/stable/2016-05-01/examples/Backups/List.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/stable/2016-05-01/examples/Backups/List.json
@@ -79,7 +79,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     },
     "404": {}

--- a/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/stable/2016-05-01/examples/Operations/List.json
+++ b/specification/azsadmin/resource-manager/backup/Microsoft.Backup.Admin/stable/2016-05-01/examples/Operations/List.json
@@ -8,7 +8,7 @@
     "200": {
       "body": {
         "value": [],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
