### PR TITLE
Fixing the structure of RESTProxy documentation:  Updating the OperationId

### DIFF
--- a/specification/hdinsight/hdinsight-kafka-rest-proxy/proxy.json
+++ b/specification/hdinsight/hdinsight-kafka-rest-proxy/proxy.json
@@ -228,7 +228,7 @@
         "tags": [ "v1metadata" ],
         "summary": "Get metadata about a specific Kafka topic-partition",
         "description": "Get metadata about a specific Kafka topic-partition with partition ID, earliest offset, latest offset, leader, replicas, and in-sync replicas",
-        "operationId": "Metadata_GetMetadataForPartitionId",
+        "operationId": "Metadata_GetMetadataForPartition",
         "consumes": [ "application/json" ],
         "produces": [ "application/json" ],
         "parameters": [

--- a/specification/hdinsight/hdinsight-kafka-rest-proxy/proxy.json
+++ b/specification/hdinsight/hdinsight-kafka-rest-proxy/proxy.json
@@ -39,7 +39,7 @@
         "tags": [ "v1consumer" ],
         "summary": "Consume records using a simple consumer",
         "description": "Consume records from one partition of a topic beginning with a specific offset. By default count is 1. It can read maximum of 6 megabytes of data at once",
-        "operationId": "consumeTopicInPartitionWithOffset",
+        "operationId": "Consumer_ConsumeTopicInPartitionWithOffset",
         "consumes": [ "application/json" ],
         "produces": [ "application/json" ],
         "parameters": [
@@ -111,7 +111,7 @@
         "tags": [ "v1metadata" ],
         "summary": "Get a list of Kafka brokers",
         "description": "Get a list of Kafka brokers with hostname, port, and broker id",
-        "operationId": "getBrokers",
+        "operationId": "Metadata_GetBrokers",
         "consumes": [ "application/json" ],
         "produces": [ "application/json" ],
         "responses": {
@@ -147,7 +147,7 @@
         "tags": [ "v1metadata" ],
         "summary": "Get a list of Kafka topics",
         "description": "Get a list of Kafka topics. If it is a newly created topic, please wait a few seconds for it to show up.",
-        "operationId": "getTopics",
+        "operationId": "Metadata_GetTopics",
         "consumes": [ "application/json" ],
         "produces": [ "application/json" ],
         "responses": {
@@ -183,7 +183,7 @@
         "tags": [ "v1metadata" ],
         "summary": "Get metadata about all partitions for a specific topic",
         "description": "Get metadata about all partitions for a specific topic with partition ID, earliest offset, latest offset, leader, replicas, and in-sync replicas",
-        "operationId": "getPartitions",
+        "operationId": "Metadata_GetTopicPartitions",
         "consumes": [ "application/json" ],
         "produces": [ "application/json" ],
         "parameters": [
@@ -228,7 +228,7 @@
         "tags": [ "v1metadata" ],
         "summary": "Get metadata about a specific Kafka topic-partition",
         "description": "Get metadata about a specific Kafka topic-partition with partition ID, earliest offset, latest offset, leader, replicas, and in-sync replicas",
-        "operationId": "getPartitionMetadata",
+        "operationId": "Metadata_GetMetadataForPartitionId",
         "consumes": [ "application/json" ],
         "produces": [ "application/json" ],
         "parameters": [
@@ -281,7 +281,7 @@
         "tags": [ "v1producer" ],
         "summary": "Produce records",
         "description": "Produce records to a topic in Kafka. If producing records to a newly created topic, please wait a few seconds for the topic to show up.",
-        "operationId": "produceMessageToTopic",
+        "operationId": "Producer_ProduceMessageToTopic",
         "consumes": [ "application/json" ],
         "produces": [ "application/json" ],
         "parameters": [
@@ -335,7 +335,7 @@
         "tags": [ "v1status" ],
         "summary": "Check the status of Kafka Rest proxy server",
         "description": "Check the status of Kafka Rest proxy server",
-        "operationId": "checkRestproxyStatus",
+        "operationId": "Admin_CheckRestProxyStatus",
         "consumes": [ "application/json" ],
         "produces": [ "application/json" ],
         "responses": {
@@ -353,7 +353,7 @@
         "tags": [ "v1topics" ],
         "summary": "Create a topic",
         "description": "Create a topic in Kafka with topic configuration",
-        "operationId": "putTopics",
+        "operationId": "Admin_CreateTopic",
         "consumes": [ "application/json" ],
         "produces": [ "application/json" ],
         "parameters": [

--- a/specification/hdinsight/hdinsight-kafka-rest-proxy/proxy.json
+++ b/specification/hdinsight/hdinsight-kafka-rest-proxy/proxy.json
@@ -32,16 +32,24 @@
       "description": "Manage Kafka topics"
     }
   ],
-  "schemes": [ "https" ],
+  "schemes": [
+    "https"
+  ],
   "paths": {
     "/v1/consumer/topics/{topic}/partitions/{partition}/offsets/{offset}": {
       "get": {
-        "tags": [ "v1consumer" ],
+        "tags": [
+          "v1consumer"
+        ],
         "summary": "Consume records using a simple consumer",
         "description": "Consume records from one partition of a topic beginning with a specific offset. By default count is 1. It can read maximum of 6 megabytes of data at once",
         "operationId": "Consumer_ConsumeTopicInPartitionWithOffset",
-        "consumes": [ "application/json" ],
-        "produces": [ "application/json" ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "topic",
@@ -108,12 +116,18 @@
     },
     "/v1/metadata/brokers": {
       "get": {
-        "tags": [ "v1metadata" ],
+        "tags": [
+          "v1metadata"
+        ],
         "summary": "Get a list of Kafka brokers",
         "description": "Get a list of Kafka brokers with hostname, port, and broker id",
         "operationId": "Metadata_GetBrokers",
-        "consumes": [ "application/json" ],
-        "produces": [ "application/json" ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -144,12 +158,18 @@
     },
     "/v1/metadata/topics": {
       "get": {
-        "tags": [ "v1metadata" ],
+        "tags": [
+          "v1metadata"
+        ],
         "summary": "Get a list of Kafka topics",
         "description": "Get a list of Kafka topics. If it is a newly created topic, please wait a few seconds for it to show up.",
         "operationId": "Metadata_GetTopics",
-        "consumes": [ "application/json" ],
-        "produces": [ "application/json" ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -180,12 +200,18 @@
     },
     "/v1/metadata/topics/{topic}/partitions": {
       "get": {
-        "tags": [ "v1metadata" ],
+        "tags": [
+          "v1metadata"
+        ],
         "summary": "Get metadata about all partitions for a specific topic",
         "description": "Get metadata about all partitions for a specific topic with partition ID, earliest offset, latest offset, leader, replicas, and in-sync replicas",
         "operationId": "Metadata_GetTopicPartitions",
-        "consumes": [ "application/json" ],
-        "produces": [ "application/json" ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "topic",
@@ -225,12 +251,18 @@
     },
     "/v1/metadata/topics/{topic}/partitions/{partition}": {
       "get": {
-        "tags": [ "v1metadata" ],
+        "tags": [
+          "v1metadata"
+        ],
         "summary": "Get metadata about a specific Kafka topic-partition",
         "description": "Get metadata about a specific Kafka topic-partition with partition ID, earliest offset, latest offset, leader, replicas, and in-sync replicas",
         "operationId": "Metadata_GetMetadataForPartition",
-        "consumes": [ "application/json" ],
-        "produces": [ "application/json" ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "topic",
@@ -278,12 +310,18 @@
     },
     "/v1/producer/topics/{topic}": {
       "post": {
-        "tags": [ "v1producer" ],
+        "tags": [
+          "v1producer"
+        ],
         "summary": "Produce records",
         "description": "Produce records to a topic in Kafka. If producing records to a newly created topic, please wait a few seconds for the topic to show up.",
         "operationId": "Producer_ProduceMessageToTopic",
-        "consumes": [ "application/json" ],
-        "produces": [ "application/json" ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "topic",
@@ -332,12 +370,18 @@
     },
     "/v1/status": {
       "get": {
-        "tags": [ "v1status" ],
+        "tags": [
+          "v1status"
+        ],
         "summary": "Check the status of Kafka Rest proxy server",
         "description": "Check the status of Kafka Rest proxy server",
         "operationId": "Admin_CheckRestProxyStatus",
-        "consumes": [ "application/json" ],
-        "produces": [ "application/json" ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -350,12 +394,18 @@
     },
     "/v1/topics/{topic}": {
       "put": {
-        "tags": [ "v1topics" ],
+        "tags": [
+          "v1topics"
+        ],
         "summary": "Create a topic",
         "description": "Create a topic in Kafka with topic configuration",
         "operationId": "Admin_CreateTopic",
-        "consumes": [ "application/json" ],
-        "produces": [ "application/json" ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "topic",
@@ -447,7 +497,9 @@
     },
     "ProducerRecord": {
       "type": "object",
-      "required": [ "value" ],
+      "required": [
+        "value"
+      ],
       "properties": {
         "value": {
           "type": "object",


### PR DESCRIPTION
Updating the OperationId because the grouping of operations isn't correct.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
