### PR TITLE
Defining ObjectReplicationMetadata name in parent object BlobItemInternal

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -9497,6 +9497,9 @@
           "$ref": "#/definitions/BlobTags"
         },
         "ObjectReplicationMetadata": {
+          "xml": {
+            "name": "OrMetadata"
+          },
           "$ref": "#/definitions/ObjectReplicationMetadata"
         }
       }


### PR DESCRIPTION
For Object Replication List Blobs Item response.

This changes the XML name to look for "OrMetadata" instead of the generator defaulting to ObjectReplicationMetadata(this is seen in the .NET generator)