### PR TITLE
adding JMS/Client-affine properties to Subscription Properties

### DIFF
--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/stable/2017-04-01/servicebus.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/stable/2017-04-01/servicebus.json
@@ -4027,7 +4027,7 @@
           "type": "string",
           "description": "Queue/Topic name to forward the Dead Letter message"
         },
-        "clientAffine": {
+        "isClientAffine": {
           "type": "boolean",
           "description": "Value that indicates whether the subscription has an affinity to the client id."
         },
@@ -4044,11 +4044,11 @@
           "type": "string",
           "description": "Indicates the Client ID of the application that created the client-affine subscription."
         },
-        "durable": {
+        "isDurable": {
           "type": "boolean",
           "description": "For client-affine subscriptions, this value indicates whether the subscription is durable or not."
         },
-        "shared": {
+        "isShared": {
           "type": "boolean",
           "description": "For client-affine subscriptions, this value indicates whether the subscription is shared or not."
         }

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/stable/2017-04-01/servicebus.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/stable/2017-04-01/servicebus.json
@@ -4031,9 +4031,18 @@
           "type": "boolean",
           "description": "Value that indicates whether the subscription has an affinity to the client id."
         },
+        "clientAffineProperties" : {
+          "$ref": "#/definitions/SBClientAffineProperties",
+          "description": "Properties specific to client affine subscriptions."
+        }
+      },
+      "description": "Description of Subscription Resource."
+    },
+    "SBClientAffineProperties": {
+      "properties":{
         "clientId": {
           "type": "string",
-          "description": "Indicates the Client ID of the application that created the Subscription."
+          "description": "Indicates the Client ID of the application that created the client-affine subscription."
         },
         "durable": {
           "type": "boolean",
@@ -4043,8 +4052,7 @@
           "type": "boolean",
           "description": "For client-affine subscriptions, this value indicates whether the subscription is shared or not."
         }
-      },
-      "description": "Description of Subscription Resource."
+      }
     },
     "EntityStatus": {
       "type": "string",

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/stable/2017-04-01/servicebus.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/stable/2017-04-01/servicebus.json
@@ -4026,6 +4026,22 @@
         "forwardDeadLetteredMessagesTo": {
           "type": "string",
           "description": "Queue/Topic name to forward the Dead Letter message"
+        },
+        "clientAffine": {
+          "type": "boolean",
+          "description": "Value that indicates whether the subscription has an affinity to the client id."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Indicates the Client ID of the application that created the Subscription."
+        },
+        "durable": {
+          "type": "boolean",
+          "description": "For client-affine subscriptions, this value indicates whether the subscription is durable or not."
+        },
+        "shared": {
+          "type": "boolean",
+          "description": "For client-affine subscriptions, this value indicates whether the subscription is shared or not."
         }
       },
       "description": "Description of Subscription Resource."


### PR DESCRIPTION
Updating the Swagger spec for Subscription properties on Service Bus to include properties for JMS/Client-affine subscriptions.

The below describes the subscription model that we're looking to represent with the Subscription properties.

'X' implies Don't care.

Shared | Durable | Client-affine| Client ID | Subscription type |
-- | -- | --| -- | -- |
X | X | F | X | "Legacy" Topic-subscription |
T | T | T | Required | Shared Durable JMS/Client-Affine Subscription | 
T | F | T | Required | Shared non-durable JMS/Client-Affine Subscription | 
F | T | T | Required | Unshared Durable JMS/Client-Affine Subscription |
F | F | T | Required | Unshared non-durable JMS/Client-Affine Subscription |

