### PR TITLE
Adding autorest cli specific section for healthcareapis

### DIFF
--- a/specification/healthcareapis/resource-manager/readme.cli.md
+++ b/specification/healthcareapis/resource-manager/readme.cli.md
@@ -1,0 +1,24 @@
+## CLI
+
+These settings apply only when `--cli` is specified on the command line.
+
+``` yaml $(cli)
+cli:
+  cli-name: healthcareapis
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  payload-flattening-threshold: 2
+  namespace: azure.mgmt.healthcareapis
+  package-name: azure-mgmt-healthcareapis
+  clear-output-folder: false
+  debug: true
+  adjustments:
+    "/sku": "Sku*/"
+    "/properties/authenticationconfiguration": "Authentication*/"
+    "/properties/corsconfiguration": "Cors*/"
+    "/properties/cosmosdbconfiguration": "CosmosDb*/"
+    "/properties/accesspolicies": "AccessPolicies*/"
+  disable-mm: true
+  test-setup:
+    - name: Create or Update a service with all parameters
+```

--- a/specification/healthcareapis/resource-manager/readme.cli.md
+++ b/specification/healthcareapis/resource-manager/readme.cli.md
@@ -18,7 +18,6 @@ cli:
     "/properties/corsconfiguration": "Cors*/"
     "/properties/cosmosdbconfiguration": "CosmosDb*/"
     "/properties/accesspolicies": "AccessPolicies*/"
-  disable-mm: true
   test-setup:
     - name: Create or Update a service with all parameters
 ```

--- a/specification/healthcareapis/resource-manager/readme.cli.md
+++ b/specification/healthcareapis/resource-manager/readme.cli.md
@@ -5,12 +5,8 @@ These settings apply only when `--cli` is specified on the command line.
 ``` yaml $(cli)
 cli:
   cli-name: healthcareapis
-  azure-arm: true
-  license-header: MICROSOFT_MIT_NO_VERSION
-  payload-flattening-threshold: 2
   namespace: azure.mgmt.healthcareapis
   package-name: azure-mgmt-healthcareapis
-  clear-output-folder: false
   debug: true
   adjustments:
     "/sku": "Sku*/"

--- a/specification/healthcareapis/resource-manager/readme.md
+++ b/specification/healthcareapis/resource-manager/readme.md
@@ -84,6 +84,10 @@ csharp:
 
 See configuration in [readme.python.md](./readme.python.md)
 
+## CLI
+
+See configuration in [readme.cli.md](./readme.cli.md)
+
 ## Go
 
 See configuration in [readme.go.md](./readme.go.md)


### PR DESCRIPTION
This is a new section for Azure CLI extensions.
It was already used to generate existing HealthCare APIs extension.