### PR TITLE
alerts management separating error responses with same name

### DIFF
--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-05-05-preview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-05-05-preview/AlertsManagement.json
@@ -116,7 +116,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -159,7 +159,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -198,7 +198,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -234,7 +234,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -273,7 +273,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -344,7 +344,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -390,7 +390,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -435,7 +435,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -471,7 +471,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -808,7 +808,7 @@
         "value"
       ]
     },
-    "errorResponse": {
+    "AlertsManagementErrorResponse": {
       "description": "An error response from the service.",
       "x-ms-external": true,
       "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-11-02-privatepreview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2018-11-02-privatepreview/AlertsManagement.json
@@ -116,7 +116,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -159,7 +159,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -198,7 +198,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -234,7 +234,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -273,7 +273,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -344,7 +344,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -390,7 +390,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -435,7 +435,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -471,7 +471,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -523,7 +523,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         }
@@ -573,7 +573,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         }
@@ -615,7 +615,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         }
@@ -664,7 +664,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         }
@@ -701,7 +701,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         }
@@ -747,7 +747,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         }
@@ -1086,7 +1086,7 @@
         "value"
       ]
     },
-    "errorResponse": {
+    "AlertsManagementErrorResponse": {
       "description": "An error response from the service.",
       "x-ms-external": true,
       "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-03-01-preview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-03-01-preview/AlertsManagement.json
@@ -128,7 +128,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -171,7 +171,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -210,7 +210,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -246,7 +246,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -315,7 +315,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -386,7 +386,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -432,7 +432,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -477,7 +477,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -513,7 +513,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -919,7 +919,7 @@
         "value"
       ]
     },
-    "errorResponse": {
+    "AlertsManagementErrorResponse": {
       "description": "An error response from the service.",
       "x-ms-external": true,
       "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/AlertsManagement.json
@@ -158,7 +158,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -201,7 +201,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -240,7 +240,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -276,7 +276,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -345,7 +345,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -416,7 +416,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -465,7 +465,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -510,7 +510,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -546,7 +546,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -616,7 +616,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -692,7 +692,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -745,7 +745,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -802,7 +802,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -850,7 +850,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -907,7 +907,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -1368,7 +1368,7 @@
         "value"
       ]
     },
-    "errorResponse": {
+    "AlertsManagementErrorResponse": {
       "description": "An error response from the service.",
       "properties": {
         "error": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2018-05-05/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2018-05-05/AlertsManagement.json
@@ -128,7 +128,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -171,7 +171,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -210,7 +210,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -246,7 +246,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -315,7 +315,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -386,7 +386,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -435,7 +435,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -480,7 +480,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -516,7 +516,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -913,7 +913,7 @@
         "value"
       ]
     },
-    "errorResponse": {
+    "AlertsManagementErrorResponse": {
       "description": "An error response from the service.",
       "properties": {
         "error": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/AlertsManagement.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/AlertsManagement.json
@@ -128,7 +128,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -171,7 +171,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -210,7 +210,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -246,7 +246,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -315,7 +315,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -386,7 +386,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -432,7 +432,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -477,7 +477,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -513,7 +513,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/errorResponse"
+              "$ref": "#/definitions/AlertsManagementErrorResponse"
             }
           }
         },
@@ -920,7 +920,7 @@
         "value"
       ]
     },
-    "errorResponse": {
+    "AlertsManagementErrorResponse": {
       "description": "An error response from the service.",
       "x-ms-external": true,
       "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/SmartDetectorAlertRulesApi.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-03-01/SmartDetectorAlertRulesApi.json
@@ -53,7 +53,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -95,7 +95,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -143,7 +143,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -192,7 +192,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -238,7 +238,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -257,7 +257,7 @@
     }
   },
   "definitions": {
-    "ErrorResponse": {
+    "SmartDetectorErrorResponse": {
       "description": "Describe the format of an Error response.",
       "type": "object",
       "properties": {

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-06-01/SmartDetectorAlertRulesApi.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2019-06-01/SmartDetectorAlertRulesApi.json
@@ -56,7 +56,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -101,7 +101,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -149,7 +149,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -198,7 +198,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -253,7 +253,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -293,7 +293,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "#/definitions/ErrorResponse"
+              "$ref": "#/definitions/SmartDetectorErrorResponse"
             }
           },
           "200": {
@@ -312,7 +312,7 @@
     }
   },
   "definitions": {
-    "ErrorResponse": {
+    "SmartDetectorErrorResponse": {
       "description": "Describe the format of an Error response.",
       "type": "object",
       "properties": {


### PR DESCRIPTION
Renamed error response to avoid clashes between AlertsManagement and SmartDetectorAlertRulesApi's `ErrorResponse`s