### PR TITLE
Exclude malformed swagger file

### DIFF
--- a/specification/security/resource-manager/readme.md
+++ b/specification/security/resource-manager/readme.md
@@ -212,6 +212,7 @@ These settings apply only when `--tag=package-2019-01-preview-only` is specified
 
 ``` yaml $(tag) == 'package-2019-01-preview-only'
 input-file:
+- Microsoft.Security/preview/2019-01-01-preview/automations.json
 - Microsoft.Security/preview/2019-01-01-preview/regulatoryCompliance.json
 - Microsoft.Security/preview/2019-01-01-preview/serverVulnerabilityAssessments.json
 

--- a/specification/security/resource-manager/readme.md
+++ b/specification/security/resource-manager/readme.md
@@ -59,7 +59,6 @@ These settings apply only when `--tag=package-composite-v1` is specified on the 
 
 ``` yaml $(tag) == 'package-composite-v1'
 input-file:
-- Microsoft.Security/preview/2019-01-01-preview/automations.json
 - Microsoft.Security/preview/2019-01-01-preview/subAssessments.json
 - Microsoft.Security/preview/2019-01-01-preview/regulatoryCompliance.json
 - Microsoft.Security/preview/2017-08-01-preview/pricings.json
@@ -94,7 +93,6 @@ These settings apply only when `--tag=package-composite-v2` is specified on the 
 
 ``` yaml $(tag) == 'package-composite-v2'
 input-file:
-- Microsoft.Security/preview/2019-01-01-preview/automations.json
 - Microsoft.Security/preview/2019-01-01-preview/subAssessments.json
 - Microsoft.Security/preview/2019-01-01-preview/regulatoryCompliance.json
 - Microsoft.Security/stable/2018-06-01/pricings.json
@@ -156,7 +154,6 @@ input-file:
 - Microsoft.Security/preview/2019-01-01-preview/regulatoryCompliance.json
 - Microsoft.Security/preview/2019-01-01-preview/serverVulnerabilityAssessments.json
 - Microsoft.Security/preview/2019-01-01-preview/subAssessments.json
-- Microsoft.Security/preview/2019-01-01-preview/automations.json
 
 # Needed when there is more than one input file
 override-info:


### PR DESCRIPTION
I have to exclude [this file](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/security/resource-manager/Microsoft.Security/preview/2019-01-01-preview/automations.json) from readme, because this swagger is malformed and causes problems in go SDK.

To be specific, it has a "discriminator" on line [450](https://github.com/Azure/azure-rest-api-specs/blob/3d4319ea8ac7a12a064658da7c6d2d270739ad75/specification/security/resource-manager/Microsoft.Security/preview/2019-01-01-preview/automations.json#L450), and the `discriminator-value` on line [484](https://github.com/Azure/azure-rest-api-specs/blob/3d4319ea8ac7a12a064658da7c6d2d270739ad75/specification/security/resource-manager/Microsoft.Security/preview/2019-01-01-preview/automations.json#L484) and line [500](https://github.com/Azure/azure-rest-api-specs/blob/3d4319ea8ac7a12a064658da7c6d2d270739ad75/specification/security/resource-manager/Microsoft.Security/preview/2019-01-01-preview/automations.json#L500) collide with each other, causing ambiguity by saying there are two different models but both have value of `LogicApp`