### PR TITLE
[Storage CMK Key Vault Key Auto Rotation] Add read-only properties for current versioned key in use and last rotation timestamp.

### DIFF
--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/examples/StorageAccountEnableCMK.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/examples/StorageAccountEnableCMK.json
@@ -11,13 +11,11 @@
           "services": {
             "file": {
               "keyType": "Account",
-              "enabled": true,
-              "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              "enabled": true
             },
             "blob": {
               "keyType": "Account",
-              "enabled": true,
-              "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              "enabled": true
             }
           },
           "keySource": "Microsoft.Keyvault",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/examples/StorageAccountEnableCMK.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/examples/StorageAccountEnableCMK.json
@@ -1,0 +1,92 @@
+{
+    "parameters": {
+      "subscriptionId": "{subscription-id}",
+      "resourceGroupName": "res9407",
+      "accountName": "sto8596",
+      "api-version": "2019-06-01",
+      "monitor": "true",
+      "parameters": {
+        "properties": {
+            "encryption": {
+                "services": {
+                  "file": {
+                    "keyType": "Account",
+                    "enabled": true,
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  },
+                  "blob": {
+                    "keyType": "Account",
+                    "enabled": true,
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  }
+                },
+                "keySource": "Microsoft.Keyvault",
+                "keyvaultproperties": {
+                  "keyvaulturi": "https://myvault8569.vault.azure.net",
+                  "keyname": "wrappingKey",
+                  "keyversion": ""
+                }
+            }
+        }
+      }
+    },
+    "responses": {
+      "200": {
+        "body": {
+          "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+          "kind": "Storage",
+          "location": "eastus2(stage)",
+          "name": "sto8596",
+          "properties": {
+            "creationTime": "2017-06-01T02:42:41.7633306Z",
+            "encryption": {
+                "services": {
+                  "file": {
+                    "keyType": "Account",
+                    "enabled": true,
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  },
+                  "blob": {
+                    "keyType": "Account",
+                    "enabled": true,
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  }
+                },
+                "keySource": "Microsoft.Keyvault",
+                "keyvaultproperties": {
+                  "keyvaulturi": "https://myvault8569.vault.azure.net",
+                  "keyname": "wrappingKey",
+                  "keyversion": "",
+                  "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+                  "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+                }
+            },
+            "primaryEndpoints": {
+              "web": "https://sto8596.web.core.windows.net/",
+              "dfs": "https://sto8596.dfs.core.windows.net/",
+              "blob": "https://sto8596.blob.core.windows.net/",
+              "file": "https://sto8596.file.core.windows.net/",
+              "queue": "https://sto8596.queue.core.windows.net/",
+              "table": "https://sto8596.table.core.windows.net/"
+            },
+            "primaryLocation": "eastus2(stage)",
+            "provisioningState": "Succeeded",
+            "secondaryLocation": "northcentralus(stage)",
+            "statusOfPrimary": "available",
+            "statusOfSecondary": "available",
+            "supportsHttpsTrafficOnly": false
+          },
+          "sku": {
+            "name": "Standard_GRS",
+            "tier": "Standard"
+          },
+          "tags": {
+            "key1": "value1",
+            "key2": "value2"
+          },
+          "type": "Microsoft.Storage/storageAccounts"
+        }
+      }
+    }
+  }
+  

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/examples/StorageAccountGetPropertiesCMKEnabled.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/examples/StorageAccountGetPropertiesCMKEnabled.json
@@ -4,31 +4,7 @@
     "resourceGroupName": "res9407",
     "accountName": "sto8596",
     "api-version": "2019-06-01",
-    "monitor": "true",
-    "parameters": {
-      "properties": {
-        "encryption": {
-          "services": {
-            "file": {
-              "keyType": "Account",
-              "enabled": true,
-              "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
-            },
-            "blob": {
-              "keyType": "Account",
-              "enabled": true,
-              "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
-            }
-          },
-          "keySource": "Microsoft.Keyvault",
-          "keyvaultproperties": {
-            "keyvaulturi": "https://myvault8569.vault.azure.net",
-            "keyname": "wrappingKey",
-            "keyversion": ""
-          }
-        }
-      }
-    }
+    "monitor": "true"
   },
   "responses": {
     "200": {
@@ -43,7 +19,48 @@
         "location": "eastus2(stage)",
         "name": "sto8596",
         "properties": {
+          "geoReplicationStats": {
+            "status": "Live",
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "canFailover": true
+          },
+          "isHnsEnabled": true,
           "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "web": "https://sto8596.web.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "microsoftEndpoints": {
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/"
+            },
+            "internetEndpoints": {
+              "web": "https://sto8596-internetrouting.web.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/"
+            }
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "routingChoice": "MicrosoftRouting",
+            "publishMicrosoftEndpoints": true,
+            "publishInternetEndpoints": true
+          },
           "encryption": {
             "services": {
               "file": {
@@ -66,16 +83,6 @@
               "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
             }
           },
-          "primaryEndpoints": {
-            "web": "https://sto8596.web.core.windows.net/",
-            "dfs": "https://sto8596.dfs.core.windows.net/",
-            "blob": "https://sto8596.blob.core.windows.net/",
-            "file": "https://sto8596.file.core.windows.net/",
-            "queue": "https://sto8596.queue.core.windows.net/",
-            "table": "https://sto8596.table.core.windows.net/"
-          },
-          "primaryLocation": "eastus2(stage)",
-          "provisioningState": "Succeeded",
           "secondaryLocation": "northcentralus(stage)",
           "statusOfPrimary": "available",
           "statusOfSecondary": "available",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/examples/StorageAccountList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/examples/StorageAccountList.json
@@ -111,6 +111,96 @@
             "type": "Microsoft.Storage/storageAccounts"
           },
           {
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+            "identity": {
+              "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+              "type": "SystemAssigned"
+            },
+            "kind": "Storage",
+            "location": "eastus2(stage)",
+            "name": "sto8596",
+            "properties": {
+              "geoReplicationStats": {
+                "status": "Live",
+                "lastSyncTime": "2018-10-30T00:25:34Z",
+                "canFailover": true
+              },
+              "isHnsEnabled": true,
+              "creationTime": "2017-06-01T02:42:41.7633306Z",
+              "networkAcls": {
+                "bypass": "AzureServices",
+                "defaultAction": "Allow",
+                "ipRules": [],
+                "virtualNetworkRules": []
+              },
+              "primaryEndpoints": {
+                "web": "https://sto8596.web.core.windows.net/",
+                "dfs": "https://sto8596.dfs.core.windows.net/",
+                "blob": "https://sto8596.blob.core.windows.net/",
+                "file": "https://sto8596.file.core.windows.net/",
+                "queue": "https://sto8596.queue.core.windows.net/",
+                "table": "https://sto8596.table.core.windows.net/",
+                "microsoftEndpoints": {
+                  "web": "https://sto8596-microsoftrouting.web.core.windows.net/",
+                  "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+                  "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+                  "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+                  "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+                  "table": "https://sto8596-microsoftrouting.table.core.windows.net/"
+                },
+                "internetEndpoints": {
+                  "web": "https://sto8596-internetrouting.web.core.windows.net/",
+                  "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+                  "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+                  "file": "https://sto8596-internetrouting.file.core.windows.net/"
+                }
+              },
+              "primaryLocation": "eastus2(stage)",
+              "provisioningState": "Succeeded",
+              "routingPreference": {
+                "routingChoice": "MicrosoftRouting",
+                "publishMicrosoftEndpoints": true,
+                "publishInternetEndpoints": true
+              },
+              "encryption": {
+                "services": {
+                  "file": {
+                    "keyType": "Account",
+                    "enabled": true,
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  },
+                  "blob": {
+                    "keyType": "Account",
+                    "enabled": true,
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  }
+                },
+                "keySource": "Microsoft.Keyvault",
+                "keyvaultproperties": {
+                  "keyvaulturi": "https://myvault8569.vault.azure.net",
+                  "keyname": "wrappingKey",
+                  "keyversion": "",
+                  "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+                  "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+                }
+              },
+              "secondaryLocation": "northcentralus(stage)",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            },
+            "type": "Microsoft.Storage/storageAccounts"
+          },
+          {
             "id": "/subscriptions/{subscription-id}/resourceGroups/testcmk3/providers/Microsoft.Storage/storageAccounts/sto6637",
             "identity": {
               "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json
@@ -209,6 +209,9 @@
         "x-ms-examples": {
           "StorageAccountGetProperties": {
             "$ref": "./examples/StorageAccountGetProperties.json"
+          },
+          "StorageAccountGetPropertiesCMKEnabled": {
+            "$ref": "./examples/StorageAccountGetPropertiesCMKEnabled.json"
           }
         },
         "parameters": [
@@ -261,6 +264,9 @@
           },
           "StorageAccountEnableAD": {
             "$ref": "./examples/StorageAccountEnableAD.json"
+          },
+          "StorageAccountEnableCMK": {
+            "$ref": "./examples/StorageAccountEnableCMK.json"
           }
         },
         "parameters": [

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json
@@ -1604,6 +1604,19 @@
           "type": "string",
           "description": "The Uri of KeyVault.",
           "x-ms-client-name": "KeyVaultUri"
+        },
+        "currentVersionedKeyIdentifier": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The object identifier of the current versioned Key Vault Key in use.",
+          "x-ms-client-name": "CurrentVersionedKeyIdentifier"
+        },
+        "lastKeyRotationTimestamp": {
+          "type": "string",
+          "readOnly": true,
+          "format": "date-time",
+          "description": "Timestamp of last rotation of the Key Vault Key.",
+          "x-ms-client-name": "LastKeyRotationTimestamp"
         }
       }
     },


### PR DESCRIPTION
…r current versioned key in use and last rotation timestamp.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
