### PR TITLE
Updating service language parameters to QnA Maker APIs

### DIFF
--- a/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMaker.json
+++ b/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMaker.json
@@ -899,6 +899,12 @@
           "description": "Text string to be used as the answer in any Q-A which has no extracted answer from the document but has a hierarchy. Required when EnableHierarchicalExtraction field is set to True.",
           "maxLength": 300,
           "minLength": 1
+        },
+        "language": {
+          "type": "string",
+          "description": "Language of the knowledgebase.",
+          "maxLength": 100,
+          "minLength": 1
         }
       }
     },
@@ -1344,6 +1350,10 @@
         "lastStableVersion": {
           "type": "string",
           "description": "Latest version of runtime."
+        },
+        "language": {
+          "type": "string",
+          "description": "Language setting of runtime."
         }
       }
     }


### PR DESCRIPTION
Updating service language parameters to QnA Maker APIs. The API changes are already in production.
Description: 
1. We are adding an optional parameter "language" to **CreateKbDTO**. Some of our customers are facing issues about not being able to explicitly set a specific language and avoid incorrect classification from our language detector. This parameter provides a way for explicitly mention language while creation of a new knowledge-base. 
2. Another change in **EndpointKeysDTO** provides a method to read what is the language of underlying azure search index used in customer's endpoint. 