### PR TITLE
Add resource type sqlServerInstances

### DIFF
--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/azuredata.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/azuredata.json
@@ -856,6 +856,294 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureData/sqlServerInstances": {
+      "get": {
+        "tags": [
+          "SqlServerInstances"
+        ],
+        "operationId": "SqlServerInstances_List",
+        "summary": "List sqlServerInstance resources in the subscription",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/apiVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SqlServerInstanceListResult"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 InvalidParameterValue - An invalid value was given to parameter.\n\n * 400 InvalidCrossSubscriptionVmMove - Invalid cross subscription move of resource.\n\n * 404 ResourceNotFound - The requested resource was not found.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Gets all SQL Server Instance in a subscription.": {
+            "$ref": "./examples/ListSubscriptionSqlServerInstance.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureData/sqlServerInstances": {
+      "get": {
+        "tags": [
+          "SqlServerInstances"
+        ],
+        "operationId": "SqlServerInstances_ListByResourceGroup",
+        "description": "Gets all sqlServerInstances in a resource group.",
+        "summary": "List sqlServerInstance resources in the resource group",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "$ref": "#/parameters/apiVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SqlServerInstanceListResult"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Gets all SQL Server Instance in a resource group.": {
+            "$ref": "./examples/ListByResourceGroupSqlServerInstance.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureData/sqlServerInstances/{sqlServerInstanceName}": {
+      "get": {
+        "tags": [
+          "SqlServerInstances"
+        ],
+        "operationId": "SqlServerInstances_Get",
+        "description": "Retrieves a SQL Server Instance resource",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "name": "sqlServerInstanceName",
+            "description": "Name of SQL Server Instance",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "$ref": "#/parameters/apiVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SqlServerInstance"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Updates a SQL Server Instance tags.": {
+            "$ref": "./examples/GetSqlServerInstance.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "SqlServerInstances"
+        ],
+        "operationId": "SqlServerInstances_Create",
+        "description": "Creates or replaces a SQL Server Instance resource",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "name": "sqlServerInstanceName",
+            "description": "The name of SQL Server Instance",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The SQL Server Instance to be created or updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SqlServerInstance"
+            }
+          },
+          {
+            "$ref": "#/parameters/apiVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SqlServerInstance"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/SqlServerInstance"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Updates a SQL Server Instance tags.": {
+            "$ref": "./examples/CreateOrUpdateSqlServerInstance.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "SqlServerInstances"
+        ],
+        "operationId": "SqlServerInstances_Delete",
+        "description": "Deletes a SQL Server Instance resource",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "name": "sqlServerInstanceName",
+            "description": "The name of SQL Server Instance",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "$ref": "#/parameters/apiVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted the SQL Server Instance."
+          },
+          "default": {
+            "description": "*** Error Responses: ***",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          },
+          "204": {
+            "description": "The specified SQL Server Instance does not exist."
+          }
+        },
+        "x-ms-examples": {
+          "Delete a SQL Server Instance.": {
+            "$ref": "./examples/DeleteSqlServerInstance.json"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "SqlServerInstances"
+        ],
+        "operationId": "SqlServerInstances_Update",
+        "description": "Updates a SQL Server Instance resource",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupName"
+          },
+          {
+            "name": "sqlServerInstanceName",
+            "description": "Name of sqlServerInstance",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The SQL Server Instance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SqlServerInstanceUpdate"
+            }
+          },
+          {
+            "$ref": "#/parameters/apiVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SqlServerInstance"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Updates a SQL Server Instance tags.": {
+            "$ref": "./examples/UpdateSqlServerInstance.json"
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/providers/Microsoft.AzureData/postgresInstances": {
       "get": {
         "tags": [
@@ -1984,6 +2272,88 @@
         }
       }
     },
+    "SqlServerInstanceProperties": {
+      "description": "Properties of SqlServerInstance.",
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "null"
+        },
+        "edition": {
+          "type": "string",
+          "description": "null"
+        },
+        "containerResourceId": {
+          "type": "string",
+          "description": "null"
+        },
+        "createTime": {
+          "type": "string",
+          "description": "null"
+        },
+        "updateTime": {
+          "type": "string",
+          "description": "null"
+        },
+        "vCore": {
+          "type": "string",
+          "description": "null"
+        },
+        "status": {
+          "type": "string",
+          "description": "null"
+        }
+      }
+    },
+    "SqlServerInstance": {
+      "description": "A SqlServerInstance.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SqlServerInstanceProperties",
+          "description": "null",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "SqlServerInstanceUpdate": {
+      "description": "An update to a SQL Server Instance.",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "description": "Resource tags.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SqlServerInstanceListResult": {
+      "description": "A list of SqlServerInstance.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Array of results.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SqlServerInstance"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "description": "Link to retrieve next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
     "HybridDataManagerProperties": {
       "description": "Hybrid data manager properties",
       "type": "object"
@@ -2179,6 +2549,14 @@
     "SqlInstanceNameParameter": {
       "in": "path",
       "name": "sqlInstanceName",
+      "description": "The name of the resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "SqlServerInstanceNameParameter": {
+      "in": "path",
+      "name": "sqlServerInstanceName",
       "description": "The name of the resource.",
       "required": true,
       "type": "string",

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/azuredata.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/azuredata.json
@@ -2290,11 +2290,13 @@
         },
         "createTime": {
           "type": "string",
-          "description": "The time when the resource was created."
+          "description": "The time when the resource was created.",
+          "readOnly": true
         },
         "updateTime": {
           "type": "string",
-          "description": "The time when the resource was last updated."
+          "description": "The time when the resource was last updated.",
+          "readOnly": true
         },
         "vCore": {
           "type": "string",
@@ -2309,8 +2311,6 @@
         "version",
         "edition",
         "containerResourceId",
-        "createTime",
-        "updateTime",
         "vCore",
         "status"
       ]

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/azuredata.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/azuredata.json
@@ -2278,33 +2278,42 @@
       "properties": {
         "version": {
           "type": "string",
-          "description": "null"
+          "description": "SQL Server version."
         },
         "edition": {
           "type": "string",
-          "description": "null"
+          "description": "SQL Server edition."
         },
         "containerResourceId": {
           "type": "string",
-          "description": "null"
+          "description": "ARM Resource id of the container resource (Azure Arc for Servers)"
         },
         "createTime": {
           "type": "string",
-          "description": "null"
+          "description": "The time when the resource was created."
         },
         "updateTime": {
           "type": "string",
-          "description": "null"
+          "description": "The time when the resource was last updated."
         },
         "vCore": {
           "type": "string",
-          "description": "null"
+          "description": "The number of logical processors used by the SQL Server instance."
         },
         "status": {
           "type": "string",
-          "description": "null"
+          "description": "The cloud connectivity status."
         }
-      }
+      },
+      "required": [
+        "version",
+        "edition",
+        "containerResourceId",
+        "createTime",
+        "updateTime",
+        "vCore",
+        "status"
+      ]
     },
     "SqlServerInstance": {
       "description": "A SqlServerInstance.",

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/CreateOrUpdateSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/CreateOrUpdateSqlServerInstance.json
@@ -13,8 +13,6 @@
         "version": "SQL Server 2017",
         "edition": "Developer",
         "containerResourceId": "Arc Machine Name",
-        "createTime": "01/01/2020 01:01:01",
-        "updateTime": "01/01/2020 01:01:01",
         "vCore": "4",
         "status": "Connected"
       }

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/CreateOrUpdateSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/CreateOrUpdateSqlServerInstance.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "testrg",
+    "sqlServerInstanceName": "testsqlServerInstance",
+    "api-version": "2017-07-24",
+    "parameters": {
+      "location": "northeurope",
+      "tags": {
+        "mytag": "myval"
+      },
+      "properties": {}
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {},
+        "location": "northeurope",
+        "tags": {
+          "mytag": "myval"
+        },
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg/providers/Microsoft.AzureData/SqlServerInstances/testsqlServerInstance",
+        "name": "testsqlServerInstance",
+        "type": "Microsoft.AzureData/SqlServerInstances"
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {},
+        "location": "northeurope",
+        "tags": {
+          "mytag": "myval"
+        },
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg/providers/Microsoft.AzureData/SqlServerInstances/testsqlServerInstance",
+        "name": "testsqlServerInstance",
+        "type": "Microsoft.AzureData/SqlServerInstances"
+      }
+    }
+  }
+}

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/CreateOrUpdateSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/CreateOrUpdateSqlServerInstance.json
@@ -9,13 +9,29 @@
       "tags": {
         "mytag": "myval"
       },
-      "properties": {}
+      "properties": {
+        "version": "SQL Server 2017",
+        "edition": "Developer",
+        "containerResourceId": "Arc Machine Name",
+        "createTime": "01/01/2020 01:01:01",
+        "updateTime": "01/01/2020 01:01:01",
+        "vCore": "4",
+        "status": "Connected"
+      }
     }
   },
   "responses": {
     "200": {
       "body": {
-        "properties": {},
+        "properties": {
+          "version": "SQL Server 2017",
+          "edition": "Developer",
+          "containerResourceId": "Arc Machine Name",
+          "createTime": "01/01/2020 01:01:01",
+          "updateTime": "01/01/2020 01:01:01",
+          "vCore": "4",
+          "status": "Connected"
+        },
         "location": "northeurope",
         "tags": {
           "mytag": "myval"
@@ -27,7 +43,15 @@
     },
     "201": {
       "body": {
-        "properties": {},
+        "properties": {
+          "version": "SQL Server 2017",
+          "edition": "Developer",
+          "containerResourceId": "Arc Machine Name",
+          "createTime": "01/01/2020 01:01:01",
+          "updateTime": "01/01/2020 01:01:01",
+          "vCore": "4",
+          "status": "Connected"
+        },
         "location": "northeurope",
         "tags": {
           "mytag": "myval"

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/DeleteSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/DeleteSqlServerInstance.json
@@ -1,0 +1,12 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "testrg",
+    "sqlServerInstanceName": "testsqlServerInstance",
+    "api-version": "2017-07-24"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/GetSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/GetSqlServerInstance.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "testrg",
+    "sqlServerInstanceName": "testsqlServerInstance",
+    "api-version": "2017-07-24"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {},
+        "location": "northeurope",
+        "tags": {
+          "mytag": "myval"
+        },
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg/providers/Microsoft.AzureData/SqlServerInstances/testsqlServerInstance",
+        "name": "testsqlServerInstance",
+        "type": "Microsoft.AzureData/SqlServerInstances"
+      }
+    }
+  }
+}

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/GetSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/GetSqlServerInstance.json
@@ -8,7 +8,15 @@
   "responses": {
     "200": {
       "body": {
-        "properties": {},
+        "properties": {
+          "version": "SQL Server 2017",
+          "edition": "Developer",
+          "containerResourceId": "Arc Machine Name",
+          "createTime": "01/01/2020 01:01:01",
+          "updateTime": "01/01/2020 01:01:01",
+          "vCore": "4",
+          "status": "Connected"
+        },
         "location": "northeurope",
         "tags": {
           "mytag": "myval"

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/ListByResourceGroupSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/ListByResourceGroupSqlServerInstance.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "testrg",
+    "api-version": "2017-07-24"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {},
+            "location": "northeurope",
+            "tags": {
+              "mytag": "myval"
+            },
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg/providers/Microsoft.AzureData/SqlServerInstances/sqlServerInstance1",
+            "name": "sqlServerInstance1",
+            "type": "Microsoft.AzureData/SqlServerInstances"
+          },
+          {
+            "properties": {},
+            "location": "northeurope",
+            "tags": {
+              "mytag": "myval"
+            },
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg/providers/Microsoft.AzureData/SqlServerInstances/sqlServerInstance2",
+            "name": "sqlServerInstance2",
+            "type": "Microsoft.AzureData/SqlServerInstances"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/ListByResourceGroupSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/ListByResourceGroupSqlServerInstance.json
@@ -9,7 +9,15 @@
       "body": {
         "value": [
           {
-            "properties": {},
+            "properties": {
+              "version": "SQL Server 2017",
+              "edition": "Developer",
+              "containerResourceId": "Arc Machine Name",
+              "createTime": "01/01/2020 01:01:01",
+              "updateTime": "01/01/2020 01:01:01",
+              "vCore": "4",
+              "status": "Connected"
+            },
             "location": "northeurope",
             "tags": {
               "mytag": "myval"
@@ -19,7 +27,15 @@
             "type": "Microsoft.AzureData/SqlServerInstances"
           },
           {
-            "properties": {},
+            "properties": {
+              "version": "SQL Server 2017",
+              "edition": "Developer",
+              "containerResourceId": "Arc Machine Name",
+              "createTime": "01/01/2020 01:01:01",
+              "updateTime": "01/01/2020 01:01:01",
+              "vCore": "4",
+              "status": "Connected"
+            },
             "location": "northeurope",
             "tags": {
               "mytag": "myval"

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/ListSubscriptionSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/ListSubscriptionSqlServerInstance.json
@@ -8,7 +8,15 @@
       "body": {
         "value": [
           {
-            "properties": {},
+            "properties": {
+              "version": "SQL Server 2017",
+              "edition": "Developer",
+              "containerResourceId": "Arc Machine Name",
+              "createTime": "01/01/2020 01:01:01",
+              "updateTime": "01/01/2020 01:01:01",
+              "vCore": "4",
+              "status": "Connected"
+            },
             "location": "northeurope",
             "tags": {
               "mytag": "myval"
@@ -18,7 +26,15 @@
             "type": "Microsoft.AzureData/SqlServerInstances"
           },
           {
-            "properties": {},
+            "properties": {
+              "version": "SQL Server 2017",
+              "edition": "Developer",
+              "containerResourceId": "Arc Machine Name",
+              "createTime": "01/01/2020 01:01:01",
+              "updateTime": "01/01/2020 01:01:01",
+              "vCore": "4",
+              "status": "Connected"
+            },
             "location": "northeurope",
             "tags": {
               "mytag": "myval"

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/ListSubscriptionSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/ListSubscriptionSqlServerInstance.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "api-version": "2017-07-24"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {},
+            "location": "northeurope",
+            "tags": {
+              "mytag": "myval"
+            },
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg/providers/Microsoft.AzureData/SqlServerInstances/sqlServerInstance1",
+            "name": "sqlServerInstance1",
+            "type": "Microsoft.AzureData/SqlServerInstances"
+          },
+          {
+            "properties": {},
+            "location": "northeurope",
+            "tags": {
+              "mytag": "myval"
+            },
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg/providers/Microsoft.AzureData/SqlServerInstances/sqlServerInstance2",
+            "name": "sqlServerInstance2",
+            "type": "Microsoft.AzureData/SqlServerInstances"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/UpdateSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/UpdateSqlServerInstance.json
@@ -13,7 +13,15 @@
   "responses": {
     "200": {
       "body": {
-        "properties": {},
+        "properties": {
+          "version": "SQL Server 2017",
+          "edition": "Developer",
+          "containerResourceId": "Arc Machine Name",
+          "createTime": "01/01/2020 01:01:01",
+          "updateTime": "01/01/2020 01:01:01",
+          "vCore": "4",
+          "status": "Connected"
+        },
         "location": "northeurope",
         "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg/providers/Microsoft.AzureData/SqlServerInstances/testsqlServerInstance",
         "name": "testsqlServerInstance",

--- a/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/UpdateSqlServerInstance.json
+++ b/specification/azuredata/resource-manager/Microsoft.AzureData/preview/2019-07-24-preview/examples/UpdateSqlServerInstance.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "testrg",
+    "sqlServerInstanceName": "testsqlServerInstance",
+    "api-version": "2017-07-24",
+    "parameters": {
+      "tags": {
+        "mytag": "myval"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {},
+        "location": "northeurope",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/testrg/providers/Microsoft.AzureData/SqlServerInstances/testsqlServerInstance",
+        "name": "testsqlServerInstance",
+        "type": "Microsoft.AzureData/SqlServerInstances"
+      }
+    }
+  }
+}


### PR DESCRIPTION
* add to resource provider - Microsoft.AzureData

* exactly same REST API definitions as existing resource types of the
  same resource provider

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [x] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
