### PR TITLE
Change npm install to npm ci for semantic/model validation

### DIFF
--- a/.azure-pipelines/ModelValidation.yml
+++ b/.azure-pipelines/ModelValidation.yml
@@ -4,8 +4,10 @@ jobs:
     vmImage: 'Ubuntu 16.04'
   steps:
   - task: Npm@1
-    displayName: 'npm install'
+    displayName: 'npm ci'
     inputs:
+      command: custom
       verbose: false
+      customCommand: ci
   - script: 'npm run tsc && node scripts/modelValidation.js'
     displayName: 'Model Validation'

--- a/.azure-pipelines/Semantic.yml
+++ b/.azure-pipelines/Semantic.yml
@@ -4,8 +4,10 @@ jobs:
     vmImage: 'Ubuntu 16.04'
   steps:
   - task: Npm@1
-    displayName: 'npm install'
+    displayName: 'npm ci'
     inputs:
+      command: custom
       verbose: false
+      customCommand: ci
   - script: 'npm run tsc && node scripts/semanticValidation.js'
     displayName: 'Semantic Validation'


### PR DESCRIPTION
Npm install needs to be changed into npm ci as semantic/model validation relies on OAV and npm install might cause OAV to automatically download new yasway packages, so we are changing it into npm ci to ensure stability
