### PR TITLE
Fix readme.python.md for Peering

### DIFF
--- a/specification/peering/resource-manager/readme.python.md
+++ b/specification/peering/resource-manager/readme.python.md
@@ -12,16 +12,16 @@ python:
   payload-flattening-threshold: 2
   namespace: azure.mgmt.peering
   package-name: azure-mgmt-peering
-  package-version: 2.0.0
+  package-version: 0.1.0
   clear-output-folder: true
 ```
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-peering/azure/mgmt/peering
+  output-folder: $(python-sdks-folder)/peering/azure-mgmt-peering/azure/mgmt/peering
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-peering
+  output-folder: $(python-sdks-folder)/peering/azure-mgmt-peering
 ```


### PR DESCRIPTION
Readme was wrong, so Python SDK was generated in a wrong location