### PR TITLE
Fix Microsoft.Authorization/policy* help generation issues

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/examples/createOrUpdatePolicyDefinitionAdvancedParams.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/examples/createOrUpdatePolicyDefinitionAdvancedParams.json
@@ -1,0 +1,117 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "EventHubDiagnosticLogs",
+    "api-version": "2019-09-01",
+    "parameters": {
+      "properties": {
+        "mode": "Indexed",
+        "displayName": "Event Hubs should have diagnostic logging enabled",
+        "description": "Audit enabling of logs and retain them up to a year. This enables recreation of activity trails for investigation purposes when a security incident occurs or your network is compromised",
+        "metadata": {
+          "category": "Event Hub"
+        },
+        "policyRule": {
+          "if": {
+            "field": "type",
+            "equals": "Microsoft.EventHub/namespaces"
+          },
+          "then": {
+            "effect": "AuditIfNotExists",
+            "details": {
+              "type": "Microsoft.Insights/diagnosticSettings",
+              "existenceCondition": {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.enabled",
+                    "equals": "true"
+                  },
+                  {
+                    "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.days",
+                    "equals": "[parameters('requiredRetentionDays')]"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "parameters": {
+          "requiredRetentionDays": {
+            "type": "Integer",
+            "defaultValue": 365,
+            "allowedValues": [
+              0,
+              30,
+              90,
+              180,
+              365
+            ],
+            "metadata": {
+              "displayName": "Required retention (days)",
+              "description": "The required diagnostic logs retention in days"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "type": "Microsoft.Authorization/policyDefinitions",
+        "name": "ResourceNaming",
+        "properties": {
+          "mode": "Indexed",
+          "displayName": "Event Hubs should have diagnostic logging enabled",
+          "description": "Audit enabling of logs and retain them up to a year. This enables recreation of activity trails for investigation purposes when a security incident occurs or your network is compromised",
+          "metadata": {
+            "category": "Event Hub"
+          },
+          "policyRule": {
+            "if": {
+              "field": "type",
+              "equals": "Microsoft.EventHub/namespaces"
+            },
+            "then": {
+              "effect": "AuditIfNotExists",
+              "details": {
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "existenceCondition": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.enabled",
+                      "equals": "true"
+                    },
+                    {
+                      "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.days",
+                      "equals": "[parameters('requiredRetentionDays')]"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "parameters": {
+            "requiredRetentionDays": {
+              "type": "Integer",
+              "defaultValue": 365,
+              "allowedValues": [
+                0,
+                30,
+                90,
+                180,
+                365
+              ],
+              "metadata": {
+                "displayName": "Required retention (days)",
+                "description": "The required diagnostic logs retention in days"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyAssignments.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyAssignments.json
@@ -600,10 +600,7 @@
           }
         }
       },
-      "description": "The policy assignment properties.",
-      "required": [
-        "policyDefinitionId"
-      ]
+      "description": "The policy assignment properties."
     },
     "ParameterValues": {
       "type": "object",
@@ -726,9 +723,6 @@
           }
         }
       },
-      "required": [
-        "type"
-      ],
       "description": "Identity for the resource."
     }
   },

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyAssignments.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyAssignments.json
@@ -600,20 +600,26 @@
           }
         }
       },
-      "description": "The policy assignment properties."
+      "description": "The policy assignment properties.",
+      "required": [
+        "policyDefinitionId"
+      ]
     },
     "ParameterValues": {
       "type": "object",
       "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "description": "The value of the parameter.",
-            "type": "object"
-          }
-        }
+        "$ref": "#/definitions/ParameterValuesValue"
       },
       "description": "The parameter values for the policy rule. The keys are the parameter names."
+    },
+    "ParameterValuesValue": {
+      "properties": {
+        "value": {
+          "description": "The value of the parameter.",
+          "type": "object"
+        }
+      },
+      "description": "The value of a parameter."
     },
     "PolicySku": {
       "properties": {
@@ -699,17 +705,30 @@
         },
         "type": {
           "type": "string",
-          "description": "The identity type.",
+          "description": "The identity type. This is the only required field when adding a system assigned identity to a resource.",
           "enum": [
             "SystemAssigned",
             "None"
           ],
           "x-ms-enum": {
             "name": "ResourceIdentityType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "SystemAssigned",
+                "description": "Indicates that a system assigned identity is associated with the resource."
+              },
+              {
+                "value": "None",
+                "description": "Indicates that no identity is associated with the resource or that the existing identity should be removed."
+              }
+            ]
           }
         }
       },
+      "required": [
+        "type"
+      ],
       "description": "Identity for the resource."
     }
   },

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyDefinitions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyDefinitions.json
@@ -521,9 +521,6 @@
           "$ref": "#/definitions/ParameterDefinitions"
         }
       },
-      "required": [
-        "policyRule"
-      ],
       "description": "The policy definition properties."
     },
     "ParameterDefinitionsValue": {

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyDefinitions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyDefinitions.json
@@ -45,6 +45,9 @@
         "x-ms-examples": {
           "Create or update a policy definition": {
             "$ref": "./examples/createOrUpdatePolicyDefinition.json"
+          },
+          "Create or update a policy definition with advanced parameters": {
+            "$ref": "./examples/createOrUpdatePolicyDefinitionAdvancedParams.json"
           }
         },
         "parameters": [
@@ -518,60 +521,66 @@
           "$ref": "#/definitions/ParameterDefinitions"
         }
       },
+      "required": [
+        "policyRule"
+      ],
       "description": "The policy definition properties."
+    },
+    "ParameterDefinitionsValue": {
+      "properties": {
+        "type": {
+          "description": "The data type of the parameter.",
+          "type": "string",
+          "enum": [
+            "String",
+            "Array",
+            "Object",
+            "Boolean",
+            "Integer",
+            "Float",
+            "DateTime"
+          ],
+          "x-ms-enum": {
+            "name": "parameterType",
+            "modelAsString": true
+          }
+        },
+        "allowedValues": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "The allowed values for the parameter."
+        },
+        "defaultValue": {
+          "type": "object",
+          "description": "The default value for the parameter if no value is provided."
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "type": "string",
+              "description": "The display name for the parameter."
+            },
+            "description": {
+              "type": "string",
+              "description": "The description of the parameter."
+            }
+          },
+          "additionalProperties": {
+            "type": "object"
+          },
+          "description": "General metadata for the parameter."
+        }
+      },
+      "description": "The definition of a parameter that can be provided to the policy."
     },
     "ParameterDefinitions": {
       "description": "The parameter definitions for parameters used in the policy. The keys are the parameter names.",
       "type": "object",
       "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "description": "The data type of the parameter.",
-            "type": "string",
-            "enum": [
-              "String",
-              "Array",
-              "Object",
-              "Boolean",
-              "Integer",
-              "Float",
-              "DateTime"
-            ],
-            "x-ms-enum": {
-              "name": "parameterType",
-              "modelAsString": true
-            }
-          },
-          "allowedValues": {
-            "type": "array",
-            "items": {
-              "type": "object"
-            },
-            "description": "The allowed values for the parameter."
-          },
-          "defaultValue": {
-            "type": "object",
-            "description": "The default value for the parameter if no value is provided."
-          },
-          "metadata": {
-            "type": "object",
-            "properties": {
-              "displayName": {
-                "type": "string",
-                "description": "The display name for the parameter."
-              },
-              "description": {
-                "type": "string",
-                "description": "The description of the parameter."
-              }
-            },
-            "additionalProperties": {
-              "type": "object"
-            },
-            "description": "General metadata for the parameter."
-          }
-        }
+        "$ref": "#/definitions/ParameterDefinitionsValue"
       }
     },
     "PolicyDefinition": {


### PR DESCRIPTION
### Latest improvements:
Support identified some gaps in the Microsoft.Authorization/policy* REST help pages.  These changes fix the following:

1. Show policyRule and policyDefinitionId as required in the documentation (they were always required on the backend).  This adds validation on the client in the various generated SDKs as well.
2. Change how the dynamic parameter values and parameter definitions are defined in swagger so they show up in the help docs.  This has no affect on the generated SDKs (verified via autorest).

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
