### PR TITLE
x-ms-client-name to DataLakeStorageError's inner error

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -9312,15 +9312,16 @@
       "type": "object",
       "properties": {
         "error": {
+          "x-ms-client-name": "DataLakeStorageErrorDetails",
           "description": "The service error response object.",
           "properties": {
-        "Code": {
+            "Code": {
               "description": "The service error code.",
-          "type": "string"
-        },
-        "Message": {
+              "type": "string"
+            },
+            "Message": {
               "description": "The service error message.",
-          "type": "string"
+              "type": "string"
             }
           }
         }


### PR DESCRIPTION
This bug fix was made in the 2019-07-07 swagger in this [PR](https://github.com/Azure/azure-rest-api-specs/pull/8739)

This is to make sure our swagger changes in the 2019-12-12 is kept up to date.
