### PR TITLE
added missing part from 2019-08-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/examples/ManagedClustersRotateClusterCertificates.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/examples/ManagedClustersRotateClusterCertificates.json
@@ -1,0 +1,12 @@
+{
+  "parameters": {
+    "api-version": "2019-10-01",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1"
+  },
+  "responses": {
+    "202": {},
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/managedClusters.json
@@ -921,6 +921,50 @@
           }
         }
       }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/rotateClusterCertificates": {
+      "post": {
+        "tags": [
+          "ManagedClusters"
+        ],
+        "operationId": "ManagedClusters_RotateClusterCertificates",
+        "summary": "Rotate certificates of a managed cluster.",
+        "description": "Rotate certificates of a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceNameParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "204": {
+            "description": "NoContent"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed. If the cluster doesn't exist, 404 (Not found) is returned.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Rotate Cluster Certificates": {
+            "$ref": "./examples/ManagedClustersRotateClusterCertificates.json"
+          }
+        }
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
During SDK generation I have noticed that Rotate Certificates API was added to 2019-08-01 in one PR while new API swagger 2019-10-01 was merged without that new API.
verified with the team that this should be also included in 2019-10-01