### PR TITLE
Cognitive Services Form Recognizer v2.0-preview: Copy APIs

### DIFF
--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -331,6 +331,15 @@
             "format": "uuid"
           },
           {
+            "name": "source",
+            "in": "query",
+            "description": "Specify if the request is against the source Form Recognizer resource or not. Source indicates the party that has the model that is to be copied to another resource.",
+            "required": false,
+            "default": false,
+            "type": "boolean",
+            "x-nullable": false
+          },
+          {
             "name": "copyRequest",
             "in": "body",
             "description": "Copy request parameters.",

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -609,18 +609,18 @@
     "AuthorizationClaim": {
       "description": "Request parameter that contains claims for authorizing an operation such as Copy.",
       "required": [
-        "claimResourceId",
-        "claimResourceRegion"
+        "resourceId",
+        "resourceRegion"
       ],
       "type": "object",
       "properties": {
-        "claimResourceId": {
-          "description": "A target artifact identifier, such as 'modelId' that will be used as a claim to authorize a request.",
+        "resourceId": {
+          "description": "Form Recognizer model identifier in the target subscription that will be used as a claim to authorize the request.",
           "type": "string",
           "format": "uuid"
         },
-        "claimResourceRegion": {
-          "description": "Azure Region where the claim resource is present. ",
+        "resourceRegion": {
+          "description": "Azure region where the claim resource is present.",
           "type": "string"
         }
       }
@@ -634,9 +634,8 @@
       "type": "object",
       "properties": {
         "targetResourceId": {
-          "description": "Azure resource identifier of the target to which the model is copied to.",
+          "description": "Azure resource identifier of the target where the model is copied.",
           "maxLength": 2048,
-          "minLength": 0,
           "type": "string",
           "x-ms-azure-resource": true
         },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -606,7 +606,7 @@
       },
       "x-nullable": false
     },
-    "AuthorizationClaim": {
+    "Authorization": {
       "description": "Request parameter that contains claims for authorizing an operation.",
       "required": [
         "modelResourceId"
@@ -639,9 +639,9 @@
           "description": "Location of the target Azure resource.",
           "$ref": "../../../Common/ExtendedRegions.json#/parameters/AzureRegion"
         },
-        "authorizationClaim": {
+        "authorization": {
           "description": "Entity that encodes claims to authorize the copy request.",
-          "$ref": "#/definitions/AuthorizationClaim"
+          "$ref": "#/definitions/Authorization"
         }
       }
     },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -368,7 +368,7 @@
       "get": {
         "summary": "Get Custom Model Copy Result",
         "description": "Obtain current status and the result of a custom model copy operation.",
-        "operationId": "GetCopyCustomModelResult",
+        "operationId": "GetCustomModelCopyResult",
         "consumes": [],
         "produces": [
           "application/json"
@@ -609,7 +609,8 @@
     "AuthorizationClaim": {
       "description": "Request parameter that contains claims for authorizing an operation such as Copy.",
       "required": [
-        "modelId"
+        "claimResourceId",
+        "claimResourceRegion"
       ],
       "type": "object",
       "properties": {
@@ -617,6 +618,10 @@
           "description": "A target artifact identifier, such as 'modelId' that will be used as a claim to authorize a request.",
           "type": "string",
           "format": "uuid"
+        },
+        "claimResourceRegion": {
+          "description": "Azure Region where the claim resource is present. ",
+          "type": "string"
         }
       }
     },
@@ -638,11 +643,6 @@
         "authorizationClaim": {
           "description": "Entity that encodes claims to authorize the copy request.",
           "$ref": "#/definitions/AuthorizationClaim"
-        },
-        "moveModel": {
-          "description": "Remove model from the source subscription after copy.",
-          "type": "boolean",
-          "default": false
         }
       }
     },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -312,6 +312,106 @@
         }
       }
     },
+    "/custom/models/{modelId}/copy": {
+      "post": {
+        "summary": "Copy Custom Model",
+        "description": "Copy custom model to user specified target Form Recognizer resource.",
+        "operationId": "CopyCustomModel",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "modelId",
+            "in": "path",
+            "description": "Model identifier.",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "name": "copyRequest",
+            "in": "body",
+            "description": "Copy request parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CopyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Copy request is queued successfully.",
+            "headers": {
+              "Operation-Location": {
+                "type": "string",
+                "description": "URL containing the resultId used to track the progress and obtain the result of the copy operation."
+              }
+            }
+          },
+          "default": {
+            "description": "Response entity accompanying non-successful responses containing additional details about the error.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Copy custom model": {
+            "$ref": "./examples/CopyModel.json"
+          }
+        }
+      }
+    },
+    "/custom/models/{modelId}/copyResults/{resultId}": {
+      "get": {
+        "summary": "Get Custom Model Copy Result",
+        "description": "Obtain current status and the result of a custom model copy operation.",
+        "operationId": "GetCopyCustomModelResult",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "modelId",
+            "in": "path",
+            "description": "Model identifier.",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          },
+          {
+            "name": "resultId",
+            "in": "path",
+            "description": "Copy operation result identifier.",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/CopyOperationResult"
+            }
+          },
+          "default": {
+            "description": "Response entity accompanying non-successful responses containing additional details about the error.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get copy custom model result": {
+            "$ref": "./examples/CopyOperationResult.json"
+          }
+        }
+      }
+    },
     "/prebuilt/receipt/analyze": {
       "post": {
         "summary": "Analyze Receipt",
@@ -505,6 +605,98 @@
         "modelAsString": false
       },
       "x-nullable": false
+    },
+    "AuthorizationClaim": {
+      "description": "Request parameter that contains claims for authorizing an operation such as Copy.",
+      "required": [
+        "modelId"
+      ],
+      "type": "object",
+      "properties": {
+        "claimResourceId": {
+          "description": "A target artifact identifier, such as 'modelId' that will be used as a claim to authorize a request.",
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    },
+    "CopyRequest": {
+      "description": "Request parameter to copy an existing custom model.",
+      "required": [
+        "targetResourceId",
+        "authorizationClaim"
+      ],
+      "type": "object",
+      "properties": {
+        "targetResourceId": {
+          "description": "Azure resource identifier of the target to which the model is copied to.",
+          "maxLength": 2048,
+          "minLength": 0,
+          "type": "string",
+          "x-ms-azure-resource": true
+        },
+        "authorizationClaim": {
+          "description": "Entity that encodes claims to authorize the copy request.",
+          "$ref": "#/definitions/AuthorizationClaim"
+        },
+        "moveModel": {
+          "description": "Remove model from the source subscription after copy.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "CopyOperationResult": {
+      "description": "Status and result of the queued copy operation.",
+      "type": "object",
+      "required": [
+        "status",
+        "createdDateTime",
+        "lastUpdatedDateTime"
+      ],
+      "properties": {
+        "status": {
+          "description": "Operation status.",
+          "$ref": "#/definitions/OperationStatus"
+        },
+        "createdDateTime": {
+          "format": "date-time",
+          "description": "Date and time (UTC) when the copy operation was submitted.",
+          "type": "string",
+          "x-nullable": false
+        },
+        "lastUpdatedDateTime": {
+          "format": "date-time",
+          "description": "Date and time (UTC) when the status was last updated.",
+          "type": "string",
+          "x-nullable": false
+        },
+        "copyResult": {
+          "description": "Results of the copy operation.",
+          "$ref": "#/definitions/CopyResult"
+        }
+      }
+    },
+    "CopyResult": {
+      "description": "Custom model copy result.",
+      "type": "object",
+      "required": [
+        "modelId"
+      ],
+      "properties": {
+        "modelId": {
+          "description": "Identifier of the model in the target subscription after the copy operation.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "errors": {
+          "description": "Errors returned during the copy operation.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorInformation"
+          }
+        }
+      }
     },
     "AnalyzeOperationResult": {
       "description": "Status and result of the queued analyze operation.",

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -609,11 +609,11 @@
     "Authorization": {
       "description": "Request parameter that contains claims for authorizing an operation.",
       "required": [
-        "modelResourceId"
+        "modelId"
       ],
       "type": "object",
       "properties": {
-        "modelResourceId": {
+        "modelId": {
           "description": "Form Recognizer model identifier that will be used as a claim token to authorize the request.",
           "type": "string",
           "format": "uuid"
@@ -684,7 +684,7 @@
       ],
       "properties": {
         "modelId": {
-          "description": "Identifier of the model in the target subscription after the copy operation.",
+          "description": "Identifier of the target model.",
           "type": "string",
           "format": "uuid"
         },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -606,6 +606,20 @@
       },
       "x-nullable": false
     },
+    "AuthorizationClaim": {
+      "description": "Request parameter that contains claims for authorizing an operation.",
+      "required": [
+        "resourceId"
+      ],
+      "type": "object",
+      "properties": {
+        "modelResourceId": {
+          "description": "Form Recognizer model identifier that will be used as a claim token to authorize the request.",
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    },
     "CopyRequest": {
       "description": "Request parameter to copy an existing custom model.",
       "required": [
@@ -624,6 +638,10 @@
         "targetResourceRegion": {
           "description": "Location of the target Azure resource.",
           "$ref": "../../../Common/ExtendedRegions.json#/parameters/AzureRegion"
+        },
+        "authorizationClaim": {
+          "description": "Entity that encodes claims to authorize the copy request.",
+          "$ref": "#/definitions/AuthorizationClaim"
         }
       }
     },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -609,7 +609,7 @@
     "AuthorizationClaim": {
       "description": "Request parameter that contains claims for authorizing an operation.",
       "required": [
-        "resourceId"
+        "modelResourceId"
       ],
       "type": "object",
       "properties": {

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -433,6 +433,9 @@
                 "type": "string",
                 "description": "Location and ID of the model being copied. The status of model copy is specified in the status property at the model location."
               }
+            },
+            "schema": {
+              "$ref": "#/definitions/CopyAuthorizationResult"
             }
           },
           "default": {

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -343,7 +343,7 @@
           }
         ],
         "responses": {
-            "202": {
+          "202": {
             "description": "Copy request is queued successfully.",
             "headers": {
               "Operation-Location": {
@@ -352,13 +352,13 @@
               }
             }
           },
-            "default": {
-              "description": "Response entity accompanying non-successful responses containing additional details about the error.",
-              "schema": {
-                "$ref": "#/definitions/ErrorResponse"
-              }
+          "default": {
+            "description": "Response entity accompanying non-successful responses containing additional details about the error.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
             }
-          },
+          }
+        },
         "x-ms-examples": {
           "Copy custom model": {
             "$ref": "./examples/CopyModel.json"
@@ -419,8 +419,7 @@
         "summary": "Generate Copy Authorization",
         "description": "Generate authorization to copy a model into the target Form Recognizer resource.",
         "operationId": "GenerateModelCopyAuthorization",
-        "consumes": [
-        ],
+        "consumes": [],
         "produces": [
           "application/json"
         ],

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -606,42 +606,24 @@
       },
       "x-nullable": false
     },
-    "AuthorizationClaim": {
-      "description": "Request parameter that contains claims for authorizing an operation such as Copy.",
-      "required": [
-        "resourceId",
-        "resourceRegion"
-      ],
-      "type": "object",
-      "properties": {
-        "resourceId": {
-          "description": "Form Recognizer model identifier in the target subscription that will be used as a claim to authorize the request.",
-          "type": "string",
-          "format": "uuid"
-        },
-        "resourceRegion": {
-          "description": "Azure region where the claim resource is present.",
-          "type": "string"
-        }
-      }
-    },
     "CopyRequest": {
       "description": "Request parameter to copy an existing custom model.",
       "required": [
         "targetResourceId",
-        "authorizationClaim"
+        "targetResourceAzureRegion"
       ],
       "type": "object",
       "properties": {
         "targetResourceId": {
-          "description": "Azure resource identifier of the target where the model is copied.",
+          "description": "Azure Resource Id of the target Form Recognizer resource where the model is copied to.",
           "maxLength": 2048,
           "type": "string",
+          "pattern": "^/subscriptions/[^/]*/resourceGroups/[^/]*/providers/Microsoft.CognitiveServices/accounts/[^/]*$",
           "x-ms-azure-resource": true
         },
-        "authorizationClaim": {
-          "description": "Entity that encodes claims to authorize the copy request.",
-          "$ref": "#/definitions/AuthorizationClaim"
+        "targetResourceRegion": {
+          "description": "Location of the target Azure resource.",
+          "$ref": "../../../Common/ExtendedRegions.json#/parameters/AzureRegion"
         }
       }
     },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -648,7 +648,7 @@
       "required": [
         "modelId",
         "accessToken",
-        "expirationDateTime"
+        "expirationDateTimeTicks"
       ],
       "type": "object",
       "properties": {
@@ -660,11 +660,10 @@
           "description": "Token claim used to authorize the request.",
           "type": "string"
         },
-        "expirationDateTime": {
-          "format": "date-time",
-          "description": "The date and time (in UTC) when the access token expires.",
-          "type": "string",
-          "x-nullable": false
+        "expirationDateTimeTicks": {
+          "description": "The time when the access token expires. The date is represented as the number of seconds from 1970-01-01T0:0:0Z UTC until the expiration time.",
+          "type": "integer",
+          "format": "int64"
         }
       }
     },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -333,15 +333,6 @@
             "format": "uuid"
           },
           {
-            "name": "source",
-            "in": "query",
-            "description": "Specify if the request is against the source Form Recognizer resource or not. Source indicates the party that has the model that is to be copied to another resource.",
-            "required": false,
-            "default": false,
-            "type": "boolean",
-            "x-nullable": false
-          },
-          {
             "name": "copyRequest",
             "in": "body",
             "description": "Copy request parameters.",
@@ -352,7 +343,7 @@
           }
         ],
         "responses": {
-          "202": {
+            "202": {
             "description": "Copy request is queued successfully.",
             "headers": {
               "Operation-Location": {
@@ -361,13 +352,13 @@
               }
             }
           },
-          "default": {
-            "description": "Response entity accompanying non-successful responses containing additional details about the error.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+            "default": {
+              "description": "Response entity accompanying non-successful responses containing additional details about the error.",
+              "schema": {
+                "$ref": "#/definitions/ErrorResponse"
+              }
             }
-          }
-        },
+          },
         "x-ms-examples": {
           "Copy custom model": {
             "$ref": "./examples/CopyModel.json"
@@ -419,6 +410,41 @@
         "x-ms-examples": {
           "Get copy custom model result": {
             "$ref": "./examples/CopyOperationResult.json"
+          }
+        }
+      }
+    },
+    "/custom/models/copyAuthorization": {
+      "post": {
+        "summary": "Generate Copy Authorization",
+        "description": "Generate authorization to copy a model into the target Form Recognizer resource.",
+        "operationId": "GenerateModelCopyAuthorization",
+        "consumes": [
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "Copy request is authorized successfully.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "Location and ID of the model being copied. The status of model copy is specified in the status property at the model location."
+              }
+            }
+          },
+          "default": {
+            "description": "Response entity accompanying non-successful responses containing additional details about the error.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Copy custom model": {
+            "$ref": "./examples/CopyModelAuthorization.json"
           }
         }
       }
@@ -617,17 +643,28 @@
       },
       "x-nullable": false
     },
-    "Authorization": {
-      "description": "Request parameter that contains claims for authorizing an operation.",
+    "CopyAuthorizationResult": {
+      "description": "Request parameter that contains authorization claims for copy operation.",
       "required": [
-        "modelId"
+        "modelId",
+        "accessToken",
+        "expirationDateTime"
       ],
       "type": "object",
       "properties": {
         "modelId": {
-          "description": "Form Recognizer model identifier that will be used as a claim token to authorize the request.",
+          "description": "Model identifier.",
+          "type": "string"
+        },
+        "accessToken": {
+          "description": "Token claim used to authorize the request.",
+          "type": "string"
+        },
+        "expirationDateTime": {
+          "format": "date-time",
+          "description": "The date and time (in UTC) when the access token expires.",
           "type": "string",
-          "format": "uuid"
+          "x-nullable": false
         }
       }
     },
@@ -635,13 +672,14 @@
       "description": "Request parameter to copy an existing custom model.",
       "required": [
         "targetResourceId",
-        "targetResourceRegion"
+        "targetResourceRegion",
+        "copyAuthorization"
       ],
       "type": "object",
       "properties": {
         "targetResourceId": {
           "description": "Azure Resource Id of the target Form Recognizer resource where the model is copied to.",
-          "maxLength": 2048,
+          "maxLength": 1024,
           "type": "string",
           "pattern": "^/subscriptions/[^/]*/resourceGroups/[^/]*/providers/Microsoft.CognitiveServices/accounts/[^/]*$",
           "x-ms-azure-resource": true
@@ -650,9 +688,9 @@
           "description": "Location of the target Azure resource.",
           "$ref": "../../../Common/ExtendedRegions.json#/parameters/AzureRegion"
         },
-        "authorization": {
+        "copyAuthorization": {
           "description": "Entity that encodes claims to authorize the copy request.",
-          "$ref": "#/definitions/Authorization"
+          "$ref": "#/definitions/CopyAuthorizationResult"
         }
       }
     },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -610,7 +610,7 @@
       "description": "Request parameter to copy an existing custom model.",
       "required": [
         "targetResourceId",
-        "targetResourceAzureRegion"
+        "targetResourceRegion"
       ],
       "type": "object",
       "properties": {

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -317,7 +317,9 @@
         "summary": "Copy Custom Model",
         "description": "Copy custom model to user specified target Form Recognizer resource.",
         "operationId": "CopyCustomModel",
-        "consumes": [],
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/json"
         ],

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -684,8 +684,11 @@
           "x-ms-azure-resource": true
         },
         "targetResourceRegion": {
-          "description": "Location of the target Azure resource.",
-          "$ref": "../../../Common/ExtendedRegions.json#/parameters/AzureRegion"
+          "description": "Location of the target Azure resource. A valid Azure region name supported by Cognitive Services.",
+          "type": "string",
+          "pattern": "^[a-z0-9]+$",
+          "minLength": 1,
+          "maxLength": 24
         },
         "copyAuthorization": {
           "description": "Entity that encodes claims to authorize the copy request.",

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -315,7 +315,7 @@
     "/custom/models/{modelId}/copy": {
       "post": {
         "summary": "Copy Custom Model",
-        "description": "Copy custom model to user specified target Form Recognizer resource.",
+        "description": "Copy custom model stored in this resource (the source) to user specified target Form Recognizer resource.",
         "operationId": "CopyCustomModel",
         "consumes": [
           "application/json"
@@ -410,6 +410,9 @@
         "x-ms-examples": {
           "Get copy custom model result": {
             "$ref": "./examples/CopyOperationResult.json"
+          },
+          "Get copy custom model result with failures": {
+            "$ref": "./examples/CopyOperationResultWithErrors.json"
           }
         }
       }
@@ -670,7 +673,7 @@
       }
     },
     "CopyRequest": {
-      "description": "Request parameter to copy an existing custom model.",
+      "description": "Request parameter to copy an existing custom model from the source resource to a target resource referenced by the resource ID.",
       "required": [
         "targetResourceId",
         "targetResourceRegion",

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -363,7 +363,8 @@
           "Copy custom model": {
             "$ref": "./examples/CopyModel.json"
           }
-        }
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/custom/models/{modelId}/copyResults/{resultId}": {

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "endpoint": "{endpoint}",
+    "Content-Type": "application/json",
+    "Ocp-Apim-Subscription-Key": "{API key}",
+    "modelId": "{model Id}",
+    "body": {},
+    "copyRequest": {
+      "targetResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{resourceName}",
+      "authorizationClaim": {
+        "targetClaimResourceId": "{model Id}"
+      },
+      "moveModel": false
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Operation-Location": "{endpoint}/formrecognizer/v2.0-preview/custom/models/{modelId}/copyResults/{resultId}"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
@@ -4,14 +4,17 @@
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
     "modelId": "{modelId}",
-    "body": {},
-    "copyRequest": {
-      "targetResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{resourceName}",
-      "targetResourceRegion": "{region}",
-      "authorization": {
-        "modelId": "{modelId}"
+    "body": {
+      "copyRequest": {
+        "targetResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{resourceName}",
+        "targetResourceRegion": "{region}",
+        "copyAuthorization": {
+          "modelId": "{modelId}",
+          "accessToken": "{accessToken}",
+          "expirationDateTime": "{dateTime}"
+        }
       }
-    }
+    }    
   },
   "responses": {
     "202": {

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
@@ -7,9 +7,9 @@
     "body": {},
     "copyRequest": {
       "targetResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{resourceName}",
-      "authorizationClaim": {
-        "resourceId": "{modelId}",
-        "resourceRegion": "{region}"
+      "targetResourceRegion": "{region}",
+      "authorization": {
+        "modelId": "{modelId}"
       }
     }
   },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
@@ -11,10 +11,10 @@
         "copyAuthorization": {
           "modelId": "{modelId}",
           "accessToken": "{accessToken}",
-          "expirationDateTime": "{dateTime}"
+          "expirationDateTimeTicks": "{expirationDateTimeTicks}"
         }
       }
-    }    
+    }
   },
   "responses": {
     "202": {

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
@@ -4,15 +4,14 @@
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
     "modelId": "{modelId}",
-    "body": {
-      "copyRequest": {
-        "targetResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{resourceName}",
-        "targetResourceRegion": "{region}",
-        "copyAuthorization": {
-          "modelId": "{modelId}",
-          "accessToken": "{accessToken}",
-          "expirationDateTimeTicks": "{expirationDateTimeTicks}"
-        }
+    "body": {},
+    "copyRequest": {
+      "targetResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{resourceName}",
+      "targetResourceRegion": "{region}",
+      "copyAuthorization": {
+        "modelId": "{modelId}",
+        "accessToken": "{accessToken}",
+        "expirationDateTimeTicks": "{expirationDateTimeTicks}"
       }
     }
   },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
@@ -3,14 +3,14 @@
     "endpoint": "{endpoint}",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "modelId": "{model Id}",
+    "modelId": "{modelId}",
     "body": {},
     "copyRequest": {
       "targetResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{resourceName}",
       "authorizationClaim": {
-        "targetClaimResourceId": "{model Id}"
-      },
-      "moveModel": false
+        "resourceId": "{modelId}",
+        "resourceRegion": "{region}"
+      }
     }
   },
   "responses": {

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModel.json
@@ -7,11 +7,11 @@
     "body": {},
     "copyRequest": {
       "targetResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{resourceName}",
-      "targetResourceRegion": "{region}",
+      "targetResourceRegion": "westus2",
       "copyAuthorization": {
         "modelId": "{modelId}",
         "accessToken": "{accessToken}",
-        "expirationDateTimeTicks": "{expirationDateTimeTicks}"
+        "expirationDateTimeTicks": 637190189980000000
       }
     }
   },

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModelAuthorization.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModelAuthorization.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "endpoint": "{endpoint}",
+    "Content-Type": "application/json",
+    "Ocp-Apim-Subscription-Key": "{API key}",
+    "body": {}
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Location": "{endpoint}/formrecognizer/v2.0-preview/custom/models/{modelId}"
+      },
+      "body": {
+        "modelInfo": {
+          "modelId": "{modelId}",
+          "accessToken": "{accessToken}",
+          "expirationDateTime": "2020-01-01T11:59:59Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModelAuthorization.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModelAuthorization.json
@@ -11,9 +11,9 @@
         "Location": "{endpoint}/formrecognizer/v2.0-preview/custom/models/{modelId}"
       },
       "body": {
-          "modelId": "{modelId}",
-          "accessToken": "{accessToken}",
-          "expirationDateTimeTicks": 637190189980000000
+        "modelId": "{modelId}",
+        "accessToken": "{accessToken}",
+        "expirationDateTimeTicks": 637190189980000000
       }
     }
   }

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModelAuthorization.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModelAuthorization.json
@@ -11,11 +11,9 @@
         "Location": "{endpoint}/formrecognizer/v2.0-preview/custom/models/{modelId}"
       },
       "body": {
-        "modelInfo": {
           "modelId": "{modelId}",
           "accessToken": "{accessToken}",
-          "expirationDateTimeTicks": "{expirationDateTimeTicks}"
-        }
+          "expirationDateTimeTicks": 637190189980000000
       }
     }
   }

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModelAuthorization.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyModelAuthorization.json
@@ -14,7 +14,7 @@
         "modelInfo": {
           "modelId": "{modelId}",
           "accessToken": "{accessToken}",
-          "expirationDateTime": "2020-01-01T11:59:59Z"
+          "expirationDateTimeTicks": "{expirationDateTimeTicks}"
         }
       }
     }

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyOperationResult.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyOperationResult.json
@@ -3,8 +3,8 @@
     "endpoint": "{endpoint}",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "modelId": "{model Id}",
-    "resultId": "{result Id}",
+    "modelId": "{modelId}",
+    "resultId": "{resultId}",
     "body": {}
   },
   "responses": {
@@ -14,7 +14,7 @@
         "createdDateTime": "2020-01-01T00:00:00Z",
         "lastUpdatedDateTime": "2020-01-01T00:01:00Z",
         "copyResult": {
-          "modelId": "{model Id}",
+          "modelId": "{modelId}",
           "errors": []
         }
       }

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyOperationResult.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyOperationResult.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "endpoint": "{endpoint}",
+    "Content-Type": "application/json",
+    "Ocp-Apim-Subscription-Key": "{API key}",
+    "modelId": "{model Id}",
+    "resultId": "{result Id}",
+    "body": {}
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "status": "succeeded",
+        "createdDateTime": "2020-01-01T00:00:00Z",
+        "lastUpdatedDateTime": "2020-01-01T00:01:00Z",
+        "copyResult": {
+          "modelId": "{model Id}",
+          "errors": []
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyOperationResultWithErrors.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyOperationResultWithErrors.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "endpoint": "{endpoint}",
+    "Content-Type": "application/json",
+    "Ocp-Apim-Subscription-Key": "{API key}",
+    "modelId": "{modelId}",
+    "resultId": "{resultId}",
+    "body": {}
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "status": "failed",
+        "createdDateTime": "2020-01-01T00:00:00Z",
+        "lastUpdatedDateTime": "2020-01-01T00:01:00Z",
+        "copyResult": {
+          "modelId": "{modelId}",
+          "errors": [
+            {
+              "code": "ResourceResolverError",
+              "message": "{ErrorMessage}"
+            }
+          ]
+      }
+    }
+  }
+}
+}

--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyOperationResultWithErrors.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/examples/CopyOperationResultWithErrors.json
@@ -21,8 +21,8 @@
               "message": "{ErrorMessage}"
             }
           ]
+        }
       }
     }
   }
-}
 }


### PR DESCRIPTION
This PR contains followimg changes to the Azure Form Recognizer v2.0-preview service.

1. API: `POST {baseurl}\formrecognizer\custom\models\{modelId}\copy` - allows for creating a new copy request.  
2. API: `GET {baseurl}\formrecognizer\custom\models\{modelId}\copyResults\{resultId}` - fetches the result of a copy operation.
3. Samples `CopyModel.json` and `CopyOperationResult.json` for the new APIs
