### PR TITLE
undid rest parity start copy response

### DIFF
--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-07-07/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-07-07/file.json
@@ -3792,44 +3792,6 @@
                                     "name": "CopyStatusType",
                                     "modelAsString": false
                                 }
-                            },
-                            "x-ms-file-permission-key": {
-                                "x-ms-client-name": "FilePermissionKey",
-                                "type": "string",
-                                "description": "Key of the permission set for the file."
-                            },
-                            "x-ms-file-attributes": {
-                                "x-ms-client-name": "FileAttributes",
-                                "type": "string",
-                                "description": "Attributes set for the file."
-                            },
-                            "x-ms-file-creation-time": {
-                                "x-ms-client-name": "FileCreationTime",
-                                "type": "string",
-                                "format": "date-time-rfc1123",
-                                "description": "Creation time for the file."
-                            },
-                            "x-ms-file-last-write-time": {
-                                "x-ms-client-name": "FileLastWriteTime",
-                                "type": "string",
-                                "format": "date-time-rfc1123",
-                                "description": "Last write time for the file."
-                            },
-                            "x-ms-file-change-time": {
-                                "x-ms-client-name": "FileChangeTime",
-                                "type": "string",
-                                "format": "date-time-rfc1123",
-                                "description": "Change time for the file."
-                            },
-                            "x-ms-file-id": {
-                                "x-ms-client-name": "FileId",
-                                "type": "string",
-                                "description": "The fileId of the directory."
-                            },
-                            "x-ms-file-parent-id": {
-                                "x-ms-client-name": "FileParentId",
-                                "type": "string",
-                                "description": "The parent fileId of the directory."
                             }
                         }
                     },


### PR DESCRIPTION
This change undoes the change made in https://github.com/Azure/azure-rest-api-specs/pull/8009