### PR TITLE
Updating the documentation of the redis staticIP property

### DIFF
--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2015-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2015-08-01/redis.json
@@ -451,7 +451,7 @@
         },
         "staticIP": {
           "type": "string",
-          "description": "Required when deploying a Redis cache inside an existing Azure Virtual Network."
+          "description": "Deprecated. May optionally be used to request a specific IP address, only when deploying a Redis cache inside an Azure virtual network. We recommend you do not set this parameter, and connect using the hostname instead."
         }
       },
       "required": [

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2016-04-01/examples/RedisCacheCreate.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2016-04-01/examples/RedisCacheCreate.json
@@ -17,8 +17,7 @@
         "redisConfiguration": {
           "maxmemory-policy": "allkeys-lru"
         },
-        "subnetId": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1",
-        "staticIP": "192.168.0.5"
+        "subnetId": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1"
       }
     }
   },

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2016-04-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2016-04-01/redis.json
@@ -1024,8 +1024,7 @@
         },
         "staticIP": {
           "type": "string",
-          "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-          "description": "Static IP address. Required when deploying a Redis cache inside an existing Azure Virtual Network."
+          "description": "Deprecated. May optionally be used to request a specific IP address, only when deploying a Redis cache inside an Azure virtual network. We recommend you do not set this parameter, and connect using the hostname instead."
         }
       },
       "description": "Properties supplied to Create or Update Redis operation.",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2017-02-01/examples/RedisCacheCreate.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2017-02-01/examples/RedisCacheCreate.json
@@ -17,8 +17,7 @@
         "redisConfiguration": {
           "maxmemory-policy": "allkeys-lru"
         },
-        "subnetId": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1",
-        "staticIP": "192.168.0.5"
+        "subnetId": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1"
       }
     }
   },

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2017-02-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2017-02-01/redis.json
@@ -1230,8 +1230,7 @@
         },
         "staticIP": {
           "type": "string",
-          "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-          "description": "Static IP address. Required when deploying a Redis cache inside an existing Azure Virtual Network."
+          "description": "Deprecated. May optionally be used to request a specific IP address, only when deploying a Redis cache inside an Azure virtual network. We recommend you do not set this parameter, and connect using the hostname instead."
         }
       },
       "description": "Properties supplied to Create or Update Redis operation.",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2017-10-01/examples/RedisCacheCreate.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2017-10-01/examples/RedisCacheCreate.json
@@ -20,8 +20,7 @@
         "redisConfiguration": {
           "maxmemory-policy": "allkeys-lru"
         },
-        "subnetId": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1",
-        "staticIP": "192.168.0.5"
+        "subnetId": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1"
       }
     }
   },

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2017-10-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2017-10-01/redis.json
@@ -1424,8 +1424,7 @@
         },
         "staticIP": {
           "type": "string",
-          "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-          "description": "Static IP address. Required when deploying a Redis cache inside an existing Azure Virtual Network."
+          "description": "Deprecated. May optionally be used to request a specific IP address, only when deploying a Redis cache inside an Azure virtual network. We recommend you do not set this parameter, and connect using the hostname instead."
         }
       },
       "required": [

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2018-03-01/examples/RedisCacheCreate.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2018-03-01/examples/RedisCacheCreate.json
@@ -21,7 +21,6 @@
           "maxmemory-policy": "allkeys-lru"
         },
         "subnetId": "/subscriptions/subid/resourceGroups/rg2/providers/Microsoft.Network/virtualNetworks/network1/subnets/subnet1",
-        "staticIP": "192.168.0.5",
         "minimumTlsVersion": "1.2"
       }
     }

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2018-03-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2018-03-01/redis.json
@@ -1440,8 +1440,7 @@
         },
         "staticIP": {
           "type": "string",
-          "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
-          "description": "Static IP address. Required when deploying a Redis cache inside an existing Azure Virtual Network."
+          "description": "Deprecated. May optionally be used to request a specific IP address, only when deploying a Redis cache inside an Azure virtual network. We recommend you do not set this parameter, and connect using the hostname instead."
         }
       },
       "required": [


### PR DESCRIPTION
It is no longer required for redis VNET create scenarios, nor even recommended.

# Conflicts:
#	specification/redis/resource-manager/Microsoft.Cache/stable/2016-04-01/redis.json

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [n/a] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
