### PR TITLE
netapp: removing the large integer validation

### DIFF
--- a/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-05-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-05-01/netapp.json
@@ -1632,9 +1632,6 @@
           "type": "integer",
           "format": "int64",
           "description": "Maximum storage quota allowed for a file system in bytes. This is a soft quota used for alerting only. Minimum size is 100 GiB. Upper limit is 100TiB. Specified in bytes.",
-          "minimum": 107374182400,
-          "maximum": 109951162777600,
-          "default": 107374182400,
           "example": 107374182400
         },
         "exportPolicy": {

--- a/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-05-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-05-01/netapp.json
@@ -1391,10 +1391,7 @@
           "title": "size",
           "type": "integer",
           "format": "int64",
-          "description": "Provisioned size of the pool (in bytes). Allowed values are in 4TiB chunks (value must be multiply of 4398046511104).",
-          "minimum": 4398046511104,
-          "maximum": 549755813888000,
-          "default": 4398046511104
+          "description": "Provisioned size of the pool (in bytes). Allowed values are in 4TiB chunks (value must be multiply of 4398046511104)."
         },
         "serviceLevel": {
           "title": "serviceLevel",

--- a/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-06-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-06-01/netapp.json
@@ -1850,9 +1850,6 @@
           "type": "integer",
           "format": "int64",
           "description": "Maximum storage quota allowed for a file system in bytes. This is a soft quota used for alerting only. Minimum size is 100 GiB. Upper limit is 100TiB. Specified in bytes.",
-          "minimum": 107374182400,
-          "maximum": 109951162777600,
-          "default": 107374182400,
           "example": 107374182400
         },
         "exportPolicy": {

--- a/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-06-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-06-01/netapp.json
@@ -1609,9 +1609,7 @@
           "title": "size",
           "type": "integer",
           "format": "int64",
-          "description": "Provisioned size of the pool (in bytes). Allowed values are in 4TiB chunks (value must be multiply of 4398046511104).",
-          "minimum": 4398046511104,
-          "maximum": 549755813888000
+          "description": "Provisioned size of the pool (in bytes). Allowed values are in 4TiB chunks (value must be multiply of 4398046511104)."
         },
         "serviceLevel": {
           "title": "serviceLevel",

--- a/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-07-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-07-01/netapp.json
@@ -1850,9 +1850,6 @@
           "type": "integer",
           "format": "int64",
           "description": "Maximum storage quota allowed for a file system in bytes. This is a soft quota used for alerting only. Minimum size is 100 GiB. Upper limit is 100TiB. Specified in bytes.",
-          "minimum": 107374182400,
-          "maximum": 109951162777600,
-          "default": 107374182400,
           "example": 107374182400
         },
         "exportPolicy": {

--- a/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-07-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-07-01/netapp.json
@@ -1609,9 +1609,7 @@
           "title": "size",
           "type": "integer",
           "format": "int64",
-          "description": "Provisioned size of the pool (in bytes). Allowed values are in 4TiB chunks (value must be multiply of 4398046511104).",
-          "minimum": 4398046511104,
-          "maximum": 549755813888000
+          "description": "Provisioned size of the pool (in bytes). Allowed values are in 4TiB chunks (value must be multiply of 4398046511104)."
         },
         "serviceLevel": {
           "title": "serviceLevel",

--- a/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-08-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-08-01/netapp.json
@@ -1853,9 +1853,6 @@
           "type": "integer",
           "format": "int64",
           "description": "Maximum storage quota allowed for a file system in bytes. This is a soft quota used for alerting only. Minimum size is 100 GiB. Upper limit is 100TiB. Specified in bytes.",
-          "minimum": 107374182400,
-          "maximum": 109951162777600,
-          "default": 107374182400,
           "example": 107374182400
         },
         "exportPolicy": {

--- a/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-08-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/stable/2019-08-01/netapp.json
@@ -1609,9 +1609,7 @@
           "title": "size",
           "type": "integer",
           "format": "int64",
-          "description": "Provisioned size of the pool (in bytes). Allowed values are in 4TiB chunks (value must be multiply of 4398046511104).",
-          "minimum": 4398046511104,
-          "maximum": 549755813888000
+          "description": "Provisioned size of the pool (in bytes). Allowed values are in 4TiB chunks (value must be multiply of 4398046511104)."
         },
         "serviceLevel": {
           "title": "serviceLevel",


### PR DESCRIPTION
Whilst this is helpful in some situations - this means that it's not
possible to build the NetApp SDK on 32 bit platforms

Fixes:

```
6 errors occurred:
--> freebsd/arm error: exit status 2
GNUmakefile:8: recipe for target 'compile' failed
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/pools.go:72:87: constant 4398046511104 overflows int
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/volumes.go:74:99: constant 107374182400 overflows int

--> openbsd/386 error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/pools.go:72:87: constant 4398046511104 overflows int
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/volumes.go:74:99: constant 107374182400 overflows int

--> linux/386 error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/pools.go:72:87: constant 4398046511104 overflows int
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/volumes.go:74:99: constant 107374182400 overflows int

--> freebsd/386 error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/pools.go:72:87: constant 4398046511104 overflows int
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/volumes.go:74:99: constant 107374182400 overflows int

--> linux/arm error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/pools.go:72:87: constant 4398046511104 overflows int
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/volumes.go:74:99: constant 107374182400 overflows int

--> windows/386 error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/pools.go:72:87: constant 4398046511104 overflows int
vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/volumes.go:74:99: constant 107374182400 overflows int
```