### PR TITLE
sort custom words

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -439,8 +439,8 @@ endtime
 Enein
 engagementfabric
 enquoted
-entitysearch
 entitydocument
+entitysearch
 entrypoint
 environmentsettings
 errordetail
@@ -1133,8 +1133,8 @@ rhel
 Rolledback
 rollouts
 rolloverdetails
-rosettanetprocessconfigurations
 rootfs
+rosettanetprocessconfigurations
 rotatediskencryptionkey
 routable
 routingendpointhealth


### PR DESCRIPTION
Sort the custom words. This makes it easier to add new custom words and have less conflicts. VSCode was used to do the sort.