### PR TITLE
remove TagValue

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -10249,17 +10249,13 @@
       "type": "object",
       "required": [
         "Name",
-        "ContainerName",
-        "TagValue"
+        "ContainerName"
       ],
       "properties": {
         "Name": {
           "type": "string"
         },
         "ContainerName": {
-          "type": "string"
-        },
-        "TagValue": {
           "type": "string"
         }
       }


### PR DESCRIPTION
TagValue is going to removed in next API interation, so we're not going to expose it from SDKs.