### PR TITLE
Adding description of unlink action to Replication Link Swagger

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/stable/2014-04-01/examples/ReplicationLinkGet.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/stable/2014-04-01/examples/ReplicationLinkGet.json
@@ -21,7 +21,7 @@
           "role": "Secondary",
           "partnerRole": "Primary",
           "replicationMode": "ASYNC",
-          "startTime": "2017-02-10T01:37:49.153",
+          "startTime": "2017-02-10T01:37:49.153Z",
           "percentComplete": 100,
           "replicationState": "CATCH_UP",
           "isTerminationAllowed": true

--- a/specification/sql/resource-manager/Microsoft.Sql/stable/2014-04-01/examples/ReplicationLinkList.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/stable/2014-04-01/examples/ReplicationLinkList.json
@@ -22,7 +22,7 @@
               "role": "Secondary",
               "partnerRole": "Primary",
               "replicationMode": "ASYNC",
-              "startTime": "2017-02-10T01:44:27.117",
+              "startTime": "2017-02-10T01:44:27.117Z",
               "percentComplete": 100,
               "replicationState": "CATCH_UP",
               "isTerminationAllowed": true

--- a/specification/sql/resource-manager/Microsoft.Sql/stable/2014-04-01/examples/ReplicationLinkUnlink.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/stable/2014-04-01/examples/ReplicationLinkUnlink.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "sqlcrudtest-8931",
+    "serverName": "sqlcrudtest-2137",
+    "databaseName": "testdb",
+    "linkId": "f0550bf5-07ce-4270-8e4b-71737975973a",
+    "api-version": "2014-04-01",
+    "parameters": {
+      "forcedTermination": true
+    }
+  },
+  "responses": {
+    "202": {},
+    "204": {}
+  }
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/stable/2014-04-01/replicationLinks.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/stable/2014-04-01/replicationLinks.json
@@ -216,6 +216,66 @@
         "x-ms-long-running-operation": true
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/replicationLinks/{linkId}/unlink": {
+      "post": {
+        "tags": [
+          "DatabaseReplicationLinks"
+        ],
+        "operationId": "ReplicationLinks_Unlink",
+        "description": "Deletes a database replication link in forced or friendly way.",
+        "x-ms-examples": {
+          "Delete replication link": {
+            "$ref": "./examples/ReplicationLinkUnlink.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/ServerNameParameter"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the database that has the replication link to be failed over."
+          },
+          {
+            "name": "linkId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The ID of the replication link to be failed over."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UnlinkParameters"
+            },
+            "description": "The required parameters for unlinking replication link."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "202": {
+            "description": "Accepted"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/replicationLinks": {
       "get": {
         "tags": [
@@ -387,6 +447,15 @@
         }
       },
       "description": "Represents the response to a List database replication link request."
+    },
+    "UnlinkParameters": {
+      "properties": {
+        "forcedTermination": {
+          "type": "boolean",
+          "description": "Determines whether link will be terminated in a forced or a friendly way."
+        }
+      },
+      "description": "Represents the parameters for Unlink Replication Link request."
     }
   },
   "parameters": {


### PR DESCRIPTION
This PR is adding missing description of unlink action for Replication Link in 2014-04-01 API. Since it is old API, it doesn't break any functionality, but needs to be added for compliance reasons.