### PR TITLE
Change storagecache name max length from 31 to 80

### DIFF
--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
@@ -266,7 +266,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           },
@@ -325,7 +325,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           },
@@ -386,7 +386,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           },
@@ -456,7 +456,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           },
@@ -518,7 +518,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           }
@@ -579,7 +579,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           }
@@ -640,7 +640,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           }
@@ -701,7 +701,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           }
@@ -758,7 +758,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           },
@@ -825,7 +825,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           },
@@ -888,7 +888,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           },
@@ -965,7 +965,7 @@
             "description": "Name of Cache.",
             "in": "path",
             "name": "cacheName",
-            "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+            "pattern": "^[-0-9a-zA-Z_]{1,80}$",
             "required": true,
             "type": "string"
           }
@@ -1306,7 +1306,7 @@
     },
     "ResourceName": {
       "description": "Schema for the name of resources served by this provider. Note that objects will contain an odata @id annotation as appropriate. This will contain the complete URL of the object. These names are case-preserving, but not case sensitive.",
-      "pattern": "^[-0-9a-zA-Z_]{1,31}$",
+      "pattern": "^[-0-9a-zA-Z_]{1,80}$",
       "type": "string"
     },
     "ResourceSku": {

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
@@ -1508,6 +1508,9 @@
           }
         }
       },
+      "required": [
+        "targetType"
+      ],
       "x-ms-azure-resource": true
     },
     "NamespaceJunction": {

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
@@ -904,6 +904,7 @@
             "description": "Object containing the definition of a Storage Target.",
             "in": "body",
             "name": "storagetarget",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/StorageTarget"
             }

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
@@ -1434,7 +1434,6 @@
     "StorageTarget": {
       "description": "A storage system being cached by a Cache.",
       "type": "object",
-      "discriminator": "targetType",
       "properties": {
         "name": {
           "description": "Name of the Storage Target.",
@@ -1455,6 +1454,10 @@
           "x-ms-client-flatten": true,
           "description": "Properties of the Storage Target.",
           "type": "object",
+          "discriminator": "targetType",
+          "required": [
+            "targetType"
+          ],
           "properties": {
             "junctions": {
               "description": "List of Cache namespace junctions to target for namespace associations.",

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2019-11-01/storagecache.json
@@ -904,7 +904,6 @@
             "description": "Object containing the definition of a Storage Target.",
             "in": "body",
             "name": "storagetarget",
-            "required": true,
             "schema": {
               "$ref": "#/definitions/StorageTarget"
             }
@@ -1508,9 +1507,6 @@
           }
         }
       },
-      "required": [
-        "targetType"
-      ],
       "x-ms-azure-resource": true
     },
     "NamespaceJunction": {


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-ruby/issues/2759

This updates the storagecache name regex to support a maximum length of 80, not 31. This is consistent with the Azure console validation messages, and with my own experience creating caches with names up to 80 characters long. This confusion may have originated from cache storage target name restrictions of 31 characters, which is correct.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
