### PR TITLE
Remove <E2><80><8B> character from default URL

### DIFF
--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-11-01-preview/monitoring.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-11-01-preview/monitoring.json
@@ -685,7 +685,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "default": "dev.azuresynapse.net​",
+      "default": "dev.azuresynapse.net",
       "x-ms-skip-url-encoding": true,
       "description": "Gets the DNS suffix used as the base for all Synapse service requests.",
       "x-ms-parameter-location": "client"

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-11-01-preview/sparkFrontend.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-11-01-preview/sparkFrontend.json
@@ -1447,7 +1447,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "default": "dev.azuresynapse.net​",
+      "default": "dev.azuresynapse.net",
       "x-ms-skip-url-encoding": true,
       "description": "Gets the DNS suffix used as the base for all Synapse service requests.",
       "x-ms-parameter-location": "client"

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-11-01-preview/workspaceAcl.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-11-01-preview/workspaceAcl.json
@@ -238,7 +238,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "default": "dev.azuresynapse.net​",
+      "default": "dev.azuresynapse.net",
       "x-ms-skip-url-encoding": true,
       "description": "Gets the DNS suffix used as the base for all Synapse service requests.",
       "x-ms-parameter-location": "client"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1050156/74974541-4abb8280-53da-11ea-9017-9e5e56d3d980.png)

That's usually a character that comes from copy/pasting a webpage