### PR TITLE
KeyVault resource-manager removing secrets.json from readme.md

### DIFF
--- a/specification/keyvault/resource-manager/readme.md
+++ b/specification/keyvault/resource-manager/readme.md
@@ -38,7 +38,6 @@ These settings apply only when `--tag=package-2019-09` is specified on the comma
 input-file:
 - Microsoft.KeyVault/stable/2019-09-01/keyvault.json
 - Microsoft.KeyVault/stable/2019-09-01/providers.json
-- Microsoft.KeyVault/stable/2019-09-01/secrets.json
 ```
 
 
@@ -50,7 +49,6 @@ These settings apply only when `--tag=package-2018-02-14-preview` is specified o
 input-file:
 - Microsoft.KeyVault/preview/2018-02-14-preview/keyvault.json
 - Microsoft.KeyVault/preview/2018-02-14-preview/providers.json
-- Microsoft.KeyVault/preview/2018-02-14-preview/secrets.json
 ```
 
 


### PR DESCRIPTION
This removes secrets.json from the readme.md of the resource-manager folder for Key Vault. The APIs in secrets.json are for ARM API documentation only and are not intended to be part of any generated SDK or command line tooling for the key vault management plane.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
