### PR TITLE
Add new Automation API version

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json
@@ -1,0 +1,284 @@
+{
+  "parameters": {
+    "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "softwareUpdateConfigurationName": "testpatch",
+    "api-version": "2017-05-15-preview",
+    "parameters": {
+      "properties": {
+        "updateConfiguration": {
+          "operatingSystem": "Windows",
+          "duration": "PT2H0M",
+          "windows": {
+            "excludedKbNumbers": [
+              "168934",
+              "168973"
+            ],
+            "includedUpdateClassifications": "Critical",
+            "rebootSetting": "IfRequired"
+          },
+          "azureVirtualMachines": [
+            "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+            "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
+            "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
+          ],
+          "nonAzureComputerNames": [
+            "box1.contoso.com",
+            "box2.contoso.com"
+          ],
+          "targets": {
+            "azureQueries": [
+              {
+                "scope": [
+                  "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources",
+                  "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067"
+                ],
+                "tagSettings": {
+                  "tags": [
+                    {
+                      "tag1": [
+                        "tag1Value1",
+                        "tag1Value2",
+                        "tag1Value3"
+                      ]
+                    },
+                    {
+                      "tag2": [
+                        "tag2Value1",
+                        "tag2Value2",
+                        "tag2Value3"
+                      ]
+                    }
+                  ],
+                  "filterOperator": "All"
+                },
+                "locations": [
+                  "Japan East",
+                  "UK South"
+                ]
+              }
+            ],
+            "nonAzureQueries": [
+              {
+                "functionAlias": "SavedSearch1",
+                "workspaceId": "WorkspaceId1"
+              },
+              {
+                "functionAlias": "SavedSearch2",
+                "workspaceId": "WorkspaceId2"
+              }
+            ]
+          }
+        },
+        "scheduleInfo": {
+          "frequency": "Hour",
+          "startTime": "2017-10-19T12:22:57+00:00",
+          "timeZone": "America/Los_Angeles",
+          "interval": 1,
+          "expiryTime": "2018-11-09T11:22:57+00:00",
+          "advancedSchedule": {
+            "weekDays": [
+              "Monday",
+              "Thursday"
+            ]
+          }
+        },
+        "tasks": {
+          "preTask": {
+            "source": "HelloWorld",
+            "parameters": {
+              "COMPUTERNAME": "Computer1"
+            }
+          },
+          "postTask": {
+            "source": "GetCache",
+            "parameters": null
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "name": "testpatch",
+        "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurations/testpatch",
+        "properties": {
+          "updateConfiguration": {
+            "operatingSystem": "Windows",
+            "windows": {
+              "includedUpdateClassifications": "Critical",
+              "excludedKbNumbers": [
+                "168934",
+                "168973"
+              ]
+            },
+            "linux": {},
+            "targets": {
+              "azureQueries": [
+                {
+                  "scope": [
+                    "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d/resourceGroups/a-stasku-rg0",
+                    "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d"
+                  ],
+                  "tagSettings": {
+                    "tags": {
+                      "tag1": [
+                        "tag1Value1",
+                        "tag1Value2"
+                      ],
+                      "tag2": [
+                        "tag2Value1",
+                        "tag2Value2"
+                      ]
+                    },
+                    "filterOperator": "All"
+                  },
+                  "locations": [
+                    "Japan East",
+                    "UK South"
+                  ]
+                }
+              ]
+            },
+            "duration": "PT2H",
+            "azureVirtualMachines": [
+              "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+              "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
+              "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
+            ],
+            "nonAzureComputerNames": [
+              "box1.contoso.com",
+              "box2.contoso.com"
+            ]
+          },
+          "scheduleInfo": {
+            "description": "",
+            "startTime": "2017-10-19T12:22:00-07:00",
+            "startTimeOffsetMinutes": -420,
+            "expiryTime": "2018-11-09T11:22:00-08:00",
+            "expiryTimeOffsetMinutes": -480,
+            "isEnabled": true,
+            "nextRun": "2017-10-19T12:22:00-07:00",
+            "nextRunOffsetMinutes": -420,
+            "interval": 1,
+            "frequency": "Week",
+            "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+            "lastModifiedTime": "2017-10-19T18:54:50.5233333+00:00",
+            "timeZone": "America/Los_Angeles",
+            "advancedSchedule": {}
+          },
+          "tasks": {
+            "preTask": {
+              "source": "HelloWorld",
+              "parameters": {
+                "COMPUTERNAME": "Computer1"
+              }
+            },
+            "postTask": {
+              "source": "GetCache",
+              "parameters": null
+            }
+          },
+          "provisioningState": "Provisioning",
+          "error": {},
+          "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+          "createdBy": "adam@contoso.com",
+          "lastModifiedBy": "adam@contoso.com",
+          "lastModifiedTime": "2017-10-19T18:54:50.68+00:00"
+        }
+      }
+    },
+    "201": {
+      "headers": {},
+      "body": {
+        "name": "testpatch",
+        "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurations/testpatch",
+        "properties": {
+          "updateConfiguration": {
+            "operatingSystem": "Windows",
+            "windows": {
+              "includedUpdateClassifications": "Critical",
+              "excludedKbNumbers": [
+                "168934",
+                "168973"
+              ]
+            },
+            "linux": {},
+            "targets": {
+              "azureQueries": [
+                {
+                  "scope": [
+                    "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d/resourceGroups/a-stasku-rg0",
+                    "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d"
+                  ],
+                  "tagSettings": {
+                    "tags": {
+                      "tag1": [
+                        "tag1Value1",
+                        "tag1Value2"
+                      ],
+                      "tag2": [
+                        "tag2Value1",
+                        "tag2Value2"
+                      ]
+                    },
+                    "filterOperator": "All"
+                  },
+                  "locations": [
+                    "Japan East",
+                    "UK South"
+                  ]
+                }
+              ]
+            },
+            "duration": "PT2H",
+            "azureVirtualMachines": [
+              "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+              "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
+              "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
+            ],
+            "nonAzureComputerNames": [
+              "box1.contoso.com",
+              "box2.contoso.com"
+            ]
+          },
+          "scheduleInfo": {
+            "description": "",
+            "startTime": "2017-10-19T12:22:00-07:00",
+            "startTimeOffsetMinutes": -420,
+            "expiryTime": "2018-11-09T11:22:00-08:00",
+            "expiryTimeOffsetMinutes": -480,
+            "isEnabled": true,
+            "nextRun": "2017-10-19T12:22:00-07:00",
+            "nextRunOffsetMinutes": -420,
+            "interval": 1,
+            "frequency": "Week",
+            "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+            "lastModifiedTime": "2017-10-19T18:54:50.5233333+00:00",
+            "timeZone": "America/Los_Angeles"
+          },
+          "tasks": {
+            "preTask": {
+              "source": "HelloWorld",
+              "parameters": {
+                "COMPUTERNAME": "Computer1"
+              }
+            },
+            "postTask": {
+              "source": "GetCache",
+              "parameters": null
+            }
+          },
+          "provisioningState": "Provisioning",
+          "error": {},
+          "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+          "lastModifiedBy": "",
+          "lastModifiedTime": "2017-10-19T18:54:50.68+00:00"
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
     "softwareUpdateConfigurationName": "testpatch",
-    "api-version": "2017-05-15-preview",
+    "api-version": "2019-06-01",
     "parameters": {
       "properties": {
         "updateConfiguration": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json
@@ -35,22 +35,18 @@
                   "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067"
                 ],
                 "tagSettings": {
-                  "tags": [
-                    {
-                      "tag1": [
-                        "tag1Value1",
-                        "tag1Value2",
-                        "tag1Value3"
-                      ]
-                    },
-                    {
-                      "tag2": [
-                        "tag2Value1",
-                        "tag2Value2",
-                        "tag2Value3"
-                      ]
-                    }
-                  ],
+                  "tags": {
+                    "tag1": [
+                      "tag1Value1",
+                      "tag1Value2",
+                      "tag1Value3"
+                    ],
+                    "tag2": [
+                      "tag2Value1",
+                      "tag2Value2",
+                      "tag2Value3"
+                    ]
+                  },
                   "filterOperator": "All"
                 },
                 "locations": [

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/deleteSoftwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/deleteSoftwareUpdateConfiguration.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "softwareUpdateConfigurationName": "mypatch",
+    "api-version": "2017-05-15-preview",
+    "body": {}
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/deleteSoftwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/deleteSoftwareUpdateConfiguration.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
     "softwareUpdateConfigurationName": "mypatch",
-    "api-version": "2017-05-15-preview",
+    "api-version": "2019-06-01",
     "body": {}
   },
   "responses": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/getSoftwareUpdateConfigurationByName.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/getSoftwareUpdateConfigurationByName.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "softwareUpdateConfigurationName": "mypatch",
+    "api-version": "2017-05-15-preview",
+    "body": {}
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "name": "testpatch",
+        "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurations/testpatch",
+        "properties": {
+          "updateConfiguration": {
+            "operatingSystem": "Windows",
+            "windows": {
+              "includedUpdateClassifications": "Critical",
+              "excludedKbNumbers": [
+                "168934",
+                "168973"
+              ]
+            },
+            "linux": {},
+            "targets": {
+              "azureQueries": [
+                {
+                  "scope": [
+                    "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d/resourceGroups/a-stasku-rg0",
+                    "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d"
+                  ],
+                  "tagSettings": {
+                    "tags": {
+                      "tag1": [
+                        "tag1Value1",
+                        "tag1Value2"
+                      ],
+                      "tag2": [
+                        "tag2Value1",
+                        "tag2Value2"
+                      ]
+                    },
+                    "filterOperator": "All"
+                  },
+                  "locations": null
+                }
+              ]
+            },
+            "duration": "PT2H",
+            "azureVirtualMachines": [
+              "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+              "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
+              "/subscriptions/5ae68d89-69a4-454f-b5ce-e443cc4e0067/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
+            ],
+            "nonAzureComputerNames": [
+              "box1.contoso.com",
+              "box2.contoso.com"
+            ]
+          },
+          "scheduleInfo": {
+            "description": "",
+            "startTime": "2017-10-19T12:22:00-07:00",
+            "startTimeOffsetMinutes": -420,
+            "expiryTime": "2018-11-09T11:22:00-08:00",
+            "expiryTimeOffsetMinutes": -480,
+            "isEnabled": true,
+            "nextRun": "2017-10-19T12:22:00-07:00",
+            "nextRunOffsetMinutes": -420,
+            "interval": 1,
+            "frequency": "Week",
+            "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+            "lastModifiedTime": "2017-10-19T18:54:50.5233333+00:00",
+            "timeZone": "America/Los_Angeles"
+          },
+          "tasks": {
+            "preTask": {
+              "source": "HelloWorld",
+              "parameters": {
+                "COMPUTERNAME": "Computer1"
+              }
+            },
+            "postTask": {
+              "source": "GetCache",
+              "parameters": null
+            }
+          },
+          "provisioningState": "Provisioning",
+          "createdBy": "eve@contoso.com",
+          "error": {},
+          "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+          "lastModifiedBy": "",
+          "lastModifiedTime": "2017-10-19T18:54:50.68+00:00"
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/getSoftwareUpdateConfigurationByName.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/getSoftwareUpdateConfigurationByName.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
     "softwareUpdateConfigurationName": "mypatch",
-    "api-version": "2017-05-15-preview",
+    "api-version": "2019-06-01",
     "body": {}
   },
   "responses": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json
@@ -1,0 +1,144 @@
+{
+  "parameters": {
+    "subscriptionId": "1a7d4044-286c-4acb-969a-96639265bf2e",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "api-version": "2017-05-15-preview",
+    "body": {}
+  },
+  "responses": {
+    "200": {
+      "value": [
+        {
+          "name": "testpatch-01",
+          "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-01",
+          "properties": {
+            "updateConfiguration": {
+              "operatingSystem": "Windows",
+              "windows": {
+                "includedUpdateClassifications": "Critical, Security, UpdateRollup, FeaturePack, ServicePack, Definition, Tools, Updates",
+                "excludedKbNumbers": null
+              },
+              "linux": null,
+              "targets": {
+                "azureQueries": [
+                  {
+                    "scope": [
+                      "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d/resourceGroups/a-stasku-rg0",
+                      "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d"
+                    ],
+                    "tagSettings": {
+                      "tags": {
+                        "tag1": [
+                          "tag1Value1",
+                          "tag1Value2"
+                        ],
+                        "tag2": [
+                          "tag2Value1",
+                          "tag2Value2"
+                        ]
+                      },
+                      "filterOperator": "All"
+                    },
+                    "locations": null
+                  }
+                ]
+              },
+              "duration": "PT2H",
+              "azureVirtualMachines": [
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
+              ],
+              "nonAzureComputerNames": null
+            },
+            "tasks": {
+              "preTask": {
+                "source": "HelloWorld",
+                "parameters": {
+                  "COMPUTERNAME": "Computer1"
+                }
+              },
+              "postTask": {
+                "source": "GetCache",
+                "parameters": null
+              }
+            },
+            "frequency": "Week",
+            "startTime": "2017-10-19T12:22:00-07:00",
+            "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+            "lastModifiedTime": "2017-10-19T18:54:50.68+00:00",
+            "provisioningState": "Succeeded",
+            "nextRun": "2017-10-23T12:22:00-07:00"
+          }
+        },
+        {
+          "name": "testpatch-02",
+          "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-02",
+          "properties": {
+            "updateConfiguration": {
+              "operatingSystem": "Windows",
+              "windows": {
+                "includedUpdateClassifications": "Critical, FeaturePack",
+                "excludedKbNumbers": null
+              },
+              "linux": null,
+              "targets": {
+                "azureQueries": [
+                  {
+                    "scope": [
+                      "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d/resourceGroups/a-stasku-rg0",
+                      "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d"
+                    ],
+                    "tagSettings": {
+                      "tags": {
+                        "tag1": [
+                          "tag1Value1",
+                          "tag1Value2"
+                        ],
+                        "tag2": [
+                          "tag2Value1",
+                          "tag2Value2"
+                        ]
+                      },
+                      "filterOperator": "All"
+                    },
+                    "locations": [
+                      "Japan East",
+                      "UK South"
+                    ]
+                  }
+                ]
+              },
+              "duration": "PT2H30M",
+              "azureVirtualMachines": [
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-04",
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-05",
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-06"
+              ],
+              "nonAzureComputerNames": null
+            },
+            "tasks": {
+              "preTask": {
+                "source": "HelloWorld",
+                "parameters": {
+                  "COMPUTERNAME": "Computer1"
+                }
+              },
+              "postTask": {
+                "source": "GetCache",
+                "parameters": null
+              }
+            },
+            "frequency": "Hour",
+            "startTime": "2018-05-05T12:26:00-07:00",
+            "creationTime": "2017-08-11T21:52:02.7733333+00:00",
+            "lastModifiedTime": "2017-08-11T21:52:22.88+00:00",
+            "provisioningState": "Succeeded",
+            "nextRun": "2018-05-05T12:26:00-07:00"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json
@@ -3,7 +3,7 @@
     "subscriptionId": "1a7d4044-286c-4acb-969a-96639265bf2e",
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
-    "api-version": "2017-05-15-preview",
+    "api-version": "2019-06-01",
     "body": {}
   },
   "responses": {
@@ -138,7 +138,8 @@
             "nextRun": "2018-05-05T12:26:00-07:00"
           }
         }
-      ]
+      ],
+      "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurations?api-version=2019-06-01&$skip=100"
     }
   }
 }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json
@@ -8,138 +8,140 @@
   },
   "responses": {
     "200": {
-      "value": [
-        {
-          "name": "testpatch-01",
-          "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-01",
-          "properties": {
-            "updateConfiguration": {
-              "operatingSystem": "Windows",
-              "windows": {
-                "includedUpdateClassifications": "Critical, Security, UpdateRollup, FeaturePack, ServicePack, Definition, Tools, Updates",
-                "excludedKbNumbers": null
-              },
-              "linux": null,
-              "targets": {
-                "azureQueries": [
-                  {
-                    "scope": [
-                      "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d/resourceGroups/a-stasku-rg0",
-                      "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d"
-                    ],
-                    "tagSettings": {
-                      "tags": {
-                        "tag1": [
-                          "tag1Value1",
-                          "tag1Value2"
-                        ],
-                        "tag2": [
-                          "tag2Value1",
-                          "tag2Value2"
-                        ]
+      "body": {
+        "value": [
+          {
+            "name": "testpatch-01",
+            "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-01",
+            "properties": {
+              "updateConfiguration": {
+                "operatingSystem": "Windows",
+                "windows": {
+                  "includedUpdateClassifications": "Critical, Security, UpdateRollup, FeaturePack, ServicePack, Definition, Tools, Updates",
+                  "excludedKbNumbers": null
+                },
+                "linux": null,
+                "targets": {
+                  "azureQueries": [
+                    {
+                      "scope": [
+                        "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d/resourceGroups/a-stasku-rg0",
+                        "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d"
+                      ],
+                      "tagSettings": {
+                        "tags": {
+                          "tag1": [
+                            "tag1Value1",
+                            "tag1Value2"
+                          ],
+                          "tag2": [
+                            "tag2Value1",
+                            "tag2Value2"
+                          ]
+                        },
+                        "filterOperator": "All"
                       },
-                      "filterOperator": "All"
-                    },
-                    "locations": null
-                  }
-                ]
+                      "locations": null
+                    }
+                  ]
+                },
+                "duration": "PT2H",
+                "azureVirtualMachines": [
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
+                ],
+                "nonAzureComputerNames": null
               },
-              "duration": "PT2H",
-              "azureVirtualMachines": [
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
-              ],
-              "nonAzureComputerNames": null
-            },
-            "tasks": {
-              "preTask": {
-                "source": "HelloWorld",
-                "parameters": {
-                  "COMPUTERNAME": "Computer1"
+              "tasks": {
+                "preTask": {
+                  "source": "HelloWorld",
+                  "parameters": {
+                    "COMPUTERNAME": "Computer1"
+                  }
+                },
+                "postTask": {
+                  "source": "GetCache",
+                  "parameters": null
                 }
               },
-              "postTask": {
-                "source": "GetCache",
-                "parameters": null
-              }
-            },
-            "frequency": "Week",
-            "startTime": "2017-10-19T12:22:00-07:00",
-            "creationTime": "2017-10-19T18:54:50.5233333+00:00",
-            "lastModifiedTime": "2017-10-19T18:54:50.68+00:00",
-            "provisioningState": "Succeeded",
-            "nextRun": "2017-10-23T12:22:00-07:00"
-          }
-        },
-        {
-          "name": "testpatch-02",
-          "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-02",
-          "properties": {
-            "updateConfiguration": {
-              "operatingSystem": "Windows",
-              "windows": {
-                "includedUpdateClassifications": "Critical, FeaturePack",
-                "excludedKbNumbers": null
-              },
-              "linux": null,
-              "targets": {
-                "azureQueries": [
-                  {
-                    "scope": [
-                      "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d/resourceGroups/a-stasku-rg0",
-                      "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d"
-                    ],
-                    "tagSettings": {
-                      "tags": {
-                        "tag1": [
-                          "tag1Value1",
-                          "tag1Value2"
-                        ],
-                        "tag2": [
-                          "tag2Value1",
-                          "tag2Value2"
-                        ]
+              "frequency": "Week",
+              "startTime": "2017-10-19T12:22:00-07:00",
+              "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+              "lastModifiedTime": "2017-10-19T18:54:50.68+00:00",
+              "provisioningState": "Succeeded",
+              "nextRun": "2017-10-23T12:22:00-07:00"
+            }
+          },
+          {
+            "name": "testpatch-02",
+            "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-02",
+            "properties": {
+              "updateConfiguration": {
+                "operatingSystem": "Windows",
+                "windows": {
+                  "includedUpdateClassifications": "Critical, FeaturePack",
+                  "excludedKbNumbers": null
+                },
+                "linux": null,
+                "targets": {
+                  "azureQueries": [
+                    {
+                      "scope": [
+                        "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d/resourceGroups/a-stasku-rg0",
+                        "/subscriptions/422b6c61-95b0-4213-b3be-7282315df71d"
+                      ],
+                      "tagSettings": {
+                        "tags": {
+                          "tag1": [
+                            "tag1Value1",
+                            "tag1Value2"
+                          ],
+                          "tag2": [
+                            "tag2Value1",
+                            "tag2Value2"
+                          ]
+                        },
+                        "filterOperator": "All"
                       },
-                      "filterOperator": "All"
-                    },
-                    "locations": [
-                      "Japan East",
-                      "UK South"
-                    ]
-                  }
-                ]
+                      "locations": [
+                        "Japan East",
+                        "UK South"
+                      ]
+                    }
+                  ]
+                },
+                "duration": "PT2H30M",
+                "azureVirtualMachines": [
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-04",
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-05",
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-06"
+                ],
+                "nonAzureComputerNames": null
               },
-              "duration": "PT2H30M",
-              "azureVirtualMachines": [
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-04",
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-05",
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-06"
-              ],
-              "nonAzureComputerNames": null
-            },
-            "tasks": {
-              "preTask": {
-                "source": "HelloWorld",
-                "parameters": {
-                  "COMPUTERNAME": "Computer1"
+              "tasks": {
+                "preTask": {
+                  "source": "HelloWorld",
+                  "parameters": {
+                    "COMPUTERNAME": "Computer1"
+                  }
+                },
+                "postTask": {
+                  "source": "GetCache",
+                  "parameters": null
                 }
               },
-              "postTask": {
-                "source": "GetCache",
-                "parameters": null
-              }
-            },
-            "frequency": "Hour",
-            "startTime": "2018-05-05T12:26:00-07:00",
-            "creationTime": "2017-08-11T21:52:02.7733333+00:00",
-            "lastModifiedTime": "2017-08-11T21:52:22.88+00:00",
-            "provisioningState": "Succeeded",
-            "nextRun": "2018-05-05T12:26:00-07:00"
+              "frequency": "Hour",
+              "startTime": "2018-05-05T12:26:00-07:00",
+              "creationTime": "2017-08-11T21:52:02.7733333+00:00",
+              "lastModifiedTime": "2017-08-11T21:52:22.88+00:00",
+              "provisioningState": "Succeeded",
+              "nextRun": "2018-05-05T12:26:00-07:00"
+            }
           }
-        }
-      ],
-      "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurations?api-version=2019-06-01&$skip=100"
+        ],
+        "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurations?api-version=2019-06-01&$skip=100"
+      }
     }
   }
 }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json
@@ -1,0 +1,94 @@
+{
+  "parameters": {
+    "subscriptionId": "1a7d4044-286c-4acb-969a-96639265bf2e",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "$filter": "properties/updateConfiguration/azureVirtualMachines/any(m: m eq '/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01')",
+    "api-version": "2017-05-15-preview",
+    "body": {}
+  },
+  "responses": {
+    "200": {
+      "value": [
+        {
+          "name": "testpatch-01",
+          "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-01",
+          "properties": {
+            "updateConfiguration": {
+              "operatingSystem": "Windows",
+              "windows": {
+                "includedUpdateClassifications": "Critical, Security, UpdateRollup, FeaturePack, ServicePack, Definition, Tools, Updates",
+                "excludedKbNumbers": null
+              },
+              "linux": null,
+              "duration": "PT2H",
+              "azureVirtualMachines": [
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
+              ],
+              "nonAzureComputerNames": null
+            },
+            "tasks": {
+              "preTask": {
+                "source": "HelloWorld",
+                "parameters": {
+                  "COMPUTERNAME": "Computer1"
+                }
+              },
+              "postTask": {
+                "source": "GetCache",
+                "parameters": null
+              }
+            },
+            "frequency": "Week",
+            "startTime": "2017-10-19T12:22:00-07:00",
+            "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+            "lastModifiedTime": "2017-10-19T18:54:50.68+00:00",
+            "provisioningState": "Succeeded",
+            "nextRun": "2017-10-23T12:22:00-07:00"
+          }
+        },
+        {
+          "name": "testpatch-02",
+          "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-02",
+          "properties": {
+            "updateConfiguration": {
+              "operatingSystem": "Windows",
+              "windows": {
+                "includedUpdateClassifications": "Critical, FeaturePack",
+                "excludedKbNumbers": null
+              },
+              "linux": null,
+              "duration": "PT2H30M",
+              "azureVirtualMachines": [
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-05",
+                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-06"
+              ],
+              "nonAzureComputerNames": null
+            },
+            "tasks": {
+              "preTask": {
+                "source": "HelloWorld",
+                "parameters": {
+                  "COMPUTERNAME": "Computer1"
+                }
+              },
+              "postTask": {
+                "source": "GetCache",
+                "parameters": null
+              }
+            },
+            "frequency": "Hour",
+            "startTime": "2018-05-05T12:26:00-07:00",
+            "creationTime": "2017-08-11T21:52:02.7733333+00:00",
+            "lastModifiedTime": "2017-08-11T21:52:22.88+00:00",
+            "provisioningState": "Succeeded",
+            "nextRun": "2018-05-05T12:26:00-07:00"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
     "$filter": "properties/updateConfiguration/azureVirtualMachines/any(m: m eq '/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01')",
-    "api-version": "2017-05-15-preview",
+    "api-version": "2019-06-01",
     "body": {}
   },
   "responses": {
@@ -88,7 +88,8 @@
             "nextRun": "2018-05-05T12:26:00-07:00"
           }
         }
-      ]
+      ],
+      "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurations?api-version=2019-06-01&$filter=properties/updateConfiguration/azureVirtualMachines/any(m: m eq '/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01')&$skip=100"
     }
   }
 }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json
@@ -9,87 +9,89 @@
   },
   "responses": {
     "200": {
-      "value": [
-        {
-          "name": "testpatch-01",
-          "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-01",
-          "properties": {
-            "updateConfiguration": {
-              "operatingSystem": "Windows",
-              "windows": {
-                "includedUpdateClassifications": "Critical, Security, UpdateRollup, FeaturePack, ServicePack, Definition, Tools, Updates",
-                "excludedKbNumbers": null
+      "body": {
+        "value": [
+          {
+            "name": "testpatch-01",
+            "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-01",
+            "properties": {
+              "updateConfiguration": {
+                "operatingSystem": "Windows",
+                "windows": {
+                  "includedUpdateClassifications": "Critical, Security, UpdateRollup, FeaturePack, ServicePack, Definition, Tools, Updates",
+                  "excludedKbNumbers": null
+                },
+                "linux": null,
+                "duration": "PT2H",
+                "azureVirtualMachines": [
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
+                ],
+                "nonAzureComputerNames": null
               },
-              "linux": null,
-              "duration": "PT2H",
-              "azureVirtualMachines": [
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-02",
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-03"
-              ],
-              "nonAzureComputerNames": null
-            },
-            "tasks": {
-              "preTask": {
-                "source": "HelloWorld",
-                "parameters": {
-                  "COMPUTERNAME": "Computer1"
+              "tasks": {
+                "preTask": {
+                  "source": "HelloWorld",
+                  "parameters": {
+                    "COMPUTERNAME": "Computer1"
+                  }
+                },
+                "postTask": {
+                  "source": "GetCache",
+                  "parameters": null
                 }
               },
-              "postTask": {
-                "source": "GetCache",
-                "parameters": null
-              }
-            },
-            "frequency": "Week",
-            "startTime": "2017-10-19T12:22:00-07:00",
-            "creationTime": "2017-10-19T18:54:50.5233333+00:00",
-            "lastModifiedTime": "2017-10-19T18:54:50.68+00:00",
-            "provisioningState": "Succeeded",
-            "nextRun": "2017-10-23T12:22:00-07:00"
-          }
-        },
-        {
-          "name": "testpatch-02",
-          "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-02",
-          "properties": {
-            "updateConfiguration": {
-              "operatingSystem": "Windows",
-              "windows": {
-                "includedUpdateClassifications": "Critical, FeaturePack",
-                "excludedKbNumbers": null
+              "frequency": "Week",
+              "startTime": "2017-10-19T12:22:00-07:00",
+              "creationTime": "2017-10-19T18:54:50.5233333+00:00",
+              "lastModifiedTime": "2017-10-19T18:54:50.68+00:00",
+              "provisioningState": "Succeeded",
+              "nextRun": "2017-10-23T12:22:00-07:00"
+            }
+          },
+          {
+            "name": "testpatch-02",
+            "id": "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/Mo-Resources-WCUS/providers/Microsoft.Automation/automationAccounts/Mo-AAA-WCUS/softwareUpdateConfigurations/testpatch-02",
+            "properties": {
+              "updateConfiguration": {
+                "operatingSystem": "Windows",
+                "windows": {
+                  "includedUpdateClassifications": "Critical, FeaturePack",
+                  "excludedKbNumbers": null
+                },
+                "linux": null,
+                "duration": "PT2H30M",
+                "azureVirtualMachines": [
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-05",
+                  "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-06"
+                ],
+                "nonAzureComputerNames": null
               },
-              "linux": null,
-              "duration": "PT2H30M",
-              "azureVirtualMachines": [
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01",
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-05",
-                "/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-06"
-              ],
-              "nonAzureComputerNames": null
-            },
-            "tasks": {
-              "preTask": {
-                "source": "HelloWorld",
-                "parameters": {
-                  "COMPUTERNAME": "Computer1"
+              "tasks": {
+                "preTask": {
+                  "source": "HelloWorld",
+                  "parameters": {
+                    "COMPUTERNAME": "Computer1"
+                  }
+                },
+                "postTask": {
+                  "source": "GetCache",
+                  "parameters": null
                 }
               },
-              "postTask": {
-                "source": "GetCache",
-                "parameters": null
-              }
-            },
-            "frequency": "Hour",
-            "startTime": "2018-05-05T12:26:00-07:00",
-            "creationTime": "2017-08-11T21:52:02.7733333+00:00",
-            "lastModifiedTime": "2017-08-11T21:52:22.88+00:00",
-            "provisioningState": "Succeeded",
-            "nextRun": "2018-05-05T12:26:00-07:00"
+              "frequency": "Hour",
+              "startTime": "2018-05-05T12:26:00-07:00",
+              "creationTime": "2017-08-11T21:52:02.7733333+00:00",
+              "lastModifiedTime": "2017-08-11T21:52:22.88+00:00",
+              "provisioningState": "Succeeded",
+              "nextRun": "2018-05-05T12:26:00-07:00"
+            }
           }
-        }
-      ],
-      "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurations?api-version=2019-06-01&$filter=properties/updateConfiguration/azureVirtualMachines/any(m: m eq '/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01')&$skip=100"
+        ],
+        "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurations?api-version=2019-06-01&$filter=properties/updateConfiguration/azureVirtualMachines/any(m: m eq '/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/myresources/providers/Microsoft.Compute/virtualMachines/vm-01')&$skip=100"
+      }
     }
   }
 }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/getSoftwareUpdateConfigurationMachineRunById.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/getSoftwareUpdateConfigurationMachineRunById.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "softwareUpdateConfigurationMachineRunId": "ca440719-34a4-4234-a1a9-3f84faf7788f",
+    "api-version": "2017-05-15-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationMachineRuns/ca440719-34a4-4234-a1a9-3f84faf7788f",
+        "name": "ca440719-34a4-4234-a1a9-3f84faf7788f",
+        "properties": {
+          "targetComputer": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Compute/virtualMachines/myvm",
+          "targetComputerType": "AzureVirtualMachines",
+          "softwareUpdateConfiguration": {
+            "name": "mypatch"
+          },
+          "status": "Succeeded",
+          "osType": "Windows",
+          "correlationId": "0b943e57-44d3-4f05-898c-6e92aa617e59",
+          "sourceComputerId": "3d3f24bf-7037-424e-bfba-aae3b9752f8e",
+          "startTime": "2017-10-23T02:33:30.7484961+00:00",
+          "endTime": "2017-10-23T02:33:36.4166667+00:00",
+          "configuredDuration": "PT2H",
+          "job": {},
+          "error": {},
+          "creationTime": "2017-10-23T02:33:30.7484961+00:00",
+          "lastModifiedBy": "",
+          "lastModifiedTime": "2017-10-23T02:34:32.4366667+00:00"
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/getSoftwareUpdateConfigurationMachineRunById.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/getSoftwareUpdateConfigurationMachineRunById.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
     "softwareUpdateConfigurationMachineRunId": "ca440719-34a4-4234-a1a9-3f84faf7788f",
-    "api-version": "2017-05-15-preview"
+    "api-version": "2019-06-01"
   },
   "responses": {
     "200": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRuns.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRuns.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "api-version": "2017-05-15-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationMachineRuns/ca440719-34a4-4234-a1a9-3f84faf7788f",
+            "name": "ca440719-34a4-4234-a1a9-3f84faf7788f",
+            "properties": {
+              "targetComputer": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Compute/virtualMachines/myvm",
+              "targetComputerType": "AzureVirtualMachines",
+              "softwareUpdateConfiguration": {
+                "name": "mypatch"
+              },
+              "status": "Succeeded",
+              "osType": "Windows",
+              "correlationId": "0b943e57-44d3-4f05-898c-6e92aa617e59",
+              "sourceComputerId": "3d3f24bf-7037-424e-bfba-aae3b9752f8e",
+              "startTime": "2017-10-23T02:33:30.7484961+00:00",
+              "endTime": "2017-10-23T02:33:36.4166667+00:00",
+              "configuredDuration": "PT2H",
+              "job": {},
+              "error": {},
+              "creationTime": "2017-10-23T02:33:30.7484961+00:00",
+              "lastModifiedBy": "",
+              "lastModifiedTime": "2017-10-23T02:34:32.4366667+00:00"
+            }
+          },
+          {
+            "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationMachineRuns/ca440719-34a4-4234-a1a9-3f84faf7789f",
+            "name": "ca440719-34a4-4234-a1a9-3f84faf7789f",
+            "properties": {
+              "targetComputer": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Compute/virtualMachines/myvm2",
+              "targetComputerType": "AzureVirtualMachines",
+              "softwareUpdateConfiguration": {
+                "name": "mypatch"
+              },
+              "status": "Succeeded",
+              "osType": "Windows",
+              "correlationId": "0b943e57-44d3-4f05-898c-6e92aa617e59",
+              "sourceComputerId": "3d3f24bf-7037-424e-bfba-aae3b9752f8e",
+              "startTime": "2017-10-23T02:33:30.7484961+00:00",
+              "endTime": "2017-10-23T02:33:36.4166667+00:00",
+              "configuredDuration": "PT2H",
+              "job": {},
+              "error": {},
+              "creationTime": "2017-10-23T02:33:30.7484961+00:00",
+              "lastModifiedBy": "",
+              "lastModifiedTime": "2017-10-23T02:34:32.4366667+00:00"
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com:443/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns?api-version=2017-05-15-preview&_=1508725900015&$skip=100"
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRuns.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRuns.json
@@ -3,7 +3,7 @@
     "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
-    "api-version": "2017-05-15-preview"
+    "api-version": "2019-06-01"
   },
   "responses": {
     "200": {
@@ -57,7 +57,7 @@
             }
           }
         ],
-        "nextLink": "https://management.azure.com:443/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns?api-version=2017-05-15-preview&_=1508725900015&$skip=100"
+        "nextLink": "https://management.azure.com:443/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns?api-version=2019-06-01&_=1508725900015&$skip=100"
       }
     }
   }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRunsByRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRunsByRun.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "$filter": "$filter=properties/correlationId%20eq%200b943e57-44d3-4f05-898c-6e92aa617e59",
+    "api-version": "2017-05-15-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationMachineRuns/ca440719-34a4-4234-a1a9-3f84faf7788f",
+            "name": "ca440719-34a4-4234-a1a9-3f84faf7788f",
+            "properties": {
+              "targetComputer": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Compute/virtualMachines/myvm",
+              "targetComputerType": "AzureVirtualMachines",
+              "softwareUpdateConfiguration": {
+                "name": "mypatch"
+              },
+              "status": "Succeeded",
+              "osType": "Windows",
+              "correlationId": "0b943e57-44d3-4f05-898c-6e92aa617e59",
+              "sourceComputerId": "3d3f24bf-7037-424e-bfba-aae3b9752f8e",
+              "startTime": "2017-10-23T02:33:30.7484961+00:00",
+              "endTime": "2017-10-23T02:33:36.4166667+00:00",
+              "configuredDuration": "PT2H",
+              "job": {},
+              "error": {},
+              "creationTime": "2017-10-23T02:33:30.7484961+00:00",
+              "lastModifiedBy": "",
+              "lastModifiedTime": "2017-10-23T02:34:32.4366667+00:00"
+            }
+          },
+          {
+            "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationMachineRuns/ca440719-34a4-4234-a1a9-3f84faf7789f",
+            "name": "ca440719-34a4-4234-a1a9-3f84faf7789f",
+            "properties": {
+              "targetComputer": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Compute/virtualMachines/myvm2",
+              "targetComputerType": "AzureVirtualMachines",
+              "softwareUpdateConfiguration": {
+                "name": "mypatch"
+              },
+              "status": "Succeeded",
+              "osType": "Windows",
+              "correlationId": "0b943e57-44d3-4f05-898c-6e92aa617e59",
+              "sourceComputerId": "3d3f24bf-7037-424e-bfba-aae3b9752f8e",
+              "startTime": "2017-10-23T02:33:30.7484961+00:00",
+              "endTime": "2017-10-23T02:33:36.4166667+00:00",
+              "configuredDuration": "PT2H",
+              "job": {},
+              "error": {},
+              "creationTime": "2017-10-23T02:33:30.7484961+00:00",
+              "lastModifiedBy": "",
+              "lastModifiedTime": "2017-10-23T02:34:32.4366667+00:00"
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com:443/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns?api-version=2017-05-15-preview&_=1508725900015&$skip=100"
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRunsByRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRunsByRun.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
     "$filter": "$filter=properties/correlationId%20eq%200b943e57-44d3-4f05-898c-6e92aa617e59",
-    "api-version": "2017-05-15-preview"
+    "api-version": "2019-06-01"
   },
   "responses": {
     "200": {
@@ -58,7 +58,7 @@
             }
           }
         ],
-        "nextLink": "https://management.azure.com:443/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns?api-version=2017-05-15-preview&_=1508725900015&$skip=100"
+        "nextLink": "https://management.azure.com:443/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns?api-version=2019-06-01&_=1508725900015&$skip=100"
       }
     }
   }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/getSoftwareUpdateConfigurationRunById.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/getSoftwareUpdateConfigurationRunById.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "softwareUpdateConfigurationRunId": "2bd77cfa-2e9c-41b4-a45b-684a77cfeca9",
+    "api-version": "2017-05-15-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns/2bd77cfa-2e9c-41b4-a45b-684a77cfeca9",
+        "name": "2bd77cfa-2e9c-41b4-a45b-684a77cfeca9",
+        "properties": {
+          "softwareUpdateConfiguration": {
+            "name": "mypatch"
+          },
+          "status": "Succeeded",
+          "tasks": {
+            "preTask": {
+              "jobId": "be430e9e-2290-462e-8f86-686407c35fab",
+              "source": "preRunbook",
+              "status": "Completed"
+            },
+            "postTask": null
+          },
+          "configuredDuration": "PT2H",
+          "osType": "Windows",
+          "startTime": "2017-10-23T02:30:36.2401233+00:00",
+          "endTime": "2017-10-23T02:30:42.8466667+00:00",
+          "computerCount": 1,
+          "failedCount": 0,
+          "creationTime": "2017-10-23T02:30:36.2401233+00:00",
+          "lastModifiedBy": "",
+          "lastModifiedTime": "2017-10-23T02:31:39.3966667+00:00"
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/getSoftwareUpdateConfigurationRunById.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/getSoftwareUpdateConfigurationRunById.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
     "softwareUpdateConfigurationRunId": "2bd77cfa-2e9c-41b4-a45b-684a77cfeca9",
-    "api-version": "2017-05-15-preview"
+    "api-version": "2019-06-01"
   },
   "responses": {
     "200": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/listFailedSoftwareUpdateConfigurationRuns.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/listFailedSoftwareUpdateConfigurationRuns.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "softwareUpdateConfigurationRunId": "a2c7c4b8-55d6-4505-bea7-756e93b18a35",
+    "$filter": "properties/status%20eq%20'Failed'",
+    "api-version": "2017-05-15-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns/2bd77cfa-2e9c-41b4-a45b-684a77cfeca9",
+            "name": "2bd77cfa-2e9c-41b4-a45b-684a77cfeca9",
+            "properties": {
+              "softwareUpdateConfiguration": {
+                "name": "mypatch"
+              },
+              "status": "Failed",
+              "configuredDuration": "PT2H",
+              "osType": "Windows",
+              "startTime": "2017-10-23T02:30:36.2401233+00:00",
+              "endTime": "2017-10-23T02:30:42.8466667+00:00",
+              "computerCount": 1,
+              "failedCount": 0,
+              "tasks": {
+                "preTask": {
+                  "jobId": "be430e9e-2290-462e-8f86-686407c35fab",
+                  "source": "preRunbook",
+                  "status": "Completed"
+                },
+                "postTask": null
+              },
+              "creationTime": "2017-10-23T02:30:36.2401233+00:00",
+              "lastModifiedBy": "",
+              "lastModifiedTime": "2017-10-23T02:31:39.3966667+00:00"
+            }
+          },
+          {
+            "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns/5dabff55-9812-4a58-af16-b0cb1d9384e8",
+            "name": "5dabff55-9812-4a58-af16-b0cb1d9384e8",
+            "properties": {
+              "softwareUpdateConfiguration": {
+                "name": "mypatch"
+              },
+              "status": "Failed",
+              "configuredDuration": "PT2H",
+              "osType": "Windows",
+              "startTime": "2017-10-23T01:33:01.8818952+00:00",
+              "endTime": "2017-10-23T01:33:08.1133333+00:00",
+              "computerCount": 1,
+              "failedCount": 0,
+              "tasks": {
+                "preTask": {
+                  "jobId": "be430e9e-2290-462e-8f86-686407c35fab",
+                  "source": "preRunbook",
+                  "status": "Completed"
+                },
+                "postTask": null
+              },
+              "creationTime": "2017-10-23T01:33:01.8818952+00:00",
+              "lastModifiedBy": "",
+              "lastModifiedTime": "2017-10-23T01:34:03.94+00:00"
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/stas-wcus/softwareUpdateConfigurationRuns?api-version=2017-05-15-preview&_=1508725900015&$skip=100"
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/listFailedSoftwareUpdateConfigurationRuns.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/listFailedSoftwareUpdateConfigurationRuns.json
@@ -5,7 +5,7 @@
     "automationAccountName": "myaccount",
     "softwareUpdateConfigurationRunId": "a2c7c4b8-55d6-4505-bea7-756e93b18a35",
     "$filter": "properties/status%20eq%20'Failed'",
-    "api-version": "2017-05-15-preview"
+    "api-version": "2019-06-01"
   },
   "responses": {
     "200": {
@@ -67,7 +67,7 @@
             }
           }
         ],
-        "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/stas-wcus/softwareUpdateConfigurationRuns?api-version=2017-05-15-preview&_=1508725900015&$skip=100"
+        "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/stas-wcus/softwareUpdateConfigurationRuns?api-version=2019-06-01&_=1508725900015&$skip=100"
       }
     }
   }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/listSoftwareUpdateConfigurationRuns.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/listSoftwareUpdateConfigurationRuns.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "subscriptionId": "51766542-3ed7-4a72-a187-0c8ab644ddab",
+    "resourceGroupName": "mygroup",
+    "automationAccountName": "myaccount",
+    "softwareUpdateConfigurationRunId": "a2c7c4b8-55d6-4505-bea7-756e93b18a35",
+    "api-version": "2017-05-15-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns/2bd77cfa-2e9c-41b4-a45b-684a77cfeca9",
+            "name": "2bd77cfa-2e9c-41b4-a45b-684a77cfeca9",
+            "properties": {
+              "softwareUpdateConfiguration": {
+                "name": "mypatch"
+              },
+              "status": "Succeeded",
+              "configuredDuration": "PT2H",
+              "osType": "Windows",
+              "startTime": "2017-10-23T02:30:36.2401233+00:00",
+              "endTime": "2017-10-23T02:30:42.8466667+00:00",
+              "computerCount": 1,
+              "failedCount": 0,
+              "tasks": {
+                "preTask": {
+                  "jobId": "be430e9e-2290-462e-8f86-686407c35fab",
+                  "source": "preRunbook",
+                  "status": "Completed"
+                },
+                "postTask": null
+              },
+              "creationTime": "2017-10-23T02:30:36.2401233+00:00",
+              "lastModifiedBy": "",
+              "lastModifiedTime": "2017-10-23T02:31:39.3966667+00:00"
+            }
+          },
+          {
+            "id": "/subscriptions/51766542-3ed7-4a72-a187-0c8ab644ddab/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/myaccount/softwareUpdateConfigurationRuns/5dabff55-9812-4a58-af16-b0cb1d9384e8",
+            "name": "5dabff55-9812-4a58-af16-b0cb1d9384e8",
+            "properties": {
+              "softwareUpdateConfiguration": {
+                "name": "mypatch"
+              },
+              "status": "Succeeded",
+              "configuredDuration": "PT2H",
+              "osType": "Windows",
+              "startTime": "2017-10-23T01:33:01.8818952+00:00",
+              "endTime": "2017-10-23T01:33:08.1133333+00:00",
+              "computerCount": 1,
+              "failedCount": 0,
+              "tasks": {
+                "preTask": {
+                  "jobId": "be430e9e-2290-462e-8f86-686407c35fab",
+                  "source": "preRunbook",
+                  "status": "Completed"
+                },
+                "postTask": null
+              },
+              "creationTime": "2017-10-23T01:33:01.8818952+00:00",
+              "lastModifiedBy": "",
+              "lastModifiedTime": "2017-10-23T01:34:03.94+00:00"
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/stas-wcus/softwareUpdateConfigurationRuns?api-version=2017-05-15-preview&_=1508725900015&$skip=100"
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/listSoftwareUpdateConfigurationRuns.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/softwareUpdateConfigurationRun/listSoftwareUpdateConfigurationRuns.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "mygroup",
     "automationAccountName": "myaccount",
     "softwareUpdateConfigurationRunId": "a2c7c4b8-55d6-4505-bea7-756e93b18a35",
-    "api-version": "2017-05-15-preview"
+    "api-version": "2019-06-01"
   },
   "responses": {
     "200": {
@@ -66,7 +66,7 @@
             }
           }
         ],
-        "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/stas-wcus/softwareUpdateConfigurationRuns?api-version=2017-05-15-preview&_=1508725900015&$skip=100"
+        "nextLink": "https://management.azure.com:443/subscriptions/1a7d4044-286c-4acb-969a-96639265bf2e/resourceGroups/mygroup/providers/Microsoft.Automation/automationAccounts/stas-wcus/softwareUpdateConfigurationRuns?api-version=2019-06-01&_=1508725900015&$skip=100"
       }
     }
   }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
@@ -1,0 +1,861 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Update Management API",
+    "description": "APIs for managing software update configurations.",
+    "contact": {
+      "name": "Mohamed Enein"
+    },
+    "version": "2017-05-15-preview",
+    "x-ms-code-generation-settings": {
+      "useDateTimeOffset": true
+    }
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "basePath": "/",
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurations/{softwareUpdateConfigurationName}": {
+      "put": {
+        "tags": [
+          "Software Update Configuration"
+        ],
+        "description": "Create a new software update configuration with the name given in the URI.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "Create software update configuration": {
+            "$ref": "./examples/softwareUpdateConfiguration/createSoftwareUpdateConfiguration.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurations_Create",
+        "parameters": [
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
+          },
+          {
+            "name": "softwareUpdateConfigurationName",
+            "description": "The name of the software update configuration to be created.",
+            "type": "string",
+            "required": true,
+            "in": "path"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/clientRequestId"
+          },
+          {
+            "name": "parameters",
+            "description": "Request body.",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/softwareUpdateConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Software update configuration with the same name and properties already exists.",
+            "schema": {
+              "$ref": "#/definitions/softwareUpdateConfiguration"
+            }
+          },
+          "201": {
+            "description": "Software update configuration is created.",
+            "schema": {
+              "$ref": "#/definitions/softwareUpdateConfiguration"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Software Update Configuration"
+        ],
+        "description": "Get a single software update configuration by name.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "Get software update configuration by name": {
+            "$ref": "./examples/softwareUpdateConfiguration/getSoftwareUpdateConfigurationByName.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurations_GetByName",
+        "parameters": [
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
+          },
+          {
+            "name": "softwareUpdateConfigurationName",
+            "description": "The name of the software update configuration to be created.",
+            "type": "string",
+            "required": true,
+            "in": "path"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/clientRequestId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single software update configuration.",
+            "schema": {
+              "$ref": "#/definitions/softwareUpdateConfiguration"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Software Update Configuration"
+        ],
+        "description": "delete a specific software update configuration.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "Delete software update configuration": {
+            "$ref": "./examples/softwareUpdateConfiguration/deleteSoftwareUpdateConfiguration.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurations_Delete",
+        "parameters": [
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
+          },
+          {
+            "name": "softwareUpdateConfigurationName",
+            "description": "The name of the software update configuration to be created.",
+            "type": "string",
+            "required": true,
+            "in": "path"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/clientRequestId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The software update configuration has been deleted."
+          },
+          "204": {
+            "description": "The software update configuration does not exist."
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurations": {
+      "get": {
+        "tags": [
+          "Software Update Configuration"
+        ],
+        "description": "Get all software update configurations for the account.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "List software update configurations": {
+            "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json"
+          },
+          "List software update configurations Targeting a specific azure virtual machine": {
+            "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurations_List",
+        "parameters": [
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/clientRequestId"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return list of software update configurations.",
+            "schema": {
+              "$ref": "#/definitions/softwareUpdateConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "softwareUpdateConfiguration": {
+      "x-ms-azure-resource": true,
+      "description": "Software update configuration properties.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "description": "Software update configuration properties.",
+          "$ref": "#/definitions/softwareUpdateConfigurationProperties"
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "softwareUpdateConfigurationProperties": {
+      "description": "Software update configuration properties.",
+      "properties": {
+        "updateConfiguration": {
+          "description": "update specific properties for the Software update configuration",
+          "$ref": "#/definitions/updateConfiguration"
+        },
+        "scheduleInfo": {
+          "description": "Schedule information for the Software update configuration",
+          "$ref": "#/definitions/ScheduleProperties"
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state for the software update configuration, which only appears in the response.",
+          "readOnly": true
+        },
+        "error": {
+          "description": "Details of provisioning error",
+          "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+        },
+        "creationTime": {
+          "type": "string",
+          "description": "Creation time of the resource, which only appears in the response.",
+          "format": "date-time",
+          "x-nullable": false,
+          "readOnly": true
+        },
+        "createdBy": {
+          "type": "string",
+          "description": "CreatedBy property, which only appears in the response.",
+          "readOnly": true
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "description": "Last time resource was modified, which only appears in the response.",
+          "format": "date-time",
+          "x-nullable": false,
+          "readOnly": true
+        },
+        "lastModifiedBy": {
+          "type": "string",
+          "description": "LastModifiedBy property, which only appears in the response.",
+          "readOnly": true
+        },
+        "tasks": {
+          "description": "Tasks information for the Software update configuration.",
+          "$ref": "#/definitions/softwareUpdateConfigurationTasks"
+        }
+      },
+      "required": [
+        "updateConfiguration",
+        "scheduleInfo"
+      ]
+    },
+    "softwareUpdateConfigurationTasks": {
+      "type": "object",
+      "description": "Task properties of the software update configuration.",
+      "properties": {
+        "preTask": {
+          "description": "Pre task properties.",
+          "$ref": "#/definitions/taskProperties"
+        },
+        "postTask": {
+          "description": "Post task properties.",
+          "$ref": "#/definitions/taskProperties"
+        }
+      }
+    },
+    "taskProperties": {
+      "type": "object",
+      "description": "Task properties of the software update configuration.",
+      "properties": {
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Gets or sets the parameters of the task."
+        },
+        "source": {
+          "type": "string",
+          "description": "Gets or sets the name of the runbook."
+        }
+      }
+    },
+    "WindowsProperties": {
+      "type": "object",
+      "description": "Windows specific update configuration.",
+      "properties": {
+        "includedUpdateClassifications": {
+          "description": "Update classification included in the software update configuration. A comma separated string with required values",
+          "type": "string",
+          "enum": [
+            "Unclassified",
+            "Critical",
+            "Security",
+            "UpdateRollup",
+            "FeaturePack",
+            "ServicePack",
+            "Definition",
+            "Tools",
+            "Updates"
+          ],
+          "x-ms-enum": {
+            "name": "WindowsUpdateClasses",
+            "modelAsString": true
+          }
+        },
+        "excludedKbNumbers": {
+          "type": "array",
+          "description": "KB numbers excluded from the software update configuration.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "includedKbNumbers": {
+          "type": "array",
+          "description": "KB numbers included from the software update configuration.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rebootSetting": {
+          "description": "Reboot setting for the software update configuration.",
+          "type": "string"
+        }
+      }
+    },
+    "operatingSystemType": {
+      "type": "string",
+      "description": "Target operating system for the software update configuration.",
+      "enum": [
+        "Windows",
+        "Linux"
+      ],
+      "x-ms-enum": {
+        "modelAsString": false,
+        "name": "OperatingSystemType"
+      }
+    },
+    "updateConfiguration": {
+      "type": "object",
+      "description": "Update specific properties of the software update configuration.",
+      "properties": {
+        "operatingSystem": {
+          "description": "operating system of target machines",
+          "$ref": "#/definitions/operatingSystemType"
+        },
+        "windows": {
+          "description": "Windows specific update configuration.",
+          "$ref": "#/definitions/WindowsProperties"
+        },
+        "linux": {
+          "description": "Linux specific update configuration.",
+          "$ref": "#/definitions/LinuxProperties"
+        },
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Maximum time allowed for the software update configuration run. Duration needs to be specified using the format PT[n]H[n]M[n]S as per ISO8601"
+        },
+        "azureVirtualMachines": {
+          "type": "array",
+          "description": "List of azure resource Ids for azure virtual machines targeted by the software update configuration.",
+          "items": {
+            "type": "string",
+            "description": "Azure Resource Manager Id for a virtual machine."
+          }
+        },
+        "nonAzureComputerNames": {
+          "type": "array",
+          "description": "List of names of non-azure machines targeted by the software update configuration.",
+          "items": {
+            "type": "string",
+            "description": "Name of Non-Azure OMS Computer."
+          }
+        },
+        "targets": {
+          "description": "Group targets for the software update configuration.",
+          "$ref": "#/definitions/TargetProperties"
+        }
+      },
+      "required": [
+        "operatingSystem"
+      ]
+    },
+    "LinuxProperties": {
+      "type": "object",
+      "description": "Linux specific update configuration.",
+      "properties": {
+        "includedPackageClassifications": {
+          "description": "Update classifications included in the software update configuration.",
+          "type": "string",
+          "enum": [
+            "Unclassified",
+            "Critical",
+            "Security",
+            "Other"
+          ],
+          "x-ms-enum": {
+            "name": "LinuxUpdateClasses",
+            "modelAsString": true
+          }
+        },
+        "excludedPackageNameMasks": {
+          "type": "array",
+          "description": "packages excluded from the software update configuration.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "includedPackageNameMasks": {
+          "type": "array",
+          "description": "packages included from the software update configuration.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rebootSetting": {
+          "description": "Reboot setting for the software update configuration.",
+          "type": "string"
+        }
+      }
+    },
+    "ScheduleProperties": {
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": false,
+          "description": "Gets or sets the start time of the schedule."
+        },
+        "startTimeOffsetMinutes": {
+          "readOnly": true,
+          "type": "number",
+          "format": "double",
+          "description": "Gets the start time's offset in minutes.",
+          "x-nullable": false
+        },
+        "expiryTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "description": "Gets or sets the end time of the schedule."
+        },
+        "expiryTimeOffsetMinutes": {
+          "type": "number",
+          "format": "double",
+          "description": "Gets or sets the expiry time's offset in minutes.",
+          "x-nullable": false
+        },
+        "isEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Gets or sets a value indicating whether this schedule is enabled."
+        },
+        "nextRun": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "description": "Gets or sets the next run time of the schedule."
+        },
+        "nextRunOffsetMinutes": {
+          "type": "number",
+          "format": "double",
+          "description": "Gets or sets the next run time's offset in minutes.",
+          "x-nullable": false
+        },
+        "interval": {
+          "type": "integer",
+          "description": "Gets or sets the interval of the schedule."
+        },
+        "frequency": {
+          "type": "string",
+          "description": "Gets or sets the frequency of the schedule.",
+          "$ref": "../../stable/2015-10-31/schedule.json#/definitions/scheduleFrequency"
+        },
+        "timeZone": {
+          "type": "string",
+          "description": "Gets or sets the time zone of the schedule."
+        },
+        "advancedSchedule": {
+          "$ref": "#/definitions/AdvancedSchedule",
+          "description": "Gets or sets the advanced schedule."
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": false,
+          "description": "Gets or sets the creation time."
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": false,
+          "description": "Gets or sets the last modified time."
+        },
+        "description": {
+          "type": "string",
+          "description": "Gets or sets the description."
+        }
+      },
+      "description": "Definition of schedule parameters."
+    },
+    "AdvancedSchedule": {
+      "properties": {
+        "weekDays": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Days of the week that the job should execute on."
+        },
+        "monthDays": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32",
+            "x-nullable": false
+          },
+          "description": "Days of the month that the job should execute on. Must be between 1 and 31."
+        },
+        "monthlyOccurrences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AdvancedScheduleMonthlyOccurrence"
+          },
+          "description": "Occurrences of days within a month."
+        }
+      },
+      "description": "The properties of the create Advanced Schedule."
+    },
+    "AdvancedScheduleMonthlyOccurrence": {
+      "properties": {
+        "occurrence": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Occurrence of the week within the month. Must be between 1 and 5"
+        },
+        "day": {
+          "type": "string",
+          "description": "Day of the occurrence. Must be one of monday, tuesday, wednesday, thursday, friday, saturday, sunday.",
+          "enum": [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday"
+          ],
+          "x-ms-enum": {
+            "name": "ScheduleDay",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "The properties of the create advanced schedule monthly occurrence."
+    },
+    "softwareUpdateConfigurationListResult": {
+      "description": "result of listing all software update configuration",
+      "properties": {
+        "value": {
+          "description": "outer object returned when listing all software update configurations",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/softwareUpdateConfigurationCollectionItem"
+          }
+        }
+      }
+    },
+    "softwareUpdateConfigurationCollectionItem": {
+      "description": "Software update configuration collection item properties.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Name of the software update configuration."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id of the software update configuration"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "description": "Software update configuration properties.",
+          "$ref": "#/definitions/softwareUpdateConfigurationCollectionItemProperties"
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "collectionItemUpdateConfiguration": {
+      "description": "object returned when requesting a collection of software update configuration",
+      "properties": {
+        "azureVirtualMachines": {
+          "type": "array",
+          "description": "List of azure resource Ids for azure virtual machines targeted by the software update configuration.",
+          "items": {
+            "type": "string",
+            "description": "Azure Resource Manager Id for a virtual machine."
+          }
+        },
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Maximum time allowed for the software update configuration run. Duration needs to be specified using the format PT[n]H[n]M[n]S as per ISO8601"
+        }
+      }
+    },
+    "softwareUpdateConfigurationCollectionItemProperties": {
+      "description": "Software update configuration collection item properties.",
+      "properties": {
+        "updateConfiguration": {
+          "description": "Update specific properties of the software update configuration.",
+          "$ref": "#/definitions/collectionItemUpdateConfiguration"
+        },
+        "frequency": {
+          "description": "execution frequency of the schedule associated with the software update configuration",
+          "type": "string",
+          "$ref": "../../stable/2015-10-31/schedule.json#/definitions/scheduleFrequency"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": false,
+          "description": "the start time of the update."
+        },
+        "creationTime": {
+          "type": "string",
+          "description": "Creation time of the software update configuration, which only appears in the response.",
+          "format": "date-time",
+          "x-nullable": false,
+          "readOnly": true
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "description": "Last time software update configuration was modified, which only appears in the response.",
+          "format": "date-time",
+          "x-nullable": false,
+          "readOnly": true
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state for the software update configuration, which only appears in the response.",
+          "readOnly": true
+        },
+        "nextRun": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "description": "ext run time of the update."
+        }
+      }
+    },
+    "TargetProperties": {
+      "type": "object",
+      "description": "Group specific to the update configuration.",
+      "properties": {
+        "azureQueries": {
+          "description": "List of Azure queries in the software update configuration.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/AzureQueryProperties"
+          }
+        },
+        "nonAzureQueries": {
+          "description": "List of non Azure queries in the software update configuration.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/NonAzureQueryProperties"
+          }
+        }
+      }
+    },
+    "NonAzureQueryProperties": {
+      "type": "object",
+      "description": "Non Azure query for the update configuration.",
+      "properties": {
+        "functionAlias": {
+          "type": "string",
+          "description": "Log Analytics Saved Search name."
+        },
+        "workspaceId": {
+          "type": "string",
+          "description": "Workspace Id for Log Analytics in which the saved Search is resided."
+        }
+      }
+    },
+    "AzureQueryProperties": {
+      "type": "object",
+      "description": "Azure query for the update configuration.",
+      "properties": {
+        "scope": {
+          "type": "array",
+          "description": "List of Subscription or Resource Group ARM Ids.",
+          "items": {
+            "type": "string",
+            "description": "Subscription or Resource Group ARM Id."
+          }
+        },
+        "locations": {
+          "type": "array",
+          "description": "List of locations to scope the query to.",
+          "items": {
+            "type": "string",
+            "description": "Location to scope the query to."
+          }
+        },
+        "tagSettings": {
+          "type": "object",
+          "description": "Tag settings for the VM.",
+          "$ref": "#/definitions/TagSettingsProperties"
+        }
+      }
+    },
+    "TagSettingsProperties": {
+      "type": "object",
+      "description": "Tag filter information for the VM.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Dictionary of tags with its list of values.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "List of tag values for a tag."
+            }
+          }
+        },
+        "filterOperator": {
+          "type": "string",
+          "description": "Filter VMs by Any or All specified tags.",
+          "enum": [
+            "All",
+            "Any"
+          ],
+          "x-ms-enum": {
+            "name": "TagOperators",
+            "modelAsString": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
@@ -6,7 +6,7 @@
     "contact": {
       "name": "Mohamed Enein"
     },
-    "version": "2017-05-15-preview",
+    "version": "2019-06-01",
     "x-ms-code-generation-settings": {
       "useDateTimeOffset": true
     }
@@ -272,6 +272,9 @@
               "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
         }
       }
     }
@@ -675,6 +678,10 @@
           "items": {
             "$ref": "#/definitions/softwareUpdateConfigurationCollectionItem"
           }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "link to next page of results."
         }
       }
     },

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
@@ -706,30 +706,16 @@
         "properties"
       ]
     },
-    "collectionItemUpdateConfiguration": {
-      "description": "Object returned when requesting a collection of software update configurations.",
-      "properties": {
-        "azureVirtualMachines": {
-          "type": "array",
-          "description": "List of azure resource IDs for azure virtual machines targeted by the software update configuration.",
-          "items": {
-            "type": "string",
-            "description": "Azure Resource Manager ID for a virtual machine."
-          }
-        },
-        "duration": {
-          "type": "string",
-          "format": "duration",
-          "description": "Maximum time allowed for the software update configuration run. Duration needs to be specified using the format PT[n]H[n]M[n]S as per ISO8601."
-        }
-      }
-    },
     "softwareUpdateConfigurationCollectionItemProperties": {
       "description": "Software update configuration collection item properties.",
       "properties": {
         "updateConfiguration": {
           "description": "Update specific properties of the software update configuration.",
-          "$ref": "#/definitions/collectionItemUpdateConfiguration"
+          "$ref": "#/definitions/updateConfiguration"
+        },
+        "tasks": {
+          "description": "Tasks information for the software update configuration.",
+          "$ref": "#/definitions/softwareUpdateConfigurationTasks"
         },
         "frequency": {
           "description": "Execution frequency of the schedule associated with the software update configuration.",

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
@@ -45,7 +45,7 @@
         ],
         "description": "Create a new software update configuration with the name given in the URI.",
         "externalDocs": {
-          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+          "url": "https://docs.microsoft.com/dotnet/api/microsoft.azure.management.automation.softwareupdateconfigurationsoperationsextensions"
         },
         "x-ms-examples": {
           "Create software update configuration": {
@@ -113,7 +113,7 @@
         ],
         "description": "Get a single software update configuration by name.",
         "externalDocs": {
-          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+          "url": "https://docs.microsoft.com/dotnet/api/microsoft.azure.management.automation.softwareupdateconfigurationsoperationsextensions"
         },
         "x-ms-examples": {
           "Get software update configuration by name": {
@@ -166,7 +166,7 @@
         ],
         "description": "Delete a specific software update configuration.",
         "externalDocs": {
-          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+          "url": "https://docs.microsoft.com/dotnet/api/microsoft.azure.management.automation.softwareupdateconfigurationsoperationsextensions"
         },
         "x-ms-examples": {
           "Delete software update configuration": {
@@ -221,7 +221,7 @@
         ],
         "description": "Get all software update configurations for the account.",
         "externalDocs": {
-          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+          "url": "https://docs.microsoft.com/dotnet/api/microsoft.azure.management.automation.softwareupdateconfigurationsoperationsextensions"
         },
         "x-ms-examples": {
           "List software update configurations": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
@@ -3,9 +3,6 @@
   "info": {
     "title": "Update Management API",
     "description": "APIs for managing software update configurations.",
-    "contact": {
-      "name": "Mohamed Enein"
-    },
     "version": "2019-06-01",
     "x-ms-code-generation-settings": {
       "useDateTimeOffset": true
@@ -167,7 +164,7 @@
         "tags": [
           "Software Update Configuration"
         ],
-        "description": "delete a specific software update configuration.",
+        "description": "Delete a specific software update configuration.",
         "externalDocs": {
           "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
         },
@@ -230,7 +227,7 @@
           "List software update configurations": {
             "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurations.json"
           },
-          "List software update configurations Targeting a specific azure virtual machine": {
+          "List software update configurations targeting a specific azure virtual machine": {
             "$ref": "./examples/softwareUpdateConfiguration/listSoftwareUpdateConfigurationsByVm.json"
           }
         },
@@ -314,11 +311,11 @@
       "description": "Software update configuration properties.",
       "properties": {
         "updateConfiguration": {
-          "description": "update specific properties for the Software update configuration",
+          "description": "Update specific properties for the Software update configuration.",
           "$ref": "#/definitions/updateConfiguration"
         },
         "scheduleInfo": {
-          "description": "Schedule information for the Software update configuration",
+          "description": "Schedule information for the Software update configuration.",
           "$ref": "#/definitions/ScheduleProperties"
         },
         "provisioningState": {
@@ -327,7 +324,7 @@
           "readOnly": true
         },
         "error": {
-          "description": "Details of provisioning error",
+          "description": "Details of provisioning error.",
           "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
         },
         "creationTime": {
@@ -344,7 +341,7 @@
         },
         "lastModifiedTime": {
           "type": "string",
-          "description": "Last time resource was modified, which only appears in the response.",
+          "description": "Last time the resource was modified, which only appears in the response.",
           "format": "date-time",
           "x-nullable": false,
           "readOnly": true
@@ -355,7 +352,7 @@
           "readOnly": true
         },
         "tasks": {
-          "description": "Tasks information for the Software update configuration.",
+          "description": "Tasks information for the software update configuration.",
           "$ref": "#/definitions/softwareUpdateConfigurationTasks"
         }
       },
@@ -400,7 +397,7 @@
       "description": "Windows specific update configuration.",
       "properties": {
         "includedUpdateClassifications": {
-          "description": "Update classification included in the software update configuration. A comma separated string with required values",
+          "description": "Update classification included in the software update configuration. A comma-separated string with required values.",
           "type": "string",
           "enum": [
             "Unclassified",
@@ -455,7 +452,7 @@
       "description": "Update specific properties of the software update configuration.",
       "properties": {
         "operatingSystem": {
-          "description": "operating system of target machines",
+          "description": "Operating system of target machines.",
           "$ref": "#/definitions/operatingSystemType"
         },
         "windows": {
@@ -469,14 +466,14 @@
         "duration": {
           "type": "string",
           "format": "duration",
-          "description": "Maximum time allowed for the software update configuration run. Duration needs to be specified using the format PT[n]H[n]M[n]S as per ISO8601"
+          "description": "Maximum time allowed for the software update configuration run. Duration needs to be specified using the format PT[n]H[n]M[n]S as per ISO8601."
         },
         "azureVirtualMachines": {
           "type": "array",
-          "description": "List of azure resource Ids for azure virtual machines targeted by the software update configuration.",
+          "description": "List of azure resource IDs for azure virtual machines targeted by the software update configuration.",
           "items": {
             "type": "string",
-            "description": "Azure Resource Manager Id for a virtual machine."
+            "description": "Azure Resource Manager ID for a virtual machine."
           }
         },
         "nonAzureComputerNames": {
@@ -516,14 +513,14 @@
         },
         "excludedPackageNameMasks": {
           "type": "array",
-          "description": "packages excluded from the software update configuration.",
+          "description": "Packages excluded from the software update configuration.",
           "items": {
             "type": "string"
           }
         },
         "includedPackageNameMasks": {
           "type": "array",
-          "description": "packages included from the software update configuration.",
+          "description": "Packages included from the software update configuration.",
           "items": {
             "type": "string"
           }
@@ -670,10 +667,10 @@
       "description": "The properties of the create advanced schedule monthly occurrence."
     },
     "softwareUpdateConfigurationListResult": {
-      "description": "result of listing all software update configuration",
+      "description": "Result of listing all software update configuration.",
       "properties": {
         "value": {
-          "description": "outer object returned when listing all software update configurations",
+          "description": "Outer object returned when listing all software update configurations.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/softwareUpdateConfigurationCollectionItem"
@@ -681,7 +678,7 @@
         },
         "nextLink": {
           "type": "string",
-          "description": "link to next page of results."
+          "description": "Link to next page of results."
         }
       }
     },
@@ -697,7 +694,7 @@
         "id": {
           "readOnly": true,
           "type": "string",
-          "description": "Resource Id of the software update configuration"
+          "description": "Resource ID of the software update configuration."
         },
         "properties": {
           "x-ms-client-flatten": true,
@@ -710,20 +707,20 @@
       ]
     },
     "collectionItemUpdateConfiguration": {
-      "description": "object returned when requesting a collection of software update configuration",
+      "description": "Object returned when requesting a collection of software update configurations.",
       "properties": {
         "azureVirtualMachines": {
           "type": "array",
-          "description": "List of azure resource Ids for azure virtual machines targeted by the software update configuration.",
+          "description": "List of azure resource IDs for azure virtual machines targeted by the software update configuration.",
           "items": {
             "type": "string",
-            "description": "Azure Resource Manager Id for a virtual machine."
+            "description": "Azure Resource Manager ID for a virtual machine."
           }
         },
         "duration": {
           "type": "string",
           "format": "duration",
-          "description": "Maximum time allowed for the software update configuration run. Duration needs to be specified using the format PT[n]H[n]M[n]S as per ISO8601"
+          "description": "Maximum time allowed for the software update configuration run. Duration needs to be specified using the format PT[n]H[n]M[n]S as per ISO8601."
         }
       }
     },
@@ -735,7 +732,7 @@
           "$ref": "#/definitions/collectionItemUpdateConfiguration"
         },
         "frequency": {
-          "description": "execution frequency of the schedule associated with the software update configuration",
+          "description": "Execution frequency of the schedule associated with the software update configuration.",
           "type": "string",
           "$ref": "../../stable/2015-10-31/schedule.json#/definitions/scheduleFrequency"
         },
@@ -743,7 +740,7 @@
           "type": "string",
           "format": "date-time",
           "x-nullable": false,
-          "description": "the start time of the update."
+          "description": "The start time of the update."
         },
         "creationTime": {
           "type": "string",
@@ -768,7 +765,7 @@
           "type": "string",
           "format": "date-time",
           "x-nullable": true,
-          "description": "ext run time of the update."
+          "description": "Next run time of the update."
         }
       }
     },
@@ -785,7 +782,7 @@
           }
         },
         "nonAzureQueries": {
-          "description": "List of non Azure queries in the software update configuration.",
+          "description": "List of non-Azure queries in the software update configuration.",
           "type": "array",
           "items": {
             "type": "object",
@@ -796,7 +793,7 @@
     },
     "NonAzureQueryProperties": {
       "type": "object",
-      "description": "Non Azure query for the update configuration.",
+      "description": "Non-Azure query for the update configuration.",
       "properties": {
         "functionAlias": {
           "type": "string",
@@ -804,7 +801,7 @@
         },
         "workspaceId": {
           "type": "string",
-          "description": "Workspace Id for Log Analytics in which the saved Search is resided."
+          "description": "Workspace ID for Log Analytics in which the saved Search is resided."
         }
       }
     },
@@ -814,10 +811,10 @@
       "properties": {
         "scope": {
           "type": "array",
-          "description": "List of Subscription or Resource Group ARM Ids.",
+          "description": "List of Subscription or Resource Group ARM IDs.",
           "items": {
             "type": "string",
-            "description": "Subscription or Resource Group ARM Id."
+            "description": "Subscription or Resource Group ARM ID."
           }
         },
         "locations": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationMachineRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationMachineRun.json
@@ -1,0 +1,327 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Update Management API",
+    "description": "APIs for managing software update configurations.",
+    "contact": {
+      "name": "Mohamed Enein"
+    },
+    "version": "2017-05-15-preview",
+    "x-ms-code-generation-settings": {
+      "useDateTimeOffset": true
+    }
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "basePath": "/",
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationMachineRuns/{softwareUpdateConfigurationMachineRunId}": {
+      "get": {
+        "tags": [
+          "Software Update Configuration Machine Run"
+        ],
+        "description": "Get a single software update configuration machine run by Id.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "Get software update configuration machine run": {
+            "$ref": "./examples/softwareUpdateConfigurationMachineRun/getSoftwareUpdateConfigurationMachineRunById.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurationMachineRuns_GetById",
+        "parameters": [
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
+          },
+          {
+            "name": "softwareUpdateConfigurationMachineRunId",
+            "description": "The Id of the software update configuration machine run.",
+            "type": "string",
+            "required": true,
+            "in": "path",
+            "format": "uuid"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/clientRequestId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single software update configuration machine run.",
+            "schema": {
+              "$ref": "#/definitions/softwareUpdateConfigurationMachineRun"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationMachineRuns": {
+      "get": {
+        "tags": [
+          "Software Update Configuration Machine Run"
+        ],
+        "description": "Return list of software update configuration machine runs",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "List software update configuration machine runs": {
+            "$ref": "./examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRuns.json"
+          },
+          "List software update configuration machine runs for a specific software update configuration run": {
+            "$ref": "./examples/softwareUpdateConfigurationMachineRun/listSoftwareUpdateConfigurationMachineRunsByRun.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurationMachineRuns_List",
+        "parameters": [
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/clientRequestId"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "number of entries you skip before returning results"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Maximum number of entries returned in the results collection"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return list of software update configuration machine runs.",
+            "schema": {
+              "$ref": "#/definitions/softwareUpdateConfigurationMachineRunListResult"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "softwareUpdateConfigurationMachineRun": {
+      "description": "Software update configuration machine run model.",
+      "x-ms-azure-resource": false,
+      "type": "object",
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Name of the software update configuration machine run"
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id of the software update configuration machine run"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "description": "Software update configuration machine run properties.",
+          "$ref": "#/definitions/updateConfigurationMachineRunProperties"
+        }
+      }
+    },
+    "softwareUpdateConfigurationMachineRunListResult": {
+      "description": "result of listing all software update configuration machine runs",
+      "properties": {
+        "value": {
+          "description": "outer object returned when listing all software update configuration machine runs",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/softwareUpdateConfigurationMachineRun"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "link to next page of results."
+        }
+      }
+    },
+    "updateConfigurationMachineRunProperties": {
+      "description": "Software update configuration machine run properties.",
+      "properties": {
+        "targetComputer": {
+          "type": "string",
+          "description": "name of the updated computer",
+          "readOnly": true
+        },
+        "targetComputerType": {
+          "type": "string",
+          "description": "type of the updated computer.",
+          "readOnly": true
+        },
+        "softwareUpdateConfiguration": {
+          "description": "software update configuration triggered this run",
+          "$ref": "#/definitions/updateConfigurationNavigation"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the software update configuration machine run.",
+          "readOnly": true
+        },
+        "osType": {
+          "type": "string",
+          "description": "Operating system target of the software update configuration triggered this run",
+          "readOnly": true
+        },
+        "correlationId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "correlation id of the software update configuration machine run",
+          "readOnly": true
+        },
+        "sourceComputerId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "source computer id of the software update configuration machine run",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": false,
+          "description": "Start time of the software update configuration machine run.",
+          "readOnly": true
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "description": "End time of the software update configuration machine run.",
+          "readOnly": true
+        },
+        "configuredDuration": {
+          "type": "string",
+          "description": "configured duration for the software update configuration run.",
+          "readOnly": true
+        },
+        "job": {
+          "description": "Job associated with the software update configuration machine run",
+          "$ref": "#/definitions/jobNavigation"
+        },
+        "creationTime": {
+          "type": "string",
+          "description": "Creation time of the resource, which only appears in the response.",
+          "format": "date-time",
+          "x-nullable": false,
+          "readOnly": true
+        },
+        "createdBy": {
+          "type": "string",
+          "description": "createdBy property, which only appears in the response.",
+          "readOnly": true
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "description": "Last time resource was modified, which only appears in the response.",
+          "format": "date-time",
+          "x-nullable": false,
+          "readOnly": true
+        },
+        "lastModifiedBy": {
+          "type": "string",
+          "description": "lastModifiedBy property, which only appears in the response.",
+          "readOnly": true
+        },
+        "error": {
+          "description": "Details of provisioning error",
+          "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+        }
+      }
+    },
+    "updateConfigurationNavigation": {
+      "description": "Software update configuration Run Navigation model.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the software update configuration triggered the software update configuration run",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "jobNavigation": {
+      "description": "Software update configuration machine run job navigation properties.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Id of the job associated with the software update configuration run",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationMachineRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationMachineRun.json
@@ -2,10 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Update Management API",
-    "description": "APIs for managing software update configurations.",
-    "contact": {
-      "name": "Mohamed Enein"
-    },
+    "description": "APIs for managing software update configuration machine runs.",
     "version": "2019-06-01",
     "x-ms-code-generation-settings": {
       "useDateTimeOffset": true
@@ -46,7 +43,7 @@
         "tags": [
           "Software Update Configuration Machine Run"
         ],
-        "description": "Get a single software update configuration machine run by Id.",
+        "description": "Get a single software update configuration machine run by ID.",
         "externalDocs": {
           "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
         },
@@ -68,7 +65,7 @@
           },
           {
             "name": "softwareUpdateConfigurationMachineRunId",
-            "description": "The Id of the software update configuration machine run.",
+            "description": "The ID of the software update configuration machine run.",
             "type": "string",
             "required": true,
             "in": "path",
@@ -136,21 +133,21 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
+            "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'."
           },
           {
             "name": "$skip",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "number of entries you skip before returning results"
+            "description": "Number of entries you skip before returning results."
           },
           {
             "name": "$top",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Maximum number of entries returned in the results collection"
+            "description": "Maximum number of entries returned in the results collection."
           }
         ],
         "responses": {
@@ -182,12 +179,12 @@
         "name": {
           "readOnly": true,
           "type": "string",
-          "description": "Name of the software update configuration machine run"
+          "description": "Name of the software update configuration machine run."
         },
         "id": {
           "readOnly": true,
           "type": "string",
-          "description": "Resource Id of the software update configuration machine run"
+          "description": "Resource ID of the software update configuration machine run."
         },
         "properties": {
           "x-ms-client-flatten": true,
@@ -197,10 +194,10 @@
       }
     },
     "softwareUpdateConfigurationMachineRunListResult": {
-      "description": "result of listing all software update configuration machine runs",
+      "description": "Result of listing all software update configuration machine runs.",
       "properties": {
         "value": {
-          "description": "outer object returned when listing all software update configuration machine runs",
+          "description": "Outer object returned when listing all software update configuration machine runs.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/softwareUpdateConfigurationMachineRun"
@@ -208,7 +205,7 @@
         },
         "nextLink": {
           "type": "string",
-          "description": "link to next page of results."
+          "description": "Link to next page of results."
         }
       }
     },
@@ -217,16 +214,16 @@
       "properties": {
         "targetComputer": {
           "type": "string",
-          "description": "name of the updated computer",
+          "description": "Name of the updated computer.",
           "readOnly": true
         },
         "targetComputerType": {
           "type": "string",
-          "description": "type of the updated computer.",
+          "description": "Type of the updated computer.",
           "readOnly": true
         },
         "softwareUpdateConfiguration": {
-          "description": "software update configuration triggered this run",
+          "description": "Software update configuration triggered this run.",
           "$ref": "#/definitions/updateConfigurationNavigation"
         },
         "status": {
@@ -236,19 +233,19 @@
         },
         "osType": {
           "type": "string",
-          "description": "Operating system target of the software update configuration triggered this run",
+          "description": "Operating system target of the software update configuration triggered this run.",
           "readOnly": true
         },
         "correlationId": {
           "type": "string",
           "format": "uuid",
-          "description": "correlation id of the software update configuration machine run",
+          "description": "Correlation ID of the software update configuration machine run",
           "readOnly": true
         },
         "sourceComputerId": {
           "type": "string",
           "format": "uuid",
-          "description": "source computer id of the software update configuration machine run",
+          "description": "Source computer ID of the software update configuration machine run.",
           "readOnly": true
         },
         "startTime": {
@@ -267,7 +264,7 @@
         },
         "configuredDuration": {
           "type": "string",
-          "description": "configured duration for the software update configuration run.",
+          "description": "Configured duration for the software update configuration run.",
           "readOnly": true
         },
         "job": {
@@ -299,7 +296,7 @@
           "readOnly": true
         },
         "error": {
-          "description": "Details of provisioning error",
+          "description": "Details of provisioning error.",
           "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
         }
       }
@@ -309,7 +306,7 @@
       "type": "object",
       "properties": {
         "name": {
-          "description": "Name of the software update configuration triggered the software update configuration run",
+          "description": "Name of the software update configuration triggered the software update configuration run.",
           "type": "string",
           "readOnly": true
         }
@@ -320,7 +317,7 @@
       "type": "object",
       "properties": {
         "id": {
-          "description": "Id of the job associated with the software update configuration run",
+          "description": "ID of the job associated with the software update configuration run.",
           "type": "string",
           "readOnly": true
         }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationMachineRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationMachineRun.json
@@ -6,7 +6,7 @@
     "contact": {
       "name": "Mohamed Enein"
     },
-    "version": "2017-05-15-preview",
+    "version": "2019-06-01",
     "x-ms-code-generation-settings": {
       "useDateTimeOffset": true
     }
@@ -166,6 +166,9 @@
               "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
         }
       }
     }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationMachineRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationMachineRun.json
@@ -45,7 +45,7 @@
         ],
         "description": "Get a single software update configuration machine run by ID.",
         "externalDocs": {
-          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+          "url": "https://docs.microsoft.com/dotnet/api/microsoft.azure.management.automation.softwareupdateconfigurationmachinerunsoperationsextensions"
         },
         "x-ms-examples": {
           "Get software update configuration machine run": {
@@ -101,7 +101,7 @@
         ],
         "description": "Return list of software update configuration machine runs",
         "externalDocs": {
-          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+          "url": "https://docs.microsoft.com/dotnet/api/microsoft.azure.management.automation.softwareupdateconfigurationmachinerunsoperationsextensions"
         },
         "x-ms-examples": {
           "List software update configuration machine runs": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
@@ -1,0 +1,332 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Update Management API",
+    "description": "APIs for managing software update configurations.",
+    "contact": {
+      "name": "Mohamed Enein"
+    },
+    "version": "2017-05-15-preview",
+    "x-ms-code-generation-settings": {
+      "useDateTimeOffset": true
+    }
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "basePath": "/",
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationRuns/{softwareUpdateConfigurationRunId}": {
+      "get": {
+        "tags": [
+          "Software Update Configuration Run"
+        ],
+        "description": "Get a single software update configuration Run by Id.",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationrunoperations"
+        },
+        "x-ms-examples": {
+          "Get software update configuration runs by Id": {
+            "$ref": "./examples/softwareUpdateConfigurationRun/getSoftwareUpdateConfigurationRunById.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurationRuns_GetById",
+        "parameters": [
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
+          },
+          {
+            "name": "softwareUpdateConfigurationRunId",
+            "description": "The Id of the software update configuration run.",
+            "type": "string",
+            "required": true,
+            "in": "path",
+            "format": "uuid"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/clientRequestId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single software update configuration Run.",
+            "schema": {
+              "$ref": "#/definitions/softwareUpdateConfigurationRun"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/softwareUpdateConfigurationRuns": {
+      "get": {
+        "tags": [
+          "Software Update Configuration Run"
+        ],
+        "description": "Return list of software update configuration runs",
+        "externalDocs": {
+          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+        },
+        "x-ms-examples": {
+          "List software update configuration machine runs": {
+            "$ref": "./examples/softwareUpdateConfigurationRun/listSoftwareUpdateConfigurationRuns.json"
+          },
+          "List software update configuration machine run with status equal to 'Failed'": {
+            "$ref": "./examples/softwareUpdateConfigurationRun/listFailedSoftwareUpdateConfigurationRuns.json"
+          }
+        },
+        "operationId": "SoftwareUpdateConfigurationRuns_List",
+        "parameters": [
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../common/v1/definitions.json#/parameters/clientRequestId"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Number of entries you skip before returning results"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Maximum number of entries returned in the results collection"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return list of software update configurations runs.",
+            "schema": {
+              "$ref": "#/definitions/softwareUpdateConfigurationRunListResult"
+            }
+          },
+          "default": {
+            "description": "Automation error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "softwareUpdateConfigurationRun": {
+      "description": "Software update configuration Run properties.",
+      "x-ms-azure-resource": false,
+      "type": "object",
+      "properties": {
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Name of the software update configuration run."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id of the software update configuration run"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "description": "Software update configuration Run properties.",
+          "$ref": "#/definitions/softwareUpdateConfigurationRunProperties"
+        }
+      }
+    },
+    "softwareUpdateConfigurationRunProperties": {
+      "description": "Software update configuration properties.",
+      "properties": {
+        "softwareUpdateConfiguration": {
+          "description": "software update configuration triggered this run",
+          "$ref": "#/definitions/updateConfigurationNavigation"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the software update configuration run.",
+          "readOnly": true
+        },
+        "configuredDuration": {
+          "type": "string",
+          "description": "Configured duration for the software update configuration run.",
+          "readOnly": true
+        },
+        "osType": {
+          "type": "string",
+          "description": "Operating system target of the software update configuration triggered this run",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": false,
+          "description": "Start time of the software update configuration run.",
+          "readOnly": true
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true,
+          "description": "End time of the software update configuration run.",
+          "readOnly": true
+        },
+        "computerCount": {
+          "type": "integer",
+          "description": "Number of computers in the software update configuration run.",
+          "readOnly": true
+        },
+        "failedCount": {
+          "type": "integer",
+          "description": "Number of computers with failed status.",
+          "readOnly": true
+        },
+        "creationTime": {
+          "type": "string",
+          "description": "Creation time of the resource, which only appears in the response.",
+          "format": "date-time",
+          "x-nullable": false,
+          "readOnly": true
+        },
+        "createdBy": {
+          "type": "string",
+          "description": "CreatedBy property, which only appears in the response.",
+          "readOnly": true
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "description": "Last time resource was modified, which only appears in the response.",
+          "format": "date-time",
+          "x-nullable": false,
+          "readOnly": true
+        },
+        "lastModifiedBy": {
+          "type": "string",
+          "description": "LastModifiedBy property, which only appears in the response.",
+          "readOnly": true
+        },
+        "tasks": {
+          "description": "Software update configuration tasks triggered in this run",
+          "$ref": "#/definitions/softareUpdateConfigurationRunTasks"
+        }
+      }
+    },
+    "softareUpdateConfigurationRunTasks": {
+      "description": "Software update configuration run tasks model.",
+      "type": "object",
+      "properties": {
+        "preTask": {
+          "description": "Pre task properties.",
+          "$ref": "#/definitions/softareUpdateConfigurationRunTaskProperties"
+        },
+        "postTask": {
+          "description": "Post task properties.",
+          "$ref": "#/definitions/softareUpdateConfigurationRunTaskProperties"
+        }
+      }
+    },
+    "softareUpdateConfigurationRunTaskProperties": {
+      "type": "object",
+      "description": "Task properties of the software update configuration.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "The status of the task."
+        },
+        "source": {
+          "type": "string",
+          "description": "The name of the source of the task."
+        },
+        "jobId": {
+          "type": "string",
+          "description": "The job id of the task."
+        }
+      }
+    },
+    "updateConfigurationNavigation": {
+      "description": "Software update configuration Run Navigation model.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the software update configuration triggered the software update configuration run",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "softwareUpdateConfigurationRunListResult": {
+      "description": "result of listing all software update configuration runs",
+      "properties": {
+        "value": {
+          "description": "outer object returned when listing all software update configuration runs",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/softwareUpdateConfigurationRun"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "link to next page of results."
+        }
+      }
+    }
+  }
+}

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
@@ -45,7 +45,7 @@
         ],
         "description": "Get a single software update configuration run by ID.",
         "externalDocs": {
-          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationrunoperations"
+          "url": "https://docs.microsoft.com/dotnet/api/microsoft.azure.management.automation.softwareupdateconfigurationrunsoperationsextensions"
         },
         "x-ms-examples": {
           "Get software update configuration runs by ID": {
@@ -101,7 +101,7 @@
         ],
         "description": "Return list of software update configuration runs.",
         "externalDocs": {
-          "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
+          "url": "https://docs.microsoft.com/dotnet/api/microsoft.azure.management.automation.softwareupdateconfigurationrunsoperationsextensions"
         },
         "x-ms-examples": {
           "List software update configuration machine runs": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
@@ -6,7 +6,7 @@
     "contact": {
       "name": "Mohamed Enein"
     },
-    "version": "2017-05-15-preview",
+    "version": "2019-06-01",
     "x-ms-code-generation-settings": {
       "useDateTimeOffset": true
     }
@@ -166,6 +166,9 @@
               "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
         }
       }
     }

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
@@ -265,25 +265,25 @@
         },
         "tasks": {
           "description": "Software update configuration tasks triggered in this run",
-          "$ref": "#/definitions/softareUpdateConfigurationRunTasks"
+          "$ref": "#/definitions/softwareUpdateConfigurationRunTasks"
         }
       }
     },
-    "softareUpdateConfigurationRunTasks": {
+    "softwareUpdateConfigurationRunTasks": {
       "description": "Software update configuration run tasks model.",
       "type": "object",
       "properties": {
         "preTask": {
           "description": "Pre task properties.",
-          "$ref": "#/definitions/softareUpdateConfigurationRunTaskProperties"
+          "$ref": "#/definitions/softwareUpdateConfigurationRunTaskProperties"
         },
         "postTask": {
           "description": "Post task properties.",
-          "$ref": "#/definitions/softareUpdateConfigurationRunTaskProperties"
+          "$ref": "#/definitions/softwareUpdateConfigurationRunTaskProperties"
         }
       }
     },
-    "softareUpdateConfigurationRunTaskProperties": {
+    "softwareUpdateConfigurationRunTaskProperties": {
       "type": "object",
       "description": "Task properties of the software update configuration.",
       "properties": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
@@ -2,10 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Update Management API",
-    "description": "APIs for managing software update configurations.",
-    "contact": {
-      "name": "Mohamed Enein"
-    },
+    "description": "APIs for managing software update configuration runs.",
     "version": "2019-06-01",
     "x-ms-code-generation-settings": {
       "useDateTimeOffset": true
@@ -46,12 +43,12 @@
         "tags": [
           "Software Update Configuration Run"
         ],
-        "description": "Get a single software update configuration Run by Id.",
+        "description": "Get a single software update configuration run by ID.",
         "externalDocs": {
           "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationrunoperations"
         },
         "x-ms-examples": {
-          "Get software update configuration runs by Id": {
+          "Get software update configuration runs by ID": {
             "$ref": "./examples/softwareUpdateConfigurationRun/getSoftwareUpdateConfigurationRunById.json"
           }
         },
@@ -68,7 +65,7 @@
           },
           {
             "name": "softwareUpdateConfigurationRunId",
-            "description": "The Id of the software update configuration run.",
+            "description": "The ID of the software update configuration run.",
             "type": "string",
             "required": true,
             "in": "path",
@@ -83,7 +80,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A single software update configuration Run.",
+            "description": "A single software update configuration run.",
             "schema": {
               "$ref": "#/definitions/softwareUpdateConfigurationRun"
             }
@@ -102,7 +99,7 @@
         "tags": [
           "Software Update Configuration Run"
         ],
-        "description": "Return list of software update configuration runs",
+        "description": "Return list of software update configuration runs.",
         "externalDocs": {
           "url": "http://aka.ms/azureautomationsdk/softwareupdateconfigurationoperations"
         },
@@ -136,21 +133,21 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'"
+            "description": "The filter to apply on the operation. You can use the following filters: 'properties/osType', 'properties/status', 'properties/startTime', and 'properties/softwareUpdateConfiguration/name'."
           },
           {
             "name": "$skip",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Number of entries you skip before returning results"
+            "description": "Number of entries you skip before returning results."
           },
           {
             "name": "$top",
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Maximum number of entries returned in the results collection"
+            "description": "Maximum number of entries returned in the results collection."
           }
         ],
         "responses": {
@@ -175,7 +172,7 @@
   },
   "definitions": {
     "softwareUpdateConfigurationRun": {
-      "description": "Software update configuration Run properties.",
+      "description": "Software update configuration run properties.",
       "x-ms-azure-resource": false,
       "type": "object",
       "properties": {
@@ -187,11 +184,11 @@
         "id": {
           "readOnly": true,
           "type": "string",
-          "description": "Resource Id of the software update configuration run"
+          "description": "Resource ID of the software update configuration run."
         },
         "properties": {
           "x-ms-client-flatten": true,
-          "description": "Software update configuration Run properties.",
+          "description": "Software update configuration run properties.",
           "$ref": "#/definitions/softwareUpdateConfigurationRunProperties"
         }
       }
@@ -200,7 +197,7 @@
       "description": "Software update configuration properties.",
       "properties": {
         "softwareUpdateConfiguration": {
-          "description": "software update configuration triggered this run",
+          "description": "Software update configuration triggered this run.",
           "$ref": "#/definitions/updateConfigurationNavigation"
         },
         "status": {
@@ -300,7 +297,7 @@
         },
         "jobId": {
           "type": "string",
-          "description": "The job id of the task."
+          "description": "The job ID of the task."
         }
       }
     },
@@ -309,17 +306,17 @@
       "type": "object",
       "properties": {
         "name": {
-          "description": "Name of the software update configuration triggered the software update configuration run",
+          "description": "Name of the software update configuration triggered the software update configuration run.",
           "type": "string",
           "readOnly": true
         }
       }
     },
     "softwareUpdateConfigurationRunListResult": {
-      "description": "result of listing all software update configuration runs",
+      "description": "Result of listing all software update configuration runs.",
       "properties": {
         "value": {
-          "description": "outer object returned when listing all software update configuration runs",
+          "description": "Outer object returned when listing all software update configuration runs.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/softwareUpdateConfigurationRun"
@@ -327,7 +324,7 @@
         },
         "nextLink": {
           "type": "string",
-          "description": "link to next page of results."
+          "description": "Link to next page of results."
         }
       }
     }

--- a/specification/automation/resource-manager/readme.md
+++ b/specification/automation/resource-manager/readme.md
@@ -25,7 +25,7 @@ These are the global settings for the Automation API.
 title: AutomationClient
 description: Automation Client
 openapi-type: arm
-tag: package-2018-06-preview
+tag: package-2019-06
 ```
 
 ### Tag: package-2015-10
@@ -154,6 +154,41 @@ input-file:
 - Microsoft.Automation/stable/2018-01-15/dscNodeCounts.json
 - Microsoft.Automation/stable/2018-06-30/runbook.json
 - Microsoft.Automation/stable/2018-06-30/python2package.json
+```
+
+### Tag: package-2019-06
+
+These settings apply only when `--tag=package-2019-06` is specified on the command line.
+
+``` yaml $(tag) == 'package-2019-06'
+input-file:
+- Microsoft.Automation/stable/2015-10-31/account.json
+- Microsoft.Automation/stable/2015-10-31/certificate.json
+- Microsoft.Automation/stable/2015-10-31/connection.json
+- Microsoft.Automation/stable/2015-10-31/connectionType.json
+- Microsoft.Automation/stable/2015-10-31/credential.json
+- Microsoft.Automation/stable/2015-10-31/dscConfiguration.json
+- Microsoft.Automation/stable/2015-10-31/hybridRunbookWorkerGroup.json
+- Microsoft.Automation/stable/2015-10-31/jobSchedule.json
+- Microsoft.Automation/stable/2015-10-31/linkedWorkspace.json
+- Microsoft.Automation/stable/2015-10-31/module.json
+- Microsoft.Automation/stable/2015-10-31/schedule.json
+- Microsoft.Automation/stable/2015-10-31/variable.json
+- Microsoft.Automation/stable/2015-10-31/webhook.json
+- Microsoft.Automation/stable/2015-10-31/watcher.json
+- Microsoft.Automation/preview/2017-05-15-preview/sourceControl.json
+- Microsoft.Automation/preview/2017-05-15-preview/sourceControlSyncJob.json
+- Microsoft.Automation/preview/2017-05-15-preview/sourceControlSyncJobStreams.json
+- Microsoft.Automation/preview/2017-05-15-preview/job.json
+- Microsoft.Automation/stable/2018-01-15/dscNode.json
+- Microsoft.Automation/stable/2018-01-15/dscCompilationJob.json
+- Microsoft.Automation/stable/2018-01-15/dscNodeConfiguration.json
+- Microsoft.Automation/stable/2018-01-15/dscNodeCounts.json
+- Microsoft.Automation/stable/2018-06-30/runbook.json
+- Microsoft.Automation/stable/2018-06-30/python2package.json
+- Microsoft.Automation/stable/2019-06-01/softwareUpdateConfiguration.json
+- Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationRun.json
+- Microsoft.Automation/stable/2019-06-01/softwareUpdateConfigurationMachineRun.json
 ```
 
 ### Tag: package-2020-01-13-preview


### PR DESCRIPTION
This PR adds a new GA Automation API version for Update Management resources. The new API version adds a paged response when listing software update configurations. It also includes fixes to the description text and the response schema for listing software update configurations.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
