### PR TITLE
Use node.js 10.16.3 in Network validation

### DIFF
--- a/.azure-pipelines/NetworkValidation.yml
+++ b/.azure-pipelines/NetworkValidation.yml
@@ -14,7 +14,7 @@ jobs:
     displayName: Bypass Strong Name validation
   - task: NodeTool@0
     inputs:
-      versionSpec: 10.x
+      versionSpec: '10.16.3'
     displayName: Install Node.js
   - script: npm install autorest -g
     displayName: Install autorest


### PR DESCRIPTION
General guideline for using AutoRest was to use node.js 10 LTS. But yesterday node.js 10.17.0 was released which seems to be incompatible. This PR updates pipeline config to use 10.16.3 which doesn't cause AutoRest errors.

Example of an error with 10.17.0:
```
PS C:\Users\v-anevse> autorest --version
AutoRest code generation utility [version: 2.0.4283; node: v10.17.0]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest


Showing All Installed Extensions

 Type       Extension Name                           Version      Location
 core       @microsoft.azure/autorest-core           2.0.4399     C:\Users\v-anevse\.autorest\@microsoft.azure_autorest-core@2.0.4399
 core       @microsoft.azure/autorest-core           2.0.4405     C:\Users\v-anevse\.autorest\@microsoft.azure_autorest-core@2.0.4405
 core       @microsoft.azure/autorest-core           3.0.5537     C:\Users\v-anevse\.autorest\@microsoft.azure_autorest-core@3.0.5537
 extension  @microsoft.azure/autorest.azureresourceschema 2.0.29       C:\Users\v-anevse\.autorest\@microsoft.azure_autorest.azureresourceschema@2.0.29
 extension  @microsoft.azure/autorest.csharp-v2      2.0.433      C:\Users\v-anevse\.autorest\@microsoft.azure_autorest.csharp-v2@2.0.433
 extension  @microsoft.azure/autorest.csharp         2.3.82       C:\Users\v-anevse\.autorest\@microsoft.azure_autorest.csharp@2.3.82
 extension  @microsoft.azure/autorest.modeler        2.3.45       C:\Users\v-anevse\.autorest\@microsoft.azure_autorest.modeler@2.3.45
 extension  @microsoft.azure/autorest.modeler        2.3.55       C:\Users\v-anevse\.autorest\@microsoft.azure_autorest.modeler@2.3.55
 extension  @microsoft.azure/autorest.powershell     2.0.678      C:\Users\v-anevse\.autorest\@microsoft.azure_autorest.powershell@2.0.678
 extension  @microsoft.azure/autorest.remodeler      2.0.382      C:\Users\v-anevse\.autorest\@microsoft.azure_autorest.remodeler@2.0.382


Failure:
TypeError: volume[member].bind is not a function
TypeError: volume[member].bind is not a function
    at patchFilesystem (C:\Users\v-anevse\AppData\Roaming\npm\node_modules\autorest\dist\static-loader.js:277:43)
    at C:\Users\v-anevse\AppData\Roaming\npm\node_modules\autorest\dist\static-loader.js:281:18
    at Object.global.staticloader.undo (C:\Users\v-anevse\AppData\Roaming\npm\node_modules\autorest\dist\static-loader.js:163:7)
    at process.exit.n [as exit] (C:\Users\v-anevse\AppData\Roaming\npm\node_modules\autorest\dist\static-loader.js:170:27)
    at main (C:\Users\v-anevse\AppData\Roaming\npm\node_modules\autorest\dist\app.js:157:21)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:3440) UnhandledPromiseRejectionWarning: Error: EBADF: bad file descriptor, close
    at Object.closeSync (fs.js:403:3)
    at StaticVolumeFile.shutdown (C:\Users\v-anevse\AppData\Roaming\npm\node_modules\autorest\dist\static-loader.js:352:10)
    at StaticFilesystem.shutdown (C:\Users\v-anevse\AppData\Roaming\npm\node_modules\autorest\dist\static-loader.js:406:17)
    at process.exit.n [as exit] (C:\Users\v-anevse\AppData\Roaming\npm\node_modules\autorest\dist\static-loader.js:169:11)
    at main (C:\Users\v-anevse\AppData\Roaming\npm\node_modules\autorest\dist\app.js:239:17)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:3440) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:3440) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```