### PR TITLE
Support listing policy assignments at MG scope

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/examples/listPolicyAssignmentsForManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/examples/listPolicyAssignmentsForManagementGroup.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "managementGroupId": "TestManagementGroup",
+    "api-version": "2019-09-01",
+    "$filter": "atScope()"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Management/managementGroups/TestManagementGroup/providers/Microsoft.Authorization/policyAssignments/TestCostManagement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "TestCostManagement",
+            "location": "eastus",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+              "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+            },
+            "properties": {
+              "displayName": "Storage Cost Management",
+              "description": "Minimize the risk of accidental cost overruns",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/TestManagementGroup/providers/Microsoft.Authorization/policyDefinitions/storageSkus",
+              "parameters": {
+                "allowedSkus": {
+                  "value": "Standard_A1"
+                }
+              },
+              "scope": "/providers/Microsoft.Management/managementGroups/TestManagementGroup",
+              "notScopes": []
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Management/managementGroups/TestManagementGroup/providers/Microsoft.Authorization/policyAssignments/TestTagEnforcement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "TestTagEnforcement",
+            "properties": {
+              "displayName": "Enforces a tag key and value",
+              "description": "Ensure a given tag key and value are present on all resources",
+              "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/TestManagementGroup/providers/Microsoft.Authorization/policyDefinitions/TagKeyValue",
+              "scope": "/providers/Microsoft.Management/managementGroups/TestManagementGroup",
+              "notScopes": []
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyAssignments.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2019-09-01/policyAssignments.json
@@ -345,6 +345,54 @@
         "x-ms-odata": "#/definitions/PolicyAssignment"
       }
     },
+    "/providers/Microsoft.Management/managementgroups/{managementGroupId}/providers/Microsoft.Authorization/policyAssignments": {
+      "get": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_ListForManagementGroup",
+        "summary": "Retrieves all policy assignments that apply to a management group.",
+        "description": "This operation retrieves the list of all policy assignments applicable to the management group that match the given $filter. Valid values for $filter are: 'atScope()' or 'policyDefinitionId eq '{value}''. If $filter=atScope() is provided, the returned list includes all policy assignments that are assigned to the management group or the management group's ancestors. If $filter=policyDefinitionId eq '{value}' is provided, the returned list includes all policy assignments of the policy definition whose id is {value} that apply to the management group.",
+        "x-ms-examples": {
+          "List policy assignments that apply to a management group": {
+            "$ref": "./examples/listPolicyAssignmentsForManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The filter to apply on the operation. Valid values for $filter are: 'atScope()' or 'policyDefinitionId eq '{value}''. A filter is required when listing policy assignments at management group scope.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy assignments.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyAssignments": {
       "get": {
         "tags": [
@@ -740,6 +788,14 @@
       "required": true,
       "type": "string",
       "description": "The API version to use for the operation."
+    },
+    "ManagementGroupIdParameter": {
+      "name": "managementGroupId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The ID of the management group.",
+      "x-ms-parameter-location": "method"
     }
   }
 }

--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -451,6 +451,10 @@ directive:
     from: policyDefinitions.json
     where: $.paths
     reason: policy definition under an extension resource with Microsoft.Management
+  - suppress: UniqueResourcePaths
+    from: policyAssignments.json
+    where: $.paths
+    reason: policy assignment under an extension resource with Microsoft.Management
   - suppress: OperationsAPIImplementation
     from: policyAssignments.json
     where: $.paths


### PR DESCRIPTION
Listing policy assignments at management group scope has been supported in the API for a long time but was missed in the swagger spec (and SDKs).

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
