### PR TITLE
fix getting agent pool available versions api path

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/examples/AgentPoolsGetAgentPoolAvailableVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/examples/AgentPoolsGetAgentPoolAvailableVersions.json
@@ -3,13 +3,12 @@
     "api-version": "2019-06-01",
     "subscriptionId": "subid1",
     "resourceGroupName": "rg1",
-    "resourceName": "clustername1",
-    "agentPoolName": "agentpool1"
+    "resourceName": "clustername1"
   },
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/availableAgentpoolVersions",
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/availableagentpoolversions",
         "name": "default",
         "properties": {
           "agentPoolVersions": [

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/managedClusters.json
@@ -779,7 +779,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/availableAgentPoolVersions": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/availableAgentPoolVersions": {
       "get": {
         "tags": [
           "AgentPools"
@@ -799,13 +799,6 @@
           },
           {
             "$ref": "#/parameters/ResourceNameParameter"
-          },
-          {
-            "name": "agentPoolName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the agent pool."
           }
         ],
         "responses": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/examples/AgentPoolsGetAgentPoolAvailableVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/examples/AgentPoolsGetAgentPoolAvailableVersions.json
@@ -3,13 +3,12 @@
     "api-version": "2019-08-01",
     "subscriptionId": "subid1",
     "resourceGroupName": "rg1",
-    "resourceName": "clustername1",
-    "agentPoolName": "agentpool1"
+    "resourceName": "clustername1"
   },
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/availableAgentpoolVersions",
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/availableagentpoolversions",
         "name": "default",
         "properties": {
           "agentPoolVersions": [

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/managedClusters.json
@@ -779,7 +779,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/availableAgentPoolVersions": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/availableAgentPoolVersions": {
       "get": {
         "tags": [
           "AgentPools"
@@ -799,13 +799,6 @@
           },
           {
             "$ref": "#/parameters/ResourceNameParameter"
-          },
-          {
-            "name": "agentPoolName",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the agent pool."
           }
         ],
         "responses": {


### PR DESCRIPTION
Accidentally included agent pool in the path for getting available agent pool versions API. This API is expected to be called before agent pool creation. So should not include agent pool name in the path. 
(The server side implementation is correct and no changed is needed. Only update the swagger to match the implementation.)

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
