### PR TITLE
Change CODEOWNERS for Azure Cognitive Search

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -58,7 +58,7 @@
 /specification/relay/ @sethmanheim @v-ajnava
 /specification/resources/ @Tiano2017 @rajshah11 @vivsriaus
 /specification/scheduler/ @pinwang81
-/specification/search/data-plane/ @brjohnstmsft @arv100kri
+/specification/search/data-plane/ @brjohnstmsft @arv100kri @bleroy
 /specification/search/resource-manager/ @abhi1509 @miwelsh @tjacobhi
 /specification/serialconsole/ @amitchat @craigw @asinn826
 /specification/service-map/ @daveirwin1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -58,7 +58,8 @@
 /specification/relay/ @sethmanheim @v-ajnava
 /specification/resources/ @Tiano2017 @rajshah11 @vivsriaus
 /specification/scheduler/ @pinwang81
-/specification/search/ @brjohnstmsft
+/specification/search/data-plane/ @brjohnstmsft @arv100kri
+/specification/search/resource-manager/ @abhi1509 @miwelsh @tjacobhi
 /specification/serialconsole/ @amitchat @craigw @asinn826
 /specification/service-map/ @daveirwin1
 /specification/servicebus/ @sazeesha @v-ajnava


### PR DESCRIPTION
We would like to have different code owners for the Azure Cognitive Search data plane and management plane. Currently there is only a single code owner (me), which causes a lot of confusion and extra work when triaging issues and PRs.

FYI @arv100kri @miwelsh @tjacobhi @abhi1509 