### PR TITLE
[Datafactory] Enable SQL DW Copy Command

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -820,6 +820,7 @@ mariadb
 Marketo
 marketplaceagreementsapi
 marketplaceordering
+MAXERRORS
 maximumblobsize
 maxmemory
 maxpagesize

--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/Pipeline.json
@@ -3222,6 +3222,14 @@
           "description": "Specifies PolyBase-related settings when allowPolyBase is true.",
           "$ref": "#/definitions/PolybaseSettings"
         },
+        "allowCopyCommand": {
+          "type": "object",
+          "description": "Indicates to use Copy Command to copy data into SQL Data Warehouse. Type: boolean (or Expression with resultType boolean)."
+        },
+        "copyCommandSettings": {
+          "description": "Specifies Copy Command related settings when allowCopyCommand is true.",
+          "$ref": "#/definitions/DWCopyCommandSettings"
+        },
         "tableOption": {
           "type": "object",
           "description": "The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression with resultType string)."
@@ -3263,6 +3271,40 @@
       "x-ms-enum": {
         "name": "PolybaseSettingsRejectType",
         "modelAsString": true
+      }
+    },
+    "DWCopyCommandSettings": {
+      "description": "DW Copy Command settings.",
+      "type": "object",
+      "properties": {
+        "defaultValues": {
+          "type": "array",
+          "description": "Specifies the default values for each target column in SQL DW. The default values in the property overwrite the DEFAULT constraint set in the DB, and identity column cannot have a default value. Type: array of objects (or Expression with resultType array of objects).",
+          "items": {
+            "$ref": "#/definitions/DWCopyCommandDefaultValue"
+          }
+        },
+        "additionalOptions": {
+          "type": "object",
+          "description": "Additional options directly passed to SQL DW in Copy Command. Type: key value pairs (value should be string type) (or Expression with resultType object). Example: \"additionalOptions\": { \"MAXERRORS\": \"1000\", \"DATEFORMAT\": \"'ymd'\" }",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DWCopyCommandDefaultValue": {
+      "description": "Default value.",
+      "type": "object",
+      "properties": {
+        "columnName": {
+          "type": "object",
+          "description": "Column name. Type: object (or Expression with resultType string)."
+        },
+        "defaultValue": {
+          "type": "object",
+          "description": "The default value of the column. Type: object (or Expression with resultType string)."
+        }
       }
     },
     "LogStorageSettings": {


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
