### PR TITLE
[Resources] Update Microsoft.Resources swagger to match service behavior

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
@@ -4614,7 +4614,7 @@
           "type": "array",
           "description": "Array of provisioned resources.",
           "items": {
-            "$ref": "#/definitions/ResourceId",
+            "$ref": "#/definitions/ResourceReference",
             "description": "Details of provisioned resources."
           }
         },
@@ -4623,7 +4623,7 @@
           "type": "array",
           "description": "Array of validated resources.",
           "items": {
-            "$ref": "#/definitions/ResourceId",
+            "$ref": "#/definitions/ResourceReference",
             "description": "Details of validated resources."
           }
         },
@@ -4635,7 +4635,7 @@
       },
       "description": "Deployment properties with additional details."
     },
-    "ResourceId": {
+    "ResourceReference": {
       "description": "The resource Id model.",
       "properties": {
         "id": {

--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
@@ -4603,6 +4603,34 @@
         "onErrorDeployment": {
           "$ref": "#/definitions/OnErrorDeploymentExtended",
           "description": "The deployment on error behavior."
+        },
+        "templateHash": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The hash produced for the template."
+        },
+        "outputResources": {
+          "readOnly": true,
+          "type": "array",
+          "description": "Array of provisioned resources.",
+          "items": {
+            "type": "object",
+            "description": "Details of provisioned resources."
+          }
+        },
+        "validatedResources": {
+          "readOnly": true,
+          "type": "array",
+          "description": "Array of validated resources.",
+          "items": {
+            "type": "object",
+            "description": "Details of validated resources."
+          }
+        },
+        "error": {
+          "readOnly": true,
+          "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/ErrorResponse",
+          "description": "The deployment error."
         }
       },
       "description": "Deployment properties with additional details."
@@ -4657,6 +4685,7 @@
     "DeploymentValidateResult": {
       "properties": {
         "error": {
+          "readOnly": true,
           "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/ErrorResponse",
           "description": "The deployment validation error."
         },

--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
@@ -4551,10 +4551,12 @@
           "description": "The duration of the template deployment."
         },
         "outputs": {
+          "readOnly": true,
           "type": "object",
           "description": "Key/value pairs that represent deployment output."
         },
         "providers": {
+          "readOnly": true,
           "type": "array",
           "items": {
             "$ref": "#/definitions/Provider"
@@ -4562,29 +4564,30 @@
           "description": "The list of resource providers needed for the deployment."
         },
         "dependencies": {
+          "readOnly": true,
           "type": "array",
           "items": {
             "$ref": "#/definitions/Dependency"
           },
           "description": "The list of deployment dependencies."
         },
-        "template": {
-          "type": "object",
-          "description": "The template content. Use only one of Template or TemplateLink."
-        },
         "templateLink": {
+          "readOnly": true,
           "$ref": "#/definitions/TemplateLink",
-          "description": "The URI referencing the template. Use only one of Template or TemplateLink."
+          "description": "The URI referencing the template."
         },
         "parameters": {
+          "readOnly": true,
           "type": "object",
-          "description": "Deployment parameters. Use only one of Parameters or ParametersLink."
+          "description": "Deployment parameters. "
         },
         "parametersLink": {
+          "readOnly": true,
           "$ref": "#/definitions/ParametersLink",
-          "description": "The URI referencing the parameters. Use only one of Parameters or ParametersLink."
+          "description": "The URI referencing the parameters. "
         },
         "mode": {
+          "readOnly": true,
           "type": "string",
           "description": "The deployment mode. Possible values are Incremental and Complete.",
           "enum": [
@@ -4597,10 +4600,12 @@
           }
         },
         "debugSetting": {
+          "readOnly": true,
           "$ref": "#/definitions/DebugSetting",
           "description": "The debug setting of the deployment."
         },
         "onErrorDeployment": {
+          "readOnly": true,
           "$ref": "#/definitions/OnErrorDeploymentExtended",
           "description": "The deployment on error behavior."
         },

--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
@@ -4603,34 +4603,6 @@
         "onErrorDeployment": {
           "$ref": "#/definitions/OnErrorDeploymentExtended",
           "description": "The deployment on error behavior."
-        },
-        "templateHash": {
-          "readOnly": true,
-          "type": "string",
-          "description": "The hash produced for the template."
-        },
-        "outputResources": {
-          "readOnly": true,
-          "type": "array",
-          "description": "Array of provisioned resources.",
-          "items": {
-            "type": "object",
-            "description": "Details of provisioned resources."
-          }
-        },
-        "validatedResources": {
-          "readOnly": true,
-          "type": "array",
-          "description": "Array of validated resources.",
-          "items": {
-            "type": "object",
-            "description": "Details of validated resources."
-          }
-        },
-        "error": {
-          "readOnly": true,
-          "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/ErrorResponse",
-          "description": "The deployment error."
         }
       },
       "description": "Deployment properties with additional details."
@@ -4685,7 +4657,6 @@
     "DeploymentValidateResult": {
       "properties": {
         "error": {
-          "readOnly": true,
           "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/ErrorResponse",
           "description": "The deployment validation error."
         },

--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
@@ -4614,7 +4614,7 @@
           "type": "array",
           "description": "Array of provisioned resources.",
           "items": {
-            "type": "object",
+            "$ref": "#/definitions/ResourceId",
             "description": "Details of provisioned resources."
           }
         },
@@ -4623,7 +4623,7 @@
           "type": "array",
           "description": "Array of validated resources.",
           "items": {
-            "type": "object",
+            "$ref": "#/definitions/ResourceId",
             "description": "Details of validated resources."
           }
         },
@@ -4634,6 +4634,16 @@
         }
       },
       "description": "Deployment properties with additional details."
+    },
+    "ResourceId": {
+      "description": "The resource Id model.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The fully qualified resource Id."
+        }
+      }
     },
     "OnErrorDeployment": {
       "properties": {


### PR DESCRIPTION
### Latest improvements:

This PR includes changes that will match the swagger with what service returns in the response body.

Changes are:
* Add missing properties
* Mark request payload properties as "readOnly"
* Remove "template" property

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
