### PR TITLE
Issue 6660 - Added api-version parameter under convertToSinglePlacementGroup for VMSS

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-03-01/compute.json
@@ -4406,6 +4406,9 @@
             "description": "The input object for ConvertToSinglePlacementGroup API."
           },
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/compute.json
@@ -4561,6 +4561,9 @@
             "description": "The input object for ConvertToSinglePlacementGroup API."
           },
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-12-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-12-01/compute.json
@@ -4903,6 +4903,9 @@
             "description": "The input object for ConvertToSinglePlacementGroup API."
           },
           {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
             "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],


### PR DESCRIPTION
Added for all the applicable versions

This PR fixes https://github.com/Azure/azure-rest-api-specs/issues/6660