### PR TITLE
Fixed misnamed sku in examples.

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresCreate.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresCreate.json
@@ -7,7 +7,7 @@
     "configStoreCreationParameters": {
       "location": "westus",
       "sku": {
-        "name": "Basic"
+        "name": "Free"
       },
       "tags": {
         "myTag": "myTagValue"
@@ -24,7 +24,7 @@
           "endpoint": "https://contoso.azconfig.io"
         },
         "sku": {
-          "name": "Basic"
+          "name": "Free"
         },
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",
@@ -43,7 +43,7 @@
           "endpoint": "https://contoso.azconfig.io"
         },
         "sku": {
-          "name": "Basic"
+          "name": "Free"
         },
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresCreateWithIdentity.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresCreateWithIdentity.json
@@ -7,7 +7,7 @@
     "configStoreCreationParameters": {
       "location": "westus",
       "sku": {
-        "name": "Basic"
+        "name": "Free"
       },
       "tags": {
         "myTag": "myTagValue"
@@ -30,7 +30,7 @@
           "endpoint": "https://contoso.azconfig.io"
         },
         "sku": {
-          "name": "Basic"
+          "name": "Free"
         },
         "identity": {
           "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
@@ -60,7 +60,7 @@
           "endpoint": "https://contoso.azconfig.io"
         },
         "sku": {
-          "name": "Basic"
+          "name": "Free"
         },
         "identity": {
           "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresGet.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresGet.json
@@ -15,7 +15,7 @@
           "endpoint": "https://contoso.azconfig.io"
         },
         "sku": {
-          "name": "Basic"
+          "name": "Free"
         },
         "identity": {
           "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresList.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresList.json
@@ -15,7 +15,7 @@
               "endpoint": "https://contoso.azconfig.io"
             },
             "sku": {
-              "name": "Basic"
+              "name": "Free"
             },
             "identity": {
               "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
@@ -35,7 +35,7 @@
               "endpoint": "https://contoso2.azconfig.io"
             },
             "sku": {
-              "name": "Basic"
+              "name": "Free"
             },
             "identity": {
               "principalId": "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC",

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresListByResourceGroup.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/examples/ConfigurationStoresListByResourceGroup.json
@@ -16,7 +16,7 @@
               "endpoint": "https://contoso.azconfig.io"
             },
             "sku": {
-              "name": "Basic"
+              "name": "Free"
             },
             "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
             "name": "contoso",
@@ -31,7 +31,7 @@
               "endpoint": "https://contoso2.azconfig.io"
             },
             "sku": {
-              "name": "Basic"
+              "name": "Free"
             },
             "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso2",
             "name": "contoso2",


### PR DESCRIPTION
The examples in the Microsoft.AppConfiguration 2019-10-01 API version use an incorrect sku name. The "Basic" sku should actually be called "Free".