### PR TITLE
Revert "Adding the structure of urlConfiguration in rewriteRuleActionSet"

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-08-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-08-01/applicationGateway.json
@@ -1826,10 +1826,6 @@
             "$ref": "#/definitions/ApplicationGatewayHeaderConfiguration"
           },
           "description": "Response Header Actions in the Action Set."
-        },
-        "urlConfiguration": {
-          "$ref": "#/definitions/ApplicationGatewayUrlConfiguration",
-          "description": "Url Configuration Action in the Action Set."
         }
       },
       "description": "Set of actions in the Rewrite Rule in Application Gateway."
@@ -1846,23 +1842,6 @@
         }
       },
       "description": "Header configuration of the Actions set in Application Gateway."
-    },
-    "ApplicationGatewayUrlConfiguration": {
-      "properties": {
-        "modifiedPath": {
-          "type": "string",
-          "description": "Url path which user has provided for url rewrite. Null means no path will be updated. Default value is null."
-        },
-        "modifiedQueryString": {
-          "type": "string",
-          "description": "Query string which user has provided for url rewrite. Null means no query string will be updated. Default value is null."
-        },
-        "reroute": {
-          "type": "boolean",
-          "description": "If set as true, it will re-evaluate the url path map provided in path based request routing rules using modified path. Default value is false."
-        }
-      },
-      "description": "Url configuration of the Actions set in Application Gateway."
     },
     "ApplicationGatewayRedirectConfigurationPropertiesFormat": {
       "properties": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-08-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-08-01/examples/ApplicationGatewayCreate.json
@@ -235,10 +235,7 @@
                         "headerName": "Strict-Transport-Security",
                         "headerValue": "max-age=31536000"
                       }
-                    ],
-                    "urlConfiguration": {
-                        "modifiedPath": "/abc"
-                    }
+                    ]
                   }
                 }
               ]
@@ -480,11 +477,7 @@
                           "headerName": "Strict-Transport-Security",
                           "headerValue": "max-age=31536000"
                         }
-                      ],
-                      "urlConfiguration": {
-                        "modifiedPath": "/abc",
-                        "reroute" : true
-                      }
+                      ]
                     }
                   }
                 ]
@@ -726,11 +719,7 @@
                           "headerName": "Strict-Transport-Security",
                           "headerValue": "max-age=31536000"
                         }
-                      ],
-                      "urlConfiguration": {
-                        "modifiedPath": "/abc",
-                        "modifiedQueryString" : "x=y&a=b"
-                      }
+                      ]
                     }
                   }
                 ]

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-08-01/examples/ApplicationGatewayGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-08-01/examples/ApplicationGatewayGet.json
@@ -239,12 +239,7 @@
                           "headerName": "Strict-Transport-Security",
                           "headerValue": "max-age=31536000"
                         }
-                      ],
-                       "urlConfiguration": {
-                        "modifiedPath": "/abc",
-                        "modifiedQueryString": "x=y&a=b",
-                        "reroute" : false
-                      }
+                      ]
                     }
                   }
                 ]


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#7275

Because of some timelines, we do not want to release the Url rewrite model changes to public swagger. Revert these changes and they should not be released as a part of October 2nd release