### PR TITLE
Add missing read-only property "outboundRules" in LoadBalancer specs

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreate.json
@@ -74,8 +74,7 @@
             }
           }
         ],
-        "inboundNatPools": [],
-        "outboundRules": []
+        "inboundNatPools": []
       }
     }
   },
@@ -192,7 +191,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }
@@ -309,7 +307,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -58,7 +61,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -115,7 +118,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithOutboundRules.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithOutboundRules.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-08-01",
+    "api-version": "2018-07-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "loadBalancerName": "lb",
@@ -14,13 +14,10 @@
           {
             "name": "fe-lb",
             "properties": {
-              "subnet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              "publicIPAddress": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
               }
-            },
-            "zones": [
-              "1"
-            ]
+            }
           }
         ],
         "backendAddressPools": [
@@ -36,18 +33,19 @@
               "frontendIPConfiguration": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
               },
-              "frontendPort": 80,
-              "backendPort": 80,
-              "enableFloatingIP": true,
-              "idleTimeoutInMinutes": 15,
-              "protocol": "Tcp",
-              "loadDistribution": "Default",
               "backendAddressPool": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
               },
               "probe": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-              }
+              },
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "idleTimeoutInMinutes": 15,
+              "enableFloatingIP": true,
+              "disableOutboundSnat": true
             }
           }
         ],
@@ -79,7 +77,22 @@
           }
         ],
         "inboundNatPools": [],
-        "outboundRules": []
+        "outboundRules": [
+          {
+            "name": "rule1",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "frontendIPConfigurations": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                }
+              ],
+              "protocol": "All"
+            }
+          }
+        ]
       }
     }
   },
@@ -89,25 +102,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -118,6 +130,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -126,8 +143,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -140,6 +163,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -150,14 +174,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -165,6 +190,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -184,6 +210,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -193,11 +220,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }
@@ -207,25 +256,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -236,6 +284,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -244,8 +297,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -258,6 +317,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -268,14 +328,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -283,6 +344,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -302,6 +364,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -311,11 +374,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerCreateWithZones.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -88,7 +91,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -206,7 +209,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerGet.json
@@ -118,7 +118,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerList.json
@@ -115,7 +115,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },
@@ -131,7 +130,6 @@
               "loadBalancingRules": [],
               "probes": [],
               "inboundNatRules": [],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/examples/LoadBalancerListAll.json
@@ -114,7 +114,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-07-01/loadBalancer.json
@@ -193,6 +193,9 @@
           },
           "Create load balancer with inbound nat pool": {
             "$ref": "./examples/LoadBalancerCreateWithInboundNatPool.json"
+          },
+          "Create load balancer with outbound rules": {
+            "$ref": "./examples/LoadBalancerCreateWithOutboundRules.json"
           }
         },
         "x-ms-long-running-operation": true
@@ -1129,6 +1132,14 @@
           "$ref": "./network.json#/definitions/SubResource",
           "description": "Gets outbound rules that use this backend address pool."
         },
+        "outboundRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Gets outbound rules that use this backend address pool."
+        },
         "provisioningState": {
           "type": "string",
           "description": "Get provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
@@ -1511,7 +1522,7 @@
         "frontendIPConfigurations",
         "protocol"
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "OutboundRule": {
       "properties": {
@@ -1534,7 +1545,7 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "LoadBalancerPropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreate.json
@@ -74,8 +74,7 @@
             }
           }
         ],
-        "inboundNatPools": [],
-        "outboundRules": []
+        "inboundNatPools": []
       }
     }
   },
@@ -192,7 +191,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }
@@ -309,7 +307,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -58,7 +61,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -115,7 +118,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateWithOutboundRules.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerCreateWithOutboundRules.json
@@ -14,13 +14,10 @@
           {
             "name": "fe-lb",
             "properties": {
-              "subnet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              "publicIPAddress": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
               }
-            },
-            "zones": [
-              "1"
-            ]
+            }
           }
         ],
         "backendAddressPools": [
@@ -36,18 +33,19 @@
               "frontendIPConfiguration": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
               },
-              "frontendPort": 80,
-              "backendPort": 80,
-              "enableFloatingIP": true,
-              "idleTimeoutInMinutes": 15,
-              "protocol": "Tcp",
-              "loadDistribution": "Default",
               "backendAddressPool": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
               },
               "probe": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-              }
+              },
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "idleTimeoutInMinutes": 15,
+              "enableFloatingIP": true,
+              "disableOutboundSnat": true
             }
           }
         ],
@@ -79,7 +77,22 @@
           }
         ],
         "inboundNatPools": [],
-        "outboundRules": []
+        "outboundRules": [
+          {
+            "name": "rule1",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "frontendIPConfigurations": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                }
+              ],
+              "protocol": "All"
+            }
+          }
+        ]
       }
     }
   },
@@ -89,25 +102,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -118,6 +130,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -126,8 +143,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -140,6 +163,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -150,14 +174,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -165,6 +190,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -184,6 +210,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -193,11 +220,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }
@@ -207,25 +256,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -236,6 +284,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -244,8 +297,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -258,6 +317,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -268,14 +328,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -283,6 +344,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -302,6 +364,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -311,11 +374,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerGet.json
@@ -118,7 +118,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerList.json
@@ -115,7 +115,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },
@@ -131,7 +130,6 @@
               "loadBalancingRules": [],
               "probes": [],
               "inboundNatRules": [],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/examples/LoadBalancerListAll.json
@@ -114,7 +114,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-08-01/loadBalancer.json
@@ -193,6 +193,9 @@
           },
           "Create load balancer with inbound nat pool": {
             "$ref": "./examples/LoadBalancerCreateWithInboundNatPool.json"
+          },
+          "Create load balancer with outbound rules": {
+            "$ref": "./examples/LoadBalancerCreateWithOutboundRules.json"
           }
         },
         "x-ms-long-running-operation": true
@@ -1227,6 +1230,14 @@
           "$ref": "./network.json#/definitions/SubResource",
           "description": "Gets outbound rules that use this backend address pool."
         },
+        "outboundRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Gets outbound rules that use this backend address pool."
+        },
         "provisioningState": {
           "type": "string",
           "description": "Get provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
@@ -1609,7 +1620,7 @@
         "frontendIPConfigurations",
         "protocol"
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "OutboundRule": {
       "properties": {
@@ -1632,7 +1643,7 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "LoadBalancerPropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreate.json
@@ -74,8 +74,7 @@
             }
           }
         ],
-        "inboundNatPools": [],
-        "outboundRules": []
+        "inboundNatPools": []
       }
     }
   },
@@ -192,7 +191,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }
@@ -309,7 +307,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -58,7 +61,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -115,7 +118,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithOutboundRules.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithOutboundRules.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-08-01",
+    "api-version": "2018-10-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "loadBalancerName": "lb",
@@ -14,13 +14,10 @@
           {
             "name": "fe-lb",
             "properties": {
-              "subnet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              "publicIPAddress": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
               }
-            },
-            "zones": [
-              "1"
-            ]
+            }
           }
         ],
         "backendAddressPools": [
@@ -36,18 +33,19 @@
               "frontendIPConfiguration": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
               },
-              "frontendPort": 80,
-              "backendPort": 80,
-              "enableFloatingIP": true,
-              "idleTimeoutInMinutes": 15,
-              "protocol": "Tcp",
-              "loadDistribution": "Default",
               "backendAddressPool": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
               },
               "probe": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-              }
+              },
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "idleTimeoutInMinutes": 15,
+              "enableFloatingIP": true,
+              "disableOutboundSnat": true
             }
           }
         ],
@@ -79,7 +77,22 @@
           }
         ],
         "inboundNatPools": [],
-        "outboundRules": []
+        "outboundRules": [
+          {
+            "name": "rule1",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "frontendIPConfigurations": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                }
+              ],
+              "protocol": "All"
+            }
+          }
+        ]
       }
     }
   },
@@ -89,25 +102,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -118,6 +130,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -126,8 +143,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -140,6 +163,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -150,14 +174,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -165,6 +190,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -184,6 +210,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -193,11 +220,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }
@@ -207,25 +256,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -236,6 +284,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -244,8 +297,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -258,6 +317,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -268,14 +328,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -283,6 +344,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -302,6 +364,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -311,11 +374,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerCreateWithZones.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -88,7 +91,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -206,7 +209,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerGet.json
@@ -118,7 +118,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerList.json
@@ -115,7 +115,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },
@@ -131,7 +130,6 @@
               "loadBalancingRules": [],
               "probes": [],
               "inboundNatRules": [],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/examples/LoadBalancerListAll.json
@@ -114,7 +114,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-10-01/loadBalancer.json
@@ -193,6 +193,9 @@
           },
           "Create load balancer with inbound nat pool": {
             "$ref": "./examples/LoadBalancerCreateWithInboundNatPool.json"
+          },
+          "Create load balancer with outbound rules": {
+            "$ref": "./examples/LoadBalancerCreateWithOutboundRules.json"
           }
         },
         "x-ms-long-running-operation": true
@@ -1227,6 +1230,14 @@
           "$ref": "./network.json#/definitions/SubResource",
           "description": "Gets outbound rules that use this backend address pool."
         },
+        "outboundRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Gets outbound rules that use this backend address pool."
+        },
         "provisioningState": {
           "type": "string",
           "description": "Get provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
@@ -1609,7 +1620,7 @@
         "frontendIPConfigurations",
         "protocol"
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "OutboundRule": {
       "properties": {
@@ -1632,7 +1643,7 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "LoadBalancerPropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerCreate.json
@@ -73,8 +73,7 @@
             }
           }
         ],
-        "inboundNatPools": [],
-        "outboundRules": []
+        "inboundNatPools": []
       }
     }
   },
@@ -191,7 +190,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }
@@ -308,7 +306,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -5,6 +5,9 @@
     "resourceGroupName": "rg1",
     "loadBalancerName": "lb",
     "parameters": {
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -57,7 +60,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "westus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -114,7 +117,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "westus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerCreateWithOutboundRules.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerCreateWithOutboundRules.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-08-01",
+    "api-version": "2018-11-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "loadBalancerName": "lb",
@@ -14,13 +14,10 @@
           {
             "name": "fe-lb",
             "properties": {
-              "subnet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              "publicIPAddress": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
               }
-            },
-            "zones": [
-              "1"
-            ]
+            }
           }
         ],
         "backendAddressPools": [
@@ -36,18 +33,19 @@
               "frontendIPConfiguration": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
               },
-              "frontendPort": 80,
-              "backendPort": 80,
-              "enableFloatingIP": true,
-              "idleTimeoutInMinutes": 15,
-              "protocol": "Tcp",
-              "loadDistribution": "Default",
               "backendAddressPool": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
               },
               "probe": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-              }
+              },
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "idleTimeoutInMinutes": 15,
+              "enableFloatingIP": true,
+              "disableOutboundSnat": true
             }
           }
         ],
@@ -79,7 +77,22 @@
           }
         ],
         "inboundNatPools": [],
-        "outboundRules": []
+        "outboundRules": [
+          {
+            "name": "rule1",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "frontendIPConfigurations": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                }
+              ],
+              "protocol": "All"
+            }
+          }
+        ]
       }
     }
   },
@@ -89,25 +102,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -118,6 +130,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -126,8 +143,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -140,6 +163,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -150,14 +174,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -165,6 +190,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -184,6 +210,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -193,11 +220,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }
@@ -207,25 +256,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -236,6 +284,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -244,8 +297,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -258,6 +317,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -268,14 +328,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -283,6 +344,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -302,6 +364,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -311,11 +374,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerCreateWithZones.json
@@ -5,6 +5,9 @@
     "resourceGroupName": "rg1",
     "loadBalancerName": "lb",
     "parameters": {
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -87,7 +90,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "westus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -205,7 +208,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "westus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerGet.json
@@ -118,7 +118,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerList.json
@@ -115,7 +115,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },
@@ -131,7 +130,6 @@
               "loadBalancingRules": [],
               "probes": [],
               "inboundNatRules": [],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/examples/LoadBalancerListAll.json
@@ -114,7 +114,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-11-01/loadBalancer.json
@@ -193,6 +193,9 @@
           },
           "Create load balancer with inbound nat pool": {
             "$ref": "./examples/LoadBalancerCreateWithInboundNatPool.json"
+          },
+          "Create load balancer with outbound rules": {
+            "$ref": "./examples/LoadBalancerCreateWithOutboundRules.json"
           }
         },
         "x-ms-long-running-operation": true
@@ -1227,6 +1230,14 @@
           "$ref": "./network.json#/definitions/SubResource",
           "description": "Gets outbound rules that use this backend address pool."
         },
+        "outboundRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Gets outbound rules that use this backend address pool."
+        },
         "provisioningState": {
           "type": "string",
           "description": "Get provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
@@ -1609,7 +1620,7 @@
         "frontendIPConfigurations",
         "protocol"
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "OutboundRule": {
       "properties": {
@@ -1632,7 +1643,7 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "LoadBalancerPropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerCreate.json
@@ -74,8 +74,7 @@
             }
           }
         ],
-        "inboundNatPools": [],
-        "outboundRules": []
+        "inboundNatPools": []
       }
     }
   },
@@ -192,7 +191,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }
@@ -309,7 +307,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -58,7 +61,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -115,7 +118,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerCreateWithOutboundRules.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerCreateWithOutboundRules.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-08-01",
+    "api-version": "2018-12-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "loadBalancerName": "lb",
@@ -14,13 +14,10 @@
           {
             "name": "fe-lb",
             "properties": {
-              "subnet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              "publicIPAddress": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
               }
-            },
-            "zones": [
-              "1"
-            ]
+            }
           }
         ],
         "backendAddressPools": [
@@ -36,18 +33,19 @@
               "frontendIPConfiguration": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
               },
-              "frontendPort": 80,
-              "backendPort": 80,
-              "enableFloatingIP": true,
-              "idleTimeoutInMinutes": 15,
-              "protocol": "Tcp",
-              "loadDistribution": "Default",
               "backendAddressPool": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
               },
               "probe": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-              }
+              },
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "idleTimeoutInMinutes": 15,
+              "enableFloatingIP": true,
+              "disableOutboundSnat": true
             }
           }
         ],
@@ -79,7 +77,22 @@
           }
         ],
         "inboundNatPools": [],
-        "outboundRules": []
+        "outboundRules": [
+          {
+            "name": "rule1",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "frontendIPConfigurations": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                }
+              ],
+              "protocol": "All"
+            }
+          }
+        ]
       }
     }
   },
@@ -89,25 +102,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -118,6 +130,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -126,8 +143,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -140,6 +163,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -150,14 +174,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -165,6 +190,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -184,6 +210,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -193,11 +220,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }
@@ -207,25 +256,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -236,6 +284,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -244,8 +297,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -258,6 +317,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -268,14 +328,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -283,6 +344,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -302,6 +364,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -311,11 +374,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerCreateWithZones.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -88,7 +91,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -206,7 +209,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerGet.json
@@ -118,7 +118,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerList.json
@@ -115,7 +115,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },
@@ -131,7 +130,6 @@
               "loadBalancingRules": [],
               "probes": [],
               "inboundNatRules": [],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/examples/LoadBalancerListAll.json
@@ -114,7 +114,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2018-12-01/loadBalancer.json
@@ -193,6 +193,9 @@
           },
           "Create load balancer with inbound nat pool": {
             "$ref": "./examples/LoadBalancerCreateWithInboundNatPool.json"
+          },
+          "Create load balancer with outbound rules": {
+            "$ref": "./examples/LoadBalancerCreateWithOutboundRules.json"
           }
         },
         "x-ms-long-running-operation": true
@@ -1227,6 +1230,14 @@
           "$ref": "./network.json#/definitions/SubResource",
           "description": "Gets outbound rules that use this backend address pool."
         },
+        "outboundRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Gets outbound rules that use this backend address pool."
+        },
         "provisioningState": {
           "type": "string",
           "description": "Get provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
@@ -1609,7 +1620,7 @@
         "frontendIPConfigurations",
         "protocol"
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "OutboundRule": {
       "properties": {
@@ -1632,7 +1643,7 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "LoadBalancerPropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerCreate.json
@@ -74,8 +74,7 @@
             }
           }
         ],
-        "inboundNatPools": [],
-        "outboundRules": []
+        "inboundNatPools": []
       }
     }
   },
@@ -192,7 +191,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }
@@ -309,7 +307,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -58,7 +61,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -115,7 +118,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerCreateWithOutboundRules.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerCreateWithOutboundRules.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-08-01",
+    "api-version": "2019-02-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "loadBalancerName": "lb",
@@ -14,13 +14,10 @@
           {
             "name": "fe-lb",
             "properties": {
-              "subnet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              "publicIPAddress": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
               }
-            },
-            "zones": [
-              "1"
-            ]
+            }
           }
         ],
         "backendAddressPools": [
@@ -36,18 +33,19 @@
               "frontendIPConfiguration": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
               },
-              "frontendPort": 80,
-              "backendPort": 80,
-              "enableFloatingIP": true,
-              "idleTimeoutInMinutes": 15,
-              "protocol": "Tcp",
-              "loadDistribution": "Default",
               "backendAddressPool": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
               },
               "probe": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-              }
+              },
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "idleTimeoutInMinutes": 15,
+              "enableFloatingIP": true,
+              "disableOutboundSnat": true
             }
           }
         ],
@@ -79,7 +77,22 @@
           }
         ],
         "inboundNatPools": [],
-        "outboundRules": []
+        "outboundRules": [
+          {
+            "name": "rule1",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "frontendIPConfigurations": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                }
+              ],
+              "protocol": "All"
+            }
+          }
+        ]
       }
     }
   },
@@ -89,25 +102,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -118,6 +130,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -126,8 +143,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -140,6 +163,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -150,14 +174,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -165,6 +190,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -184,6 +210,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -193,11 +220,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }
@@ -207,25 +256,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -236,6 +284,11 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
                 ]
               }
             }
@@ -244,8 +297,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -258,6 +317,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -268,14 +328,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -283,6 +344,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -302,6 +364,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -311,11 +374,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerCreateWithZones.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -88,7 +91,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -206,7 +209,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerGet.json
@@ -118,7 +118,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerList.json
@@ -115,7 +115,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },
@@ -131,7 +130,6 @@
               "loadBalancingRules": [],
               "probes": [],
               "inboundNatRules": [],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/examples/LoadBalancerListAll.json
@@ -114,7 +114,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-02-01/loadBalancer.json
@@ -196,6 +196,9 @@
           },
           "Create load balancer with inbound nat pool": {
             "$ref": "./examples/LoadBalancerCreateWithInboundNatPool.json"
+          },
+          "Create load balancer with outbound rules": {
+            "$ref": "./examples/LoadBalancerCreateWithOutboundRules.json"
           }
         },
         "x-ms-long-running-operation": true,
@@ -1231,6 +1234,14 @@
           "$ref": "./network.json#/definitions/SubResource",
           "description": "Gets outbound rules that use this backend address pool."
         },
+        "outboundRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Gets outbound rules that use this backend address pool."
+        },
         "provisioningState": {
           "type": "string",
           "description": "Get provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
@@ -1620,7 +1631,7 @@
         "frontendIPConfigurations",
         "protocol"
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "OutboundRule": {
       "properties": {
@@ -1643,7 +1654,7 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "LoadBalancerPropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerCreate.json
@@ -74,8 +74,7 @@
             }
           }
         ],
-        "inboundNatPools": [],
-        "outboundRules": []
+        "inboundNatPools": []
       }
     }
   },
@@ -192,7 +191,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }
@@ -309,7 +307,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerCreateWithInboundNatPool.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerCreateWithInboundNatPool.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -58,7 +61,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -115,7 +118,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerCreateWithOutboundRules.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerCreateWithOutboundRules.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2018-08-01",
+    "api-version": "2019-04-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "loadBalancerName": "lb",
@@ -14,13 +14,10 @@
           {
             "name": "fe-lb",
             "properties": {
-              "subnet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+              "publicIPAddress": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
               }
-            },
-            "zones": [
-              "1"
-            ]
+            }
           }
         ],
         "backendAddressPools": [
@@ -36,18 +33,19 @@
               "frontendIPConfiguration": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
               },
-              "frontendPort": 80,
-              "backendPort": 80,
-              "enableFloatingIP": true,
-              "idleTimeoutInMinutes": 15,
-              "protocol": "Tcp",
-              "loadDistribution": "Default",
               "backendAddressPool": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
               },
               "probe": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-              }
+              },
+              "protocol": "Tcp",
+              "loadDistribution": "Default",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "idleTimeoutInMinutes": 15,
+              "enableFloatingIP": true,
+              "disableOutboundSnat": true
             }
           }
         ],
@@ -79,7 +77,22 @@
           }
         ],
         "inboundNatPools": [],
-        "outboundRules": []
+        "outboundRules": [
+          {
+            "name": "rule1",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+              },
+              "frontendIPConfigurations": [
+                {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                }
+              ],
+              "protocol": "All"
+            }
+          }
+        ]
       }
     }
   },
@@ -89,25 +102,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -118,7 +130,13 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
-                ]
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
+                "privateIPAddressVersion": "IPv4"
               }
             }
           ],
@@ -126,8 +144,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -140,6 +164,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -150,14 +175,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -165,6 +191,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -184,6 +211,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -193,11 +221,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }
@@ -207,25 +257,24 @@
         "name": "lb",
         "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb",
         "type": "Microsoft.Network/loadBalancers",
+        "etag": "W/\"00000000-0000-0000-0000-00000000\"",
         "location": "eastus",
         "sku": {
           "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
+          "resourceGuid": "00000000-0000-0000-0000-00000000",
           "frontendIPConfigurations": [
             {
               "name": "fe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb",
-              "zones": [
-                "1"
-              ],
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
-                "privateIPAddress": "10.0.1.4",
                 "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnetlb/subnets/subnetlb"
+                "publicIPAddress": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/pip"
                 },
                 "loadBalancingRules": [
                   {
@@ -236,7 +285,13 @@
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule"
                   }
-                ]
+                ],
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
+                "privateIPAddressVersion": "IPv4"
               }
             }
           ],
@@ -244,8 +299,14 @@
             {
               "name": "be-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
+                "outboundRules": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1"
+                  }
+                ],
                 "loadBalancingRules": [
                   {
                     "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb"
@@ -258,6 +319,7 @@
             {
               "name": "rulelb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/loadBalancingRules/rulelb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -268,14 +330,15 @@
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
                 "protocol": "Tcp",
+                "enableTcpReset": false,
                 "loadDistribution": "Default",
+                "disableOutboundSnat": true,
                 "backendAddressPool": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
                 },
                 "probe": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb"
-                },
-                "disableOutboundSnat": false
+                }
               }
             }
           ],
@@ -283,6 +346,7 @@
             {
               "name": "probe-lb",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/probes/probe-lb",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "protocol": "Http",
@@ -302,6 +366,7 @@
             {
               "name": "in-nat-rule",
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/inboundNatRules/in-nat-rule",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
               "properties": {
                 "provisioningState": "Succeeded",
                 "frontendIPConfiguration": {
@@ -311,11 +376,33 @@
                 "backendPort": 3389,
                 "enableFloatingIP": true,
                 "idleTimeoutInMinutes": 15,
-                "protocol": "Tcp"
+                "protocol": "Tcp",
+                "enableTcpReset": false
               }
             }
           ],
-          "outboundRules": [],
+          "outboundRules": [
+            {
+              "name": "rule1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/outboundRules/rule1",
+              "etag": "W/\"00000000-0000-0000-0000-00000000\"",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "allocatedOutboundPorts": 1024,
+                "protocol": "All",
+                "enableTcpReset": false,
+                "idleTimeoutInMinutes": 4,
+                "backendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/be-lb"
+                },
+                "frontendIPConfigurations": [
+                  {
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe-lb"
+                  }
+                ]
+              }
+            }
+          ],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerCreateWithZones.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerCreateWithZones.json
@@ -6,6 +6,9 @@
     "loadBalancerName": "lb",
     "parameters": {
       "location": "eastus",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "frontendIPConfigurations": [
           {
@@ -88,7 +91,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",
@@ -206,7 +209,7 @@
         "type": "Microsoft.Network/loadBalancers",
         "location": "eastus",
         "sku": {
-          "name": "Basic"
+          "name": "Standard"
         },
         "properties": {
           "provisioningState": "Succeeded",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerGet.json
@@ -119,7 +119,6 @@
               }
             }
           ],
-          "outboundRules": [],
           "inboundNatPools": []
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerList.json
@@ -116,7 +116,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },
@@ -132,7 +131,6 @@
               "loadBalancingRules": [],
               "probes": [],
               "inboundNatRules": [],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/examples/LoadBalancerListAll.json
@@ -115,7 +115,6 @@
                   }
                 }
               ],
-              "outboundRules": [],
               "inboundNatPools": []
             }
           },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/loadBalancer.json
@@ -196,6 +196,9 @@
           },
           "Create load balancer with inbound nat pool": {
             "$ref": "./examples/LoadBalancerCreateWithInboundNatPool.json"
+          },
+          "Create load balancer with outbound rules": {
+            "$ref": "./examples/LoadBalancerCreateWithOutboundRules.json"
           }
         },
         "x-ms-long-running-operation": true,
@@ -1235,6 +1238,14 @@
           "$ref": "./network.json#/definitions/SubResource",
           "description": "Gets outbound rules that use this backend address pool."
         },
+        "outboundRules": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          },
+          "description": "Gets outbound rules that use this backend address pool."
+        },
         "provisioningState": {
           "type": "string",
           "description": "Get provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
@@ -1624,7 +1635,7 @@
         "frontendIPConfigurations",
         "protocol"
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "OutboundRule": {
       "properties": {
@@ -1647,7 +1658,7 @@
           "$ref": "./network.json#/definitions/SubResource"
         }
       ],
-      "description": "Outbound pool of the load balancer."
+      "description": "Outbound rule of the load balancer."
     },
     "LoadBalancerPropertiesFormat": {
       "properties": {


### PR DESCRIPTION
Copied changes for outbound rules from https://github.com/Azure/azure-rest-api-specs/pull/6493 to older API versions:
- Added read-only property "outboundRules" to backendAddressPool
- Added example for creating LB with outbound rules
- Updated other load balancer examples to reflect the fact that outbound rules are available only with Standard SKU

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
