### PR TITLE
Add privateLinkConnectionProperties to network interface.

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/networkInterface.json
@@ -897,9 +897,33 @@
         "provisioningState": {
           "$ref": "./network.json#/definitions/ProvisioningState",
           "description": "The provisioning state of the network interface IP configuration."
+        },
+        "privateLinkConnectionProperties": {
+          "$ref": "#/definitions/NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties",
+          "description": "PrivateLinkConnection properties for the network interface."
         }
       },
       "description": "Properties of IP configuration."
+    },
+    "NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties": {
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The group id for current private link connection."
+        },
+        "requiredMemberName": {
+          "type": "string",
+          "description": "The require member name for current private link connection."
+        },
+        "fqdns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of FQDNs for current private link connection."
+        }
+      },
+      "description": "PrivateLinkConnection properties for the network interface."
     },
     "NetworkInterfaceIPConfiguration": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/networkInterface.json
@@ -900,7 +900,8 @@
         },
         "privateLinkConnectionProperties": {
           "$ref": "#/definitions/NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties",
-          "description": "PrivateLinkConnection properties for the network interface."
+          "description": "PrivateLinkConnection properties for the network interface.",
+          "readOnly": true
         }
       },
       "description": "Properties of IP configuration."
@@ -909,10 +910,12 @@
       "properties": {
         "groupId": {
           "type": "string",
+          "readOnly": true,
           "description": "The group ID for current private link connection."
         },
         "requiredMemberName": {
           "type": "string",
+          "readOnly": true,
           "description": "The required member name for current private link connection."
         },
         "fqdns": {
@@ -920,6 +923,7 @@
           "items": {
             "type": "string"
           },
+          "readOnly": true,
           "description": "List of FQDNs for current private link connection."
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-07-01/networkInterface.json
@@ -909,11 +909,11 @@
       "properties": {
         "groupId": {
           "type": "string",
-          "description": "The group id for current private link connection."
+          "description": "The group ID for current private link connection."
         },
         "requiredMemberName": {
           "type": "string",
-          "description": "The require member name for current private link connection."
+          "description": "The required member name for current private link connection."
         },
         "fqdns": {
           "type": "array",


### PR DESCRIPTION
Adding one property in network interface to display private link connection properties.

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
