### PR TITLE
AKS: making the `count` field optional

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/examples/AgentPools_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/examples/AgentPools_Update.json
@@ -51,7 +51,7 @@
         "type": "Microsoft.ContainerService/managedClusters/agentPools",
         "name": "agentpool1",
         "properties": {
-          "provisioningState": "Creating",
+          "provisioningState": "Updating",
           "orchestratorVersion": "1.9.6",
           "count": 3,
           "enableAutoScaling": true,

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/examples/AgentPools_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/examples/AgentPools_Update.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2019-06-01",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "agentPoolName": "agentpool1",
+    "parameters": {
+      "properties": {
+        "orchestratorVersion": "",
+        "enableAutoScaling": true,
+        "minCount": 2,
+        "maxCount": 2,
+        "vmSize": "Standard_DS1_v2",
+        "osType": "Linux",
+        "nodeTaints": [
+          "Key1=Value1:NoSchedule"
+        ],
+        "scaleSetPriority": "Low",
+        "scaleSetEvictionPolicy": "Delete"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "name": "agentpool1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "orchestratorVersion": "1.9.6",
+          "enableAutoScaling": true,
+          "minCount": 2,
+          "maxCount": 2,
+          "count": 3,
+          "vmSize": "Standard_DS1_v2",
+          "maxPods": 110,
+          "osType": "Linux",
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "scaleSetPriority": "Low",
+          "scaleSetEvictionPolicy": "Delete"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "name": "agentpool1",
+        "properties": {
+          "provisioningState": "Creating",
+          "orchestratorVersion": "1.9.6",
+          "count": 3,
+          "enableAutoScaling": true,
+          "minCount": 2,
+          "maxCount": 2,
+          "vmSize": "Standard_DS1_v2",
+          "maxPods": 110,
+          "osType": "Linux",
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "scaleSetPriority": "Low",
+          "scaleSetEvictionPolicy": "Delete"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/managedClusters.json
@@ -1416,9 +1416,6 @@
           "description": "Taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule."
         }
       },
-      "required": [
-        "vmSize"
-      ],
       "description": "Properties for the container service agent pool profile."
     },
     "ManagedClusterAgentPoolProfile": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/managedClusters.json
@@ -676,6 +676,9 @@
         "x-ms-examples": {
           "Create/Update Agent Pool": {
             "$ref": "./examples/AgentPoolsCreate_Update.json"
+          },
+          "Update Agent Pool": {
+            "$ref": "./examples/AgentPools_Update.json"
           }
         }
       },
@@ -1417,8 +1420,7 @@
         }
       },
       "required": [
-        "vmSize",
-        "count"
+        "vmSize"
       ],
       "description": "Properties for the container service agent pool profile."
     },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-06-01/managedClusters.json
@@ -1339,10 +1339,7 @@
         "count": {
           "type": "integer",
           "format": "int32",
-          "maximum": 100,
-          "minimum": 1,
-          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. ",
-          "default": 1
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1."
         },
         "vmSize": {
           "$ref": "#/definitions/ContainerServiceVMSize",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/examples/AgentPools_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/examples/AgentPools_Update.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2019-08-01",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "agentPoolName": "agentpool1",
+    "parameters": {
+      "properties": {
+        "orchestratorVersion": "",
+        "enableAutoScaling": true,
+        "minCount": 2,
+        "maxCount": 2,
+        "vmSize": "Standard_DS1_v2",
+        "osType": "Linux",
+        "nodeTaints": [
+          "Key1=Value1:NoSchedule"
+        ],
+        "scaleSetPriority": "Low",
+        "scaleSetEvictionPolicy": "Delete"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "name": "agentpool1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "orchestratorVersion": "1.9.6",
+          "count": 3,
+          "enableAutoScaling": true,
+          "minCount": 2,
+          "maxCount": 2,
+          "vmSize": "Standard_DS1_v2",
+          "maxPods": 110,
+          "osType": "Linux",
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "scaleSetPriority": "Low",
+          "scaleSetEvictionPolicy": "Delete"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "name": "agentpool1",
+        "properties": {
+          "provisioningState": "Creating",
+          "orchestratorVersion": "1.9.6",
+          "count": 3,
+          "enableAutoScaling": true,
+          "minCount": 2,
+          "maxCount": 2,
+          "vmSize": "Standard_DS1_v2",
+          "maxPods": 110,
+          "osType": "Linux",
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "scaleSetPriority": "Low",
+          "scaleSetEvictionPolicy": "Delete"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/examples/AgentPools_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/examples/AgentPools_Update.json
@@ -51,7 +51,7 @@
         "type": "Microsoft.ContainerService/managedClusters/agentPools",
         "name": "agentpool1",
         "properties": {
-          "provisioningState": "Creating",
+          "provisioningState": "Updating",
           "orchestratorVersion": "1.9.6",
           "count": 3,
           "enableAutoScaling": true,

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/managedClusters.json
@@ -1383,10 +1383,7 @@
         "count": {
           "type": "integer",
           "format": "int32",
-          "maximum": 100,
-          "minimum": 1,
-          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. ",
-          "default": 1
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1."
         },
         "vmSize": {
           "$ref": "#/definitions/ContainerServiceVMSize",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/managedClusters.json
@@ -1460,9 +1460,6 @@
           "description": "Taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule."
         }
       },
-      "required": [
-        "vmSize"
-      ],
       "description": "Properties for the container service agent pool profile."
     },
     "ManagedClusterAgentPoolProfile": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-08-01/managedClusters.json
@@ -676,6 +676,9 @@
         "x-ms-examples": {
           "Create/Update Agent Pool": {
             "$ref": "./examples/AgentPoolsCreate_Update.json"
+          },
+          "Update Agent Pool": {
+            "$ref": "./examples/AgentPools_Update.json"
           }
         }
       },
@@ -1461,8 +1464,7 @@
         }
       },
       "required": [
-        "vmSize",
-        "count"
+        "vmSize"
       ],
       "description": "Properties for the container service agent pool profile."
     },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/examples/AgentPools_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/examples/AgentPools_Update.json
@@ -52,7 +52,7 @@
         "type": "Microsoft.ContainerService/managedClusters/agentPools",
         "name": "agentpool1",
         "properties": {
-          "provisioningState": "Creating",
+          "provisioningState": "Updating",
           "orchestratorVersion": "1.9.6",
           "count": 3,
           "enableAutoScaling": true,

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/examples/AgentPools_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/examples/AgentPools_Update.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "api-version": "2019-10-01",
+    "subscriptionId": "subid1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "agentPoolName": "agentpool1",
+    "parameters": {
+      "properties": {
+        "orchestratorVersion": "",
+        "count": 3,
+        "enableAutoScaling": true,
+        "minCount": 2,
+        "maxCount": 2,
+        "vmSize": "Standard_DS1_v2",
+        "osType": "Linux",
+        "nodeTaints": [
+          "Key1=Value1:NoSchedule"
+        ],
+        "scaleSetPriority": "Low",
+        "scaleSetEvictionPolicy": "Delete"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "name": "agentpool1",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "orchestratorVersion": "1.9.6",
+          "count": 3,
+          "enableAutoScaling": true,
+          "minCount": 2,
+          "maxCount": 2,
+          "vmSize": "Standard_DS1_v2",
+          "maxPods": 110,
+          "osType": "Linux",
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "scaleSetPriority": "Low",
+          "scaleSetEvictionPolicy": "Delete"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "name": "agentpool1",
+        "properties": {
+          "provisioningState": "Creating",
+          "orchestratorVersion": "1.9.6",
+          "count": 3,
+          "enableAutoScaling": true,
+          "minCount": 2,
+          "maxCount": 2,
+          "vmSize": "Standard_DS1_v2",
+          "maxPods": 110,
+          "osType": "Linux",
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "scaleSetPriority": "Low",
+          "scaleSetEvictionPolicy": "Delete"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/managedClusters.json
@@ -1383,10 +1383,7 @@
         "count": {
           "type": "integer",
           "format": "int32",
-          "maximum": 100,
-          "minimum": 1,
-          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. ",
-          "default": 1
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1."
         },
         "vmSize": {
           "$ref": "#/definitions/ContainerServiceVMSize",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/managedClusters.json
@@ -1460,9 +1460,6 @@
           "description": "Taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule."
         }
       },
-      "required": [
-        "vmSize"
-      ],
       "description": "Properties for the container service agent pool profile."
     },
     "ManagedClusterAgentPoolProfile": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2019-10-01/managedClusters.json
@@ -676,6 +676,9 @@
         "x-ms-examples": {
           "Create/Update Agent Pool": {
             "$ref": "./examples/AgentPoolsCreate_Update.json"
+          },
+          "Update Agent Pool": {
+            "$ref": "./examples/AgentPools_Update.json"
           }
         }
       },
@@ -1461,8 +1464,7 @@
         }
       },
       "required": [
-        "vmSize",
-        "count"
+        "vmSize"
       ],
       "description": "Properties for the container service agent pool profile."
     },


### PR DESCRIPTION
This PR makes the `count` field within the Node Pool Properties for a Kubernetes Cluster optional - since whilst it's Required at Creation time it's Optional during Update.

This issue becomes apparently when creating an auto-scaled Node Pool, where you must specify the initial number of nodes, from which point onwards AKS will manage the number of nodes within the Node Pool

Fixes https://github.com/Azure/azure-sdk-for-go/issues/6271