### PR TITLE
fixing example in sig

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/CreateOrUpdateASimpleGalleryImageVersionWithSnapshotsAsSource.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/CreateOrUpdateASimpleGalleryImageVersionWithSnapshotsAsSource.json
@@ -24,12 +24,17 @@
         },
         "storageProfile": {
           "osDiskImage": {
-            "source": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{snapshotName}",
+            "source": {
+              "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{snapshotName}",
+            },
             "hostCaching": "ReadOnly"
           },
           "dataDiskImages": [
             {
-              "source": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{diskSnapshotName}",
+              "source":
+              {
+                "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{diskSnapshotName}"
+              },
               "lun": 1,
               "hostCaching": "None"
             }
@@ -61,13 +66,17 @@
           },
           "storageProfile": {
             "osDiskImage": {
-              "source": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{osSnapshotName}",
+              "source": {
+                "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{osSnapshotName}"
+              },
               "sizeInGB": 10,
               "hostCaching": "ReadOnly"
             },
             "dataDiskImages": [
               {
-                "source": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{diskSnapshotName}",
+                "source": {
+                  "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{diskSnapshotName}"
+                },
                 "lun": 1,
                 "sizeInGB": 10,
                 "hostCaching": "None"
@@ -102,13 +111,17 @@
           },
           "storageProfile": {
             "osDiskImage": {
-              "source": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{osSnapshotName}",
+              "source": {
+                "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{osSnapshotName}"
+              },
               "sizeInGB": 10,
               "hostCaching": "ReadOnly"
             },
             "dataDiskImages": [
               {
-                "source": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{diskSnapshotName}",
+                "source": {
+                  "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{diskSnapshotName}"
+                },
                 "lun": 1,
                 "sizeInGB": 10,
                 "hostCaching": "None"
@@ -143,13 +156,17 @@
           },
           "storageProfile": {
             "osDiskImage": {
-              "source": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{snapshotName}",
+              "source": {
+                "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{osSnapshotName}"
+              },
               "sizeInGB": 10,
               "hostCaching": "ReadOnly"
             },
             "dataDiskImages": [
               {
-                "source": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{diskSnapshotName}",
+                "source": {
+                  "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{diskSnapshotName}"
+                },
                 "lun": 1,
                 "sizeInGB": 10,
                 "hostCaching": "None"

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/CreateOrUpdateASimpleGalleryImageVersionWithSnapshotsAsSource.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/CreateOrUpdateASimpleGalleryImageVersionWithSnapshotsAsSource.json
@@ -25,7 +25,7 @@
         "storageProfile": {
           "osDiskImage": {
             "source": {
-              "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{snapshotName}",
+              "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/snapshots/{snapshotName}"
             },
             "hostCaching": "ReadOnly"
           },


### PR DESCRIPTION
The sample provided didn't work. It returned:

 GalleryImageVersion instance: Azure Error: BadRequest\nMessage: Error converting value \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/zimstgxxz/providers/Microsoft.Compute/snapshots/mySnapshot\" to type 'Microsoft.WindowsAzure.ComputeArtifactPublishing.Service.API.Model.GalleryArtifactVersionSource'. Path 'properties.storageProfile.osDiskImage.source', line 1, position 210.\nTarget: galleryImageVersion.properties.storageProfile.osDiskImage.source