### PR TITLE
Remove `package-2020-03` for search in go SDK config

### DIFF
--- a/specification/search/resource-manager/readme.go.md
+++ b/specification/search/resource-manager/readme.go.md
@@ -13,18 +13,8 @@ go:
 
 ``` yaml $(go) && $(multiapi)
 batch:
-  - tag: package-2020-03
   - tag: package-2015-08
   - tag: package-2015-02
-```
-
-### Tag: package-2020-03 and go
-
-These settings apply only when `--tag=package-2020-03 --go` is specified on the command line.
-Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
-
-``` yaml $(tag) == 'package-2020-03' && $(go)
-output-folder: $(go-sdk-folder)/services/$(namespace)/mgmt/2020-03-13/$(namespace)
 ```
 
 ### Tag: package-2015-08 and go


### PR DESCRIPTION
This PR removes the multiapi batch for go SDK generation in search, since the swagger is buggy and keeps producing code that cannot compile (see [this issue](https://github.com/Azure/azure-rest-api-specs/issues/8883)).
This package never released in go SDK, therefore this will not cause any breaking changes.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
