### PR TITLE
Fix read-only property in expressRouteCircuit.json

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/expressRouteCircuit.json
@@ -1523,7 +1523,6 @@
     "ExpressRouteCircuitPeeringConfig": {
       "properties": {
         "advertisedPublicPrefixes": {
-          "readOnly": true,
           "type": "array",
           "items": {
             "type": "string"
@@ -1538,6 +1537,7 @@
           "description": "The communities of bgp peering. Specified for microsoft peering."
         },
         "advertisedPublicPrefixesState": {
+          "readOnly": true,
           "type": "string",
           "description": "The advertised public prefix state of the Peering resource.",
           "enum": [


### PR DESCRIPTION
One of properties in https://github.com/Azure/azure-rest-api-specs/pull/7488 was marked as read-only incorrectly. This PR fixes that.

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
