### PR TITLE
[FrontDoor WAF] Add RuleSetId to Managed Rule Set Definitions API

### DIFF
--- a/specification/frontdoor/resource-manager/Microsoft.Network/stable/2019-03-01/examples/WafListManagedRuleSets.json
+++ b/specification/frontdoor/resource-manager/Microsoft.Network/stable/2019-03-01/examples/WafListManagedRuleSets.json
@@ -13,6 +13,7 @@
             "type": "Microsoft.Network/frontdoorwebapplicationfirewallmanagedrulesets",
             "properties": {
               "provisioningState": "Succeeded",
+              "ruleSetId": "8125d145-ddc5-4d90-9bc3-24c5f2de69a2",
               "ruleSetType": "DefaultRuleSet",
               "ruleSetVersion": "1.0",
               "ruleGroups": [

--- a/specification/frontdoor/resource-manager/Microsoft.Network/stable/2019-03-01/webapplicationfirewall.json
+++ b/specification/frontdoor/resource-manager/Microsoft.Network/stable/2019-03-01/webapplicationfirewall.json
@@ -667,6 +667,11 @@
           "readOnly": true,
           "description": "Provisioning state of the managed rule set."
         },
+        "ruleSetId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Id of the managed rule set."
+        },
         "ruleSetType": {
           "type": "string",
           "readOnly": true,

--- a/specification/frontdoor/resource-manager/Microsoft.Network/stable/2019-10-01/examples/WafListManagedRuleSets.json
+++ b/specification/frontdoor/resource-manager/Microsoft.Network/stable/2019-10-01/examples/WafListManagedRuleSets.json
@@ -13,6 +13,7 @@
             "type": "Microsoft.Network/frontdoorwebapplicationfirewallmanagedrulesets",
             "properties": {
               "provisioningState": "Succeeded",
+              "ruleSetId": "8125d145-ddc5-4d90-9bc3-24c5f2de69a2",
               "ruleSetType": "DefaultRuleSet",
               "ruleSetVersion": "1.0",
               "ruleGroups": [

--- a/specification/frontdoor/resource-manager/Microsoft.Network/stable/2019-10-01/webapplicationfirewall.json
+++ b/specification/frontdoor/resource-manager/Microsoft.Network/stable/2019-10-01/webapplicationfirewall.json
@@ -688,6 +688,11 @@
           "readOnly": true,
           "description": "Provisioning state of the managed rule set."
         },
+        "ruleSetId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Id of the managed rule set."
+        },
         "ruleSetType": {
           "type": "string",
           "readOnly": true,


### PR DESCRIPTION
## Changes:
* Adds new RuleSetId (read-only field) to managed rule set definitions API
* This enables consumers to determine if two rule sets are the same without relying on the name

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [X] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [X] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [X] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
