### PR TITLE
some naming replacing in examples to make it inline with cli commands

### DIFF
--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreateDirectPeering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreateDirectPeering.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-08-01-preview",
     "peering": {
       "sku": {
@@ -112,8 +112,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     },
@@ -176,8 +176,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreateExchangePeering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreateExchangePeering.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-08-01-preview",
     "peering": {
       "sku": {
@@ -98,8 +98,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     },
@@ -156,8 +156,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreatePeerAsn.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreatePeerAsn.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "peerAsnName": "peerAsnName",
+    "peerAsnName": "MyPeerAsn",
     "api-version": "2019-08-01-preview",
     "peerAsn": {
       "properties": {
@@ -36,8 +36,8 @@
           "peerName": "Contoso",
           "validationState": "Pending"
         },
-        "name": "peerAsnName",
-        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/peerAsnName",
+        "name": "MyPeerAsn",
+        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/MyPeerAsn",
         "type": "Microsoft.Peering/peerAsns"
       }
     },
@@ -57,8 +57,8 @@
           "peerName": "Contoso",
           "validationState": "Pending"
         },
-        "name": "peerAsnName",
-        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/peerAsnName",
+        "name": "MyPeerAsn",
+        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/MyPeerAsn",
         "type": "Microsoft.Peering/peerAsns"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreatePeeringService.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreatePeeringService.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-08-01-preview",
     "peeringService": {
       "properties": {
@@ -21,8 +21,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringServiceName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+        "name": "MyPeeringService",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
         "type": "Microsoft.Peering/peeringServices"
       }
     },
@@ -34,8 +34,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringServiceName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+        "name": "MyPeeringService",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
         "type": "Microsoft.Peering/peeringServices"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreatePeeringServicePrefix.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/CreatePeeringServicePrefix.json
@@ -1,9 +1,9 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
-    "prefixName": "peeringServicePrefixName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
+    "prefixName": "MyPeeringServicePrefix",
     "api-version": "2019-08-01-preview",
     "peeringServicePrefix": {
       "properties": {
@@ -20,8 +20,8 @@
           "learnedType": "None",
           "provisioningState": "Succeeded"
         },
-        "name": "peeringServicePrefixName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName"
+        "name": "MyPeeringServicePrefix",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix"
       }
     },
     "201": {
@@ -32,8 +32,8 @@
           "learnedType": "None",
           "provisioningState": "Succeeded"
         },
-        "name": "peeringServicePrefixName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName"
+        "name": "MyPeeringServicePrefix",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix"
       }
     }
   }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/DeletePeerAsn.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/DeletePeerAsn.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "peerAsnName": "peerAsnName",
+    "peerAsnName": "MyPeerAsn",
     "api-version": "2019-08-01-preview"
   },
   "responses": {

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/DeletePeering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/DeletePeering.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-08-01-preview"
   },
   "responses": {

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/DeletePeeringService.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/DeletePeeringService.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-08-01-preview"
   },
   "responses": {

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/DeletePeeringServicePrefix.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/DeletePeeringServicePrefix.json
@@ -1,9 +1,9 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
-    "prefixName": "peeringServicePrefixName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
+    "prefixName": "MyPeeringServicePrefix",
     "api-version": "2019-08-01-preview"
   },
   "responses": {

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/GetPeerAsn.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/GetPeerAsn.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "peerAsnName": "peerAsnName",
+    "peerAsnName": "MyPeerAsn",
     "api-version": "2019-08-01-preview"
   },
   "responses": {
@@ -21,8 +21,8 @@
           "peerName": "Contoso",
           "validationState": "Approved"
         },
-        "name": "peerAsnName",
-        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/peerAsnName",
+        "name": "MyPeerAsn",
+        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/MyPeerAsn",
         "type": "Microsoft.Peering/peerAsns"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/GetPeering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/GetPeering.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-08-01-preview"
   },
   "responses": {
@@ -59,8 +59,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/GetPeeringService.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/GetPeeringService.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-08-01-preview"
   },
   "responses": {
@@ -14,8 +14,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringServiceName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+        "name": "MyPeeringService",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
         "type": "Microsoft.Peering/peeringServices"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/GetPeeringServicePrefix.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/GetPeeringServicePrefix.json
@@ -1,9 +1,9 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
-    "prefixName": "peeringServicePrefixName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
+    "prefixName": "MyPeeringServicePrefix",
     "api-version": "2019-08-01-preview"
   },
   "responses": {
@@ -15,8 +15,8 @@
           "learnedType": "None",
           "provisioningState": "Succeeded"
         },
-        "name": "peeringServicePrefixName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName"
+        "name": "MyPeeringServicePrefix",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix"
       }
     }
   }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListLegacyPeerings.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListLegacyPeerings.json
@@ -61,8 +61,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "centralus",
-            "name": "peeringName",
-            "id": "/subscriptions/subId/providers/Microsoft.Peering/peerings/peeringName",
+            "name": "MyPeering",
+            "id": "/subscriptions/subId/providers/Microsoft.Peering/peerings/MyPeering",
             "type": "Microsoft.Peering/peerings"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeerAsnsBySubscription.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeerAsnsBySubscription.json
@@ -22,8 +22,8 @@
               "peerName": "Contoso",
               "validationState": "Approved"
             },
-            "name": "peerAsnName",
-            "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/peerAsnName",
+            "name": "MyPeerAsn",
+            "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/MyPeerAsn",
             "type": "Microsoft.Peering/peerAsns"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeeringServicesByResourceGroup.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeeringServicesByResourceGroup.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
+    "resourceGroupName": "MyResourceGroup",
     "api-version": "2019-08-01-preview"
   },
   "responses": {
@@ -15,8 +15,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "eastus",
-            "name": "peeringServiceName",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+            "name": "MyPeeringService",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
             "type": "Microsoft.Peering/peeringServices"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeeringServicesBySubscription.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeeringServicesBySubscription.json
@@ -14,8 +14,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "eastus",
-            "name": "peeringServiceName",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+            "name": "MyPeeringService",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
             "type": "Microsoft.Peering/peeringServices"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeeringsByResourceGroup.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeeringsByResourceGroup.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
+    "resourceGroupName": "MyResourceGroup",
     "api-version": "2019-08-01-preview"
   },
   "responses": {
@@ -60,8 +60,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "eastus",
-            "name": "peeringName",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+            "name": "MyPeering",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
             "type": "Microsoft.Peering/peerings"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeeringsBySubscription.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPeeringsBySubscription.json
@@ -59,8 +59,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "eastus",
-            "name": "peeringName",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+            "name": "MyPeering",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
             "type": "Microsoft.Peering/peerings"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPrefixesByPeeringService.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/ListPrefixesByPeeringService.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-08-01-preview"
   },
   "responses": {
@@ -16,8 +16,8 @@
               "learnedType": "None",
               "provisioningState": "Succeeded"
             },
-            "name": "peeringServicePrefixName1",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName1"
+            "name": "MyPeeringServicePrefix1",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix1"
           },
           {
             "properties": {
@@ -26,8 +26,8 @@
               "learnedType": "None",
               "provisioningState": "Succeeded"
             },
-            "name": "peeringServicePrefixName2",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName2"
+            "name": "MyPeeringServicePrefix2",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix2"
           }
         ]
       }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/UpdatePeeringServiceTags.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/UpdatePeeringServiceTags.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-08-01-preview",
     "tags": {
       "tags": {
@@ -24,8 +24,8 @@
           "tag0": "value0",
           "tag1": "value1"
         },
-        "name": "peeringServiceName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+        "name": "MyPeeringService",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
         "type": "Microsoft.Peering/peeringServices"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/UpdatePeeringTags.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/examples/UpdatePeeringTags.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-08-01-preview",
     "tags": {
       "tags": {
@@ -69,8 +69,8 @@
           "tag0": "value0",
           "tag1": "value1"
         },
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/peering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/peering.json
@@ -158,7 +158,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.Peering/peerAsns/{MyPeerAsn}": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Peering/peerAsns/{peerAsnName}": {
       "get": {
         "tags": [
           "PeerAsns"
@@ -167,7 +167,7 @@
         "operationId": "PeerAsns_Get",
         "parameters": [
           {
-            "name": "MyPeerAsn",
+            "name": "peerAsnName",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -208,7 +208,7 @@
         "operationId": "PeerAsns_CreateOrUpdate",
         "parameters": [
           {
-            "name": "MyPeerAsn",
+            "name": "peerAsnName",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -264,7 +264,7 @@
         "operationId": "PeerAsns_Delete",
         "parameters": [
           {
-            "name": "MyPeerAsn",
+            "name": "peerAsnName",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -419,7 +419,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeering",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -467,7 +467,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeering",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -533,7 +533,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeering",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -581,7 +581,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeering",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/peering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/peering.json
@@ -158,7 +158,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.Peering/peerAsns/{peerAsnName}": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Peering/peerAsns/{MyPeerAsn}": {
       "get": {
         "tags": [
           "PeerAsns"
@@ -167,7 +167,7 @@
         "operationId": "PeerAsns_Get",
         "parameters": [
           {
-            "name": "peerAsnName",
+            "name": "MyPeerAsn",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -208,7 +208,7 @@
         "operationId": "PeerAsns_CreateOrUpdate",
         "parameters": [
           {
-            "name": "peerAsnName",
+            "name": "MyPeerAsn",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -264,7 +264,7 @@
         "operationId": "PeerAsns_Delete",
         "parameters": [
           {
-            "name": "peerAsnName",
+            "name": "MyPeerAsn",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -403,7 +403,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peerings/{peeringName}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peerings/{MyPeering}": {
       "get": {
         "tags": [
           "Peerings"
@@ -419,7 +419,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "MyPeering",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -467,7 +467,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "MyPeering",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -533,7 +533,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "MyPeering",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -581,7 +581,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "MyPeering",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/peering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-08-01-preview/peering.json
@@ -403,7 +403,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peerings/{MyPeering}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peerings/{peeringName}": {
       "get": {
         "tags": [
           "Peerings"

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreateDirectPeering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreateDirectPeering.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-09-01-preview",
     "peering": {
       "sku": {
@@ -105,8 +105,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     },
@@ -160,8 +160,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreateExchangePeering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreateExchangePeering.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-09-01-preview",
     "peering": {
       "sku": {
@@ -99,8 +99,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     },
@@ -157,8 +157,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreatePeerAsn.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreatePeerAsn.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "peerAsnName": "peerAsnName",
+    "peerAsnName": "MyPeerAsn",
     "api-version": "2019-09-01-preview",
     "peerAsn": {
       "properties": {
@@ -36,8 +36,8 @@
           "peerName": "Contoso",
           "validationState": "Pending"
         },
-        "name": "peerAsnName",
-        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/peerAsnName",
+        "name": "MyPeerAsn",
+        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/MyPeerAsn",
         "type": "Microsoft.Peering/peerAsns"
       }
     },
@@ -57,8 +57,8 @@
           "peerName": "Contoso",
           "validationState": "Pending"
         },
-        "name": "peerAsnName",
-        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/peerAsnName",
+        "name": "MyPeerAsn",
+        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/MyPeerAsn",
         "type": "Microsoft.Peering/peerAsns"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreatePeeringService.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreatePeeringService.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-09-01-preview",
     "peeringService": {
       "properties": {
@@ -21,8 +21,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringServiceName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+        "name": "MyPeeringService",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
         "type": "Microsoft.Peering/peeringServices"
       }
     },
@@ -34,8 +34,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringServiceName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+        "name": "MyPeeringService",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
         "type": "Microsoft.Peering/peeringServices"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreatePeeringServicePrefix.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/CreatePeeringServicePrefix.json
@@ -1,9 +1,9 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
-    "prefixName": "peeringServicePrefixName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
+    "prefixName": "MyPeeringServicePrefix",
     "api-version": "2019-09-01-preview",
     "peeringServicePrefix": {
       "properties": {
@@ -21,8 +21,8 @@
           "errorMessage": "Prefix is not announced by the service provider to Microsoft.",
           "provisioningState": "Succeeded"
         },
-        "name": "peeringServicePrefixName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName"
+        "name": "MyPeeringServicePrefix",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix"
       }
     },
     "201": {
@@ -34,8 +34,8 @@
           "errorMessage": "Prefix is not announced by the service provider to Microsoft.",
           "provisioningState": "Succeeded"
         },
-        "name": "peeringServicePrefixName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName"
+        "name": "MyPeeringServicePrefix",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix"
       }
     }
   }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/DeletePeerAsn.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/DeletePeerAsn.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "peerAsnName": "peerAsnName",
+    "peerAsnName": "MyPeerAsn",
     "api-version": "2019-09-01-preview"
   },
   "responses": {

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/DeletePeering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/DeletePeering.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-09-01-preview"
   },
   "responses": {

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/DeletePeeringService.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/DeletePeeringService.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-09-01-preview"
   },
   "responses": {

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/DeletePeeringServicePrefix.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/DeletePeeringServicePrefix.json
@@ -1,9 +1,9 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
-    "prefixName": "peeringServicePrefixName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
+    "prefixName": "MyPeeringServicePrefix",
     "api-version": "2019-09-01-preview"
   },
   "responses": {

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/GetPeerAsn.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/GetPeerAsn.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "peerAsnName": "peerAsnName",
+    "peerAsnName": "MyPeerAsn",
     "api-version": "2019-09-01-preview"
   },
   "responses": {
@@ -21,8 +21,8 @@
           "peerName": "Contoso",
           "validationState": "Approved"
         },
-        "name": "peerAsnName",
-        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/peerAsnName",
+        "name": "MyPeerAsn",
+        "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/MyPeerAsn",
         "type": "Microsoft.Peering/peerAsns"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/GetPeering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/GetPeering.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-09-01-preview"
   },
   "responses": {
@@ -59,8 +59,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/GetPeeringService.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/GetPeeringService.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-09-01-preview"
   },
   "responses": {
@@ -14,8 +14,8 @@
           "provisioningState": "Succeeded"
         },
         "location": "eastus",
-        "name": "peeringServiceName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+        "name": "MyPeeringService",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
         "type": "Microsoft.Peering/peeringServices"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/GetPeeringServicePrefix.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/GetPeeringServicePrefix.json
@@ -1,9 +1,9 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
-    "prefixName": "peeringServicePrefixName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
+    "prefixName": "MyPeeringServicePrefix",
     "api-version": "2019-09-01-preview"
   },
   "responses": {
@@ -15,8 +15,8 @@
           "learnedType": "ViaServiceProvider",
           "provisioningState": "Succeeded"
         },
-        "name": "peeringServicePrefixName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName"
+        "name": "MyPeeringServicePrefix",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix"
       }
     }
   }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListLegacyPeerings.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListLegacyPeerings.json
@@ -61,8 +61,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "centralus",
-            "name": "peeringName",
-            "id": "/subscriptions/subId/providers/Microsoft.Peering/peerings/peeringName",
+            "name": "MyPeering",
+            "id": "/subscriptions/subId/providers/Microsoft.Peering/peerings/MyPeering",
             "type": "Microsoft.Peering/peerings"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeerAsnsBySubscription.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeerAsnsBySubscription.json
@@ -22,8 +22,8 @@
               "peerName": "Contoso",
               "validationState": "Approved"
             },
-            "name": "peerAsnName",
-            "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/peerAsnName",
+            "name": "MyPeerAsn",
+            "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/MyPeerAsn",
             "type": "Microsoft.Peering/peerAsns"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeeringServicesByResourceGroup.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeeringServicesByResourceGroup.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
+    "resourceGroupName": "MyResourceGroup",
     "api-version": "2019-09-01-preview"
   },
   "responses": {
@@ -15,8 +15,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "eastus",
-            "name": "peeringServiceName",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+            "name": "MyPeeringService",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
             "type": "Microsoft.Peering/peeringServices"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeeringServicesBySubscription.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeeringServicesBySubscription.json
@@ -14,8 +14,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "eastus",
-            "name": "peeringServiceName",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+            "name": "MyPeeringService",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
             "type": "Microsoft.Peering/peeringServices"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeeringsByResourceGroup.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeeringsByResourceGroup.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
+    "resourceGroupName": "MyResourceGroup",
     "api-version": "2019-09-01-preview"
   },
   "responses": {
@@ -60,8 +60,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "eastus",
-            "name": "peeringName",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+            "name": "MyPeering",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
             "type": "Microsoft.Peering/peerings"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeeringsBySubscription.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPeeringsBySubscription.json
@@ -59,8 +59,8 @@
               "provisioningState": "Succeeded"
             },
             "location": "eastus",
-            "name": "peeringName",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+            "name": "MyPeering",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
             "type": "Microsoft.Peering/peerings"
           }
         ]

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPrefixesByPeeringService.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/ListPrefixesByPeeringService.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-09-01-preview"
   },
   "responses": {
@@ -16,8 +16,8 @@
               "learnedType": "ViaServiceProvider",
               "provisioningState": "Succeeded"
             },
-            "name": "peeringServicePrefixName1",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName1"
+            "name": "MyPeeringServicePrefix1",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix1"
           },
           {
             "properties": {
@@ -26,8 +26,8 @@
               "learnedType": "ViaServiceProvider",
               "provisioningState": "Succeeded"
             },
-            "name": "peeringServicePrefixName2",
-            "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName/prefixes/peeringServicePrefixName2"
+            "name": "MyPeeringServicePrefix2",
+            "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService/prefixes/MyPeeringServicePrefix2"
           }
         ]
       }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/UpdatePeeringServiceTags.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/UpdatePeeringServiceTags.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringServiceName": "peeringServiceName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringServiceName": "MyPeeringService",
     "api-version": "2019-09-01-preview",
     "tags": {
       "tags": {
@@ -24,8 +24,8 @@
           "tag0": "value0",
           "tag1": "value1"
         },
-        "name": "peeringServiceName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peeringServices/peeringServiceName",
+        "name": "MyPeeringService",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peeringServices/MyPeeringService",
         "type": "Microsoft.Peering/peeringServices"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/UpdatePeeringTags.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/examples/UpdatePeeringTags.json
@@ -1,8 +1,8 @@
 {
   "parameters": {
     "subscriptionId": "subId",
-    "resourceGroupName": "rgName",
-    "peeringName": "peeringName",
+    "resourceGroupName": "MyResourceGroup",
+    "peeringName": "MyPeering",
     "api-version": "2019-09-01-preview",
     "tags": {
       "tags": {
@@ -69,8 +69,8 @@
           "tag0": "value0",
           "tag1": "value1"
         },
-        "name": "peeringName",
-        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "name": "MyPeering",
+        "id": "/subscriptions/subId/resourceGroups/MyResourceGroup/providers/Microsoft.Peering/peerings/MyPeering",
         "type": "Microsoft.Peering/peerings"
       }
     }

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/peering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/peering.json
@@ -158,7 +158,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.Peering/peerAsns/{peerAsnName}": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Peering/peerAsns/{MyPeerAsn}": {
       "get": {
         "tags": [
           "PeerAsns"
@@ -167,7 +167,7 @@
         "operationId": "PeerAsns_Get",
         "parameters": [
           {
-            "name": "peerAsnName",
+            "name": "MyPeerAsn",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -208,7 +208,7 @@
         "operationId": "PeerAsns_CreateOrUpdate",
         "parameters": [
           {
-            "name": "peerAsnName",
+            "name": "MyPeerAsn",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -264,7 +264,7 @@
         "operationId": "PeerAsns_Delete",
         "parameters": [
           {
-            "name": "peerAsnName",
+            "name": "MyPeerAsn",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -403,7 +403,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peerings/{peeringName}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peerings/{MyPeering}": {
       "get": {
         "tags": [
           "Peerings"
@@ -419,7 +419,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "MyPeering",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -467,7 +467,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "MyPeering",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -533,7 +533,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "MyPeering",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -581,7 +581,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "MyPeering",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -748,7 +748,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{peeringServiceName}/prefixes/{prefixName}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{MyPeeringService}/prefixes/{prefixName}": {
       "get": {
         "tags": [
           "PeeringServicePrefixes"
@@ -764,7 +764,7 @@
             "type": "string"
           },
           {
-            "name": "peeringServiceName",
+            "name": "MyPeeringService",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -826,7 +826,7 @@
             "type": "string"
           },
           {
-            "name": "peeringServiceName",
+            "name": "MyPeeringService",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -896,7 +896,7 @@
             "type": "string"
           },
           {
-            "name": "peeringServiceName",
+            "name": "MyPeeringService",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -937,7 +937,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{peeringServiceName}/prefixes": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{MyPeeringService}/prefixes": {
       "get": {
         "tags": [
           "PeeringServicePrefixes"
@@ -953,7 +953,7 @@
             "type": "string"
           },
           {
-            "name": "peeringServiceName",
+            "name": "MyPeeringService",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -1036,7 +1036,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{peeringServiceName}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{MyPeeringService}": {
       "get": {
         "tags": [
           "PeeringServices"
@@ -1052,7 +1052,7 @@
             "type": "string"
           },
           {
-            "name": "peeringServiceName",
+            "name": "MyPeeringService",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -1100,7 +1100,7 @@
             "type": "string"
           },
           {
-            "name": "peeringServiceName",
+            "name": "MyPeeringService",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -1163,7 +1163,7 @@
             "type": "string"
           },
           {
-            "name": "peeringServiceName",
+            "name": "MyPeeringService",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -1211,7 +1211,7 @@
             "type": "string"
           },
           {
-            "name": "peeringServiceName",
+            "name": "MyPeeringService",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/peering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/peering.json
@@ -764,7 +764,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeeringService",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -826,7 +826,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeeringService",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -896,7 +896,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeeringService",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -953,7 +953,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeeringService",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -1052,7 +1052,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeeringService",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -1100,7 +1100,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeeringService",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -1163,7 +1163,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeeringService",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -1211,7 +1211,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeeringService",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/peering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/peering.json
@@ -397,7 +397,7 @@
           "List exchange peering locations": {
             "$ref": "./examples/ListExchangePeeringLocations.json"
           }
-        },  
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -826,7 +826,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "peeringServiceName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -953,7 +953,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "peeringServiceName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -1052,7 +1052,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "peeringServiceName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -1100,7 +1100,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "peeringServiceName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -1163,7 +1163,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "peeringServiceName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/peering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2019-09-01-preview/peering.json
@@ -158,7 +158,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.Peering/peerAsns/{MyPeerAsn}": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Peering/peerAsns/{peerAsnName}": {
       "get": {
         "tags": [
           "PeerAsns"
@@ -167,7 +167,7 @@
         "operationId": "PeerAsns_Get",
         "parameters": [
           {
-            "name": "MyPeerAsn",
+            "name": "peerAsnName",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -208,7 +208,7 @@
         "operationId": "PeerAsns_CreateOrUpdate",
         "parameters": [
           {
-            "name": "MyPeerAsn",
+            "name": "peerAsnName",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -264,7 +264,7 @@
         "operationId": "PeerAsns_Delete",
         "parameters": [
           {
-            "name": "MyPeerAsn",
+            "name": "peerAsnName",
             "in": "path",
             "description": "The peer ASN name.",
             "required": true,
@@ -397,13 +397,13 @@
           "List exchange peering locations": {
             "$ref": "./examples/ListExchangePeeringLocations.json"
           }
-        },
+        },  
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peerings/{MyPeering}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peerings/{peeringName}": {
       "get": {
         "tags": [
           "Peerings"
@@ -419,7 +419,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeering",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -467,7 +467,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeering",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -533,7 +533,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeering",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -581,7 +581,7 @@
             "type": "string"
           },
           {
-            "name": "MyPeering",
+            "name": "peeringName",
             "in": "path",
             "description": "The name of the peering.",
             "required": true,
@@ -748,7 +748,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{MyPeeringService}/prefixes/{prefixName}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{peeringServiceName}/prefixes/{prefixName}": {
       "get": {
         "tags": [
           "PeeringServicePrefixes"
@@ -764,7 +764,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "peeringServiceName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -896,7 +896,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "peeringServiceName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,
@@ -937,7 +937,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{MyPeeringService}/prefixes": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{peeringServiceName}/prefixes": {
       "get": {
         "tags": [
           "PeeringServicePrefixes"
@@ -1036,7 +1036,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{MyPeeringService}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Peering/peeringServices/{peeringServiceName}": {
       "get": {
         "tags": [
           "PeeringServices"
@@ -1211,7 +1211,7 @@
             "type": "string"
           },
           {
-            "name": "peeringName",
+            "name": "peeringServiceName",
             "in": "path",
             "description": "The name of the peering service.",
             "required": true,


### PR DESCRIPTION
This is discussed with the team.
This PR it the effort to unify names between different services, so we can have examples and tests consistently generated with similar name conventions. for instance "MyResourceGroup"