### PR TITLE
Revert "[SRP] Add default response status code"

### DIFF
--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json
@@ -162,12 +162,6 @@
           },
           "202": {
             "description": "Accepted -- Create or update request accepted; operation will complete asynchronously."
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
           }
         },
         "x-ms-long-running-operation": true
@@ -251,12 +245,6 @@
             "schema": {
               "$ref": "#/definitions/StorageAccount"
             }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
           }
         }
       },
@@ -302,12 +290,6 @@
             "description": "OK -- storage account properties updated successfully.",
             "schema": {
               "$ref": "#/definitions/StorageAccount"
-            }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
             }
           }
         }
@@ -474,12 +456,6 @@
             "description": "OK -- specified key regenerated successfully.",
             "schema": {
               "$ref": "#/definitions/StorageAccountListKeysResult"
-            }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
             }
           }
         }
@@ -690,12 +666,6 @@
             "schema": {
               "$ref": "#/definitions/ManagementPolicy"
             }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
           }
         }
       },
@@ -741,12 +711,6 @@
             "description": "OK -- Put managementpolicy successfully.",
             "schema": {
               "$ref": "#/definitions/ManagementPolicy"
-            }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
             }
           }
         }


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#8065

We need to revert Azure/azure-rest-api-specs#8065, since it will cause the display issue of the error responds, and is a breaking change to SDK. 
We should not make it in until the display issue is fixed?
Or PSH upgrade to new SRP SDK will be blocked.

Such as for an error responds with StatusCode as `Conflict (409)`, and following content:
```
{
  "error": {
    "code": "StorageDomainNameCouldNotVerify",
    "message": "The custom domain name could not be verified. CNAME mapping from foo.example.com to any of sto1511.blob.core.windows.net,sto1511.z1.web.core.windows.net does not exist."
  }
}
```

Before the change, the exception will have the Error code and message in Exception.Body.code, and Exception.Message
•	Exception.Response.StatusCode:             `Conflict`
•	Exception.Body.code:                                 `StorageDomainNameCouldNotVerify`
•	Exception.Message:                                    `The custom domain name could not be verified. CNAME mapping from foo.example.com to any of sto1511.blob.core.windows.net,sto1511.z1.web.core.windows.net does not exist.`

But after the change, no properties of the exception has the Error Code and Message, but only has the status code (a property has whole responds content, which is not friendly for user to read):
•	Exception.Response.StatusCode:             `Conflict`
•	Exception.Body.code:                                 `null`
•	Exception.Message:                                    `Operation returned an invalid status code 'Conflict'`

So it’s difficult for user to know the failure reason, especially for Powershell (depends on .NET SRP SDK generated from swagger) since it will display the Exception.Message to console output.
After the change the Exception.Message can’t show the detail reason, so it’s difficult for powershell user to handle the failures.
