### PR TITLE
Update Microsoft.Peering 2020-01-01-preview API specification

### DIFF
--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2020-01-01-preview/examples/CreatePeeringWithExchangeRouteServer.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2020-01-01-preview/examples/CreatePeeringWithExchangeRouteServer.json
@@ -1,0 +1,134 @@
+{
+  "parameters": {
+    "subscriptionId": "subId",
+    "resourceGroupName": "rgName",
+    "peeringName": "peeringName",
+    "api-version": "2020-01-01-preview",
+    "peering": {
+      "sku": {
+        "name": "Premium_Direct_Free"
+      },
+      "kind": "Direct",
+      "properties": {
+        "direct": {
+          "connections": [
+            {
+              "bandwidthInMbps": 10000,
+              "sessionAddressProvider": "Peer",
+              "useForPeeringService": true,
+              "peeringDBFacilityId": 99999,
+              "bgpSession": {
+                "sessionPrefixV4": "192.168.0.0/24",
+                "microsoftSessionIPv4Address": "192.168.0.123",
+                "peerSessionIPv4Address": "192.168.0.234",
+                "maxPrefixesAdvertisedV4": 1000,
+                "maxPrefixesAdvertisedV6": 100
+              },
+              "connectionIdentifier": "5F4CB5C7-6B43-4444-9338-9ABC72606C16"
+            }
+          ],
+          "peerAsn": {
+            "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/myAsn1"
+          },
+          "directPeeringType": "IxRs"
+        },
+        "peeringLocation": "peeringLocation0"
+      },
+      "location": "eastus"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sku": {
+          "name": "Premium_Direct_Free",
+          "tier": "Premium",
+          "family": "Direct",
+          "size": "Free"
+        },
+        "kind": "Direct",
+        "properties": {
+          "direct": {
+            "connections": [
+              {
+                "bandwidthInMbps": 10000,
+                "provisionedBandwidthInMbps": 10000,
+                "sessionAddressProvider": "Peer",
+                "useForPeeringService": true,
+                "peeringDBFacilityId": 99999,
+                "connectionState": "Active",
+                "bgpSession": {
+                  "sessionPrefixV4": "192.168.0.0/24",
+                  "microsoftSessionIPv4Address": "192.168.0.123",
+                  "peerSessionIPv4Address": "192.168.0.234",
+                  "sessionStateV4": "Established",
+                  "sessionStateV6": "Established",
+                  "maxPrefixesAdvertisedV4": 1000,
+                  "maxPrefixesAdvertisedV6": 100
+                },
+                "connectionIdentifier": "5F4CB5C7-6B43-4444-9338-9ABC72606C16"
+              }
+            ],
+            "useForPeeringService": true,
+            "peerAsn": {
+              "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/myAsn1"
+            },
+            "directPeeringType": "IxRs"
+          },
+          "peeringLocation": "peeringLocation0",
+          "provisioningState": "Succeeded"
+        },
+        "location": "eastus",
+        "name": "peeringName",
+        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "type": "Microsoft.Peering/peerings"
+      }
+    },
+    "201": {
+      "body": {
+        "sku": {
+          "name": "Premium_Direct_Free",
+          "tier": "Premium",
+          "family": "Direct",
+          "size": "Free"
+        },
+        "kind": "Direct",
+        "properties": {
+          "direct": {
+            "connections": [
+              {
+                "bandwidthInMbps": 10000,
+                "provisionedBandwidthInMbps": 0,
+                "sessionAddressProvider": "Peer",
+                "useForPeeringService": true,
+                "peeringDBFacilityId": 99999,
+                "connectionState": "PendingApproval",
+                "bgpSession": {
+                  "sessionPrefixV4": "192.168.0.0/24",
+                  "microsoftSessionIPv4Address": "192.168.0.123",
+                  "peerSessionIPv4Address": "192.168.0.234",
+                  "sessionStateV4": "PendingAdd",
+                  "sessionStateV6": "PendingAdd",
+                  "maxPrefixesAdvertisedV4": 1000,
+                  "maxPrefixesAdvertisedV6": 100
+                },
+                "connectionIdentifier": "5F4CB5C7-6B43-4444-9338-9ABC72606C16"
+              }
+            ],
+            "useForPeeringService": true,
+            "peerAsn": {
+              "id": "/subscriptions/subId/providers/Microsoft.Peering/peerAsns/myAsn1"
+            },
+            "directPeeringType": "IxRs"
+          },
+          "peeringLocation": "peeringLocation0",
+          "provisioningState": "Succeeded"
+        },
+        "location": "eastus",
+        "name": "peeringName",
+        "id": "/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Peering/peerings/peeringName",
+        "type": "Microsoft.Peering/peerings"
+      }
+    }
+  }
+}

--- a/specification/peering/resource-manager/Microsoft.Peering/preview/2020-01-01-preview/peering.json
+++ b/specification/peering/resource-manager/Microsoft.Peering/preview/2020-01-01-preview/peering.json
@@ -995,6 +995,9 @@
           },
           "Create an exchange peering": {
             "$ref": "./examples/CreateExchangePeering.json"
+          },
+          "Create a peering with exchange route server": {
+            "$ref": "./examples/CreatePeeringWithExchangeRouteServer.json"
           }
         }
       },
@@ -2222,13 +2225,11 @@
         },
         "microsoftSessionIPv4Address": {
           "description": "The IPv4 session address on Microsoft's end.",
-          "type": "string",
-          "readOnly": true
+          "type": "string"
         },
         "microsoftSessionIPv6Address": {
           "description": "The IPv6 session address on Microsoft's end.",
-          "type": "string",
-          "readOnly": true
+          "type": "string"
         },
         "peerSessionIPv4Address": {
           "description": "The IPv4 session address on peer's end.",


### PR DESCRIPTION
- Remove readonly flag from microsoftSessionIPv4Address and microsoftSessionIPv6Address properties in BgpSession data model definition. 
- Add an example for creating a direct peering of directPeeringType IxRs.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
