### PR TITLE
Remove http scheme from Datalake storage

### DIFF
--- a/specification/storage/data-plane/Microsoft.StorageDataLake/preview/2018-06-17/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/preview/2018-06-17/DataLakeStorage.json
@@ -21,7 +21,6 @@
     ]
   },
   "schemes": [
-    "http",
     "https"
   ],
   "produces": [

--- a/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2018-11-09/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2018-11-09/DataLakeStorage.json
@@ -21,7 +21,6 @@
     ]
   },
   "schemes": [
-    "http",
     "https"
   ],
   "produces": [


### PR DESCRIPTION
In DataLake Storage Swagger, two schemes are mentioned: ```http``` and ```https```.  Because of this Autorest(V2) ignores the https and uses only http. The default auth mechanism used in our SDK is the Token Credentials which uses only https scheme. So, the requests are failing in our SDKs(irrespective of the language). So, this PR has been created to remove the ```http``` scheme