### PR TITLE
Fixed scope assignments and some documentation

### DIFF
--- a/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/examples/ScopeAssignment/ScopeAssignmentsDelete.json
+++ b/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/examples/ScopeAssignment/ScopeAssignmentsDelete.json
@@ -2,7 +2,7 @@
   "title": "Create/Update Managed Network",
   "parameters": {
     "api-version": "2019-06-01",
-    "scope": "/subscriptions/subscriptionC",
+    "scope": "subscriptions/subscriptionC",
     "scopeAssignmentName": "subscriptionCAssignment"
   },
   "responses": {

--- a/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/examples/ScopeAssignment/ScopeAssignmentsGet.json
+++ b/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/examples/ScopeAssignment/ScopeAssignmentsGet.json
@@ -2,7 +2,7 @@
   "title": "Create/Update Managed Network",
   "parameters": {
     "api-version": "2019-06-01",
-    "scope": "/subscriptions/subscriptionC",
+    "scope": "subscriptions/subscriptionC",
     "scopeAssignmentName": "subscriptionCAssignment"
   },
   "responses": {

--- a/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/examples/ScopeAssignment/ScopeAssignmentsList.json
+++ b/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/examples/ScopeAssignment/ScopeAssignmentsList.json
@@ -2,7 +2,7 @@
   "title": "Create/Update Managed Network",
   "parameters": {
     "api-version": "2019-06-01",
-    "scope": "/subscriptions/subscriptionC"
+    "scope": "subscriptions/subscriptionC"
   },
   "responses": {
     "200": {

--- a/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/examples/ScopeAssignment/ScopeAssignmentsPut.json
+++ b/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/examples/ScopeAssignment/ScopeAssignmentsPut.json
@@ -2,7 +2,7 @@
   "title": "Create/Update Managed Network",
   "parameters": {
     "api-version": "2019-06-01",
-    "scope": "/subscriptions/subscriptionC",
+    "scope": "subscriptions/subscriptionC",
     "scopeAssignmentName": "subscriptionCAssignment",
     "parameters": {
       "properties": {

--- a/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/managedNetwork.json
+++ b/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/managedNetwork.json
@@ -330,7 +330,7 @@
         }
       }
     },
-    "/{scope}/providers/Microsoft.ManagedNetwork/scopeAssignments/{scopeAssignmentName}": {
+    "{scope}/providers/Microsoft.ManagedNetwork/scopeAssignments/{scopeAssignmentName}": {
       "get": {
         "tags": [
           "ScopeAssignments"

--- a/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/managedNetwork.json
+++ b/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/managedNetwork.json
@@ -330,7 +330,7 @@
         }
       }
     },
-    "{scope}/providers/Microsoft.ManagedNetwork/scopeAssignments/{scopeAssignmentName}": {
+    "/{scope}/providers/Microsoft.ManagedNetwork/scopeAssignments/{scopeAssignmentName}": {
       "get": {
         "tags": [
           "ScopeAssignments"
@@ -398,7 +398,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The base resource of the scope assignment to create. The scope can be any REST resource instance. For example, use '/subscriptions/{subscription-id}/' for a subscription, '/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}' for a resource group, and '/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/providers/{resource-provider}/{resource-type}/{resource-name}' for a resource.",
+            "description": "The base resource of the scope assignment to create. The scope can be any REST resource instance. For example, use 'subscriptions/{subscription-id}' for a subscription, 'subscriptions/{subscription-id}/resourceGroups/{resource-group-name}' for a resource group, and 'subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/providers/{resource-provider}/{resource-type}/{resource-name}' for a resource.",
             "x-ms-skip-url-encoding": true
           },
           {
@@ -479,7 +479,7 @@
         }
       }
     },
-    "{scope}/providers/Microsoft.ManagedNetwork/scopeAssignments": {
+    "/{scope}/providers/Microsoft.ManagedNetwork/scopeAssignments": {
       "get": {
         "tags": [
           "ScopeAssignments"

--- a/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/managedNetwork.json
+++ b/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/managedNetwork.json
@@ -479,7 +479,7 @@
         }
       }
     },
-    "/{scope}/providers/Microsoft.ManagedNetwork/scopeAssignments": {
+    "{scope}/providers/Microsoft.ManagedNetwork/scopeAssignments": {
       "get": {
         "tags": [
           "ScopeAssignments"

--- a/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/managedNetwork.json
+++ b/specification/managednetwork/resource-manager/Microsoft.ManagedNetwork/preview/2019-06-01-preview/managedNetwork.json
@@ -1469,7 +1469,7 @@
         "provisioningState": {
           "type": "string",
           "readOnly": true,
-          "description": "Provisioning state of the ManagedNetwork resource. Possible values are: 'Updating', 'Deleting', and 'Failed'.",
+          "description": "Provisioning state of the ManagedNetwork resource.",
           "enum": [
             "Updating",
             "Deleting",

--- a/specification/managednetwork/resource-manager/readme.cli.md
+++ b/specification/managednetwork/resource-manager/readme.cli.md
@@ -4,13 +4,51 @@ These settings apply only when `--cli` is specified on the command line.
 
 ``` yaml $(cli)
 cli:
-  cli-name: managednetwork
+  cli-name: managed-network
   namespace: azure.mgmt.managednetwork
   package-name: azure-mgmt-managednetwork
-  debug: true
   cmd-override:
-    "^.*[/]microsoft.managednetwork/scopeassignments([/][^/]*)?$": "managednetwork scope-assignment"
+    "^.*[/]microsoft.managednetwork/scopeassignments([/][^/]*)?$": "managed-network scope-assignment"
+    "^.*[/]managednetworkgroups([/][^/]*)?$": "managed-network group"
+    "^.*[/]managednetworkpeeringpolicies([/][^/]*)?$": "managed-network peering-policy"
+  option-override:
+    "scope_management_groups_id":
+      name: scope_management_groups
+    "scope_subscriptions_id":
+      name: scope_subscriptions
+    "scope_virtual_networks_id":
+      name: scope_virtual_networks
+    "scope_subnets_id":
+      name: scope_subnets
+    "management_groups_id":
+      name: management_groups
+    "subscriptions_id":
+      name: subscriptions
+    "virtual_networks_id":
+      name: virtual_networks
+    "subnets_id":
+      name: subnets
+    "spokes_id":
+      name: spokes
+    "mesh_id":
+      name: mesh
   flatten-all: true
   test-setup:
-    - name: Create or Update a service with all parameters
+    - name: ManagedNetworksPut
+    - name: ManagedNetworksGet
+    - name: ManagedNetworksListByResourceGroup
+    - name: ManagedNetworksListBySubscription
+    - name: ScopeAssignmentsPut
+    - name: ScopeAssignmentsGet
+    - name: ScopeAssignmentsList
+    - name: ManagementNetworkGroupsPut
+    - name: ManagementNetworkGroupsGet
+    - name: ManagedNetworksGroupsListByManagedNetwork
+    - name: ManagedNetworkPeeringPoliciesPut
+    - name: ManagedNetworkPeeringPoliciesGet
+    - name: ManagedNetworkPeeringPoliciesListByManagedNetwork
+    - name: ManagedNetworkPeeringPoliciesDelete
+    - name: ScopeAssignmentsDelete
+    - name: ManagementNetworkGroupsDelete
+    - name: ManagedNetworksDelete
 ```

--- a/specification/managednetwork/resource-manager/readme.cli.md
+++ b/specification/managednetwork/resource-manager/readme.cli.md
@@ -35,16 +35,16 @@ cli:
   flatten-all: true
   test-setup:
     - name: ManagedNetworksPut
+    - name: ManagementNetworkGroupsPut
+    - name: ScopeAssignmentsPut
+    - name: ManagedNetworkPeeringPoliciesPut
     - name: ManagedNetworksGet
     - name: ManagedNetworksListByResourceGroup
     - name: ManagedNetworksListBySubscription
-    - name: ScopeAssignmentsPut
     - name: ScopeAssignmentsGet
     - name: ScopeAssignmentsList
-    - name: ManagementNetworkGroupsPut
     - name: ManagementNetworkGroupsGet
     - name: ManagedNetworksGroupsListByManagedNetwork
-    - name: ManagedNetworkPeeringPoliciesPut
     - name: ManagedNetworkPeeringPoliciesGet
     - name: ManagedNetworkPeeringPoliciesListByManagedNetwork
     - name: ManagedNetworkPeeringPoliciesDelete

--- a/specification/web/resource-manager/readme.cli.md
+++ b/specification/web/resource-manager/readme.cli.md
@@ -9,4 +9,5 @@ cli:
   namespace: azure.mgmt.web
   test-setup:
     - name: "Create Or Update App Service plan"
+    - name: "List operations"
 ```


### PR DESCRIPTION
Fixed scope in examples and in documentation to match common practice.
if URL is defined like "/{scope}/...." then scope should not contain leading and trailing slashes. otherwise we will end up with double // in the url.