### PR TITLE
Adding swagger spec for unprepare subnet

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1387,6 +1387,9 @@ UNOY
 unpairing
 Unparked
 unparsed
+unprepare
+unprepares
+unpreparing
 Unprovision
 unprovisioned
 Unprovisioning

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/SubnetUnprepareNetworkPolicies.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/examples/SubnetUnprepareNetworkPolicies.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2019-06-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "rg1",
+    "virtualNetworkName": "test-vnet",
+    "subnetName": "subnet1",
+    "unprepareNetworkPoliciesRequestParameters": {
+      "serviceName": "Microsoft.Sql/managedInstances"
+    }
+  },
+  "responses": {
+    "200": {},
+    "202": {}
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/virtualNetwork.json
@@ -648,7 +648,7 @@
           "final-state-via": "location"
         },
         "x-ms-examples": {
-          "Prepare Network Policies": {
+          "Unprepare Network Policies": {
             "$ref": "./examples/SubnetUnprepareNetworkPolicies.json"
           }
         }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/virtualNetwork.json
@@ -593,6 +593,67 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/UnprepareNetworkPolicies": {
+      "post": {
+        "operationId": "Subnets_UnprepareNetworkPolicies",
+        "description": "Unprepares a subnet by removing network intent policies.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the virtual network."
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the subnet."
+          },
+          {
+            "name": "unprepareNetworkPoliciesRequestParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UnprepareNetworkPoliciesRequest"
+            },
+            "description": "Parameters supplied to unprepare subnet to remove network intent policies."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unpreparing subnet by removing network intent policies is successful."
+          },
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-examples": {
+          "Prepare Network Policies": {
+            "$ref": "./examples/SubnetUnprepareNetworkPolicies.json"
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/ResourceNavigationLinks": {
       "get": {
         "operationId": "ResourceNavigationLinks_List",
@@ -1691,6 +1752,15 @@
         }
       },
       "description": "Details of PrepareNetworkPolicies for Subnet."
+    },
+    "UnprepareNetworkPoliciesRequest": {
+      "properties": {
+        "serviceName": {
+          "type": "string",
+          "description": "The name of the service for which subnet is being unprepared for."
+        }
+      },
+      "description": "Details of UnprepareNetworkPolicies for Subnet."
     },
     "NetworkIntentPolicyConfiguration": {
       "properties": {


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
