### PR TITLE
Add parameter for minimum TLS version while enabling https on a custom domain

### DIFF
--- a/specification/cdn/resource-manager/Microsoft.Cdn/stable/2019-04-15/examples/CustomDomains_EnableCustomHttpsUsingBYOC.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/stable/2019-04-15/examples/CustomDomains_EnableCustomHttpsUsingBYOC.json
@@ -7,7 +7,7 @@
     "endpointName": "endpoint1",
     "customDomainName": "www-someDomain-net",
     "customHttpsParameters": {
-      "MinimumTLSVersion": "TLS12",
+      "minimumTlsVersion": "TLS12",
       "certificateSource": "AzureKeyVault",
       "protocolType": "ServerNameIndication",
       "certificateSourceParameters": {

--- a/specification/cdn/resource-manager/Microsoft.Cdn/stable/2019-04-15/examples/CustomDomains_EnableCustomHttpsUsingBYOC.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/stable/2019-04-15/examples/CustomDomains_EnableCustomHttpsUsingBYOC.json
@@ -7,6 +7,7 @@
     "endpointName": "endpoint1",
     "customDomainName": "www-someDomain-net",
     "customHttpsParameters": {
+      "MinimumTLSVersion": "TLS12",
       "certificateSource": "AzureKeyVault",
       "protocolType": "ServerNameIndication",
       "certificateSourceParameters": {

--- a/specification/cdn/resource-manager/Microsoft.Cdn/stable/2019-04-15/examples/CustomDomains_EnableCustomHttpsUsingCDNManagedCertificate.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/stable/2019-04-15/examples/CustomDomains_EnableCustomHttpsUsingCDNManagedCertificate.json
@@ -7,7 +7,7 @@
     "endpointName": "endpoint1",
     "customDomainName": "www-someDomain-net",
     "customHttpsParameters": {
-      "MinimumTLSVersion": "TLS12",
+      "minimumTlsVersion": "TLS12",
       "certificateSource": "Cdn",
       "protocolType": "ServerNameIndication",
       "certificateSourceParameters": {

--- a/specification/cdn/resource-manager/Microsoft.Cdn/stable/2019-04-15/examples/CustomDomains_EnableCustomHttpsUsingCDNManagedCertificate.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/stable/2019-04-15/examples/CustomDomains_EnableCustomHttpsUsingCDNManagedCertificate.json
@@ -7,6 +7,7 @@
     "endpointName": "endpoint1",
     "customDomainName": "www-someDomain-net",
     "customHttpsParameters": {
+      "MinimumTLSVersion": "TLS12",
       "certificateSource": "Cdn",
       "protocolType": "ServerNameIndication",
       "certificateSourceParameters": {


### PR DESCRIPTION
Adding a parameter to the custom https parameters and setting it to "TLS12" in the example. This parameter sets the TLS version while enabling https.