### PR TITLE
PolicyInsights: Add policy version columns

### DIFF
--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryManagementGroupScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryManagementGroupScope.json
@@ -42,7 +42,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": "2.0.1",
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -75,7 +78,10 @@
             "complianceState": "Compliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryNestedResourceScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryNestedResourceScope.json
@@ -41,7 +41,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -74,7 +77,10 @@
             "complianceState": "Compliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryResourceGroupLevelPolicyAssignmentScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryResourceGroupLevelPolicyAssignmentScope.json
@@ -44,7 +44,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -77,7 +80,10 @@
             "complianceState": "Compliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryResourceGroupScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryResourceGroupScope.json
@@ -42,7 +42,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": "2.0.1",
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -75,7 +78,10 @@
             "complianceState": "Compliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": "2.0.1",
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryResourceScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryResourceScope.json
@@ -41,7 +41,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -74,7 +77,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryResourceScopeExpandPolicyEvaluationDetails.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QueryResourceScopeExpandPolicyEvaluationDetails.json
@@ -43,6 +43,9 @@
             "policyDefinitionGroupNames": [
               "myGroup"
             ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0",
             "policyEvaluationDetails": {
               "evaluatedExpressions": [
                 {
@@ -96,6 +99,9 @@
             "policyDefinitionGroupNames": [
               "myGroup"
             ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0",
             "policyEvaluationDetails": {
               "evaluatedExpressions": [
                 {

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelNestedResourceScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelNestedResourceScope.json
@@ -41,7 +41,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -74,7 +77,10 @@
             "complianceState": "Compliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelPolicyAssignmentScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelPolicyAssignmentScope.json
@@ -43,7 +43,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": "2.0.1",
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -76,7 +79,10 @@
             "complianceState": "Compliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": "2.0.1",
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelPolicyDefinitionScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelPolicyDefinitionScope.json
@@ -43,7 +43,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -76,7 +79,10 @@
             "complianceState": "Compliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelPolicySetDefinitionScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelPolicySetDefinitionScope.json
@@ -43,7 +43,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": "2.0.1",
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -76,7 +79,10 @@
             "complianceState": "Compliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": "2.0.1",
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelResourceScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionLevelResourceScope.json
@@ -41,7 +41,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -74,7 +77,10 @@
             "complianceState": "Compliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": null,
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/PolicyStates_QuerySubscriptionScope.json
@@ -41,7 +41,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": "2.0.1",
+            "policyAssignmentVersion": "1.0.0"
           },
           {
             "@odata.id": null,
@@ -74,7 +77,10 @@
             "complianceState": "NonCompliant",
             "policyDefinitionGroupNames": [
               "myGroup"
-            ]
+            ],
+            "policyDefinitionVersion": "1.0.0-preview",
+            "policySetDefinitionVersion": "2.0.1",
+            "policyAssignmentVersion": "1.0.0"
           }
         ]
       }

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/policyStates.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/policyStates.json
@@ -1228,6 +1228,21 @@
           "items": {
             "type": "string"
           }
+        },
+        "policyDefinitionVersion": {
+          "description": "Evaluated policy definition version.",
+          "type": "string",
+          "readOnly": true
+        },
+        "policySetDefinitionVersion": {
+          "description": "Evaluated policy set definition version.",
+          "type": "string",
+          "readOnly": true
+        },
+        "policyAssignmentVersion": {
+          "description": "Evaluated policy definition version.",
+          "type": "string",
+          "readOnly": true
         }
       },
       "additionalProperties": {

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/policyStates.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/policyStates.json
@@ -1240,7 +1240,7 @@
           "readOnly": true
         },
         "policyAssignmentVersion": {
-          "description": "Evaluated policy definition version.",
+          "description": "Evaluated policy assignment version.",
           "type": "string",
           "readOnly": true
         }


### PR DESCRIPTION
Added the read-only policy entity version columns to the OData query responses in the Microsoft.PolicyInsights/policyStates API.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
