### PR TITLE
Set RoleAssignmentProperties to be a direct paramter of RoleAssignmen…

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2/rbac.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2/rbac.json
@@ -153,7 +153,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/RoleAssignmentCreateParameters"
+              "$ref": "#/definitions/RoleAssignmentProperties"
             },
             "description": "Parameters for the role assignment."
           },
@@ -349,6 +349,7 @@
       "description": "Role assignment list operation result."
     },
     "RoleAssignmentProperties": {
+      "type":"object",
       "properties": {
         "roleDefinitionId": {
           "type": "string",
@@ -364,18 +365,6 @@
         "principalId"
       ],
       "description": "Role assignment properties."
-    },
-    "RoleAssignmentCreateParameters": {
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/RoleAssignmentProperties",
-          "description": "Role assignment properties."
-        }
-      },
-      "required": [
-        "properties"
-      ],
-      "description": "Role assignment create parameters."
     },
     "RoleDefinitionFilter": {
       "properties": {


### PR DESCRIPTION
…ts_Create

<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Contribution checklist:
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Service team MUST add the "**WaitForARMFeedback**" label if the management plane API changes fall into one of the below categories. 
  - adding/removing APIs.
  - adding/removing properties.
  - adding/removing API-version. 
  - adding a new service in Azure.

<i>Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.</i>

- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://aka.ms/SwaggerPRReview).

# Summary of Changes
Prior to this change, request body from generated clients for `RoleAssignments_Create` was unnecessarily wrapped in an additional `properties` object, resulting in 400 errors for those requests. 

**Request body shape before:**
```JSON
{
    "properties": 
    {
        "roleDefinitionId": "<someRoleDefinition>",
        "principalId":"<somePrincipalId>"
    }
}
```

**Request body shape after:**
```JSON
{
    "roleDefinitionId": "<someRoleDefinition>",
    "principalId":"<somePrincipalId>"
}
```