### PR TITLE
enum name must be fixed here as well

### DIFF
--- a/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/preview/2019-05-01-preview/containerregistry_scopemap.json
+++ b/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/preview/2019-05-01-preview/containerregistry_scopemap.json
@@ -802,7 +802,7 @@
           ],
           "type": "string",
           "x-ms-enum": {
-            "name": "Status",
+            "name": "TokenStatus",
             "modelAsString": true
           }
         },


### PR DESCRIPTION
This was fixed in one place, but needs to be fixed here as well, otherwise we end up with TokenStatus and Status enums which are the same really, and "Status" is causing rename of another structure in Python SDK to "Status1"