### PR TITLE
remove waitForAzureAPIBoard label for SLA-bot

### DIFF
--- a/.github/sla.yml
+++ b/.github/sla.yml
@@ -4,7 +4,7 @@
     repoWhitelist:
       - Azure/azure-rest-api-specs
     args:
-      booleanFilterExpression: "!(WaitForARMFeedback||WaitingForAzureAPIBoard||(DoNotMerge&&(ARMSignedOff||Approved)))"
+      booleanFilterExpression: "!(WaitForARMFeedback||(DoNotMerge&&(ARMSignedOff||Approved)))"
       limit: 48h
       message: '<p> Dear Swagger reviewer, <br> <br> Please response to the PR ${PR_URL}. The PR isn''t updated in 48 hours. <br> <hr /> <br> Quick info. <ul> <li>If no response from ARM review board, please send email to armapireview@microsoft.com.</li> <li>If need immediate ARM review, please get ARM review oncall contact point from ICM https://icm.ad.msft.net/imp/v3/oncall/current under Service "Azure Resource Manager" and Team "RP Manifest Approvers"</li> <li>If no response from Azure API review board, please send email to azureapirbcore@microsoft.com.</li> <li>If you have problem to fix CI task errors, please send email to Visual Studio China Swagger and Tool team vscswagger@microsoft.com.</li> <li>If you want to opt out from Swagger reviewing for out of office period, please set vacation date at https://inframonitorweb1.azurewebsites.net/Home/MyView.</li> <li>Pls refer to <a href="onenote:https://microsoft.sharepoint.com/teams/IoTToolingTeam/SiteAssets/IoT Tooling Team Notebook/Azure Management Experience - transition.one#Swagger%20reviewing%20process§ion-id={ECE847C4-519B-4448-A1A0-8E84A7EFE8AB}&page-id={F6E345FE-46E1-420F-B837-6BF76167DE05}&end">Swagger review process (onenote)</a> for more about Swagger review process.</li> </ul> Best regards, <br> Azure Management Experience </p>'
       subject: "Action Required: Please respond to PR ${PR_URL}"
@@ -16,7 +16,7 @@
     repoWhitelist:
       - Azure/azure-rest-api-specs-pr
     args:
-      booleanFilterExpression: "!(WaitForARMFeedback||WaitingForAzureAPIBoard||Approved-OkToMerge||(DoNotMerge&&(ARMSignedOff||Approved))"
+      booleanFilterExpression: "!(WaitForARMFeedback||Approved-OkToMerge||(DoNotMerge&&(ARMSignedOff||Approved))"
       limit: 48h
       message: '<p> Dear Swagger reviewer, <br> <br> Please response to the PR ${PR_URL}. The PR isn''t updated in 48 hours. <br> <hr /> <br> Quick info. <ul> <li>If no response from ARM review board, please send email to armapireview@microsoft.com.</li> <li>If need immediate ARM review, please get ARM review oncall contact point from ICM https://icm.ad.msft.net/imp/v3/oncall/current under Service "Azure Resource Manager" and Team "RP Manifest Approvers"</li> <li>If no response from Azure API review board, please send email to azureapirbcore@microsoft.com.</li> <li>If you have problem to fix CI task errors, please send email to Visual Studio China Swagger and Tool team vscswagger@microsoft.com.</li> <li>If you want to opt out from Swagger reviewing for out of office period, please set vacation date at https://inframonitorweb1.azurewebsites.net/Home/MyView.</li> <li>Pls refer to <a href="onenote:https://microsoft.sharepoint.com/teams/IoTToolingTeam/SiteAssets/IoT Tooling Team Notebook/Azure Management Experience - transition.one#Swagger%20reviewing%20process§ion-id={ECE847C4-519B-4448-A1A0-8E84A7EFE8AB}&page-id={F6E345FE-46E1-420F-B837-6BF76167DE05}&end">Swagger review process (onenote)</a> for more about Swagger review process.</li> </ul> Best regards, <br> Azure Management Experience </p>'
       subject: "Action Required: Please respond to PR ${PR_URL}"


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
