### PR TITLE
Add unregister feature api in Microsoft.Features swagger spec

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Features/stable/2015-12-01/examples/unregisterFeature.json
+++ b/specification/resources/resource-manager/Microsoft.Features/stable/2015-12-01/examples/unregisterFeature.json
@@ -3,7 +3,7 @@
     "resourceProviderNamespace": "Resource Provider Namespace",
     "featureName": "feature",
     "api-version": "2015-12-01",
-    "subscriptionId": "subid"
+    "subscriptionId": "ff23096b-f5a2-46ea-bd62-59c3e93fef9a"
   },
   "responses": {
     "200": {
@@ -13,8 +13,8 @@
         "properties": {
           "state": "unregistered"
         },
-        "id": "feature_id1",
-        "type": "type1"
+        "id": "/subscriptions/ff23096b-f5a2-46ea-bd62-59c3e93fef9a/providers/Microsoft.Features/providers/Microsoft.Test/features/Feature1",
+        "type": "Microsoft.Features/providers/features"
       }
     }
   }

--- a/specification/resources/resource-manager/Microsoft.Features/stable/2015-12-01/examples/unregisterFeature.json
+++ b/specification/resources/resource-manager/Microsoft.Features/stable/2015-12-01/examples/unregisterFeature.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "resourceProviderNamespace": "Resource Provider Namespace",
+    "featureName": "feature",
+    "api-version": "2015-12-01",
+    "subscriptionId": "subid"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "name": "Feature1",
+        "properties": {
+          "state": "unregistered"
+        },
+        "id": "feature_id1",
+        "type": "type1"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Features/stable/2015-12-01/features.json
+++ b/specification/resources/resource-manager/Microsoft.Features/stable/2015-12-01/features.json
@@ -226,6 +226,50 @@
           }
         }
       }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Features/providers/{resourceProviderNamespace}/features/{featureName}/unregister": {
+      "post": {
+        "tags": [
+          "Features"
+        ],
+        "operationId": "Features_Unregister",
+        "description": "Unregisters the preview feature for the subscription.",
+        "x-ms-examples": {
+          "Register feature": {
+            "$ref": "./examples/unregisterFeature.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "resourceProviderNamespace",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The namespace of the resource provider."
+          },
+          {
+            "name": "featureName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the feature to unregister."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns metadata about the unregistered feature. The metadata includes the name of the feature, the registration state, the resource ID, and resource type.",
+            "schema": {
+              "$ref": "#/definitions/FeatureResult"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
Add unregister feature api in Microsoft.Features swagger spec.
We need to update the swagger to include the unregister action, so we can support unregistering non-application owned features.