### PR TITLE
Object Replication update to swagger (update from James OR branch)

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -3191,6 +3191,11 @@
                 "x-ms-client-name": "Metadata",
                 "x-ms-header-collection-prefix": "x-ms-meta-"
               },
+              "x-ms-or": {
+                "type": "string",
+                "x-ms-client-name": "ObjectReplication",
+                "x-ms-header-collection-prefix": "x-ms-or-"
+              },
               "Content-Length": {
                 "type": "integer",
                 "format": "int64",

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -2959,10 +2959,16 @@
                 "x-ms-client-name": "Metadata",
                 "x-ms-header-collection-prefix": "x-ms-meta-"
               },
+              "x-ms-or-policy-id": {
+                "x-ms-client-name": "ObjectReplicationPolicyId",
+                "type": "string",
+                "description": "Optional. Only valid when Object Replication is enabled for the storage container and on the destination blob of the replication."
+              },
               "x-ms-or": {
                 "type": "string",
-                "x-ms-client-name": "ObjectReplication",
-                "x-ms-header-collection-prefix": "x-ms-or-"
+                "x-ms-client-name": "ObjectReplicationRuleStatus",
+                "x-ms-header-collection-prefix": "x-ms-or-",
+                "description": "Optional. Only valid when Object Replication is enabled for the storage container and on the source blob of the replication. When retrieving this header, it will return the header with the policy id and rule id (e.g. x-ms-or-policyid_ruleid), and the value will be the status of the replication (e.g. complete, failed)."
               },
               "Content-Length": {
                 "type": "integer",
@@ -3191,10 +3197,16 @@
                 "x-ms-client-name": "Metadata",
                 "x-ms-header-collection-prefix": "x-ms-meta-"
               },
+              "x-ms-or-policy-id": {
+                "x-ms-client-name": "ObjectReplicationPolicyId",
+                "type": "string",
+                "description": "Optional. Only valid when Object Replication is enabled for the storage container and on the destination blob of the replication."
+              },
               "x-ms-or": {
                 "type": "string",
-                "x-ms-client-name": "ObjectReplication",
-                "x-ms-header-collection-prefix": "x-ms-or-"
+                "x-ms-client-name": "ObjectReplicationRuleStatus",
+                "x-ms-header-collection-prefix": "x-ms-or-",
+                "description": "Optional. Only valid when Object Replication is enabled for the storage container and on the source blob of the replication. When retrieving this header, it will return the header with the policy id and rule id (e.g. x-ms-or-policyid_ruleid), and the value will be the status of the replication (e.g. complete, failed)."
               },
               "Content-Length": {
                 "type": "integer",
@@ -3492,10 +3504,16 @@
                 "x-ms-client-name": "Metadata",
                 "x-ms-header-collection-prefix": "x-ms-meta-"
               },
+              "x-ms-or-policy-id": {
+                "x-ms-client-name": "ObjectReplicationPolicyId",
+                "type": "string",
+                "description": "Optional. Only valid when Object Replication is enabled for the storage container and on the destination blob of the replication."
+              },
               "x-ms-or": {
                 "type": "string",
-                "x-ms-client-name": "ObjectReplication",
-                "x-ms-header-collection-prefix": "x-ms-or-"
+                "x-ms-client-name": "ObjectReplicationRuleStatus",
+                "x-ms-header-collection-prefix": "x-ms-or-",
+                "description": "Optional. Only valid when Object Replication is enabled for the storage container and on the source blob of the replication. When retrieving this header, it will return the header with the policy id and rule id (e.g. x-ms-or-policyid_ruleid), and the value will be the status of the replication (e.g. complete, failed)."
               },
               "x-ms-blob-type": {
                 "x-ms-client-name": "BlobType",
@@ -9396,8 +9414,11 @@
         "BlobTags": {
           "$ref": "#/definitions/BlobTags"
         },
-        "ObjectReplication": {
-          "$ref": "#/definitions/BlobObjectReplication"
+        "ObjectReplicationPolicyId": {
+          "type": "string"
+        },
+        "ObjectReplicationRuleStatus": {
+          "$ref": "#/definitions/BlobObjectReplicationRuleStatus"
         }
       }
     },
@@ -10302,10 +10323,10 @@
         "type": "string"
       }
     },
-    "BlobObjectReplication": {
+    "BlobObjectReplicationRuleStatus": {
       "type": "object",
       "xml": {
-        "name": "ObjectReplication"
+        "name": "BlobObjectReplicationRuleStatus"
       },
       "additionalProperties": {
         "type": "string"
@@ -11483,14 +11504,23 @@
       "x-ms-parameter-location": "method",
       "description": "Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed; boundary=batch_<GUID>"
     },
-    "ObjectReplication": {
-      "name": "x-ms-or",
-      "x-ms-client-name": "objectReplication",
+    "ObjectReplicationPolicyId": {
+      "name": "x-ms-or-policy-id",
+      "x-ms-client-name": "objectReplicationPolicyId",
       "in": "header",
       "required": false,
       "type": "string",
       "x-ms-parameter-location": "method",
-      "description": "Optional. Only valid when Object Replication is enabled for the storage container. When retrieving this header on the source blob, it will return the header with the policy id and rule id (e.g. x-ms-or-policyid_ruleid), and the value will be the status of the replication (e.g. complete, failed). When retrieving the status on the destination blob, the policy id will be provided as the value of this header (e.g. x-ms-or-policy-id: policy-id).",
+      "description": "Optional. Only valid when Object Replication is enabled for the storage container and on the destination blob of the replication."
+    },
+    "ObjectReplicationRuleStatus": {
+      "name": "x-ms-or",
+      "x-ms-client-name": "ObjectReplicationRuleStatus",
+      "in": "header",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "description": "Optional. Only valid when Object Replication is enabled for the storage container and on the source blob of the replication. When retrieving this header, it will return the header with the policy id and rule id (e.g. x-ms-or-policyid_ruleid), and the value will be the status of the replication (e.g. complete, failed).",
       "x-ms-header-collection-prefix": "x-ms-or-"
     },
     "PathRenameMode": {

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -2959,6 +2959,11 @@
                 "x-ms-client-name": "Metadata",
                 "x-ms-header-collection-prefix": "x-ms-meta-"
               },
+              "x-ms-or": {
+                "type": "string",
+                "x-ms-client-name": "ObjectReplication",
+                "x-ms-header-collection-prefix": "x-ms-or-"
+              },
               "Content-Length": {
                 "type": "integer",
                 "format": "int64",
@@ -3481,6 +3486,11 @@
                 "type": "string",
                 "x-ms-client-name": "Metadata",
                 "x-ms-header-collection-prefix": "x-ms-meta-"
+              },
+              "x-ms-or": {
+                "type": "string",
+                "x-ms-client-name": "ObjectReplication",
+                "x-ms-header-collection-prefix": "x-ms-or-"
               },
               "x-ms-blob-type": {
                 "x-ms-client-name": "BlobType",
@@ -9380,6 +9390,9 @@
         },
         "BlobTags": {
           "$ref": "#/definitions/BlobTags"
+        },
+        "ObjectReplication": {
+          "$ref": "#/definitions/BlobObjectReplication"
         }
       }
     },
@@ -10279,6 +10292,15 @@
             "attribute": true
           }
         }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "BlobObjectReplication": {
+      "type": "object",
+      "xml": {
+        "name": "ObjectReplication"
       },
       "additionalProperties": {
         "type": "string"
@@ -11455,6 +11477,16 @@
       "type": "string",
       "x-ms-parameter-location": "method",
       "description": "Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed; boundary=batch_<GUID>"
+    },
+    "ObjectReplication": {
+      "name": "x-ms-or",
+      "x-ms-client-name": "objectReplication",
+      "in": "header",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "description": "Optional. Only valid when Object Replication is enabled for the storage container. When retrieving this header on the source blob, it will return the header with the policy id and rule id (e.g. x-ms-or-policyid_ruleid), and the value will be the status of the replication (e.g. complete, failed). When retrieving the status on the destination blob, the policy id will be provided as the value of this header (e.g. x-ms-or-policy-id: policy-id).",
+      "x-ms-header-collection-prefix": "x-ms-or-"
     },
     "PathRenameMode": {
       "name": "mode",


### PR DESCRIPTION
### Latest improvements:
Object Replication - Object replication service: user set a policy on source account to back up some blobs to another account. 

This header is optional. Only valid when Object Replication is enabled for the storage container. When retrieving this header on the source blob, it will return the header with the policy id and rule id (e.g. x-ms-or-policyid_ruleid), and the value will be the status of the replication (e.g. complete, failed). When retrieving the status on the destination blob, the policy id will be provided as the value of this header (e.g. x-ms-or-policy-id: policy-id).

### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
