### PR TITLE
Remove SKU from workflowProperties in Logic swagger

### DIFF
--- a/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json
+++ b/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json
@@ -6508,6 +6508,10 @@
           "$ref": "#/definitions/FlowEndpointsConfiguration",
           "description": "The endpoints configuration."
         },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The sku."
+        },
         "integrationAccount": {
           "$ref": "#/definitions/ResourceReference",
           "description": "The integration account."

--- a/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json
+++ b/specification/logic/resource-manager/Microsoft.Logic/stable/2019-05-01/logic.json
@@ -6508,10 +6508,6 @@
           "$ref": "#/definitions/FlowEndpointsConfiguration",
           "description": "The endpoints configuration."
         },
-        "sku": {
-          "$ref": "#/definitions/Sku",
-          "description": "The sku."
-        },
         "integrationAccount": {
           "$ref": "#/definitions/ResourceReference",
           "description": "The integration account."


### PR DESCRIPTION
The latest logic app API service no longer supports a SKU. This PR removes the SKU from workflow properties.

 (WorkflowHostingPlanNotSupportedForApiVersion) The workflow 'atest' uses a hosting plan. Usage of a hosting plan is deprecated since API version '2016-06-01'

Discussion with the logic app service team confirmed this should be removed. 

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
