### PR TITLE
Removing duplicate autoQuotaIncreaseState from supportTicketAction.

### DIFF
--- a/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-07-19/examples/getAutoQuotaIncreaseStatus.json
+++ b/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-07-19/examples/getAutoQuotaIncreaseStatus.json
@@ -11,7 +11,7 @@
         "name": "Automatic Quota Increase",
         "properties": {
           "settings": {
-            "autoQuotaIncreaseState": "enabledForPreview"
+            "autoQuotaIncreaseState": "enabled"
           },
           "onSuccess": {
             "emailActions": {
@@ -38,7 +38,6 @@
             }
           },
           "supportTicketAction": {
-            "autoQuotaIncreaseState": "enabledForPreview",
             "severity": "Minimal",
             "firstName": "FN",
             "lastName": "LN",

--- a/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-07-19/examples/putAutoQuotaIncrease.json
+++ b/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-07-19/examples/putAutoQuotaIncrease.json
@@ -5,7 +5,7 @@
     "autoQuotaIncreaseRequest": {
       "properties": {
         "settings": {
-          "autoQuotaIncreaseState": "enabledForPreview"
+          "autoQuotaIncreaseState": "enabled"
         },
         "onSuccess": {
           "emailActions": {
@@ -32,7 +32,6 @@
           }
         },
         "supportTicketAction": {
-          "autoQuotaIncreaseState": "enabledForPreview",
           "severity": "Minimal",
           "firstName": "FN",
           "lastName": "LN",
@@ -57,7 +56,7 @@
         "name": "Automatic Quota Increase",
         "properties": {
           "settings": {
-            "autoQuotaIncreaseState": "enabledForPreview"
+            "autoQuotaIncreaseState": "enabled"
           },
           "onSuccess": {
             "emailActions": {
@@ -84,7 +83,6 @@
             }
           },
           "supportTicketAction": {
-            "autoQuotaIncreaseState": "enabledForPreview",
             "severity": "Minimal",
             "firstName": "FN",
             "lastName": "LN",

--- a/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-07-19/examples/putAutoQuotaIncreaseTurnOff.json
+++ b/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-07-19/examples/putAutoQuotaIncreaseTurnOff.json
@@ -32,7 +32,6 @@
           }
         },
         "supportTicketAction": {
-          "autoQuotaIncreaseState": "disabled",
           "severity": "Minimal",
           "firstName": "FN",
           "lastName": "LN",
@@ -84,7 +83,6 @@
             }
           },
           "supportTicketAction": {
-            "autoQuotaIncreaseState": "disabled",
             "severity": "Minimal",
             "firstName": "FN",
             "lastName": "LN",

--- a/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-07-19/quota.json
+++ b/specification/reservations/resource-manager/Microsoft.Capacity/preview/2019-07-19/quota.json
@@ -927,10 +927,6 @@
       "description": "The SupportRequest action.",
       "type": "object",
       "properties": {
-        "autoQuotaIncreaseState": {
-          "description": "Is support request action enabled.",
-          "$ref": "#/definitions/AqiState"
-        },
         "severity": {
           "description": "The support request severity.",
           "$ref": "#/definitions/SeverityTypes"
@@ -997,10 +993,9 @@
       }
     },
     "AqiState": {
-      "description": "The Auto quota increase feature state - enabled: feature is fully enabled, enabledForPreview: feature enabled for preview only, disabled: feature is disabled.",
+      "description": "The Auto quota increase feature state - enabled: feature is enabled, disabled: feature is disabled.",
       "enum": [
         "enabled",
-        "enabledForPreview",
         "disabled"
       ],
       "x-ms-enum": {


### PR DESCRIPTION
1.Removing duplicate autoQuotaIncreaseState from supportTicketAction. (Breaking Change) - There is no active user.
2. Removing state=enabledForPreview.
3. Updating Example.

<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Contribution checklist:
- [ ] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [ ] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Service team MUST add the "**WaitForARMFeedback**" label if the management plane API changes fall into one of the below categories. 
  - adding/removing APIs.
  - adding/removing properties.
  - adding/removing API-version. 
  - adding a new service in Azure.

<i>Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.</i>

- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://aka.ms/SwaggerPRReview).
