### PR TITLE
remove web 2019-08 to generate python sdk before service is ready

### DIFF
--- a/specification/web/resource-manager/readme.python.md
+++ b/specification/web/resource-manager/readme.python.md
@@ -22,7 +22,6 @@ Generate all API versions currently shipped for this package
 
 ```yaml $(python) && $(multiapi)
 batch:
-  - tag: package-2019-08-only
   - tag: package-2018-11-only
   - tag: package-2018-02-only
   - tag: package-2016-09-only
@@ -30,17 +29,6 @@ batch:
   - tag: package-2016-03-only
   - tag: package-2015-08-only
   - tag: package-2015-04-only
-```
-
-### Tag: package-2019-08-only and python
-
-These settings apply only when `--tag=package-2019-08-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-``` yaml $(tag) == 'package-2019-08-only' && $(python)
-python:
-  namespace: azure.mgmt.web.v2019_08_01
-  output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2019_08_01
 ```
 
 ### Tag: package-2018-11-only and python


### PR DESCRIPTION
service side is not ready for web 2019-08. need to generate SDK without it and fix some issues. Do not merge this PR.