### PR TITLE
Recovery Services: Generating SDK's for Golang

### DIFF
--- a/specification/recoveryservicesbackup/resource-manager/readme.go.md
+++ b/specification/recoveryservicesbackup/resource-manager/readme.go.md
@@ -13,9 +13,19 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
+  - tag: package-2019-05
   - tag: package-2017-07
   - tag: package-2016-12
   - tag: package-2016-06
+```
+
+### Tag: package-2019-05 and go
+
+These settings apply only when `--tag=package-2019-05 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2019-05' && $(go)
+output-folder: $(go-sdk-folder)/services/recoveryservices/mgmt/2019-05-13/$(namespace)
 ```
 
 ### Tag: package-2017-07 and go

--- a/specification/recoveryservicesbackup/resource-manager/readme.md
+++ b/specification/recoveryservicesbackup/resource-manager/readme.md
@@ -46,13 +46,24 @@ semantic-validator: true
 message-format: json
 ```
 
+### Tag: package-2019-05
+
+These settings apply only when `--tag=package-2019-05` is specified on the command line.
+
+``` yaml $(tag) == 'package-2019-05'
+input-file:
+- Microsoft.RecoveryServices/stable/2019-05-13/bms.json
+- Microsoft.RecoveryServices/stable/2017-07-01/bms.json
+- Microsoft.RecoveryServices/stable/2016-12-01/bms.json
+- Microsoft.RecoveryServices/stable/2016-08-10/operations.json
+```
+
 ### Tag: package-2017-07
 
 These settings apply only when `--tag=package-2017-07` is specified on the command line.
 
 ``` yaml $(tag) == 'package-2017-07'
 input-file:
-- Microsoft.RecoveryServices/stable/2019-05-13/bms.json
 - Microsoft.RecoveryServices/stable/2017-07-01/bms.json
 - Microsoft.RecoveryServices/stable/2016-12-01/bms.json
 - Microsoft.RecoveryServices/stable/2016-08-10/operations.json
@@ -141,7 +152,7 @@ See configuration in [readme.go.md](./readme.go.md)
 
 See configuration in [readme.java.md](./readme.java.md)
 
-## Multi-API/Profile support for AutoRest v3 generators 
+## Multi-API/Profile support for AutoRest v3 generators
 
 AutoRest V3 generators require the use of `--tag=all-api-versions` to select api files.
 
@@ -162,11 +173,10 @@ input-file:
 
 ```
 
-If there are files that should not be in the `all-api-versions` set, 
+If there are files that should not be in the `all-api-versions` set,
 uncomment the  `exclude-file` section below and add the file paths.
 
 ``` yaml $(tag) == 'all-api-versions'
-#exclude-file: 
+#exclude-file:
 #  - $(this-folder)/Microsoft.Example/stable/2010-01-01/somefile.json
 ```
-

--- a/specification/recoveryservicessiterecovery/resource-manager/readme.go.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.go.md
@@ -13,8 +13,18 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
+  - tag: package-2018-07
   - tag: package-2018-01
   - tag: package-2016-08
+```
+
+### Tag: package-2018-07 and go
+
+These settings apply only when `--tag=package-2018-07 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2018-07' && $(go)
+output-folder: $(go-sdk-folder)/services/recoveryservices/mgmt/2018-07-10/$(namespace)
 ```
 
 ### Tag: package-2018-01 and go


### PR DESCRIPTION
This PR generates the Go SDK for 2 Recovery Services SDK's which should allow us to support Soft Delete in https://github.com/terraform-providers/terraform-provider-azurerm/issues/4774

- Generates the `2019-05-13` SDK for Recovery Services Backup
- Generates the `2018-07-10` SDK for Recovery Services Recovery (since I noticed the Swagger was there but not being generated)

cc @pvrk