### PR TITLE
[Fix]Address the File Swagger Problem

### DIFF
--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-02-02/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-02-02/file.json
@@ -579,7 +579,7 @@
                     "application/json"
                 ],
                 "parameters": [{
-                        "$ref": "#/parameters/FilePermissionKey"
+                        "$ref": "#/parameters/FilePermissionKeyRequired"
                     },
                     {
                         "$ref": "#/parameters/Timeout"
@@ -4191,6 +4191,15 @@
             "required": false,
             "type": "string",
             "x-ms-parameter-location": "method"
+        },
+        "FilePermissionKeyRequired": {
+          "name": "x-ms-file-permission-key",
+          "x-ms-client-name": "FilePermissionKey",
+          "in": "header",
+          "description": "Key of the permission to be set for the directory/file.",
+          "required": true,
+          "type": "string",
+          "x-ms-parameter-location": "method"
         },
         "FileRangeWriteFromUrl": {
             "name": "x-ms-write",


### PR DESCRIPTION
get_permission of Storage File has file_permission_key parameter which should be required instead of optional

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
