### PR TITLE
appservice: adding back in the `SystemAssigned, UserAssigned` constant

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/stable/2019-08-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2019-08-01/CommonDefinitions.json
@@ -1234,6 +1234,7 @@
           "enum": [
             "None",
             "SystemAssigned",
+            "SystemAssigned, UserAssigned",
             "UserAssigned"
           ],
           "type": "string",


### PR DESCRIPTION
Looks like this was omited when introducing the new API version - but this value exists in the previous 2018-02-01 API version:

https://github.com/Azure/azure-rest-api-specs/blob/cef7cf08a3a4abf162f651235ef026c218f586f7/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/CommonDefinitions.json#L1316