### PR TITLE
Fix: Capacity is a mandatory Property

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/apimdeployment.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/apimdeployment.json
@@ -248,6 +248,9 @@
           },
           "ApiManagementCreateServiceWithSystemCertificates": {
             "$ref": "./examples/ApiManagementCreateServiceWithSystemCertificates.json"
+          },
+          "ApiManagementCreateServiceWithUserAssignedIdentity":{
+            "$ref": "./examples/ApiManagementCreateServiceWithUserAssignedIdentity.json"
           }
         },
         "parameters": [

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/apimdeployment.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/apimdeployment.json
@@ -249,7 +249,7 @@
           "ApiManagementCreateServiceWithSystemCertificates": {
             "$ref": "./examples/ApiManagementCreateServiceWithSystemCertificates.json"
           },
-          "ApiManagementCreateServiceWithUserAssignedIdentity":{
+          "ApiManagementCreateServiceWithUserAssignedIdentity": {
             "$ref": "./examples/ApiManagementCreateServiceWithUserAssignedIdentity.json"
           }
         },

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/apimdeployment.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/apimdeployment.json
@@ -1250,11 +1250,12 @@
         "capacity": {
           "type": "integer",
           "format": "int32",
-          "description": "Capacity of the SKU (number of deployed units of the SKU)."
+          "description": "Capacity of the SKU (number of deployed units of the SKU). For Consumption SKU capacity must be specified as 0."
         }
       },
       "required": [
-        "name"
+        "name",
+        "capacity"
       ],
       "description": "API Management service resource SKU properties."
     },

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/examples/ApiManagementCreateServiceHavingMsi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/examples/ApiManagementCreateServiceHavingMsi.json
@@ -10,7 +10,8 @@
         "publisherName": "autorestsdk"
       },
       "sku": {
-        "name": "Consumption"
+        "name": "Consumption",
+        "capacity": 0
       },
       "identity": {
         "type": "SystemAssigned"

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/examples/ApiManagementCreateServiceWithUserAssignedIdentity.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/examples/ApiManagementCreateServiceWithUserAssignedIdentity.json
@@ -1,0 +1,137 @@
+{
+  "parameters": {
+    "serviceName": "apimService1",
+    "resourceGroupName": "rg1",
+    "api-version": "2019-12-01-preview",
+    "subscriptionId": "subid",
+    "parameters": {
+      "properties": {
+        "publisherEmail": "apim@autorestsdk.com",
+        "publisherName": "autorestsdk"
+      },
+      "sku": {
+        "name": "Consumption",
+        "capacity": 0
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/subid/resourcegroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/apimService1": {}
+        }
+      },
+      "location": "West US",
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2",
+        "tag3": "value3"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/operationresults/dGVjaGVkX01hbmFnZVJvbGVfNWRiNGI3Ng==?api-version=2019-12-01-preview"
+      },
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2",
+          "tag3": "value3"
+        },
+        "location": "West US",
+        "etag": "AAAAAAAFzyQ=",
+        "properties": {
+          "publisherEmail": "apim@autorestsdk.com",
+          "publisherName": "autorestsdk",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Created",
+          "targetProvisioningState": "Activating",
+          "createdAtUtc": "2020-03-12T01:05:33.4573398Z",
+          "hostnameConfigurations": [
+            {
+              "type": "Proxy",
+              "hostName": "apimService1.azure-api.net",
+              "negotiateClientCertificate": false,
+              "defaultSslBinding": true
+            }
+          ],
+          "virtualNetworkType": "None"
+        },
+        "sku": {
+          "name": "Consumption",
+          "capacity": 0
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/subid/resourcegroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/apimService1": {
+            }
+          }
+        }
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1",
+        "name": "apimService1",
+        "type": "Microsoft.ApiManagement/service",
+        "tags": {
+            "tag1": "value1",
+            "tag2": "value2",
+            "tag3": "value3"
+        },
+        "location": "West US",
+        "etag": "AAAAAAAFzyk=",
+        "properties": {
+            "publisherEmail": "apim@autorestsdk.com",
+            "publisherName": "autorestsdk",
+            "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+            "provisioningState": "Succeeded",
+            "targetProvisioningState": "",
+            "createdAtUtc": "2020-03-12T01:05:33.4573398Z",
+            "gatewayUrl": "https://apimService1.azure-api.net",
+            "hostnameConfigurations": [
+                {
+                    "type": "Proxy",
+                    "hostName": "apimService1.azure-api.net",
+                    "negotiateClientCertificate": false,
+                    "defaultSslBinding": true
+                }
+            ],
+            "customProperties": {
+                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False",
+                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11": "False",
+                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10": "False",
+                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11": "False",
+                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30": "False",
+                "Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2": "False"
+            },
+            "virtualNetworkType": "None",
+            "disableGateway": false
+        },
+        "sku": {
+            "name": "Consumption",
+            "capacity": 0
+        },
+        "identity": {
+            "type": "UserAssigned",
+            "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+            "userAssignedIdentities": {
+                "/subscriptions/subid/resourcegroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/apimService1": {
+                    "principalId": "3e099fbe-6e62-4649-9f54-a119fc1ba85e",
+                    "clientId": "5a2c6b8e-0905-45b7-a772-993c9418137f"
+                }
+            }
+        }
+    }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/operationresults/dGVjaGVkX01hbmFnZVJvbGVfNWRiNGI3Ng==?api-version=2019-12-01-preview"
+      }
+    }
+  }
+}

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/examples/ApiManagementCreateServiceWithUserAssignedIdentity.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2019-12-01-preview/examples/ApiManagementCreateServiceWithUserAssignedIdentity.json
@@ -67,8 +67,7 @@
         "identity": {
           "type": "UserAssigned",
           "userAssignedIdentities": {
-            "/subscriptions/subid/resourcegroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/apimService1": {
-            }
+            "/subscriptions/subid/resourcegroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/apimService1": {}
           }
         }
       }
@@ -79,54 +78,54 @@
         "name": "apimService1",
         "type": "Microsoft.ApiManagement/service",
         "tags": {
-            "tag1": "value1",
-            "tag2": "value2",
-            "tag3": "value3"
+          "tag1": "value1",
+          "tag2": "value2",
+          "tag3": "value3"
         },
         "location": "West US",
         "etag": "AAAAAAAFzyk=",
         "properties": {
-            "publisherEmail": "apim@autorestsdk.com",
-            "publisherName": "autorestsdk",
-            "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
-            "provisioningState": "Succeeded",
-            "targetProvisioningState": "",
-            "createdAtUtc": "2020-03-12T01:05:33.4573398Z",
-            "gatewayUrl": "https://apimService1.azure-api.net",
-            "hostnameConfigurations": [
-                {
-                    "type": "Proxy",
-                    "hostName": "apimService1.azure-api.net",
-                    "negotiateClientCertificate": false,
-                    "defaultSslBinding": true
-                }
-            ],
-            "customProperties": {
-                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False",
-                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11": "False",
-                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10": "False",
-                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11": "False",
-                "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30": "False",
-                "Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2": "False"
-            },
-            "virtualNetworkType": "None",
-            "disableGateway": false
+          "publisherEmail": "apim@autorestsdk.com",
+          "publisherName": "autorestsdk",
+          "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+          "provisioningState": "Succeeded",
+          "targetProvisioningState": "",
+          "createdAtUtc": "2020-03-12T01:05:33.4573398Z",
+          "gatewayUrl": "https://apimService1.azure-api.net",
+          "hostnameConfigurations": [
+            {
+              "type": "Proxy",
+              "hostName": "apimService1.azure-api.net",
+              "negotiateClientCertificate": false,
+              "defaultSslBinding": true
+            }
+          ],
+          "customProperties": {
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False",
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11": "False",
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10": "False",
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11": "False",
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30": "False",
+            "Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2": "False"
+          },
+          "virtualNetworkType": "None",
+          "disableGateway": false
         },
         "sku": {
-            "name": "Consumption",
-            "capacity": 0
+          "name": "Consumption",
+          "capacity": 0
         },
         "identity": {
-            "type": "UserAssigned",
-            "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-            "userAssignedIdentities": {
-                "/subscriptions/subid/resourcegroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/apimService1": {
-                    "principalId": "3e099fbe-6e62-4649-9f54-a119fc1ba85e",
-                    "clientId": "5a2c6b8e-0905-45b7-a772-993c9418137f"
-                }
+          "type": "UserAssigned",
+          "tenantId": "XXXXX-86f1-41af-XXXX-2d7cd011db47",
+          "userAssignedIdentities": {
+            "/subscriptions/subid/resourcegroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/apimService1": {
+              "principalId": "XXXXX-6e62-4649-9f54-a119fc1ba85e",
+              "clientId": "5a2c6b8e-0905-XXXX-a772-993c9418137f"
             }
+          }
         }
-    }
+      }
     },
     "202": {
       "headers": {


### PR DESCRIPTION
### Latest improvements:
- This is a preview version of the API and capacity property on the Resource is actually mandatory in this version. This PR is just for fixing the mistake in the spec.

### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
