### PR TITLE
[Storage] Set supportsHttpsTrafficOnly's default to true

### DIFF
--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-04-01/storage.json
@@ -1432,6 +1432,7 @@
         },
         "supportsHttpsTrafficOnly": {
           "type": "boolean",
+          "default": true,
           "x-ms-client-name": "EnableHttpsTrafficOnly",
           "description": "Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01."
         },

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2019-06-01/storage.json
@@ -1850,6 +1850,7 @@
         },
         "supportsHttpsTrafficOnly": {
           "type": "boolean",
+          "default": true,
           "x-ms-client-name": "EnableHttpsTrafficOnly",
           "description": "Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01."
         },


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/12519 [Storage] Azure policy denies storage account creation if `--https-only` is omitted

This PR sets `StorageAccountPropertiesCreateParameters.supportsHttpsTrafficOnly`'s default to `true`.

Without the default value, SDK will send an HTTPS request without `supportsHttpsTrafficOnly`, thus be blocked by the built-in Azure policy `Secure transfer to storage accounts should be enabled`.
