### PR TITLE
Remove features mode

### DIFF
--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2019-05-06-preview/examples/SearchIndexSearchDocumentsGet.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2019-05-06-preview/examples/SearchIndexSearchDocumentsGet.json
@@ -21,7 +21,6 @@
     ],
     "queryType": "simple",
     "sessionId": "mysessionid",
-    "featuresMode": "enabled",
     "scoringStatistics": "global",
     "scoringParameters": [
       "currentLocation--122.123,44.77233"
@@ -76,16 +75,6 @@
               "title": [
                 "Fancy <em>Hotel</em>"
               ]
-            },
-            "@search.features": {
-              "description": {
-                "uniqueTokenMatches": 1.0,
-                "similarityScore": 0.023745812
-              },
-              "title": {
-                "uniqueTokenMatches": 1.0,
-                "similarityScore": 0.016049799
-              }
             },
             "description": "Best hotel in town",
             "docId": "2",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2019-05-06-preview/examples/SearchIndexSearchDocumentsPost.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2019-05-06-preview/examples/SearchIndexSearchDocumentsPost.json
@@ -24,7 +24,6 @@
       "searchFields": "title,description",
       "searchMode": "any",
       "sessionId": "mysessionid",
-      "featuresMode": "enabled",
       "scoringStatistics": "global",
       "select": "docId,title,description",
       "skip": 0,
@@ -60,7 +59,6 @@
           "orderby": "search.score() desc,rating desc",
           "queryType": "simple",
           "sessionId": "mysessionid",
-          "featuresMode": "enabled",
           "scoringStatistics": "global",
           "scoringParameters": [
             "currentLocation--122.123,44.77233"
@@ -91,16 +89,6 @@
               "title": [
                 "Fancy <em>Hotel</em>"
               ]
-            },
-            "@search.features": {
-              "description": {
-                "uniqueTokenMatches": 1.0,
-                "similarityScore": 0.023745812
-              },
-              "title": {
-                "uniqueTokenMatches": 1.0,
-                "similarityScore": 0.016049799
-              }
             },
             "description": "Best hotel in town",
             "docId": "2",

--- a/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2019-05-06-preview/searchindex.json
+++ b/specification/search/data-plane/Microsoft.Azure.Search.Data/preview/2019-05-06-preview/searchindex.json
@@ -249,24 +249,6 @@
             }
           },
           {
-            "name": "featuresMode",
-            "in": "query",
-            "type": "string",
-            "enum": [
-              "disabled",
-              "enabled"
-            ],
-            "x-ms-enum": {
-              "name": "FeaturesMode",
-              "modelAsString": false
-            },
-            "x-nullable": false,
-            "description": "A value that specifies whether the results should include scoring features such as per field similarity.",
-            "x-ms-parameter-grouping": {
-              "name": "SearchParameters"
-            }
-          },
-          {
             "name": "scoringStatistics",
             "in": "query",
             "type": "string",
@@ -902,27 +884,6 @@
       "additionalProperties": true,
       "description": "A single bucket of a facet query result. Reports the number of documents with a field value falling within a particular range or having a particular value or interval."
     },
-    "SearchFeatures": {
-      "properties": {
-        "uniqueTokenMatches": {
-          "type": "number",
-          "readOnly": true,
-          "format": "double",
-          "description": "The number of unique tokens from the search query that matched this field."
-        },
-        "similarityScore": {
-          "type": "number",
-          "readOnly": true,
-          "format": "double",
-          "description": "The similarity score computed between the search query and this field."
-        }
-      },
-      "required": [
-        "uniqueTokenMatches",
-        "similarityScore"
-      ],
-      "description": "A list of features describing the scoring of a specific field against the search query."
-    },
     "DocumentSearchResult": {
       "properties": {
         "@odata.count": {
@@ -996,15 +957,6 @@
           "readOnly": true,
           "x-ms-client-name": "Highlights",
           "description": "Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query."
-        },
-        "@search.features": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/SearchFeatures"
-          },
-          "readOnly": true,
-          "x-ms-client-name": "Features",
-          "description": "description for the feature"
         }
       },
       "additionalProperties": true,
@@ -1114,18 +1066,6 @@
       },
       "description": "Specifies the syntax of the search query. The default is 'simple'. Use 'full' if your query uses the Lucene query syntax."
     },
-    "FeaturesMode": {
-      "type": "string",
-      "enum": [
-        "disabled",
-        "enabled"
-      ],
-      "x-ms-enum": {
-        "name": "FeaturesMode",
-        "modelAsString": false
-      },
-      "description": "A value that specifies whether the results should include scoring features, such as per field similarity. The default is 'disabled'. Use 'enabled' to expose additional scoring features."
-    },
     "ScoringStatistics": {
       "type": "string",
       "enum": [
@@ -1201,10 +1141,6 @@
         "queryType": {
           "$ref": "#/definitions/QueryType",
           "description": "A value that specifies the syntax of the search query. The default is 'simple'. Use 'full' if your query uses the Lucene query syntax."
-        },
-        "featuresMode": {
-          "$ref": "#/definitions/FeaturesMode",
-          "description": "A value that specifies whether the results should include scoring features, such as per field similarity. The default is 'disabled'. Use 'enabled' to expose additional scoring features."
         },
         "scoringStatistics": {
           "$ref": "#/definitions/ScoringStatistics",


### PR DESCRIPTION
This change removes the "featuresMode" parameter from Azure Cognitive Search Document GETS API. This feature is staying in preview for the near future, and will be added back to the specs once we get closer to GA.

<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Contribution checklist:
- [ ] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [ ] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Service team MUST add the "**WaitForARMFeedback**" label if the management plane API changes fall into one of the below categories. 
  - adding/removing APIs.
  - adding/removing properties.
  - adding/removing API-version. 
  - adding a new service in Azure.

<i>Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.</i>

- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://aka.ms/SwaggerPRReview).
