### PR TITLE
Set correct property types in PrivateEndpoint specs

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/privateEndpoint.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/privateEndpoint.json
@@ -74,7 +74,7 @@
             "description": "Delete successful."
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -133,7 +133,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -176,7 +176,7 @@
             "schema": {
               "$ref": "#/definitions/PrivateEndpoint"
             },
-            "description": "Parameters supplied to the create or update private endpoint operation"
+            "description": "Parameters supplied to the create or update private endpoint operation."
           },
           {
             "$ref": "./network.json#/parameters/ApiVersionParameter"
@@ -199,7 +199,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -249,7 +249,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -288,7 +288,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -396,7 +396,7 @@
         },
         "etag": {
           "type": "string",
-          "description": "Gets a unique read-only string that changes whenever the resource is updated."
+          "description": "A unique read-only string that changes whenever the resource is updated."
         }
       },
       "allOf": [
@@ -409,21 +409,21 @@
     "PrivateEndpointProperties": {
       "properties": {
         "subnet": {
-          "$ref": "./virtualNetwork.json#/definitions/Subnet",
+          "$ref": "./network.json#/definitions/SubResource",
           "description": "The ID of the subnet from which the private IP will be allocated."
         },
         "networkInterfaces": {
           "type": "array",
           "readOnly": true,
           "items": {
-            "$ref": "./networkInterface.json#/definitions/NetworkInterface"
+            "$ref": "./network.json#/definitions/SubResource"
           },
-          "description": "Gets an array of references to the network interfaces created for this private endpoint."
+          "description": "An array of references to the network interfaces created for this private endpoint."
         },
         "provisioningState": {
           "readOnly": true,
-          "type": "string",
-          "description": "The provisioning state of the private endpoint. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private endpoint."
         },
         "privateLinkServiceConnections": {
           "type": "array",
@@ -452,6 +452,16 @@
         "name": {
           "type": "string",
           "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource type."
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
         }
       },
       "allOf": [
@@ -463,6 +473,11 @@
     },
     "PrivateLinkServiceConnectionProperties": {
       "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private link service connection."
+        },
         "privateLinkServiceId": {
           "type": "string",
           "description": "The resource id of private link service."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/privateLinkService.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/privateLinkService.json
@@ -74,7 +74,7 @@
             "description": "Delete successful."
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -133,7 +133,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -173,7 +173,7 @@
             "schema": {
               "$ref": "#/definitions/PrivateLinkService"
             },
-            "description": "Parameters supplied to the create or update private link service operation"
+            "description": "Parameters supplied to the create or update private link service operation."
           },
           {
             "$ref": "./network.json#/parameters/ApiVersionParameter"
@@ -196,7 +196,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -243,7 +243,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -282,7 +282,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -351,7 +351,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -409,7 +409,7 @@
             "description": "Delete successful."
           },
           "default": {
-            "description": "Error",
+            "description": "Error.",
             "schema": {
               "$ref": "./network.json#/definitions/Error"
             }
@@ -623,7 +623,7 @@
         },
         "etag": {
           "type": "string",
-          "description": "Gets a unique read-only string that changes whenever the resource is updated."
+          "description": "A unique read-only string that changes whenever the resource is updated."
         }
       },
       "allOf": [
@@ -638,7 +638,7 @@
         "loadBalancerFrontendIpConfigurations": {
           "type": "array",
           "items": {
-            "$ref": "./loadBalancer.json#/definitions/FrontendIPConfiguration"
+            "$ref": "./network.json#/definitions/SubResource"
           },
           "description": "An array of references to the load balancer IP configurations."
         },
@@ -647,20 +647,20 @@
           "items": {
             "$ref": "#/definitions/PrivateLinkServiceIpConfiguration"
           },
-          "description": "An array of references to the private link service IP configuration."
+          "description": "An array of private link service IP configurations."
         },
         "networkInterfaces": {
           "type": "array",
           "readOnly": true,
           "items": {
-            "$ref": "./networkInterface.json#/definitions/NetworkInterface"
+            "$ref": "./network.json#/definitions/SubResource"
           },
-          "description": "Gets an array of references to the network interfaces created for this private link service."
+          "description": "An array of references to the network interfaces created for this private link service."
         },
         "provisioningState": {
           "readOnly": true,
-          "type": "string",
-          "description": "The provisioning state of the private link service. Possible values are: 'Updating', 'Succeeded', and 'Failed'."
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private link service."
         },
         "privateEndpointConnections": {
           "type": "array",
@@ -722,8 +722,23 @@
         "name": {
           "type": "string",
           "description": "The name of private link service ip configuration."
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource type."
         }
       },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
       "description": "The private link service ip configuration."
     },
     "PrivateLinkServiceIpConfigurationProperties": {
@@ -737,16 +752,17 @@
           "description": "The private IP address allocation method."
         },
         "subnet": {
-          "$ref": "./virtualNetwork.json#/definitions/Subnet",
-          "description": "The reference of the subnet resource."
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to the subnet resource."
         },
-        "publicIPAddress": {
-          "$ref": "./publicIpAddress.json#/definitions/PublicIPAddress",
-          "description": "The reference of the public IP resource."
+        "primary": {
+          "type": "boolean",
+          "description": "Whether the ip configuration is primary or not."
         },
         "provisioningState": {
-          "type": "string",
-          "description": "Gets the provisioning state of the public IP resource. Possible values are: 'Updating', 'Deleting', and 'Failed'."
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private link service ip configuration."
         },
         "privateIPAddressVersion": {
           "$ref": "./network.json#/definitions/IPVersion",
@@ -765,6 +781,16 @@
         "name": {
           "type": "string",
           "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The resource type."
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated."
         }
       },
       "allOf": [
@@ -777,12 +803,17 @@
     "PrivateEndpointConnectionProperties": {
       "properties": {
         "privateEndpoint": {
-          "$ref": "./privateEndpoint.json#/definitions/PrivateEndpoint",
-          "description": "The resource of private end point."
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to the private endpoint."
         },
         "privateLinkServiceConnectionState": {
           "$ref": "#/definitions/PrivateLinkServiceConnectionState",
           "description": "A collection of information about the state of the connection between service consumer and provider."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private endpoint connection."
         }
       },
       "description": "Properties of the PrivateEndpointConnectProperties."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/privateEndpoint.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/privateEndpoint.json
@@ -409,18 +409,19 @@
     "PrivateEndpointProperties": {
       "properties": {
         "subnet": {
-          "$ref": "./virtualNetwork.json#/definitions/Subnet",
+          "$ref": "./network.json#/definitions/SubResource",
           "description": "The ID of the subnet from which the private IP will be allocated."
         },
         "networkInterfaces": {
           "type": "array",
           "readOnly": true,
           "items": {
-            "$ref": "./networkInterface.json#/definitions/NetworkInterface"
+            "$ref": "./network.json#/definitions/SubResource"
           },
-          "description": "Gets an array of references to the network interfaces created for this private endpoint."
+          "description": "An array of references to the network interfaces created for this private endpoint."
         },
         "provisioningState": {
+          "readOnly": true,
           "$ref": "./network.json#/definitions/ProvisioningState",
           "description": "The provisioning state of the private endpoint."
         },
@@ -473,6 +474,7 @@
     "PrivateLinkServiceConnectionProperties": {
       "properties": {
         "provisioningState": {
+          "readOnly": true,
           "$ref": "./network.json#/definitions/ProvisioningState",
           "description": "The provisioning state of the private link service connection."
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/privateLinkService.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-06-01/privateLinkService.json
@@ -638,7 +638,7 @@
         "loadBalancerFrontendIpConfigurations": {
           "type": "array",
           "items": {
-            "$ref": "./loadBalancer.json#/definitions/FrontendIPConfiguration"
+            "$ref": "./network.json#/definitions/SubResource"
           },
           "description": "An array of references to the load balancer IP configurations."
         },
@@ -647,17 +647,18 @@
           "items": {
             "$ref": "#/definitions/PrivateLinkServiceIpConfiguration"
           },
-          "description": "An array of references to the private link service IP configuration."
+          "description": "An array of private link service IP configurations."
         },
         "networkInterfaces": {
           "type": "array",
           "readOnly": true,
           "items": {
-            "$ref": "./networkInterface.json#/definitions/NetworkInterface"
+            "$ref": "./network.json#/definitions/SubResource"
           },
-          "description": "Gets an array of references to the network interfaces created for this private link service."
+          "description": "An array of references to the network interfaces created for this private link service."
         },
         "provisioningState": {
+          "readOnly": true,
           "$ref": "./network.json#/definitions/ProvisioningState",
           "description": "The provisioning state of the private link service."
         },
@@ -751,14 +752,15 @@
           "description": "The private IP address allocation method."
         },
         "subnet": {
-          "$ref": "./virtualNetwork.json#/definitions/Subnet",
-          "description": "The reference of the subnet resource."
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to the subnet resource."
         },
         "primary": {
           "type": "boolean",
           "description": "Whether the ip configuration is primary or not."
         },
         "provisioningState": {
+          "readOnly": true,
           "$ref": "./network.json#/definitions/ProvisioningState",
           "description": "The provisioning state of the private link service ip configuration."
         },
@@ -801,14 +803,15 @@
     "PrivateEndpointConnectionProperties": {
       "properties": {
         "privateEndpoint": {
-          "$ref": "./privateEndpoint.json#/definitions/PrivateEndpoint",
-          "description": "The resource of private end point."
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The reference to the private endpoint."
         },
         "privateLinkServiceConnectionState": {
           "$ref": "#/definitions/PrivateLinkServiceConnectionState",
           "description": "A collection of information about the state of the connection between service consumer and provider."
         },
         "provisioningState": {
+          "readOnly": true,
           "$ref": "./network.json#/definitions/ProvisioningState",
           "description": "The provisioning state of the private endpoint connection."
         }


### PR DESCRIPTION
Possible fix for https://github.com/Azure/azure-rest-api-specs/issues/6988
Also, copies all changes for private endpoints from API version 2019-06-01 to API version 2019-04-01 (makes https://github.com/Azure/azure-rest-api-specs/pull/6959 obsolete)

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
