### PR TITLE
next link can't be empty string

### DIFF
--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetQuotas.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetQuotas.json
@@ -20,7 +20,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByApi.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByApi.json
@@ -46,7 +46,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByGeo.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByGeo.json
@@ -29,7 +29,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByOperation.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByOperation.json
@@ -67,7 +67,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByProduct.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByProduct.json
@@ -46,7 +46,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsBySubscription.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsBySubscription.json
@@ -70,7 +70,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByTime.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByTime.json
@@ -47,7 +47,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByUser.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementGetReportsByUser.json
@@ -64,7 +64,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementListApisOperationsPolicies.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementListApisOperationsPolicies.json
@@ -14,7 +14,7 @@
             "policyContent": "<!--\r\n    IMPORTANT:\r\n    - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.\r\n    - Only the <forward-request> policy element can appear within the <backend> section element.\r\n    - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.\r\n    - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.\r\n    - To add a policy position the cursor at the desired insertion point and click on the round button associated with the policy.\r\n    - To remove a policy, delete the corresponding policy statement from the policy document.\r\n    - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.\r\n    - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.\r\n    - Policies are applied in the order of their appearance, from the top down.\r\n-->\r\n<policies>\r\n  <inbound>\r\n    <validate-jwt header-name=\"dd\">\r\n      <required-claims>\r\n        <claim name=\"bla\" separator=\"\">\r\n          <value>xxx</value>\r\n        </claim>\r\n      </required-claims>\r\n    </validate-jwt>\r\n    <base />\r\n  </inbound>\r\n  <backend>\r\n    <base />\r\n  </backend>\r\n  <outbound>\r\n    <base />\r\n  </outbound>\r\n</policies>"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementListRegions.json
+++ b/specification/apimanagement/control-plane/Microsoft.ApiManagement/preview/2017-03-01/examples/ApiManagementListRegions.json
@@ -14,7 +14,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetQuotaCounterKeys.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetQuotaCounterKeys.json
@@ -22,7 +22,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByApi.json
@@ -48,7 +48,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByGeo.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByGeo.json
@@ -31,7 +31,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByOperation.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByOperation.json
@@ -69,7 +69,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByProduct.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByProduct.json
@@ -48,7 +48,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsBySubscription.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsBySubscription.json
@@ -72,7 +72,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByTime.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByTime.json
@@ -49,7 +49,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByUser.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetReportsByUser.json
@@ -66,7 +66,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetTagsForOperation.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementGetTagsForOperation.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiDiagnostics.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiDiagnostics.json
@@ -60,7 +60,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiIssueAttachments.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiIssueAttachments.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiIssueComments.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiIssueComments.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiIssues.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiIssues.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiOperationPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiOperationPolicies.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiOperationTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiOperationTags.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiOperations.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiOperations.json
@@ -62,7 +62,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiPolicies.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiProducts.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiProducts.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiReleases.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiReleases.json
@@ -21,7 +21,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiRevisions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiRevisions.json
@@ -19,7 +19,7 @@
             "isCurrent": true
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiSchemas.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiSchemas.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiTagDescriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiTagDescriptions.json
@@ -21,7 +21,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiTags.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiVersionSets.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApiVersionSets.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListApis.json
@@ -74,7 +74,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListAuthorizationServers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListAuthorizationServers.json
@@ -69,7 +69,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListBackends.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListBackends.json
@@ -73,7 +73,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListCertificates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListCertificates.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListDiagnostics.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListDiagnostics.json
@@ -59,7 +59,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListEmailTemplates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListEmailTemplates.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListGroupUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListGroupUsers.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListGroups.json
@@ -55,7 +55,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListIdentityProviders.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListIdentityProviders.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListIssues.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListIssues.json
@@ -23,7 +23,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListLoggers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListLoggers.json
@@ -39,7 +39,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListNotificationRecipientEmails.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListNotificationRecipientEmails.json
@@ -35,7 +35,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListNotificationRecipientUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListNotificationRecipientUsers.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListNotifications.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListNotifications.json
@@ -119,7 +119,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListOpenIdConnectProviders.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListOpenIdConnectProviders.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListPolicies.json
@@ -18,7 +18,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductApis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductApis.json
@@ -27,7 +27,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductGroups.json
@@ -44,7 +44,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductPolicies.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductSubscriptions.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProductTags.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProducts.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProducts.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProperties.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListProperties.json
@@ -34,7 +34,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListRegions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListRegions.json
@@ -16,7 +16,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListSubscriptions.json
@@ -54,7 +54,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListTags.json
@@ -26,7 +26,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListUserGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListUserGroups.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListUserIdentities.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListUserIdentities.json
@@ -16,7 +16,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListUserSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListUserSubscriptions.json
@@ -41,7 +41,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2018-06-01-preview/examples/ApiManagementListUsers.json
@@ -64,7 +64,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetProductsForApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetProductsForApi.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetQuotaCounterKeys.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetQuotaCounterKeys.json
@@ -22,7 +22,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByApi.json
@@ -48,7 +48,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByGeo.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByGeo.json
@@ -31,7 +31,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByOperation.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByOperation.json
@@ -69,7 +69,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByProduct.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByProduct.json
@@ -48,7 +48,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsBySubscription.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsBySubscription.json
@@ -72,7 +72,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByTime.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByTime.json
@@ -49,7 +49,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByUser.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetReportsByUser.json
@@ -66,7 +66,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetTagDescriptionsForApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetTagDescriptionsForApi.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetTagsForApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetTagsForApi.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetTagsForOperation.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetTagsForOperation.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetTagsForProduct.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementGetTagsForProduct.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiDiagnosticLoggers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiDiagnosticLoggers.json
@@ -25,7 +25,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiDiagnostics.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiDiagnostics.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiIssueAttachments.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiIssueAttachments.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiIssueComments.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiIssueComments.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiIssues.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiIssues.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiOperationPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiOperationPolicies.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiOperations.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiOperations.json
@@ -62,7 +62,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiPolicies.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiReleases.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiReleases.json
@@ -21,7 +21,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiRevisions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiRevisions.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiSchemas.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiSchemas.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiVersionSets.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApiVersionSets.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApis.json
@@ -74,7 +74,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApisByTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListApisByTags.json
@@ -94,7 +94,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListAuthorizationServers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListAuthorizationServers.json
@@ -69,7 +69,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListBackends.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListBackends.json
@@ -73,7 +73,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListCertificates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListCertificates.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListDiagnosticLoggers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListDiagnosticLoggers.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListDiagnostics.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListDiagnostics.json
@@ -18,7 +18,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListEmailTemplates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListEmailTemplates.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListGroupUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListGroupUsers.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListGroups.json
@@ -55,7 +55,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListIdentityProviders.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListIdentityProviders.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListLoggers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListLoggers.json
@@ -37,7 +37,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListNotificationRecipientEmail.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListNotificationRecipientEmail.json
@@ -35,7 +35,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListNotificationRecipientUser.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListNotificationRecipientUser.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListNotifications.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListNotifications.json
@@ -119,7 +119,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListOpenIdConnectProviders.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListOpenIdConnectProviders.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListOperationsByTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListOperationsByTags.json
@@ -63,7 +63,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListPolicies.json
@@ -18,7 +18,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProductApis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProductApis.json
@@ -27,7 +27,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProductGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProductGroups.json
@@ -44,7 +44,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProductPolicy.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProductPolicy.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProductSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProductSubscriptions.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProducts.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProducts.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProperties.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListProperties.json
@@ -34,7 +34,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListRegions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListRegions.json
@@ -16,7 +16,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListSubscriptions.json
@@ -54,7 +54,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListTagResources.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListTagResources.json
@@ -117,7 +117,7 @@
           }
         ]
       },
-      "nextLink": ""
+      "nextLink": null
     }
   }
 }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListTags.json
@@ -26,7 +26,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListUserGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListUserGroups.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListUserSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListUserSubscriptions.json
@@ -41,7 +41,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListUsers.json
@@ -64,7 +64,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListUsersIdentities.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2017-03-01/examples/ApiManagementListUsersIdentities.json
@@ -16,7 +16,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetProductsForApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetProductsForApi.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetQuotaCounterKeys.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetQuotaCounterKeys.json
@@ -22,7 +22,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByApi.json
@@ -48,7 +48,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByGeo.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByGeo.json
@@ -31,7 +31,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByOperation.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByOperation.json
@@ -69,7 +69,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByProduct.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByProduct.json
@@ -48,7 +48,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsBySubscription.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsBySubscription.json
@@ -72,7 +72,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByTime.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByTime.json
@@ -49,7 +49,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByUser.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetReportsByUser.json
@@ -66,7 +66,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetTagDescriptionsForApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetTagDescriptionsForApi.json
@@ -21,7 +21,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetTagsForApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetTagsForApi.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetTagsForOperation.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetTagsForOperation.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetTagsForProduct.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementGetTagsForProduct.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiDiagnosticLoggers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiDiagnosticLoggers.json
@@ -25,7 +25,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiDiagnostics.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiDiagnostics.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiIssueAttachments.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiIssueAttachments.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiIssueComments.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiIssueComments.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiIssues.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiIssues.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiOperationPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiOperationPolicies.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiOperations.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiOperations.json
@@ -62,7 +62,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiPolicies.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiReleases.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiReleases.json
@@ -21,7 +21,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiRevisions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiRevisions.json
@@ -19,7 +19,7 @@
             "isCurrent": true
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiSchemas.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiSchemas.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiVersionSets.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApiVersionSets.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListApis.json
@@ -74,7 +74,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListAuthorizationServers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListAuthorizationServers.json
@@ -69,7 +69,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListBackends.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListBackends.json
@@ -73,7 +73,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListCertificates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListCertificates.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListDiagnosticLoggers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListDiagnosticLoggers.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListDiagnostics.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListDiagnostics.json
@@ -18,7 +18,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListEmailTemplates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListEmailTemplates.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListGroupUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListGroupUsers.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListGroups.json
@@ -55,7 +55,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListIdentityProviders.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListIdentityProviders.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListIssues.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListIssues.json
@@ -23,7 +23,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListLoggers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListLoggers.json
@@ -37,7 +37,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListNotificationRecipientEmail.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListNotificationRecipientEmail.json
@@ -35,7 +35,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListNotificationRecipientUser.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListNotificationRecipientUser.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListNotifications.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListNotifications.json
@@ -119,7 +119,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListOpenIdConnectProviders.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListOpenIdConnectProviders.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListPolicies.json
@@ -18,7 +18,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProductApis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProductApis.json
@@ -27,7 +27,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProductGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProductGroups.json
@@ -44,7 +44,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProductPolicy.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProductPolicy.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProductSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProductSubscriptions.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProducts.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProducts.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProperties.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListProperties.json
@@ -34,7 +34,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListRegions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListRegions.json
@@ -16,7 +16,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListSubscriptions.json
@@ -54,7 +54,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListTags.json
@@ -26,7 +26,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListUserGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListUserGroups.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListUserSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListUserSubscriptions.json
@@ -41,7 +41,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListUsers.json
@@ -64,7 +64,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListUsersIdentities.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2018-01-01/examples/ApiManagementListUsersIdentities.json
@@ -16,7 +16,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetQuotaCounterKeys.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetQuotaCounterKeys.json
@@ -21,7 +21,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByApi.json
@@ -48,7 +48,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByGeo.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByGeo.json
@@ -30,7 +30,7 @@
             "serviceTimeMax": 1697.3612
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByOperation.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByOperation.json
@@ -69,7 +69,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByProduct.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByProduct.json
@@ -48,7 +48,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsBySubscription.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsBySubscription.json
@@ -72,7 +72,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByTime.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByTime.json
@@ -49,7 +49,7 @@
           }
         ],
         "count": 2,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByUser.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementGetReportsByUser.json
@@ -66,7 +66,7 @@
           }
         ],
         "count": 3,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiDiagnostics.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiDiagnostics.json
@@ -60,7 +60,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiIssueAttachments.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiIssueAttachments.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiIssueComments.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiIssueComments.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiIssues.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiIssues.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiOperationPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiOperationPolicies.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiOperationTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiOperationTags.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiOperations.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiOperations.json
@@ -62,7 +62,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiPolicies.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiProducts.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiProducts.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiReleases.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiReleases.json
@@ -21,7 +21,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiRevisions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiRevisions.json
@@ -19,7 +19,7 @@
             "isCurrent": true
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiSchemas.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiSchemas.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiTagDescriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiTagDescriptions.json
@@ -21,7 +21,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiTags.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiVersionSets.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApiVersionSets.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListApis.json
@@ -74,7 +74,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListAuthorizationServers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListAuthorizationServers.json
@@ -69,7 +69,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListBackends.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListBackends.json
@@ -73,7 +73,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListCertificates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListCertificates.json
@@ -20,7 +20,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListDiagnostics.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListDiagnostics.json
@@ -59,7 +59,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListEmailTemplates.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListEmailTemplates.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListGroupUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListGroupUsers.json
@@ -30,7 +30,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListGroups.json
@@ -55,7 +55,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListIdentityProviders.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListIdentityProviders.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListIssues.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListIssues.json
@@ -23,7 +23,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListLoggers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListLoggers.json
@@ -39,7 +39,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListNotificationRecipientEmails.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListNotificationRecipientEmails.json
@@ -35,7 +35,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListNotificationRecipientUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListNotificationRecipientUsers.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListNotifications.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListNotifications.json
@@ -119,7 +119,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListOpenIdConnectProviders.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListOpenIdConnectProviders.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListPolicies.json
@@ -18,7 +18,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductApis.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductApis.json
@@ -27,7 +27,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductGroups.json
@@ -44,7 +44,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductPolicies.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductPolicies.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductSubscriptions.json
@@ -24,7 +24,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProductTags.json
@@ -19,7 +19,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProducts.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProducts.json
@@ -48,7 +48,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProperties.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListProperties.json
@@ -34,7 +34,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListRegions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListRegions.json
@@ -16,7 +16,7 @@
           }
         ],
         "count": 1,
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListSubscriptions.json
@@ -54,7 +54,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListTags.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListTags.json
@@ -26,7 +26,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListUserGroups.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListUserGroups.json
@@ -22,7 +22,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListUserIdentities.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListUserIdentities.json
@@ -15,7 +15,7 @@
             "id": "086cf9********55ab"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListUserSubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListUserSubscriptions.json
@@ -41,7 +41,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListUsers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/examples/ApiManagementListUsers.json
@@ -64,7 +64,7 @@
             }
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
