### PR TITLE
fixed next link in automation

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/job/listJobStreamsByJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/job/listJobStreamsByJob.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/job/listJobsByAutomationAccount.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/job/listJobsByAutomationAccount.json
@@ -46,7 +46,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJobStreams/getSourceControlSyncJobStreams.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/preview/2017-05-15-preview/examples/sourceControlSyncJobStreams/getSourceControlSyncJobStreams.json
@@ -40,7 +40,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/examples/listTestJobStreamsByJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/examples/listTestJobStreamsByJob.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2018-06-30/examples/listTestJobStreamsByJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2018-06-30/examples/listTestJobStreamsByJob.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
