### PR TITLE
Remove api-version for composite-v3 in golang

### DIFF
--- a/specification/sql/resource-manager/readme.go.md
+++ b/specification/sql/resource-manager/readme.go.md
@@ -15,21 +15,11 @@ From api-version 2017-10 and onwards, only pure package versions should be used.
 
 ``` yaml $(go) && $(multiapi)
 batch:
-  - tag: package-composite-v3
   - tag: package-pure-2018-06-preview
   - tag: package-pure-2017-10-preview
   - tag: package-2017-03-preview
   - tag: package-2015-05-preview
   - tag: package-pure-2014-04
-```
-
-#### Tag: package-composite-v3
-
-These settings apply only when `--tag=package-composite-v3 --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag) == 'package-composite-v3' && $(go)
-output-folder: $(go-sdk-folder)/services/preview/$(namespace)/mgmt/2018-06-15-preview/$(namespace)
 ```
 
 #### Tag: package-pure-2018-06-preview and go


### PR DESCRIPTION
This tag is added for internal usage. This package is not longer needed any more. And in this [pr](https://github.com/Azure/azure-rest-api-specs/pull/7349) the service team are adding newer version of swagger into this tag, which makes the api-version (2018-06-15-preview) for this package makes no sense any more.
In addition, this is a preview package, removing this tag will cause this api-version to stop receiving more update and be removed on the next major release of the go SDK.