### PR TITLE
Microsoft.Web FunctionSecrets incorrect response body

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/WebApps.json
@@ -18896,25 +18896,15 @@
     "FunctionSecrets": {
       "description": "Function secrets.",
       "type": "object",
-      "allOf": [
-        {
-          "$ref": "./CommonDefinitions.json#/definitions/ProxyOnlyResource"
-        }
-      ],
       "properties": {
-        "properties": {
-          "description": "FunctionSecrets resource specific properties",
-          "properties": {
-            "key": {
-              "description": "Secret key.",
-              "type": "string"
-            },
-            "trigger_url": {
-              "description": "Trigger URL.",
-              "type": "string"
-            }
-          },
-          "x-ms-client-flatten": true
+        "description": "FunctionSecrets resource specific properties",
+        "key": {
+          "description": "Secret key.",
+          "type": "string"
+        },
+        "trigger_url": {
+          "description": "Trigger URL.",
+          "type": "string"
         }
       }
     },

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/WebApps.json
@@ -18897,7 +18897,6 @@
       "description": "Function secrets.",
       "type": "object",
       "properties": {
-        "description": "FunctionSecrets resource specific properties",
         "key": {
           "description": "Secret key.",
           "type": "string"

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/WebApps.json
@@ -18896,25 +18896,15 @@
     "FunctionSecrets": {
       "description": "Function secrets.",
       "type": "object",
-      "allOf": [
-        {
-          "$ref": "../2018-02-01/CommonDefinitions.json#/definitions/ProxyOnlyResource"
-        }
-      ],
       "properties": {
-        "properties": {
-          "description": "FunctionSecrets resource specific properties",
-          "properties": {
-            "key": {
-              "description": "Secret key.",
-              "type": "string"
-            },
-            "trigger_url": {
-              "description": "Trigger URL.",
-              "type": "string"
-            }
-          },
-          "x-ms-client-flatten": true
+        "description": "FunctionSecrets resource specific properties",
+        "key": {
+          "description": "Secret key.",
+          "type": "string"
+        },
+        "trigger_url": {
+          "description": "Trigger URL.",
+          "type": "string"
         }
       }
     },

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/WebApps.json
@@ -18897,7 +18897,6 @@
       "description": "Function secrets.",
       "type": "object",
       "properties": {
-        "description": "FunctionSecrets resource specific properties",
         "key": {
           "description": "Secret key.",
           "type": "string"


### PR DESCRIPTION
This is a quick PR to resolve an inconsistency between the rest specs and the actual response from the service API which is blocking a Terraform change. 

Terraform Change: https://github.com/terraform-providers/terraform-provider-azurerm/pull/4066

Response does not container `key` and `trigger` under a `properties` object. They are at the top level. Also the `ProxyOnlyResource` values are not populated so I have removed these. Below is a response observed from the API. 

```
2019/09/06 18:44:58 [DEBUG] AzureRM Response for https://management.azure.com/subscriptions/5774ad8f-d51e-4456-a72e-0447910568d3/resourceGroups/acctestRG-190906184259523442/providers/Microsoft.Web/sites/acctest-190906184259523442-func/functions/testfunc/listsecrets?api-version=2018-02-01: 
HTTP/2.0 200 OK
Cache-Control: no-cache
Content-Type: application/json; charset=utf-8
Date: Fri, 06 Sep 2019 17:44:57 GMT
Expires: -1
Pragma: no-cache
Server: Microsoft-IIS/10.0
Server: Microsoft-IIS/10.0
Set-Cookie: ARRAffinity=dcb710fa4b4f37e252a09aa7622aa6877443e01a6826dc6315d627d3e24938b7;Path=/;HttpOnly;Domain=acctest-190906184259523442-func.scm.azurewebsites.net
Strict-Transport-Security: max-age=31536000; includeSubDomains
Vary: Accept-Encoding,Accept-Encoding
X-Aspnet-Version: 4.0.30319
X-Content-Type-Options: nosniff
X-Ms-Correlation-Request-Id: 6798cf5f-0f80-4edb-417a-795f39053598
X-Ms-Ratelimit-Remaining-Subscription-Writes: 1195
X-Ms-Request-Id: 3ec9d873-52eb-40a3-b3cb-c757384b029c
X-Ms-Routing-Request-Id: UKWEST:20190906T174458Z:9c9e5933-e722-4a86-94de-6ddf9d4a0a80
X-Powered-By: ASP.NET
X-Powered-By: ASP.NET

Body:
{"key":"eL43nOMQie1Yd5somekeyhere0y5V2AqEX2tA==","trigger_url":"https://acctest-190906184259523442-func.azurewebsites.net/api/testfunc?code=eL43nOMQie1Yd5somekeyhereWrzS30y5V2AqEX2tA=="}
```

Co-authored-by: Eliise Seling <Eliise.Seling@microsoft.com>

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.

