### PR TITLE
not setting the identity property of Resource as readonly

### DIFF
--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2018-03-01-preview/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2018-03-01-preview/machineLearningServices.json
@@ -1046,7 +1046,6 @@
         },
         "identity": {
           "$ref": "#/definitions/Identity",
-          "readOnly": true,
           "description": "The identity of the resource."
         },
         "location": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2020-02-18-preview/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2020-02-18-preview/machineLearningServices.json
@@ -2081,7 +2081,6 @@
         },
         "identity": {
           "$ref": "#/definitions/Identity",
-          "readOnly": true,
           "description": "The identity of the resource."
         },
         "location": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2018-11-19/machineLearningServices.json
@@ -1329,7 +1329,6 @@
         },
         "identity": {
           "$ref": "#/definitions/Identity",
-          "readOnly": true,
           "description": "The identity of the resource."
         },
         "location": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2019-05-01/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2019-05-01/machineLearningServices.json
@@ -1346,7 +1346,6 @@
         },
         "identity": {
           "$ref": "#/definitions/Identity",
-          "readOnly": true,
           "description": "The identity of the resource."
         },
         "location": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2019-06-01/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2019-06-01/machineLearningServices.json
@@ -1630,7 +1630,6 @@
         },
         "identity": {
           "$ref": "#/definitions/Identity",
-          "readOnly": true,
           "description": "The identity of the resource."
         },
         "location": {

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2020-03-01/machineLearningServices.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2020-03-01/machineLearningServices.json
@@ -1970,7 +1970,6 @@
         },
         "identity": {
           "$ref": "#/definitions/Identity",
-          "readOnly": true,
           "description": "The identity of the resource."
         },
         "location": {


### PR DESCRIPTION
This caused an issue, since `Workspace` was being used as an input parameter, and the `type` property of its `identity` property is required to pass, but since `identity` was set to readonly, `type` was not being passed.