### PR TITLE
[Azure Search] Add access condition to skillset operations

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/stable/2019-05-06/searchservice.json
@@ -642,6 +642,12 @@
             "$ref": "#/parameters/ClientRequestIdParameter"
           },
           {
+            "$ref": "#/parameters/IfMatchParameter"
+          },
+          {
+            "$ref": "#/parameters/IfNoneMatchParameter"
+          },
+          {
             "$ref": "#/parameters/PreferHeaderParameter"
           },
           {
@@ -688,6 +694,12 @@
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"
+          },
+          {
+            "$ref": "#/parameters/IfMatchParameter"
+          },
+          {
+            "$ref": "#/parameters/IfNoneMatchParameter"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/track1/preview/2019-05-06-preview/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/track1/preview/2019-05-06-preview/searchservice.json
@@ -642,6 +642,12 @@
             "$ref": "#/parameters/ClientRequestIdParameter"
           },
           {
+            "$ref": "#/parameters/IfMatchParameter"
+          },
+          {
+            "$ref": "#/parameters/IfNoneMatchParameter"
+          },
+          {
             "$ref": "#/parameters/PreferHeaderParameter"
           },
           {
@@ -688,6 +694,12 @@
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"
+          },
+          {
+            "$ref": "#/parameters/IfMatchParameter"
+          },
+          {
+            "$ref": "#/parameters/IfNoneMatchParameter"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -3768,7 +3780,7 @@
         "azuresql",
         "cosmosdb",
         "azureblob",
-        "azuretable"
+        "azuretable",
       ],
       "x-ms-enum": {
         "name": "DataSourceType",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Service/track1/preview/2019-05-06-preview/searchservice.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Service/track1/preview/2019-05-06-preview/searchservice.json
@@ -3781,6 +3781,7 @@
         "cosmosdb",
         "azureblob",
         "azuretable",
+        "mysql"
       ],
       "x-ms-enum": {
         "name": "DataSourceType",
@@ -3801,6 +3802,10 @@
           {
             "value": "azuretable",
             "name": "AzureTable"
+          },
+          {
+            "value": "mysql",
+            "name": "MySql"
           }
         ]
       },


### PR DESCRIPTION
1. To the yet unshipped "track1" preview swagger and "track2" GA swagger add access condition parameters for skillset operations.
2. To "track1" preview swagger, add the MySQL data source type

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
