### PR TITLE
[FormRecognizer] adds x-ms-long-running-operation to LROs that use Operation-Location header

### DIFF
--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -261,7 +261,8 @@
           "Analyze form with custom model": {
             "$ref": "./examples/AnalyzeBatch.json"
           }
-        }
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/custom/models/{modelId}/analyzeResults/{resultId}": {
@@ -363,7 +364,8 @@
             "$ref": "./examples/ReceiptsBatch.json"
           }
         }
-      }
+      },
+      "x-ms-long-running-operation": true
     },
     "/prebuilt/receipt/analyzeResults/{resultId}": {
       "get": {
@@ -447,7 +449,8 @@
             "$ref": "./examples/LayoutBatch.json"
           }
         }
-      }
+      },
+      "x-ms-long-running-operation": true
     },
     "/layout/analyzeResults/{resultId}": {
       "get": {


### PR DESCRIPTION
Adds `"x-ms-long-running-operation": true` to the following endpoints:
* /custom/models/{modelId}/analyze
* /prebuilt/receipt/analyze
* /layout/analyze