### PR TITLE
Adding 200 response in CreateOrUpdate api

### DIFF
--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
@@ -32,8 +32,8 @@
           "provisioningState": "Succeeded",
           "externalIP": "10.0.0.1",
           "hostName": "myservice.service.signalr.net",
-          "publicPort": 5001,
-          "serverPort": 5002,
+          "publicPort": 443,
+          "serverPort": 443,
           "version": "1.0-preview",
           "hostNamePrefix": null
         },
@@ -44,9 +44,6 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
         "name": "mySignalRService",
         "type": "Microsoft.SignalRService/SignalR"
-      },
-      "headers": {
-        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult..."
       }
     },
     "201": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/examples/CreateOrUpdate.json
@@ -20,6 +20,35 @@
     "resourceName": "mySignalRService"
   },
   "responses": {
+    "200": {
+      "body": {
+        "sku": {
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "externalIP": "10.0.0.1",
+          "hostName": "myservice.service.signalr.net",
+          "publicPort": 5001,
+          "serverPort": 5002,
+          "version": "1.0-preview",
+          "hostNamePrefix": null
+        },
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+        "name": "mySignalRService",
+        "type": "Microsoft.SignalRService/SignalR"
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult..."
+      }
+    },
     "201": {
       "body": {
         "sku": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2018-03-01-preview/signalr.json
@@ -308,6 +308,12 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Success. The response describes a SignalR service.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          },
           "201": {
             "description": "Created. The response describes the new service and contains a Location header to query the operation result.",
             "schema": {

--- a/specification/signalr/resource-manager/readme.md
+++ b/specification/signalr/resource-manager/readme.md
@@ -40,7 +40,7 @@ directive:
   - suppress: EnumInsteadOfBoolean
     from: signalr.json
     where: $.definitions.Dimension.properties.toBeExportedForShoebox
-    reason:  The boolean properties 'toBeExportedForShoebox' is defined by Geneva metrics
+    reason:  The boolean properties 'toBeExportedForShoebox' is defined by Geneva metrics.
   - suppress: PutRequestResponseScheme
     from: signalr.json
     where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}"].put


### PR DESCRIPTION
Adding 200 response in CreateOrUpdate API

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [x] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
