### PR TITLE
[Data Factory]Add property blockSizeInMB for AzureBlobStorageWriteSettings and AzureBlobFSWriteSettings

### DIFF
--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
@@ -2761,6 +2761,10 @@
         "copyBehavior": {
           "description": "The type of copy behavior for copy sink.",
           "type": "object"
+        },
+        "blockSizeInMB": {
+          "description": "Indicates the block size(MB) when writing data to blob. Type: integer (or Expression with resultType integer).",
+          "type": "integer"
         }
       }
     },
@@ -3104,6 +3108,10 @@
         "copyBehavior": {
           "description": "The type of copy behavior for copy sink.",
           "type": "object"
+        },
+        "blockSizeInMB": {
+          "type": "integer",
+          "description": "Indicates the block size(MB) when writing data to blobFS. Type: integer."
         }
       }
     },

--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
@@ -555,7 +555,6 @@
     },
     "AzureBlobStorageWriteSettings": {
       "description": "Azure blob write settings.",
-      "x-ms-discriminator-value": "AzureBlobStorageWriteSettings",
       "type": "object",
       "allOf": [
         {
@@ -571,7 +570,6 @@
     },
     "AzureBlobFSWriteSettings": {
       "description": "Azure blobFS write settings.",
-      "x-ms-discriminator-value": "AzureBlobFSWriteSettings",
       "type": "object",
       "allOf": [
         {

--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
@@ -2764,7 +2764,7 @@
         },
         "blockSizeInMB": {
           "description": "Indicates the block size(MB) when writing data to blob. Type: integer (or Expression with resultType integer).",
-          "type": "integer"
+          "type": "object"
         }
       }
     },
@@ -3110,8 +3110,8 @@
           "type": "object"
         },
         "blockSizeInMB": {
-          "type": "integer",
-          "description": "Indicates the block size(MB) when writing data to blobFS. Type: integer."
+          "description": "Indicates the block size(MB) when writing data to blobFS. Type: integer (or Expression with resultType integer).",
+          "type": "object"
         }
       }
     },

--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
@@ -559,7 +559,13 @@
         {
           "$ref": "#/definitions/StoreWriteSettings"
         }
-      ]
+      ],
+      "properties": {
+        "blockSizeInMB": {
+          "description": "Indicates the block size(MB) when writing data to blob. Type: integer (or Expression with resultType integer).",
+          "type": "object"
+        }
+      }
     },
     "AzureBlobFSWriteSettings": {
       "description": "Azure blobFS write settings.",
@@ -568,7 +574,13 @@
         {
           "$ref": "#/definitions/StoreWriteSettings"
         }
-      ]
+      ],
+      "properties": {
+        "blockSizeInMB": {
+          "description": "Indicates the block size(MB) when writing data to blob. Type: integer (or Expression with resultType integer).",
+          "type": "object"
+        }
+      }
     },
     "AzureDataLakeStoreWriteSettings": {
       "description": "Azure data lake store write settings.",
@@ -2732,7 +2744,7 @@
       ],
       "properties": {
         "storeSettings": {
-          "$ref": "#/definitions/StoreReadSettings",
+          "$ref": "#/definitions/StoreWriteSettings",
           "description": "Binary store settings."
         }
       }
@@ -2760,10 +2772,6 @@
         },
         "copyBehavior": {
           "description": "The type of copy behavior for copy sink.",
-          "type": "object"
-        },
-        "blockSizeInMB": {
-          "description": "Indicates the block size(MB) when writing data to blob. Type: integer (or Expression with resultType integer).",
           "type": "object"
         }
       }
@@ -3107,10 +3115,6 @@
       "properties": {
         "copyBehavior": {
           "description": "The type of copy behavior for copy sink.",
-          "type": "object"
-        },
-        "blockSizeInMB": {
-          "description": "Indicates the block size(MB) when writing data to blobFS. Type: integer (or Expression with resultType integer).",
           "type": "object"
         }
       }

--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
@@ -530,6 +530,7 @@
     },
     "StoreWriteSettings": {
       "description": "Connector write settings.",
+      "discriminator": "type",
       "type": "object",
       "properties": {
         "type": {
@@ -554,6 +555,7 @@
     },
     "AzureBlobStorageWriteSettings": {
       "description": "Azure blob write settings.",
+      "x-ms-discriminator-value": "AzureBlobStorageWriteSettings",
       "type": "object",
       "allOf": [
         {
@@ -569,6 +571,7 @@
     },
     "AzureBlobFSWriteSettings": {
       "description": "Azure blobFS write settings.",
+      "x-ms-discriminator-value": "AzureBlobFSWriteSettings",
       "type": "object",
       "allOf": [
         {


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
