### PR TITLE
Modify SecureString to SecretBase in SDK for ExecuteSSISPackage activity in pipeline

### DIFF
--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
@@ -4195,7 +4195,7 @@
       "type": "object",
       "properties": {
         "packagePassword": {
-          "$ref": "../datafactory.json#/definitions/SecureString",
+          "$ref": "../datafactory.json#/definitions/SecretBase",
           "description": "Password of the package."
         },
         "accessCredential": {
@@ -4281,7 +4281,7 @@
           "description": "UseName for windows authentication."
         },
         "password": {
-          "$ref": "../datafactory.json#/definitions/SecureString",
+          "$ref": "../datafactory.json#/definitions/SecretBase",
           "description": "Password for windows authentication."
         }
       },


### PR DESCRIPTION
Change the type 'SecureString' for PackageAccessPassword, PackagePassword and LogAccessPassword to type 'SecretBase' in pipeline SDK. 