### PR TITLE
Adding missing tag required by network release

### DIFF
--- a/specification/network/resource-manager/readme.go.md
+++ b/specification/network/resource-manager/readme.go.md
@@ -13,6 +13,7 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
+  - tag: package-2019-08
   - tag: package-2019-07
   - tag: package-2019-06
   - tag: package-2019-04
@@ -38,6 +39,15 @@ batch:
   - tag: package-2016-03
   - tag: package-2015-06split
   - tag: package-2015-05-preview
+```
+
+### Tag: package-2019-08 and go
+
+These settings apply only when `--tag=package-2019-08 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2019-08' && $(go)
+output-folder: $(go-sdk-folder)/services/$(namespace)/mgmt/2019-08-01/$(namespace)
 ```
 
 ### Tag: package-2019-07 and go

--- a/specification/network/resource-manager/readme.java.md
+++ b/specification/network/resource-manager/readme.java.md
@@ -16,6 +16,7 @@ output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-network
 
 ``` yaml $(java) && $(multiapi)
 batch:
+  - tag: package-2019-08
   - tag: package-2019-07
   - tag: package-2019-06
   - tag: package-2019-04
@@ -26,6 +27,19 @@ batch:
   - tag: package-2018-06
   - tag: package-2018-04
   - tag: package-2017-10
+```
+
+### Tag: package-2019-08 and java
+
+These settings apply only when `--tag=package-2019-08 --java` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+``` yaml $(tag) == 'package-2019-08' && $(java) && $(multiapi)
+java:
+  namespace: com.microsoft.azure.management.network.v2019_08_01
+  output-folder: $(azure-libraries-for-java-folder)/network/resource-manager/v2019_08_01
+  regenerate-manager: true
+  generate-interface: true
 ```
 
 ### Tag: package-2019-07 and java

--- a/specification/network/resource-manager/readme.python.md
+++ b/specification/network/resource-manager/readme.python.md
@@ -18,6 +18,8 @@ Generate all API versions currently shipped for this package
 
 ```yaml $(python) && $(multiapi)
 batch:
+  - tag: package-2019-08
+  - tag: package-2019-07
   - tag: package-2019-06
   - tag: package-2019-04
   - tag: package-2019-02

--- a/specification/network/resource-manager/readme.python.md
+++ b/specification/network/resource-manager/readme.python.md
@@ -42,6 +42,17 @@ batch:
   - tag: package-2015-06split
 ```
 
+### Tag: package-2019-07 and python
+
+These settings apply only when `--tag=package-2019-07 --python` is specified on the command line.
+Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
+
+``` yaml $(tag) == 'package-2019-07' && $(python)
+python:
+  namespace: azure.mgmt.network.v2019_07_01
+  output-folder: $(python-sdks-folder)/network/azure-mgmt-network/azure/mgmt/network/v2019_07_01
+```
+
 ### Tag: package-2019-06 and python
 
 These settings apply only when `--tag=package-2019-06 --python` is specified on the command line.

--- a/specification/network/resource-manager/readme.python.md
+++ b/specification/network/resource-manager/readme.python.md
@@ -18,7 +18,6 @@ Generate all API versions currently shipped for this package
 
 ```yaml $(python) && $(multiapi)
 batch:
-  - tag: package-2019-08
   - tag: package-2019-07
   - tag: package-2019-06
   - tag: package-2019-04

--- a/specification/network/resource-manager/readme.python.md
+++ b/specification/network/resource-manager/readme.python.md
@@ -18,6 +18,7 @@ Generate all API versions currently shipped for this package
 
 ```yaml $(python) && $(multiapi)
 batch:
+  - tag: package-2019-08
   - tag: package-2019-07
   - tag: package-2019-06
   - tag: package-2019-04
@@ -40,6 +41,17 @@ batch:
   - tag: package-2016-12
   - tag: package-2016-09
   - tag: package-2015-06split
+```
+
+### Tag: package-2019-08 and python
+
+These settings apply only when `--tag=package-2019-08 --python` is specified on the command line.
+Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
+
+``` yaml $(tag) == 'package-2019-08' && $(python)
+python:
+  namespace: azure.mgmt.network.v2019_08_01
+  output-folder: $(python-sdks-folder)/network/azure-mgmt-network/azure/mgmt/network/v2019_08_01
 ```
 
 ### Tag: package-2019-07 and python


### PR DESCRIPTION
I got request to release network tag 2019-07-01, but appropriate definitions were missing from readme.python.md