### PR TITLE
fixed nextLink in web

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/examples/ListResourceHealthMetadataByResourceGroup.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/examples/ListResourceHealthMetadataByResourceGroup.json
@@ -18,7 +18,7 @@
             "type": "Microsoft.Web/sites/resourceHealthMetadata"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/examples/ListResourceHealthMetadataBySite.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/examples/ListResourceHealthMetadataBySite.json
@@ -20,7 +20,7 @@
             "type": "Microsoft.Web/sites/resourceHealthMetadata"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/examples/ListResourceHealthMetadataBySubscription.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/examples/ListResourceHealthMetadataBySubscription.json
@@ -17,7 +17,7 @@
             "type": "Microsoft.Web/sites/resourceHealthMetadata"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/examples/ListResourceHealthMetadataByResourceGroup.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/examples/ListResourceHealthMetadataByResourceGroup.json
@@ -18,7 +18,7 @@
             "type": "Microsoft.Web/sites/resourceHealthMetadata"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/examples/ListResourceHealthMetadataBySite.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/examples/ListResourceHealthMetadataBySite.json
@@ -20,7 +20,7 @@
             "type": "Microsoft.Web/sites/resourceHealthMetadata"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/examples/ListResourceHealthMetadataBySubscription.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/examples/ListResourceHealthMetadataBySubscription.json
@@ -17,7 +17,7 @@
             "type": "Microsoft.Web/sites/resourceHealthMetadata"
           }
         ],
-        "nextLink": ""
+        "nextLink": null
       }
     }
   }


### PR DESCRIPTION
This PR is fixing a problem with **nextLink**.

According to the guidelines below, **nextLink** should never be empty string.
I am fixing examples in specs first and in the same time this should be escalated with service teams.
If the service returns empty string I will escalate this accordingly.

Please note that not following this guideline may result in unpredictable behaviour of client implementations.

https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/resource-api-reference.md#get-resource

If a resource provider does not support paging, it should return the same body (JSON object with "value" property) but omit nextLink entirely (or set to null, *not* empty string) for future compatibility.
