### PR TITLE
[Hub Generated] Review request for Microsoft.Attestation to add version preview/2018-09-01-preview

### DIFF
--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/attestation.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/attestation.json
@@ -65,7 +65,7 @@
         "tags": [
           "AttestationProvider"
         ],
-        "operationId": "AttestationProviders_Get",
+        "operationId": "AttestationProvider_Get",
         "description": "Get the status of Attestation Provider.",
         "x-ms-examples": {
           "AttestationProviders_Get": {
@@ -109,7 +109,7 @@
         "tags": [
           "AttestationProvider"
         ],
-        "operationId": "AttestationProviders_Create",
+        "operationId": "AttestationProvider_Create",
         "description": "Creates or updates the Attestation Provider.",
         "x-ms-examples": {
           "AttestationProviders_Create": {
@@ -136,6 +136,7 @@
           {
             "name": "creationParams",
             "in": "body",
+            "required": true,
             "description": "Client supplied parameters.",
             "schema": {
               "$ref": "#/definitions/AttestationServiceCreationParams"
@@ -164,11 +165,65 @@
           }
         }
       },
+      "patch": {
+        "tags": [
+          "AttestationProvider"
+        ],
+        "operationId": "AttestationProvider_Update",
+        "description": "Updates the Attestation Provider.",
+        "x-ms-examples": {
+          "AttestationProviders_Update": {
+            "$ref": "./examples/Update_AttestationProvider.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "providerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Name of the attestation service"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "updateParams",
+            "in": "body",
+            "required": true,
+            "description": "Client supplied parameters.",
+            "schema": {
+              "$ref": "#/definitions/AttestationServicePatchParams"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated attestation service",
+            "schema": {
+              "$ref": "#/definitions/AttestationProvider"
+            }
+          },
+          "default": {
+            "description": "Error result from Attestation service",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "AttestationProvider"
         ],
-        "operationId": "AttestationProviders_Delete",
+        "operationId": "AttestationProvider_Delete",
         "description": "Delete Attestation Service.",
         "x-ms-examples": {
           "AttestationProviders_Delete": {
@@ -344,7 +399,7 @@
       ],
       "allOf": [
         {
-          "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/Resource"
+          "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/TrackedResource"
         }
       ],
       "properties": {
@@ -363,6 +418,10 @@
         "status"
       ],
       "properties": {
+        "trustModel": {
+          "type": "string",
+          "description": "Trust model for the attestation service instance."
+        },
         "status": {
           "type": "string",
           "description": "Status of attestation service.",
@@ -417,8 +476,46 @@
         }
       }
     },
+    "AttestationServicePatchParams": {
+      "description": "Parameters for patching an attestation service instance",
+      "x-ms-azure-resource": true,
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The tags that will be assigned to the attestation service instance."
+        }
+      }
+    },
     "AttestationServiceCreationParams": {
-      "description": "Client supplied parameters passed to attestation service.",
+      "description": "Parameters for creating an attestation service instance",
+      "required": [
+        "location",
+        "properties"
+      ],
+      "x-ms-azure-resource": true,
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "The supported Azure location where the attestation service instance should be created."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The tags that will be assigned to the attestation service instance."
+        },
+        "properties": {
+          "$ref": "#/definitions/AttestationServiceCreationSpecificParams",
+          "description": "Properties of the attestation service instance"
+        }
+      }
+    },
+    "AttestationServiceCreationSpecificParams": {
+      "description": "Client supplied parameters used to create a new attestation service instance.",
       "properties": {
         "attestationPolicy": {
           "type": "string",

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/attestation.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/attestation.json
@@ -63,9 +63,9 @@
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Attestation/attestationProviders/{providerName}": {
       "get": {
         "tags": [
-          "AttestationProvider"
+          "AttestationProviders"
         ],
-        "operationId": "AttestationProvider_Get",
+        "operationId": "AttestationProviders_Get",
         "description": "Get the status of Attestation Provider.",
         "x-ms-examples": {
           "AttestationProviders_Get": {
@@ -107,9 +107,9 @@
       },
       "put": {
         "tags": [
-          "AttestationProvider"
+          "AttestationProviders"
         ],
-        "operationId": "AttestationProvider_Create",
+        "operationId": "AttestationProviders_Create",
         "description": "Creates or updates the Attestation Provider.",
         "x-ms-examples": {
           "AttestationProviders_Create": {
@@ -167,9 +167,9 @@
       },
       "patch": {
         "tags": [
-          "AttestationProvider"
+          "AttestationProviders"
         ],
-        "operationId": "AttestationProvider_Update",
+        "operationId": "AttestationProviders_Update",
         "description": "Updates the Attestation Provider.",
         "x-ms-examples": {
           "AttestationProviders_Update": {
@@ -221,9 +221,9 @@
       },
       "delete": {
         "tags": [
-          "AttestationProvider"
+          "AttestationProviders"
         ],
-        "operationId": "AttestationProvider_Delete",
+        "operationId": "AttestationProviders_Delete",
         "description": "Delete Attestation Service.",
         "x-ms-examples": {
           "AttestationProviders_Delete": {

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Create_AttestationProvider.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Create_AttestationProvider.json
@@ -3,14 +3,14 @@
     "resourceGroupName": "MyResourceGroup",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "api-version": "2018-09-01-preview",
-    "providerName": "MyAttestationProvider",
+    "providerName": "myattestationprovider",
     "creationParams": "test"
   },
   "responses": {
     "200": {
       "body": {
-        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
-        "name": "MyAttestationProvider",
+        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/myattestationprovider",
+        "name": "myattestationprovider",
         "type": "Microsoft.Attestation/attestationProviders",
         "location": "East US",
         "tags": {
@@ -27,8 +27,8 @@
     },
     "201": {
       "body": {
-        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
-        "name": "MyAttestationProvider",
+        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/myattestationprovider",
+        "name": "myattestationprovider",
         "type": "Microsoft.Attestation/attestationProviders",
         "location": "East US",
         "tags": {

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Create_AttestationProvider.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Create_AttestationProvider.json
@@ -12,9 +12,16 @@
         "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
         "name": "MyAttestationProvider",
         "type": "Microsoft.Attestation/attestationProviders",
+        "location": "East US",
+        "tags": {
+          "Property1": "Value1",
+          "Property2": "Value2",
+          "Property3": "Value3"
+        },
         "properties": {
+          "trustModel": "Isolated",
           "status": "Ready",
-          "attestUri": "https://sample-attestation.attestation.azure.net"
+          "attestUri": "https://superservice.attestation.azure.net"
         }
       }
     },
@@ -23,9 +30,16 @@
         "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
         "name": "MyAttestationProvider",
         "type": "Microsoft.Attestation/attestationProviders",
+        "location": "East US",
+        "tags": {
+          "Property1": "Value1",
+          "Property2": "Value2",
+          "Property3": "Value3"
+        },
         "properties": {
+          "trustModel": "Isolated",
           "status": "Ready",
-          "attestUri": "https://sample-attestation.attestation.azure.net"
+          "attestUri": "https://superservice.attestation.azure.net"
         }
       }
     }

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Delete_AttestationProvider.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Delete_AttestationProvider.json
@@ -1,9 +1,10 @@
 {
   "parameters": {
-    "resourceGroupName": "MyResourceGroup",
+    "resourceGroupName": "sample-resource-group",
+    "serviceName": "sampleservicename",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "api-version": "2018-09-01-preview",
-    "providerName": "MyAttestationProvider"
+    "providerName": "myattestationprovider"
   },
   "responses": {
     "202": {

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvider.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvider.json
@@ -3,13 +3,13 @@
     "resourceGroupName": "MyResourceGroup",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "api-version": "2018-09-01-preview",
-    "providerName": "MyAttestationProvider"
+    "providerName": "myattestationprovider"
   },
   "responses": {
     "200": {
       "body": {
-        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
-        "name": "MyAttestationProvider",
+        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/myattestationprovider",
+        "name": "myattestationprovider",
         "type": "Microsoft.Attestation/attestationProviders",
         "location": "East US",
         "tags": {

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvidersList.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvidersList.json
@@ -8,8 +8,8 @@
       "body": {
         "value": [
           {
-            "id": "subscriptions/6c96b33e-f5b8-40a6-9011-5cb1c58b0915/resourceGroups/testrg1/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
-            "name": "MyAttestationProvider",
+            "id": "subscriptions/6c96b33e-f5b8-40a6-9011-5cb1c58b0915/resourceGroups/testrg1/providers/Microsoft.Attestation/attestationProviders/myattestationprovider",
+            "name": "myattestationprovider",
             "type": "Microsoft.Attestation/attestationProviders",
             "location": "East US",
             "properties": {

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvidersList.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvidersList.json
@@ -11,6 +11,7 @@
             "id": "subscriptions/6c96b33e-f5b8-40a6-9011-5cb1c58b0915/resourceGroups/testrg1/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
             "name": "MyAttestationProvider",
             "type": "Microsoft.Attestation/attestationProviders",
+            "location": "East US",
             "properties": {
               "status": "Ready"
             }
@@ -19,6 +20,7 @@
             "id": "subscriptions/6c96b33e-f5b8-40a6-9011-5cb1c58b0915/resourceGroups/testrg2/providers/Microsoft.Attestation/attestationProviders/codes2",
             "name": "codes2",
             "type": "Microsoft.Attestation/attestationProviders",
+            "location": "East US",
             "properties": {
               "status": "Ready"
             }

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvidersListByResourceGroup.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvidersListByResourceGroup.json
@@ -12,6 +12,7 @@
             "id": "subscriptions/6c96b33e-f5b8-40a6-9011-5cb1c58b0915/resourceGroups/testrg1/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
             "name": "MyAttestationProvider",
             "type": "Microsoft.Attestation/attestationProviders",
+            "location": "East US",
             "properties": {
               "status": "Ready"
             }
@@ -20,6 +21,7 @@
             "id": "subscriptions/6c96b33e-f5b8-40a6-9011-5cb1c58b0915/resourceGroups/testrg1/providers/Microsoft.Attestation/attestationProviders/codes2",
             "name": "codes2",
             "type": "Microsoft.Attestation/attestationProviders",
+            "location": "East US",
             "properties": {
               "status": "Ready"
             }

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvidersListByResourceGroup.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Get_AttestationProvidersListByResourceGroup.json
@@ -9,8 +9,8 @@
       "body": {
         "value": [
           {
-            "id": "subscriptions/6c96b33e-f5b8-40a6-9011-5cb1c58b0915/resourceGroups/testrg1/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
-            "name": "MyAttestationProvider",
+            "id": "subscriptions/6c96b33e-f5b8-40a6-9011-5cb1c58b0915/resourceGroups/testrg1/providers/Microsoft.Attestation/attestationProviders/myattestationprovider",
+            "name": "myattestationprovider",
             "type": "Microsoft.Attestation/attestationProviders",
             "location": "East US",
             "properties": {

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Update_AttestationProvider.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Update_AttestationProvider.json
@@ -3,7 +3,14 @@
     "resourceGroupName": "MyResourceGroup",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "api-version": "2018-09-01-preview",
-    "providerName": "MyAttestationProvider"
+    "providerName": "MyAttestationProvider",
+    "updateParams": {
+      "tags": {
+        "Property1": "Value1",
+        "Property2": "Value2",
+        "Property3": "Value3"
+      }
+    }
   },
   "responses": {
     "200": {

--- a/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Update_AttestationProvider.json
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/preview/2018-09-01-preview/examples/Update_AttestationProvider.json
@@ -3,7 +3,7 @@
     "resourceGroupName": "MyResourceGroup",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "api-version": "2018-09-01-preview",
-    "providerName": "MyAttestationProvider",
+    "providerName": "myattestationprovider",
     "updateParams": {
       "tags": {
         "Property1": "Value1",
@@ -15,8 +15,8 @@
   "responses": {
     "200": {
       "body": {
-        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/MyAttestationProvider",
-        "name": "MyAttestationProvider",
+        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.Attestation/attestationProviders/myattestationprovider",
+        "name": "myattestationprovider",
         "type": "Microsoft.Attestation/attestationProviders",
         "location": "East US",
         "tags": {


### PR DESCRIPTION
If you are a MSFT employee you can view your [work branch via this link](https://portal.azure-devex-tools.com/branch/gkostal/azure-rest-api-specs/arm-tracked-resource-attestation-Microsoft.Attestation-2018-09-01-preview...master/).

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.

### Description
The Microsoft.Attestation resource provider is currently in very early preview.  Currently from the ARM perspective it's a global resource provider that's routed using the "proxyOnly" routing type. In order to support multiple regions, the Microsoft.Attestation resource provider must switch to be a "tracked" ARM resource. The changes in this PR reflect the required changes we need to make to the REST protocol in order to enable the "tracked" ARM resource mode.

The changes in this PR include a breaking change to the PUT operation for the Microsoft.Attestation/attestationProviders resource type.  We have intentionally made this change to the existing api-version since customers will already encounter a breaking change when we switch the service from global to regional in the upcoming month via updating the ARM manifest.

There is one failing test in the test automation -- SDK NET.  I have verified that the cause of this failure is due to the intentional breaking change to the PUT operation.  This test failure can be considered a false positive.

