### PR TITLE
[KeyVault] [TypeScript] azure-arm is not needed

### DIFF
--- a/specification/keyvault/data-plane/readme.typescript.md
+++ b/specification/keyvault/data-plane/readme.typescript.md
@@ -5,7 +5,6 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 
 ``` yaml $(typescript)
 typescript:
-  azure-arm: true
   package-name: "@azure/keyvault"
   output-folder: "$(typescript-sdks-folder)/sdk/keyvault/keyvault"
   generate-license-txt: true


### PR DESCRIPTION
Following up on David Wilson's issue: https://github.com/azure/azure-sdk-for-js/issues/4386

This is pending though:
> Once we do decide to remove it and send a PR to the azure-rest-api-specs repo, we'll have to use autorest.typescript to regenerate the keyvault modules again.

What would be the action item at this point?
Help & feedback appreciated.

Fixes https://github.com/Azure/azure-sdk-for-js/issues/4386.