### PR TITLE
Iops, throughput and instance view

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/compute.json
@@ -2529,11 +2529,12 @@
             }
           }
         },
-		"x-ms-examples": {
+        "x-ms-examples": {
           "Get a Virtual Machine.": {
             "$ref": "./examples/GetVirtualMachine.json"
           }
         }
+      }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/instanceView": {
       "get": {
@@ -2572,7 +2573,7 @@
             }
           }
         },
-		"x-ms-examples": {
+        "x-ms-examples": {
           "Get Virtual Machine Instance View.": {
             "$ref": "./examples/GetVirtualMachineInstanceView.json"
           }

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/compute.json
@@ -2528,8 +2528,12 @@
               "$ref": "#/definitions/VirtualMachine"
             }
           }
+        },
+		"x-ms-examples": {
+          "Get a Virtual Machine.": {
+            "$ref": "./examples/GetVirtualMachine.json"
+          }
         }
-      }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/instanceView": {
       "get": {
@@ -2567,7 +2571,12 @@
               "$ref": "#/definitions/VirtualMachineInstanceView"
             }
           }
-        }
+        },
+		"x-ms-examples": {
+          "Get Virtual Machine Instance View.": {
+            "$ref": "./examples/GetVirtualMachineInstanceView.json"
+          }
+        }		
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/convertToManagedDisks": {
@@ -2734,6 +2743,13 @@
           },
           {
             "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "statusOnly",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "statusOnly=true enables fetching run time status of all Virtual Machines in the subscription."
           }
         ],
         "responses": {
@@ -7092,7 +7108,19 @@
         "toBeDetached": {
           "type": "boolean",
           "description": "Specifies whether the data disk is in process of detachment from the VirtualMachine/VirtualMachineScaleset"
-        }
+        },
+        "diskIOPSReadWrite": {
+          "type": "integer",
+          "readOnly": true,          
+          "format": "int64",
+          "description": "Specifies the Read-Write IOPS for the managed disk when StorageAccountType is UltraSSD_LRS. Returned only for VirtualMachine ScaleSet VM disks. Can be updated only via updates to the VirtualMachine Scale Set."
+        },
+        "diskMBpsReadWrite": {
+          "type": "integer",
+          "readOnly": true,          
+          "format": "int64",
+          "description": "Specifies the bandwidth in MB per second for the managed disk when StorageAccountType is UltraSSD_LRS. Returned only for VirtualMachine ScaleSet VM disks. Can be updated only via updates to the VirtualMachine Scale Set."
+        }        
       },
       "required": [
         "lun",
@@ -8383,6 +8411,16 @@
         "managedDisk": {
           "description": "The managed disk parameters.",
           "$ref": "#/definitions/VirtualMachineScaleSetManagedDiskParameters"
+        },
+        "diskIOPSReadWrite": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Specifies the Read-Write IOPS for the managed disk. Should be used only when StorageAccountType is UltraSSD_LRS. If not specified, a default value would be assigned based on diskSizeGB."
+        },
+        "diskMBpsReadWrite": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Specifies the bandwidth in MB per second for the managed disk. Should be used only when StorageAccountType is UltraSSD_LRS. If not specified, a default value would be assigned based on diskSizeGB."
         }
       },
       "required": [

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachine.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachine.json
@@ -1,9 +1,9 @@
 {
   "parameters": {
     "subscriptionId": "{subscription-id}",
-    "resourceGroupName": "myResourceGroup",
-    "api-version": "2019-07-01",
-    "vmName": "myVM"
+	"resourceGroupName": "myResourceGroup",
+	"vmName": "myVM",
+    "api-version": "2019-07-01"
   },
   "responses": {
     "200": {
@@ -24,15 +24,14 @@
 				"id" : "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/proximityPlacementGroups/my-ppg01"
 			},
 			"hardwareProfile" : {
-				"vmSize" : "Standard_DS3_V2"
+				"vmSize" : "Standard_DS3_v2"
 			},
 			"storageProfile" : {
 				"imageReference" : {
 					"publisher" : "MicrosoftWindowsServer",
 					"offer" : "WindowsServer",
 					"sku" : "2016-Datacenter",
-					"version" : "latest",
-					"exactVersion" : "14393.3274.1910061629"
+					"version" : "latest"
 				},
 				"osDisk" : {
 					"osType": "Windows",

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachine.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachine.json
@@ -3,7 +3,7 @@
     "subscriptionId": "{subscription-id}",
     "resourceGroupName": "myResourceGroup",
     "api-version": "2019-07-01",
-    "vmName": "myVM",
+    "vmName": "myVM"
   },
   "responses": {
     "200": {
@@ -44,7 +44,7 @@
 						"id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myOsDisk"
 					},
 					"diskSizeGB": 30
-				}
+				},
 				"dataDisks" : [
 					{
 					    "lun": 0,

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachine.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachine.json
@@ -1,0 +1,121 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "api-version": "2019-07-01",
+    "vmName": "myVM",
+  },
+  "responses": {
+    "200": {
+      "body": {		          
+        "name": "myVM",
+		"id" : "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVM",
+		"type" : "Microsoft.Compute/virtualMachines",
+		"location": "West US",
+		"tags" : {
+			"myTag1" : "tagValue1"
+		},
+        "properties": {
+			"vmId" : "0f47b100-583c-48e3-a4c0-aefc2c9bbcc1",
+			"availabilitySet" : {
+				"id" : "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/availabilitySets/my-AvailabilitySet"
+			},
+			"proximityPlacementGroup" : {
+				"id" : "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/proximityPlacementGroups/my-ppg01"
+			},
+			"hardwareProfile" : {
+				"vmSize" : "Standard_DS3_V2"
+			},
+			"storageProfile" : {
+				"imageReference" : {
+					"publisher" : "MicrosoftWindowsServer",
+					"offer" : "WindowsServer",
+					"sku" : "2016-Datacenter",
+					"version" : "latest",
+					"exactVersion" : "14393.3274.1910061629"
+				},
+				"osDisk" : {
+					"osType": "Windows",
+					"name": "myOsDisk",
+					"createOption": "FromImage",
+					"caching": "ReadWrite",
+					"managedDisk": {
+						"storageAccountType": "Premium_LRS",
+						"id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myOsDisk"
+					},
+					"diskSizeGB": 30
+				}
+				"dataDisks" : [
+					{
+					    "lun": 0,
+					    "name": "myDataDisk0",
+					    "createOption": "Empty",
+					    "caching": "ReadWrite",
+					    "managedDisk": {
+						    "storageAccountType": "Premium_LRS",
+						    "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myDataDisk0"
+					    },
+					    "diskSizeGB": 30
+    				}, 
+					{
+					    "lun": 1,
+					    "name": "myDataDisk1",
+					    "createOption": "Attach",
+					    "caching": "ReadWrite",
+					    "managedDisk": {
+						    "storageAccountType": "Premium_LRS",
+						    "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myDataDisk1"
+					    },
+					    "diskSizeGB": 100
+    				}
+				]
+			},
+			"osProfile" : {
+				"computerName" : "myVM",
+				"adminUsername" : "admin",
+				"windowsConfiguration" : {
+					"provisionVMAgent" : true,
+					"enableAutomaticUpdates" : false
+				},
+				"secrets" : [
+				]
+			},
+			"networkProfile" : {
+				"networkInterfaces" : [{
+						"id" : "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Network/networkInterfaces/{myNIC}"
+					}
+				]
+			},
+			"diagnosticsProfile" : {
+				"bootDiagnostics" : {
+					"enabled" : true,
+					"storageUri" : "http://{myStorageAccount}.blob.core.windows.net"
+				}
+			},
+			"provisioningState" : "Succeeded"		
+		},
+		"resources" : [{
+			"name" : "CustomScriptExtension-DSC",
+			"id" : "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVM/extensions/CustomScriptExtension-DSC",
+			"type" : "Microsoft.Compute/virtualMachines/extensions",
+			"location" : "west us",
+			"tags" : {
+				"displayName" : "CustomScriptExtension-DSC"
+			},
+			"properties" : {
+				"autoUpgradeMinorVersion" : true,
+				"provisioningState" : "Succeeded",
+				"publisher" : "Microsoft.Compute",
+				"type" : "CustomScriptExtension",
+				"typeHandlerVersion" : "1.9",
+				"settings" : {
+				}
+			}
+		}]
+      }
+    }
+  }
+}
+
+
+

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachineInstanceView.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachineInstanceView.json
@@ -1,0 +1,91 @@
+{
+	"parameters" : {
+		"subscriptionId" : "{subscription-id}",
+		"resourceGroupName" : "myResourceGroup",
+		"api-version" : "2019-07-01",
+		"vmName" : "myVM",
+	},
+	"responses" : {
+		"200" : {
+			"body" : {
+				"platformUpdateDomain" : 1,
+				"platformFaultDomain" : 1,
+				"computerName" : "myVM",
+				"osName" : "Windows Server 2016 Datacenter",
+				"osVersion" : "Microsoft Windows NT 10.0.14393.0",
+				"vmAgent" : {
+					"vmAgentVersion" : "2.7.41491.949",
+					"statuses" : [{
+							"code" : "ProvisioningState/succeeded",
+							"level" : "Info",
+							"displayStatus" : "Ready",
+							"message" : "GuestAgent is running and accepting new configurations.",
+							"time" : "2019-10-14T23:11:22+00:00"
+						}
+					],
+					"extensionHandlers" : [{
+							"type" : "Microsoft.Azure.Security.IaaSAntimalware",
+							"typeHandlerVersion" : "1.5.5.9",
+							"status" : {
+								"code" : "ProvisioningState/succeeded",
+								"level" : "Info",
+								"displayStatus" : "Ready"
+							}
+						},
+					]
+				},
+				"disks" : [
+					{
+						"name" : "myOsDisk",
+						"statuses" : [{
+								"code" : "ProvisioningState/succeeded",
+								"level" : "Info",
+								"displayStatus" : "Provisioning succeeded",
+								"time" : "2019-10-14T21:29:47.477089+00:00"
+							}
+						]
+					}, 
+					{
+						"name" : "myDataDisk0",
+						"statuses" : [{
+								"code" : "ProvisioningState/succeeded",
+								"level" : "Info",
+								"displayStatus" : "Provisioning succeeded",
+								"time" : "2019-10-14T21:29:47.461517+00:00"
+							}
+						]
+					},
+				],
+				"bootDiagnostics" : {
+					"consoleScreenshotBlobUri" : "https://{myStorageAccount}.blob.core.windows.net/bootdiagnostics-myOsDisk/myOsDisk.screenshot.bmp",
+					"serialConsoleLogBlobUri" : "https://{myStorageAccount}.blob.core.windows.net/bootdiagnostics-myOsDisk/myOsDisk.serialconsole.log"
+				},
+				"extensions" : [{
+						"name" : "IaaSAntiMalware-dev-bgp02",
+						"type" : "Microsoft.Azure.Security.IaaSAntimalware",
+						"typeHandlerVersion" : "1.5.5.9",
+						"statuses" : [{
+								"code" : "ProvisioningState/succeeded",
+								"level" : "Info",
+								"displayStatus" : "Provisioning succeeded",
+								"message" : "Microsoft Antimalware enabled"
+							}
+						]
+					}
+				],
+				"hyperVGeneration" : "V1",
+				"statuses" : [{
+						"code" : "ProvisioningState/succeeded",
+						"level" : "Info",
+						"displayStatus" : "Provisioning succeeded",
+						"time" : "2019-10-14T21:30:12.8051917+00:00"
+					}, {
+						"code" : "PowerState/running",
+						"level" : "Info",
+						"displayStatus" : "VM running"
+					}
+				]
+			}
+		}
+	}
+}

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachineInstanceView.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/examples/GetVirtualMachineInstanceView.json
@@ -3,7 +3,7 @@
 		"subscriptionId" : "{subscription-id}",
 		"resourceGroupName" : "myResourceGroup",
 		"api-version" : "2019-07-01",
-		"vmName" : "myVM",
+		"vmName" : "myVM"
 	},
 	"responses" : {
 		"200" : {
@@ -31,7 +31,7 @@
 								"level" : "Info",
 								"displayStatus" : "Ready"
 							}
-						},
+						}
 					]
 				},
 				"disks" : [
@@ -54,14 +54,14 @@
 								"time" : "2019-10-14T21:29:47.461517+00:00"
 							}
 						]
-					},
+					}
 				],
 				"bootDiagnostics" : {
 					"consoleScreenshotBlobUri" : "https://{myStorageAccount}.blob.core.windows.net/bootdiagnostics-myOsDisk/myOsDisk.screenshot.bmp",
 					"serialConsoleLogBlobUri" : "https://{myStorageAccount}.blob.core.windows.net/bootdiagnostics-myOsDisk/myOsDisk.serialconsole.log"
 				},
 				"extensions" : [{
-						"name" : "IaaSAntiMalware-dev-bgp02",
+						"name" : "IaaSAntiMalware-ext0",
 						"type" : "Microsoft.Azure.Security.IaaSAntimalware",
 						"typeHandlerVersion" : "1.5.5.9",
 						"statuses" : [{


### PR DESCRIPTION
Added IOPS and BW properties on managed disk  for UltraSSD disks.
These properties can be set only on the VMScaleSet but are also returned via VMSCaleSet VMs.
ListVMs at susbcription level now supports a statusOnly=true query param and CRP would returned a trimmed down instance view in that case
Added samples for GETVM and GETVMInstanceView

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
