### PR TITLE
Fix Parameter Description for validate resource move

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
@@ -5658,7 +5658,7 @@
       "type": "string",
       "description": "The ID of the target subscription."
     },
-	"SourceSubscriptionIdParameter": {
+    "SourceSubscriptionIdParameter": {
       "name": "subscriptionId",
       "in": "path",
       "required": true,

--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
@@ -2600,7 +2600,7 @@
             "$ref": "#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
+            "$ref": "#/parameters/SourceSubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -5657,6 +5657,13 @@
       "required": true,
       "type": "string",
       "description": "The ID of the target subscription."
+    },
+	"SourceSubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The ID of the source subscription."
     },
     "DeploymentNameParameter": {
       "name": "deploymentName",


### PR DESCRIPTION
Fix issue in https://github.com/Azure/azure-rest-api-specs/issues/7204
Per discussion with @Tiano2017 and @ifeoluwaokunoren  creating a new parameter for source subscription id.
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
