### PR TITLE
Add remoteBgpCommunities to VirtualNetworkPeering resource

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkCreateWithBgpCommunities.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkCreateWithBgpCommunities.json
@@ -20,7 +20,7 @@
           }
         ],
         "bgpCommunities": {
-          "virtualNetworkCommunity": "12076:60000"
+          "virtualNetworkCommunity": "12076:20000"
         }
       },
       "location": "eastus"
@@ -51,7 +51,7 @@
             }
           ],
           "bgpCommunities": {
-            "virtualNetworkCommunity": "12076:60000",
+            "virtualNetworkCommunity": "12076:20000",
             "regionalCommunity": "12076:50004"
           },
           "virtualNetworkPeerings": []
@@ -82,8 +82,8 @@
             }
           ],
           "bgpCommunities": {
-            "virtualNetworkCommunity": "12076:60000",
-            "regionalCommunity": "12076:51004"
+            "virtualNetworkCommunity": "12076:20000",
+            "regionalCommunity": "12076:50004"
           },
           "virtualNetworkPeerings": []
         }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkCreateWithBgpCommunities.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkCreateWithBgpCommunities.json
@@ -52,7 +52,7 @@
           ],
           "bgpCommunities": {
             "virtualNetworkCommunity": "12076:60000",
-            "regionalCommunity": "12076:51004"
+            "regionalCommunity": "12076:50004"
           },
           "virtualNetworkPeerings": []
         }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkPeeringCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkPeeringCreate.json
@@ -35,6 +35,10 @@
               "12.0.0.0/8"
             ]
           },
+          "remoteBgpCommunities": {
+            "virtualNetworkCommunity": "12076:20002",
+            "regionalCommunity": "12076:50004"
+          },
           "peeringState": "Initiated",
           "provisioningState": "Succeeded"
         }
@@ -56,6 +60,10 @@
             "addressPrefixes": [
               "12.0.0.0/8"
             ]
+          },
+          "remoteBgpCommunities": {
+            "virtualNetworkCommunity": "12076:20002",
+            "regionalCommunity": "12076:50004"
           },
           "peeringState": "Initiated",
           "provisioningState": "Succeeded"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkPeeringGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkPeeringGet.json
@@ -24,6 +24,10 @@
               "12.0.0.0/8"
             ]
           },
+          "remoteBgpCommunities": {
+            "virtualNetworkCommunity": "12076:20002",
+            "regionalCommunity": "12076:50004"
+          },
           "peeringState": "Initiated",
           "provisioningState": "Succeeded"
         }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkPeeringList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/examples/VirtualNetworkPeeringList.json
@@ -25,6 +25,10 @@
                   "12.0.0.0/8"
                 ]
               },
+              "remoteBgpCommunities": {
+                "virtualNetworkCommunity": "12076:20002",
+                "regionalCommunity": "12076:50004"
+              },
               "peeringState": "Initiated",
               "provisioningState": "Succeeded"
             }
@@ -44,6 +48,10 @@
                 "addressPrefixes": [
                   "13.0.0.0/8"
                 ]
+              },
+              "remoteBgpCommunities": {
+                "virtualNetworkCommunity": "12076:20003",
+                "regionalCommunity": "12076:50004"
               },
               "peeringState": "Initiated",
               "provisioningState": "Succeeded"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2020-06-01/virtualNetwork.json
@@ -1552,6 +1552,11 @@
           "$ref": "#/definitions/AddressSpace",
           "description": "The reference to the remote virtual network address space."
         },
+        "remoteBgpCommunities": {
+          "$ref": "#/definitions/VirtualNetworkBgpCommunities",
+          "default": null,
+          "description": "The reference to the remote virtual network's Bgp Communities."
+        },
         "peeringState": {
           "type": "string",
           "description": "The status of the virtual network peering.",


### PR DESCRIPTION
This pull request adds the remoteBgpCommunities property to the VirtualNetworkPeering resource. The value of this property is populated from the value of the bgpCommunities property of the remote VNET that is being peered to the local VNET.

This is an addition being done for important scalability reasons. ExpressRoute needs to read the BgpCommunities of all the spoke VNETs that are peered with a hub VNET. Performing GET operations on each peered VNET does not scale because the number of peered VNETs can be large.
The efficient way to obtain this information is from the VirtualNetworkPeering child resources of the hub VNET.


### Contribution checklist:
- [ x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x ] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [x] Service team MUST add the "**WaitForARMFeedback**" label if the management plane API changes fall into one of the below categories. 
  - adding/removing APIs.
  - adding/removing properties.
  - adding/removing API-version. 
  - adding a new service in Azure.

<i>Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.</i>

- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://aka.ms/SwaggerPRReview).
