### PR TITLE
Update API version in VMSS' specs

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssNetworkInterfaceGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssNetworkInterfaceGet.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2017-03-30",
+    "api-version": "2018-10-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "networkInterfaceName": "nic1",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssNetworkInterfaceIpConfigGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssNetworkInterfaceIpConfigGet.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2017-03-30",
+    "api-version": "2018-10-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "virtualMachineScaleSetName": "vmss1",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssNetworkInterfaceIpConfigList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssNetworkInterfaceIpConfigList.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2017-03-30",
+    "api-version": "2018-10-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "virtualMachineScaleSetName": "vmss1",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssNetworkInterfaceList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssNetworkInterfaceList.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2017-03-30",
+    "api-version": "2018-10-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "virtualMachineScaleSetName": "vmss1"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssPublicIpGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssPublicIpGet.json
@@ -2,7 +2,7 @@
   "parameters": {
     "virtualMachineScaleSetName": "vmss1",
     "resourceGroupName": "vmss-tester",
-    "api-version": "2017-03-30",
+    "api-version": "2018-10-01",
     "subscriptionId": "subid",
     "virtualmachineIndex": 1,
     "networkInterfaceName": "nic1",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssPublicIpListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssPublicIpListAll.json
@@ -2,7 +2,7 @@
   "parameters": {
     "virtualMachineScaleSetName": "vmss1",
     "resourceGroupName": "vmss-tester",
-    "api-version": "2017-03-30",
+    "api-version": "2018-10-01",
     "subscriptionId": "subid"
   },
   "responses": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssVmNetworkInterfaceList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssVmNetworkInterfaceList.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2017-03-30",
+    "api-version": "2018-10-01",
     "subscriptionId": "subid",
     "resourceGroupName": "rg1",
     "virtualMachineScaleSetName": "vmss1",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssVmPublicIpList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/examples/VmssVmPublicIpList.json
@@ -2,7 +2,7 @@
   "parameters": {
     "virtualMachineScaleSetName": "vmss1",
     "resourceGroupName": "vmss-tester",
-    "api-version": "2017-03-30",
+    "api-version": "2018-10-01",
     "subscriptionId": "subid",
     "virtualmachineIndex": 1,
     "networkInterfaceName": "nic1",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/vmssNetworkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/vmssNetworkInterface.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NetworkManagementClient",
     "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
-    "version": "2017-03-30"
+    "version": "2018-10-01"
   },
   "host": "management.azure.com",
   "schemes": [

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/vmssPublicIpAddress.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/vmssPublicIpAddress.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NetworkManagementClient",
     "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
-    "version": "2017-03-30"
+    "version": "2018-10-01"
   },
   "host": "management.azure.com",
   "schemes": [


### PR DESCRIPTION
Applying changes from https://github.com/Azure/azure-rest-api-specs/pull/6692 and https://github.com/Azure/azure-rest-api-specs/pull/6916 to release branch

VMSS specs have their own API version independent from the rest of Network specs. This PR updates it to the latest one.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
