### PR TITLE
Fixed healthcare readme.md / readme.python.md

### DIFF
--- a/specification/healthcareapis/resource-manager/readme.md
+++ b/specification/healthcareapis/resource-manager/readme.md
@@ -60,31 +60,7 @@ swagger-to-sdk:
 
 ## Python
 
-These settings apply only when `--python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
-
-``` yaml $(python)
-python-mode: create
-python:
-  azure-arm: true
-  license-header: MICROSOFT_MIT_NO_VERSION
-  payload-flattening-threshold: 2
-  namespace: azure.mgmt.healthcareapis
-  package-name: azure-mgmt-healthcareapis
-  clear-output-folder: true
-  package-version: 0.1.0
-```
-``` yaml $(python) && $(python-mode) == 'update'
-python:
-  no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-healthcareapis/azure/mgmt/healthcareapis
-```
-``` yaml $(python) && $(python-mode) == 'create'
-python:
-  basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-healthcareapis
-```
+See configuration in [readme.python.md](./readme.python.md)
 
 ## Go
 

--- a/specification/healthcareapis/resource-manager/readme.md
+++ b/specification/healthcareapis/resource-manager/readme.md
@@ -1,4 +1,4 @@
-# HealthcareApis XX
+# HealthcareApis XXx
 
 > see https://aka.ms/autorest
 

--- a/specification/healthcareapis/resource-manager/readme.md
+++ b/specification/healthcareapis/resource-manager/readme.md
@@ -1,4 +1,4 @@
-# HealthcareApis XXx
+# HealthcareApis
 
 > see https://aka.ms/autorest
 

--- a/specification/healthcareapis/resource-manager/readme.md
+++ b/specification/healthcareapis/resource-manager/readme.md
@@ -1,4 +1,4 @@
-# HealthcareApis
+# HealthcareApis XX
 
 > see https://aka.ms/autorest
 

--- a/specification/healthcareapis/resource-manager/readme.python.md
+++ b/specification/healthcareapis/resource-manager/readme.python.md
@@ -1,4 +1,4 @@
-## Python XX
+## Python
 
 These settings apply only when `--python` is specified on the command line.
 Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.

--- a/specification/healthcareapis/resource-manager/readme.python.md
+++ b/specification/healthcareapis/resource-manager/readme.python.md
@@ -1,4 +1,4 @@
-## Python
+## Python XX
 
 These settings apply only when `--python` is specified on the command line.
 Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.


### PR DESCRIPTION
Python parameters were defined in both **readme.md** and **readme.python.md**.
Parameters defined in **readme.md** were invalid (wrong output folder defined), and the result was that package structure was wrong: **healthcareapis** component was missing, and some top-level files, like release history, were missing.

This PR removes wrong version from **readme.md**.