### PR TITLE
Removing one nat rule restriction in a nat rule collection - Firewall Policy[DO NOT MERGE]

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2020-04-01/firewallPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2020-04-01/firewallPolicy.json
@@ -717,17 +717,12 @@
           "$ref": "#/definitions/FirewallPolicyNatRuleCollectionAction",
           "description": "The action type of a Nat rule collection."
         },
-        "translatedAddress": {
-          "type": "string",
-          "description": "The translated address for this NAT rule collection."
-        },
-        "translatedPort": {
-          "type": "string",
-          "description": "The translated port for this NAT rule collection."
-        },
-        "rule": {
-          "$ref": "#/definitions/FirewallPolicyRule",
-          "description": "The match rule for incoming traffic."
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRule"
+          },
+          "description": "List of rules included in a rule collection."
         }
       },
       "allOf": [
@@ -879,6 +874,14 @@
           "items": {
             "type": "string"
           }
+        },
+        "translatedAddress": {
+          "type": "string",
+          "description": "The translated address for this NAT rule."
+        },
+        "translatedPort": {
+          "type": "string",
+          "description": "The translated port for this NAT rule."
         },
         "sourceIpGroups": {
           "type": "array",


### PR DESCRIPTION
### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [x] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
