### PR TITLE
CreateMode is not a required parameter. Removed the tag to allow not …

### DIFF
--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/mariadb.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-preview/mariadb.json
@@ -1466,9 +1466,6 @@
     },
     "ServerPropertiesForCreate": {
       "discriminator": "createMode",
-      "required": [
-        "createMode"
-      ],
       "properties": {
         "version": {
           "$ref": "#/definitions/ServerVersion",

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-privatepreview/mariadb.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-privatepreview/mariadb.json
@@ -2026,9 +2026,6 @@
     },
     "ServerPropertiesForCreate": {
       "discriminator": "createMode",
-      "required": [
-        "createMode"
-      ],
       "properties": {
         "version": {
           "$ref": "#/definitions/ServerVersion",

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/mariadb.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/mariadb.json
@@ -1466,9 +1466,6 @@
     },
     "ServerPropertiesForCreate": {
       "discriminator": "createMode",
-      "required": [
-        "createMode"
-      ],
       "properties": {
         "version": {
           "$ref": "#/definitions/ServerVersion",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/mysql.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2017-12-01-preview/mysql.json
@@ -1659,9 +1659,6 @@
     },
     "ServerPropertiesForCreate": {
       "discriminator": "createMode",
-      "required": [
-        "createMode"
-      ],
       "properties": {
         "version": {
           "$ref": "#/definitions/ServerVersion",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2018-06-01-privatepreview/mysql.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2018-06-01-privatepreview/mysql.json
@@ -2218,9 +2218,6 @@
     },
     "ServerPropertiesForCreate": {
       "discriminator": "createMode",
-      "required": [
-        "createMode"
-      ],
       "properties": {
         "version": {
           "$ref": "#/definitions/ServerVersion",

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/stable/2017-12-01/mysql.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/stable/2017-12-01/mysql.json
@@ -1463,9 +1463,6 @@
     },
     "ServerPropertiesForCreate": {
       "discriminator": "createMode",
-      "required": [
-        "createMode"
-      ],
       "properties": {
         "version": {
           "$ref": "#/definitions/ServerVersion",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/postgresql.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2017-12-01-preview/postgresql.json
@@ -1662,9 +1662,6 @@
     },
     "ServerPropertiesForCreate": {
       "discriminator": "createMode",
-      "required": [
-        "createMode"
-      ],
       "properties": {
         "version": {
           "$ref": "#/definitions/ServerVersion",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2017-12-01/postgresql.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2017-12-01/postgresql.json
@@ -1466,9 +1466,6 @@
     },
     "ServerPropertiesForCreate": {
       "discriminator": "createMode",
-      "required": [
-        "createMode"
-      ],
       "properties": {
         "version": {
           "$ref": "#/definitions/ServerVersion",


### PR DESCRIPTION
…passing the param

This is to fix for the issue reported https://github.com/Azure/azure-resource-manager-schemas/issues/812.

Service never requires this to be a required input. Instead service has default value. Fix the swagger file to reflect the same.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
