### PR TITLE
[Express Route] Added Support for IPv6 Circuit Connection Configuration.

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionCreate.json
@@ -36,7 +36,11 @@
           "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
           "addressPrefix": "10.0.0.0/24",
           "circuitConnectionStatus": "Connected",
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "ipv6CircuitConnectionConfig": {
+            "addressPrefix": "aa:bb::1/125",
+            "circuitConnectionStatus": "Connected"
+          }
         }
       }
     },
@@ -55,7 +59,11 @@
           "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
           "addressPrefix": "10.0.0.0/24",
           "circuitConnectionStatus": "Connected",
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "ipv6CircuitConnectionConfig": {
+            "addressPrefix": "aa:bb::1/125",
+            "circuitConnectionStatus": "Connected"
+          }
         }
       }
     }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionCreate.json
@@ -18,7 +18,7 @@
         "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
         "addressPrefix": "10.0.0.0/29",
         "ipv6CircuitConnectionConfig": {
-          "AddressPrefix": "aa:bb::/125"
+          "addressPrefix": "aa:bb::/125"
         }
       }
     }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionCreate.json
@@ -16,7 +16,10 @@
           "id": "/subscriptions/subid2/resourceGroups/dedharcktpeer/providers/Microsoft.Network/expressRouteCircuits/dedharcktremote/peerings/AzurePrivatePeering"
         },
         "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
-        "addressPrefix": "10.0.0.0/29"
+        "addressPrefix": "10.0.0.0/29",
+        "ipv6CircuitConnectionConfig": {
+          "AddressPrefix": "aa:bb::/125"
+        }
       }
     }
   },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionGet.json
@@ -23,7 +23,11 @@
           "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
           "addressPrefix": "10.0.0.0/24",
           "circuitConnectionStatus": "Connected",
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "ipv6CircuitConnectionConfig": {
+            "addressPrefix": "aa:bb::1/125",
+            "circuitConnectionStatus": "Connected"
+          }
         },
         "type": "Microsoft.Network/expressRouteCircuits/peerings/connections"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/examples/ExpressRouteCircuitConnectionList.json
@@ -24,7 +24,11 @@
               "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
               "addressPrefix": "10.0.0.0/24",
               "circuitConnectionStatus": "Connected",
-              "provisioningState": "Succeeded"
+              "provisioningState": "Succeeded",
+              "ipv6CircuitConnectionConfig": {
+                "addressPrefix": "aa:bb::1/125",
+                "circuitConnectionStatus": "Connected"
+              }
             }
           },
           {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/expressRouteCircuit.json
@@ -1949,7 +1949,7 @@
       }
     },
     "Ipv6CircuitConnectionConfig": {
-      "description": "IPv6 Circuit Connection properties for Global Reach",
+      "description": "IPv6 Circuit Connection properties for Global Reach.",
       "properties": {
         "addressPrefix": {
           "type": "string",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/expressRouteCircuit.json
@@ -1949,6 +1949,7 @@
       }
     },
     "Ipv6CircuitConnectionConfig": {
+      "description": "IPv6 Circuit Connection properties for Global Reach",
       "properties": {
         "addressPrefix": {
           "type": "string",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-09-01/expressRouteCircuit.json
@@ -1948,6 +1948,18 @@
         "modelAsString": true
       }
     },
+    "Ipv6CircuitConnectionConfig": {
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "/125 IP address space to carve out Customer addresses for Global Reach."
+        },
+        "circuitConnectionStatus": {
+          "$ref": "#/definitions/CircuitConnectionStatus",
+          "description": "Express Route Circuit connection state."
+        }
+      }
+    },
     "ExpressRouteCircuitConnectionPropertiesFormat": {
       "properties": {
         "expressRouteCircuitPeering": {
@@ -1965,6 +1977,10 @@
         "authorizationKey": {
           "type": "string",
           "description": "The authorization key."
+        },
+        "ipv6CircuitConnectionConfig": {
+          "$ref": "#/definitions/Ipv6CircuitConnectionConfig",
+          "description": "IPv6 Address PrefixProperties of the express route circuit connection."
         },
         "circuitConnectionStatus": {
           "$ref": "#/definitions/CircuitConnectionStatus",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionCreate.json
@@ -18,7 +18,7 @@
         "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
         "addressPrefix": "10.0.0.0/29",
         "ipv6CircuitConnectionConfig": {
-          "AddressPrefix": "aa:bb::/125"
+          "addressPrefix": "aa:bb::/125"
         }
       }
     }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionCreate.json
@@ -16,7 +16,10 @@
           "id": "/subscriptions/subid2/resourceGroups/dedharcktpeer/providers/Microsoft.Network/expressRouteCircuits/dedharcktremote/peerings/AzurePrivatePeering"
         },
         "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
-        "addressPrefix": "10.0.0.0/29"
+        "addressPrefix": "10.0.0.0/29",
+        "IPv6CircuitConnectionConfig": {
+          "AddressPrefix": "aa:bb::/125"
+        }
       }
     }
   },
@@ -36,7 +39,11 @@
           "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
           "addressPrefix": "10.0.0.0/24",
           "circuitConnectionStatus": "Connected",
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "ipv6CircuitConnectionConfig": {
+            "addressPrefix": "aa:bb::1/125",
+            "circuitConnectionStatus": "Connected"
+          }
         }
       }
     },
@@ -55,7 +62,11 @@
           "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
           "addressPrefix": "10.0.0.0/24",
           "circuitConnectionStatus": "Connected",
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "ipv6CircuitConnectionConfig": {
+            "addressPrefix": "aa:bb::1/125",
+            "circuitConnectionStatus": "Connected"
+          }
         }
       }
     }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionCreate.json
@@ -17,7 +17,7 @@
         },
         "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
         "addressPrefix": "10.0.0.0/29",
-        "IPv6CircuitConnectionConfig": {
+        "ipv6CircuitConnectionConfig": {
           "AddressPrefix": "aa:bb::/125"
         }
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionGet.json
@@ -23,7 +23,11 @@
           "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
           "addressPrefix": "10.0.0.0/24",
           "circuitConnectionStatus": "Connected",
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "ipv6CircuitConnectionConfig": {
+            "addressPrefix": "aa:bb::1/125",
+            "circuitConnectionStatus": "Connected"
+          }
         },
         "type": "Microsoft.Network/expressRouteCircuits/peerings/connections"
       }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/examples/ExpressRouteCircuitConnectionList.json
@@ -24,7 +24,11 @@
               "authorizationKey": "946a1918-b7a2-4917-b43c-8c4cdaee006a",
               "addressPrefix": "10.0.0.0/24",
               "circuitConnectionStatus": "Connected",
-              "provisioningState": "Succeeded"
+              "provisioningState": "Succeeded",
+              "ipv6CircuitConnectionConfig": {
+                "addressPrefix": "aa:bb::1/125",
+                "circuitConnectionStatus": "Connected"
+              }
             }
           },
           {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/expressRouteCircuit.json
@@ -1949,7 +1949,7 @@
       }
     },
     "Ipv6CircuitConnectionConfig": {
-      "description": "IPv6 Circuit Connection properties for Global Reach",
+      "description": "IPv6 Circuit Connection properties for Global Reach.",
       "properties": {
         "addressPrefix": {
           "type": "string",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/expressRouteCircuit.json
@@ -1949,6 +1949,7 @@
       }
     },
     "Ipv6CircuitConnectionConfig": {
+      "description": "IPv6 Circuit Connection properties for Global Reach",
       "properties": {
         "addressPrefix": {
           "type": "string",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/expressRouteCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/expressRouteCircuit.json
@@ -1948,6 +1948,18 @@
         "modelAsString": true
       }
     },
+    "Ipv6CircuitConnectionConfig": {
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "/125 IP address space to carve out Customer addresses for Global Reach."
+        },
+        "circuitConnectionStatus": {
+          "$ref": "#/definitions/CircuitConnectionStatus",
+          "description": "Express Route Circuit connection state."
+        }
+      }
+    },
     "ExpressRouteCircuitConnectionPropertiesFormat": {
       "properties": {
         "expressRouteCircuitPeering": {
@@ -1965,6 +1977,10 @@
         "authorizationKey": {
           "type": "string",
           "description": "The authorization key."
+        },
+        "ipv6CircuitConnectionConfig": {
+          "$ref": "#/definitions/Ipv6CircuitConnectionConfig",
+          "description": "IPv6 Address PrefixProperties of the express route circuit connection."
         },
         "circuitConnectionStatus": {
           "$ref": "#/definitions/CircuitConnectionStatus",


### PR DESCRIPTION
### Latest improvements:
Below changes to ExpressRouteCircuitConfig are to provide the support for IPv6 properties. 
The support was added to NRP in the September release. Although the feature was not published or GA'd.

The below configurations would add a node IPv6CircuitConnectionProperties to the existing expressRouteCircuitConnection object. 

The above block would be used by all the northbound clients like azure-powershell/ azcli/terraform/portal.


<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
