### PR TITLE
fixing python sdk paths

### DIFF
--- a/specification/support/resource-manager/readme.python.md
+++ b/specification/support/resource-manager/readme.python.md
@@ -18,10 +18,10 @@ python:
 ``` yaml $(python) && $(python-mode) == 'update'
 python:
   no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-support/azure/mgmt/support
+  output-folder: $(python-sdks-folder)/support/azure-mgmt-support/azure/mgmt/support
 ```
 ``` yaml $(python) && $(python-mode) == 'create'
 python:
   basic-setup-py: true
-  output-folder: $(python-sdks-folder)/azure-mgmt-support
+  output-folder: $(python-sdks-folder)/support/azure-mgmt-support
 ```


### PR DESCRIPTION
Paths defined in readme.md are invalid, SDK is generated in a wrong folder.