### PR TITLE
fixed next link in storagesync

### DIFF
--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/preview/2017-06-05-preview/examples/Operations_List.json
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/preview/2017-06-05-preview/examples/Operations_List.json
@@ -207,7 +207,7 @@
             "origin": "User"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2018-04-02/examples/Operations_List.json
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2018-04-02/examples/Operations_List.json
@@ -207,7 +207,7 @@
             "origin": "User"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2018-07-01/examples/Operations_List.json
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2018-07-01/examples/Operations_List.json
@@ -207,7 +207,7 @@
             "origin": "User"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2018-10-01/examples/Operations_List.json
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2018-10-01/examples/Operations_List.json
@@ -207,7 +207,7 @@
             "origin": "User"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2019-02-01/examples/Operations_List.json
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2019-02-01/examples/Operations_List.json
@@ -207,7 +207,7 @@
             "origin": "User"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2019-03-01/examples/Operations_List.json
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/stable/2019-03-01/examples/Operations_List.json
@@ -207,7 +207,7 @@
             "origin": "User"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
