### PR TITLE
add IgnoreResourceCheck query parameter to subscriptions to be cancelled

### DIFF
--- a/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/examples/cancelSubscription.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/examples/cancelSubscription.json
@@ -1,6 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "83aa47df-e3e9-49ff-877b-94304bf3d3ad",
+    "IgnoreResourceCheck": true,
     "api-version": "2019-03-01-preview"
   },
   "responses": {

--- a/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/subscriptions.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/subscriptions.json
@@ -31,6 +31,9 @@
           },
           {
             "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ignoreResourceCheckParameter"
           }
         ],
         "responses": {
@@ -233,6 +236,13 @@
       "required": true,
       "type": "string",
       "description": "Subscription Id."
+    },
+    "ignoreResourceCheckParameter": {
+      "name": "IgnoreResourceCheck",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "Ignore existing resources in the subscription to be cancelled."
     },
     "subscriptionNameParameter": {
       "name": "body",

--- a/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/subscriptions.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/subscriptions.json
@@ -241,7 +241,7 @@
       "name": "IgnoreResourceCheck",
       "in": "query",
       "required": false,
-      "type": "bool",
+      "type": "boolean",
       "description": "Ignore existing resources in the subscription to be cancelled."
     },
     "subscriptionNameParameter": {

--- a/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/subscriptions.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-03-01-preview/subscriptions.json
@@ -241,7 +241,7 @@
       "name": "IgnoreResourceCheck",
       "in": "query",
       "required": false,
-      "type": "string",
+      "type": "bool",
       "description": "Ignore existing resources in the subscription to be cancelled."
     },
     "subscriptionNameParameter": {

--- a/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-10-01-preview/examples/cancelSubscription.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-10-01-preview/examples/cancelSubscription.json
@@ -1,6 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "83aa47df-e3e9-49ff-877b-94304bf3d3ad",
+    "IgnoreResourceCheck": true,
     "api-version": "2019-10-01-preview"
   },
   "responses": {

--- a/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-10-01-preview/subscriptions.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-10-01-preview/subscriptions.json
@@ -629,7 +629,7 @@
       "name": "IgnoreResourceCheck",
       "in": "query",
       "required": false,
-      "type": "bool",
+      "type": "boolean",
       "description": "Ignore existing resources in the subscription to be cancelled."
     }
   },

--- a/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-10-01-preview/subscriptions.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/preview/2019-10-01-preview/subscriptions.json
@@ -91,6 +91,9 @@
           },
           {
             "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ignoreResourceCheckParameter"
           }
         ],
         "responses": {
@@ -621,6 +624,13 @@
       "schema": {
         "$ref": "#/definitions/SubscriptionName"
       }
+    },
+    "ignoreResourceCheckParameter": {
+      "name": "IgnoreResourceCheck",
+      "in": "query",
+      "required": false,
+      "type": "bool",
+      "description": "Ignore existing resources in the subscription to be cancelled."
     }
   },
   "security": [

--- a/specification/subscription/resource-manager/Microsoft.Subscription/stable/2020-01-01/examples/cancelSubscription.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/stable/2020-01-01/examples/cancelSubscription.json
@@ -1,6 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "83aa47df-e3e9-49ff-877b-94304bf3d3ad",
+    "IgnoreResourceCheck": true,
     "api-version": "2020-01-01"
   },
   "responses": {

--- a/specification/subscription/resource-manager/Microsoft.Subscription/stable/2020-01-01/subscriptions.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/stable/2020-01-01/subscriptions.json
@@ -91,6 +91,9 @@
           },
           {
             "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ignoreResourceCheckParameter"
           }
         ],
         "responses": {
@@ -617,6 +620,13 @@
       "schema": {
         "$ref": "#/definitions/SubscriptionName"
       }
+    },
+    "ignoreResourceCheckParameter": {
+      "name": "IgnoreResourceCheck",
+      "in": "query",
+      "required": false,
+      "type": "bool",
+      "description": "Ignore existing resources in the subscription to be cancelled."
     }
   },
   "security": [

--- a/specification/subscription/resource-manager/Microsoft.Subscription/stable/2020-01-01/subscriptions.json
+++ b/specification/subscription/resource-manager/Microsoft.Subscription/stable/2020-01-01/subscriptions.json
@@ -625,7 +625,7 @@
       "name": "IgnoreResourceCheck",
       "in": "query",
       "required": false,
-      "type": "bool",
+      "type": "boolean",
       "description": "Ignore existing resources in the subscription to be cancelled."
     }
   },


### PR DESCRIPTION
### Changes:
add IgnoreResourceCheck query parameter to subscriptions to be cancelled.
Allow sdk users to cancel azure subscriptions even if subscription has resources deployed in it.

Issue: #9042

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
Signed-off-by: Saad Zaher <eng.szaher@gmail.com>