### PR TITLE
[Storage][Blob]Blob Versioning: listBlobs add include {versions} and undo set metadata

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -4807,9 +4807,6 @@
           "enum": [
             "metadata"
           ]
-        },
-        {
-          "$ref": "#/parameters/VersionId"
         }
       ]
     },
@@ -10513,7 +10510,8 @@
           "deleted",
           "metadata",
           "snapshots",
-          "uncommittedblobs"
+          "uncommittedblobs",
+          "versions"
         ],
         "x-ms-enum": {
           "name": "ListBlobsIncludeItem",
@@ -10795,7 +10793,7 @@
       "required": false,
       "type": "string",
       "x-ms-parameter-location": "method",
-      "description": "The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to delete. It for service version 2019_10_10 and newer."
+      "description": "The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on. It's for service version 2019-10-10 and newer."
     },
     "SourceContentMD5": {
       "name": "x-ms-source-content-md5",

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -4762,6 +4762,11 @@
                 "type": "string",
                 "description": "Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above."
               },
+              "x-ms-version-id": {
+                "x-ms-client-name": "VersionId",
+                "type": "string",
+                "description": "A DateTime value returned by the service that uniquely identifies the blob. The value of this header indicates the blob version, and may be used in subsequent requests to access this version of the blob."
+              },
               "Date": {
                 "type": "string",
                 "format": "date-time-rfc1123",
@@ -7661,6 +7666,11 @@
                 "x-ms-client-name": "Version",
                 "type": "string",
                 "description": "Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above."
+              },
+              "x-ms-version-id": {
+                "x-ms-client-name": "VersionId",
+                "type": "string",
+                "description": "A DateTime value returned by the service that uniquely identifies the blob. The value of this header indicates the blob version, and may be used in subsequent requests to access this version of the blob."
               },
               "Date": {
                 "type": "string",

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -5736,6 +5736,11 @@
                 "type": "string",
                 "description": "Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above."
               },
+              "x-ms-version-id": {
+                "x-ms-client-name": "VersionId",
+                "type": "string",
+                "description": "A DateTime value returned by the service that uniquely identifies the blob. The value of this header indicates the blob version, and may be used in subsequent requests to access this version of the blob."
+              },
               "Date": {
                 "type": "string",
                 "format": "date-time-rfc1123",
@@ -5838,6 +5843,11 @@
                 "x-ms-client-name": "Version",
                 "type": "string",
                 "description": "Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above."
+              },
+              "x-ms-version-id": {
+                "x-ms-client-name": "VersionId",
+                "type": "string",
+                "description": "A DateTime value returned by the service that uniquely identifies the blob. The value of this header indicates the blob version, and may be used in subsequent requests to access this version of the blob."
               },
               "Date": {
                 "type": "string",

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -5839,11 +5839,6 @@
                 "type": "string",
                 "description": "This header uniquely identifies the request that was made and can be used for troubleshooting the request."
               },
-              "x-ms-version": {
-                "x-ms-client-name": "Version",
-                "type": "string",
-                "description": "Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above."
-              },
               "x-ms-version-id": {
                 "x-ms-client-name": "VersionId",
                 "type": "string",

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -5839,6 +5839,11 @@
                 "type": "string",
                 "description": "This header uniquely identifies the request that was made and can be used for troubleshooting the request."
               },
+              "x-ms-version": {
+                "x-ms-client-name": "Version",
+                "type": "string",
+                "description": "Indicates the version of the Blob service used to execute the request. This header is returned for requests made against version 2009-09-19 and above."
+              },
               "x-ms-version-id": {
                 "x-ms-client-name": "VersionId",
                 "type": "string",


### PR DESCRIPTION
Fix issues found in #8515

1. Add support for include={versions} for List Blobs.
2. Undo the change in BlobSetMetadataOptionalParams as set metadata is only allowed on the root blob.
3. Fix the ‘the version to delete’ comments.
4. Add `versionId` to the response headers of `syncCopyFromURL`.


**TODO**

Add `versionId` to the response headers:
- [x] abortCopyFromURL: reverted by #8762
- [x] pageBlob incrementalCopy: reverted by #8762
- [x] set metadata
