### PR TITLE
Add VMScaleSet ScaleIn Policy

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
@@ -7483,23 +7483,23 @@
       "description": "The configuration parameters used while performing a rolling upgrade."
     },
     "ScaleInPolicy": {
-	  "properties": {
-	    "rules": {
+      "properties": {
+        "rules": {
           "type": "array",
           "items": {
-            "type": "string",
-			"enum": [
-			  "Default",
-			  "OldestVM",
-			  "NewestVM"
-			],
-			"x-ms-enum": {
-              "name": "VirtualMachineScaleSetScaleInRules",
-              "modelAsString": true
-            }
+           "type": "string",
+           "enum": [
+            "Default",
+            "OldestVM",
+            "NewestVM"
+           ],
+           "x-ms-enum": {
+            "name": "VirtualMachineScaleSetScaleInRules",
+            "modelAsString": true
+           }
           },
           "description": "The rules to be followed when scaling-in a virtual machine scale set. <br><br> Possible values are: <br><br> **Default** When a virtual machine scale set is scaled in, the scale set will first be balanced across zones if it is a zonal scale set. Then, it will be balanced across Fault Domains as far as possible. Within each Fault Domain, the virtual machines chosen for removal will be the newest ones that are not protected from scale-in. <br><br> **OldestVM** When a virtual machine scale set is being scaled-in, the oldest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the oldest virtual machines that are not protected will be chosen for removal. <br><br> **NewestVM** When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal. <br><br>" 
-        } 
+       } 
       },
       "description": "Describes a scale-in policy for a virtual machine scale set."
     },

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
@@ -7487,15 +7487,15 @@
         "rules": {
           "type": "array",
           "items": {
-           "type": "string",
-           "enum": [
-            "Default",
-            "OldestVM",
-            "NewestVM"
+            "type": "string",
+            "enum": [
+              "Default",
+              "OldestVM",
+              "NewestVM"
            ],
            "x-ms-enum": {
-            "name": "VirtualMachineScaleSetScaleInRules",
-            "modelAsString": true
+             "name": "VirtualMachineScaleSetScaleInRules",
+             "modelAsString": true
            }
           },
           "description": "The rules to be followed when scaling-in a virtual machine scale set. <br><br> Possible values are: <br><br> **Default** When a virtual machine scale set is scaled in, the scale set will first be balanced across zones if it is a zonal scale set. Then, it will be balanced across Fault Domains as far as possible. Within each Fault Domain, the virtual machines chosen for removal will be the newest ones that are not protected from scale-in. <br><br> **OldestVM** When a virtual machine scale set is being scaled-in, the oldest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the oldest virtual machines that are not protected will be chosen for removal. <br><br> **NewestVM** When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal. <br><br>" 

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
@@ -7482,6 +7482,27 @@
       },
       "description": "The configuration parameters used while performing a rolling upgrade."
     },
+    "ScaleInPolicy": {
+	  "properties": {
+	    "rules": {
+          "type": "array",
+          "items": {
+            "type": "string",
+			"enum": [
+			  "Default",
+			  "OldestVM",
+			  "NewestVM"
+			],
+			"x-ms-enum": {
+              "name": "VirtualMachineScaleSetScaleInRules",
+              "modelAsString": true
+            }
+          },
+          "description": "The rules to be followed when scaling-in a virtual machine scale set. <br><br> Possible values are: <br><br> **Default** When a virtual machine scale set is scaled in, the scale set will first be balanced across zones if it is a zonal scale set. Then, it will be balanced across Fault Domains as far as possible. Within each Fault Domain, the virtual machines chosen for removal will be the newest ones that are not protected from scale-in. <br><br> **OldestVM** When a virtual machine scale set is being scaled-in, the oldest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the oldest virtual machines that are not protected will be chosen for removal. <br><br> **NewestVM** When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal. <br><br>" 
+        } 
+      },
+      "description": "Describes a scale-in policy for a virtual machine scale set."
+    },
     "ImageOSDisk": {
       "properties": {
         "osType": {
@@ -8607,7 +8628,11 @@
         "additionalCapabilities": {
           "$ref": "#/definitions/AdditionalCapabilities",
           "description": "Specifies additional capabilities enabled or disabled on the Virtual Machines in the Virtual Machine Scale Set. For instance: whether the Virtual Machines have the capability to support attaching managed data disks with UltraSSD_LRS storage account type."
-        }
+        },
+		"scaleInPolicy": {
+		  "$ref": "#/definitions/ScaleInPolicy",
+		  "description": "Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled-in."
+		}
       },
       "description": "Describes the properties of a Virtual Machine Scale Set."
     },
@@ -8632,7 +8657,11 @@
         "additionalCapabilities": {
           "$ref": "#/definitions/AdditionalCapabilities",
           "description": "Specifies additional capabilities enabled or disabled on the Virtual Machines in the Virtual Machine Scale Set. For instance: whether the Virtual Machines have the capability to support attaching managed data disks with UltraSSD_LRS storage account type."
-        }
+        },
+		"scaleInPolicy": {
+		  "$ref": "#/definitions/ScaleInPolicy",
+		  "description": "Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled-in."
+		}
       },
       "description": "Describes the properties of a Virtual Machine Scale Set."
     },

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
@@ -8629,10 +8629,10 @@
           "$ref": "#/definitions/AdditionalCapabilities",
           "description": "Specifies additional capabilities enabled or disabled on the Virtual Machines in the Virtual Machine Scale Set. For instance: whether the Virtual Machines have the capability to support attaching managed data disks with UltraSSD_LRS storage account type."
         },
-		"scaleInPolicy": {
-		  "$ref": "#/definitions/ScaleInPolicy",
-		  "description": "Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled-in."
-		}
+        "scaleInPolicy": {
+          "$ref": "#/definitions/ScaleInPolicy",
+          "description": "Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled-in."
+        }
       },
       "description": "Describes the properties of a Virtual Machine Scale Set."
     },
@@ -8658,10 +8658,10 @@
           "$ref": "#/definitions/AdditionalCapabilities",
           "description": "Specifies additional capabilities enabled or disabled on the Virtual Machines in the Virtual Machine Scale Set. For instance: whether the Virtual Machines have the capability to support attaching managed data disks with UltraSSD_LRS storage account type."
         },
-		"scaleInPolicy": {
-		  "$ref": "#/definitions/ScaleInPolicy",
-		  "description": "Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled-in."
-		}
+        "scaleInPolicy": {
+          "$ref": "#/definitions/ScaleInPolicy",
+          "description": "Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled-in."
+        }
       },
       "description": "Describes the properties of a Virtual Machine Scale Set."
     },

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
@@ -7499,7 +7499,7 @@
            }
           },
           "description": "The rules to be followed when scaling-in a virtual machine scale set. <br><br> Possible values are: <br><br> **Default** When a virtual machine scale set is scaled in, the scale set will first be balanced across zones if it is a zonal scale set. Then, it will be balanced across Fault Domains as far as possible. Within each Fault Domain, the virtual machines chosen for removal will be the newest ones that are not protected from scale-in. <br><br> **OldestVM** When a virtual machine scale set is being scaled-in, the oldest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the oldest virtual machines that are not protected will be chosen for removal. <br><br> **NewestVM** When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal. For zonal virtual machine scale sets, the scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal. <br><br>" 
-       } 
+        } 
       },
       "description": "Describes a scale-in policy for a virtual machine scale set."
     },


### PR DESCRIPTION
Adds VMScaleSet ScaleIn policy that is supported with the 2019-03-01 header but not included in Swagger

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
