### PR TITLE
Remove readonly in machinelearningservice.workspace.identity

### DIFF
--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2019-11-01/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2019-11-01/machineLearningServices.json
@@ -1738,7 +1738,6 @@
         },
         "identity": {
           "$ref": "#/definitions/Identity",
-          "readOnly": true,
           "description": "The identity of the resource."
         },
         "location": {


### PR DESCRIPTION
The identity in workspace should not be readonly, there are examples in other services you can find [here](https://github.com/Azure/azure-rest-api-specs/blob/95a07a02a137d4850a3a2c5b53da757ea891151f/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/compute.json#L7949), [here](https://github.com/Azure/azure-rest-api-specs/blob/95a07a02a137d4850a3a2c5b53da757ea891151f/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/compute.json#L7978), [here](https://github.com/Azure/azure-rest-api-specs/blob/95a07a02a137d4850a3a2c5b53da757ea891151f/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/disk.json#L1786) and more (I only listed those in the compute service).
