### PR TITLE
[Azure Search] Add missing $select parameter to List APIs

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListDataSources.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListDataSources.json
@@ -2,6 +2,7 @@
   "parameters": {
     "searchServiceName": "myservice",
     "searchDnsSuffix": "search.windows.net",
+    "$select": "*",
     "api-version": "2019-05-06"
   },
   "responses": {

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListIndexers.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListIndexers.json
@@ -2,6 +2,7 @@
   "parameters": {
     "searchServiceName": "myservice",
     "searchDnsSuffix": "search.windows.net",
+    "$select": "*",
     "api-version": "2019-05-06"
   },
   "responses": {

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListIndexes.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListIndexes.json
@@ -2,7 +2,7 @@
   "parameters": {
     "searchServiceName": "myservice",
     "searchDnsSuffix": "search.windows.net",
-    "$select": "name",
+    "$select": "*",
     "api-version": "2019-05-06"
   },
   "responses": {

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListSkillsets.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListSkillsets.json
@@ -2,6 +2,7 @@
   "parameters": {
     "searchServiceName": "myservice",
     "searchDnsSuffix": "search.windows.net",
+    "$select": "*",
     "api-version": "2019-05-06"
   },
   "responses": {

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListSynonymMaps.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/examples/SearchServiceListSynonymMaps.json
@@ -2,6 +2,7 @@
   "parameters": {
     "searchServiceName": "myservice",
     "searchDnsSuffix": "search.windows.net",
+    "$select": "*",
     "api-version": "2019-05-06"
   },
   "responses": {

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -193,6 +193,13 @@
         },
         "parameters": [
           {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Selects which top-level properties of the data sources to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+          },
+          {
             "$ref": "#/parameters/ClientRequestIdParameter"
           },
           {
@@ -493,6 +500,13 @@
         },
         "parameters": [
           {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Selects which top-level properties of the indexers to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+          },
+          {
             "$ref": "#/parameters/ClientRequestIdParameter"
           },
           {
@@ -746,6 +760,13 @@
         },
         "parameters": [
           {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Selects which top-level properties of the skillsets to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+          },
+          {
             "$ref": "#/parameters/ClientRequestIdParameter"
           },
           {
@@ -970,6 +991,13 @@
         },
         "parameters": [
           {
+            "name": "$select",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Selects which top-level properties of the synonym maps to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+          },
+          {
             "$ref": "#/parameters/ClientRequestIdParameter"
           },
           {
@@ -1090,7 +1118,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Selects which properties of the index definitions to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+            "description": "Selects which top-level properties of the index definitions to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"


### PR DESCRIPTION
The Azure Search REST API has always supported $select across all List APIs, but we forgot to specify it in the Swagger spec for all but List Indexes.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
