### PR TITLE
Object Replication - Renaming BlobProperties to BlobPropertiesInternal

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -9412,7 +9412,7 @@
           "type": "boolean"
         },
         "Properties": {
-          "$ref": "#/definitions/BlobProperties"
+          "$ref": "#/definitions/BlobPropertiesInternal"
         },
         "Metadata": {
           "$ref": "#/definitions/BlobMetadata"
@@ -9428,7 +9428,7 @@
         }
       }
     },
-    "BlobProperties": {
+    "BlobPropertiesInternal": {
       "xml": {
         "name": "Properties"
       },


### PR DESCRIPTION
Renaming BlobProperties to BlobPropertiesInternal for Object Replication. So we can add in the ObjectReplication object to the Properties and parse the headers keys of the OR header. The BlobProperties object will be remade manually.

Notes:
In the readme.md swagger, we will have to make the BlobPropertiesInternal class internal.