### PR TITLE
add SKU name to PrivateCloud for AVS 2019-08-09-preview

### DIFF
--- a/specification/vmwarevirtustream/resource-manager/Microsoft.VMwareVirtustream/preview/2019-08-09-preview/vmwarevirtustream.json
+++ b/specification/vmwarevirtustream/resource-manager/Microsoft.VMwareVirtustream/preview/2019-08-09-preview/vmwarevirtustream.json
@@ -1030,6 +1030,10 @@
         }
       ],
       "properties": {
+        "sku": {
+          "description": "The private cloud SKU",
+          "$ref": "#/definitions/Sku"
+        },
         "properties": {
           "description": "The properties of a private cloud resource",
           "$ref": "#/definitions/PrivateCloudProperties"
@@ -1246,6 +1250,18 @@
           "readOnly": true
         }
       }
+    },
+    "Sku": {
+      "description": "The resource model definition representing SKU",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU."
+        }
+      },
+      "required": [
+        "name"
+      ]
     }
   }
 }


### PR DESCRIPTION
SKU is already supported by the API. This ads it to the spec. This This is already supported by the `az vmware` extension in https://github.com/virtustream/azure-vmware-virtustream-cli-extension/pull/17. 

Should I `$ref` the common type instead, even through only `name` is supported?
https://github.com/Azure/azure-rest-api-specs/blob/master/specification/common-types/resource-management/v1/types.json#L177-L215

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [x] I have reviewed the [documentation](https://github.com/Azure/adx-documentation-pr/wiki/Overall-basic-flow) for the workflow.
- [x] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
