### PR TITLE
Add Microsoft.PolicyInsights/attestations to 2019-10-01

### DIFF
--- a/specification/common-types/resource-management/v1/types.json
+++ b/specification/common-types/resource-management/v1/types.json
@@ -356,18 +356,8 @@
           "description": "The identity that created the resource."
         },
         "createdByType": {
-          "type": "string",
-          "description": "The type of identity that created the resource.",
-          "enum": [
-            "User",
-            "Application",
-            "ManagedIdentity",
-            "Key"
-          ],
-          "x-ms-enum": {
-            "name": "createdByType",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/createdByType",
+          "description": "The type of identity that created the resource."
         },
         "createdAt": {
           "type": "string",
@@ -379,24 +369,28 @@
           "description": "The identity that last modified the resource."
         },
         "lastModifiedByType": {
-          "type": "string",
-          "description": "The type of identity that last modified the resource.",
-          "enum": [
-            "User",
-            "Application",
-            "ManagedIdentity",
-            "Key"
-          ],
-          "x-ms-enum": {
-            "name": "createdByType",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/createdByType",
+          "description": "The type of identity that last modified the resource."
         },
         "lastModifiedAt": {
           "type": "string",
           "format": "date-time",
           "description": "The type of identity that last modified the resource."
         }
+      }
+    },
+    "createdByType": {
+      "type": "string",
+      "description": "The type of identity that operated on the resource.",
+      "enum": [
+        "User",
+        "Application",
+        "ManagedIdentity",
+        "Key"
+      ],
+      "x-ms-enum": {
+        "name": "createdByType",
+        "modelAsString": true
       }
     },
     "encryptionProperties": {

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/attestations.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/attestations.json
@@ -628,7 +628,7 @@
         },
         "owner": {
           "type": "string",
-          "description": "The person responsible for setting the state of the resource."
+          "description": "The person responsible for setting the state of the resource. This value is typically an Azure Active Directory object ID."
         },
         "comments": {
           "type": "string",

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/attestations.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/attestations.json
@@ -1,0 +1,779 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "AttestationsClient",
+    "version": "2019-10-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.PolicyInsights/attestations": {
+      "get": {
+        "operationId": "Attestations_ListForSubscription",
+        "description": "Gets all attestations for the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/topParameter"
+          },
+          {
+            "$ref": "#/parameters/filterParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The retrieved attestations.",
+            "schema": {
+              "$ref": "#/definitions/AttestationListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List attestations at subscription scope": {
+            "$ref": "./examples/Attestations_ListSubscriptionScope.json"
+          },
+          "List attestations at subscription scope with query parameters": {
+            "$ref": "./examples/Attestations_ListSubscriptionScope_WithQuery.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.PolicyInsights/attestations/{attestationName}": {
+      "put": {
+        "operationId": "Attestations_CreateOrUpdateAtSubscription",
+        "description": "Creates or updates an attestation at subscription scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/attestationNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            },
+            "description": "The attestation parameters."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated attestation.",
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            }
+          },
+          "201": {
+            "description": "The created attestation.",
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Create attestation at subscription scope": {
+            "$ref": "./examples/Attestations_CreateSubscriptionScope.json"
+          },
+          "Create attestation at subscription scope with all properties": {
+            "$ref": "./examples/Attestations_CreateSubscriptionScope_AllProperties.json"
+          }
+        }
+      },
+      "get": {
+        "operationId": "Attestations_GetAtSubscription",
+        "description": "Gets an existing attestation at subscription scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/attestationNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The retrieved attestation.",
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get attestation at subscription scope": {
+            "$ref": "./examples/Attestations_GetSubscriptionScope.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Attestations_DeleteAtSubscription",
+        "description": "Deletes an existing attestation at subscription scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/attestationNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The attestation was successfully deleted."
+          },
+          "204": {
+            "description": "The attestation did not exist."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete attestation at subscription scope": {
+            "$ref": "./examples/Attestations_DeleteSubscriptionScope.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PolicyInsights/attestations": {
+      "get": {
+        "operationId": "Attestations_ListForResourceGroup",
+        "description": "Gets all attestations for the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/topParameter"
+          },
+          {
+            "$ref": "#/parameters/filterParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The retrieved attestations.",
+            "schema": {
+              "$ref": "#/definitions/AttestationListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List attestations at resource group scope": {
+            "$ref": "./examples/Attestations_ListResourceGroupScope.json"
+          },
+          "List attestations at resource group scope with query parameters": {
+            "$ref": "./examples/Attestations_ListResourceGroupScope_WithQuery.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PolicyInsights/attestations/{attestationName}": {
+      "put": {
+        "operationId": "Attestations_CreateOrUpdateAtResourceGroup",
+        "description": "Creates or updates an attestation at resource group scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/attestationNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            },
+            "description": "The attestation parameters."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated attestation.",
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            }
+          },
+          "201": {
+            "description": "The created attestation.",
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Create attestation at resource group scope": {
+            "$ref": "./examples/Attestations_CreateResourceGroupScope.json"
+          }
+        }
+      },
+      "get": {
+        "operationId": "Attestations_GetAtResourceGroup",
+        "description": "Gets an existing attestation at resource group scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/attestationNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The retrieved attestation.",
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get attestation at resource group scope": {
+            "$ref": "./examples/Attestations_GetResourceGroupScope.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Attestations_DeleteAtResourceGroup",
+        "description": "Deletes an existing attestation at resource group scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/attestationNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The attestation was successfully deleted."
+          },
+          "204": {
+            "description": "The attestation did not exist."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete attestation at resource group scope": {
+            "$ref": "./examples/Attestations_DeleteResourceGroupScope.json"
+          }
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.PolicyInsights/attestations": {
+      "get": {
+        "operationId": "Attestations_ListForResource",
+        "description": "Gets all attestations for a resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceIdParameter"
+          },
+          {
+            "$ref": "#/parameters/topParameter"
+          },
+          {
+            "$ref": "#/parameters/filterParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The retrieved attestations.",
+            "schema": {
+              "$ref": "#/definitions/AttestationListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List attestations at individual resource scope": {
+            "$ref": "./examples/Attestations_ListResourceScope.json"
+          },
+          "List attestations at individual resource scope with query parameters": {
+            "$ref": "./examples/Attestations_ListResourceScope_WithQuery.json"
+          }
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.PolicyInsights/attestations/{attestationName}": {
+      "put": {
+        "operationId": "Attestations_CreateOrUpdateAtResource",
+        "description": "Creates or updates an attestation at resource scope.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceIdParameter"
+          },
+          {
+            "$ref": "#/parameters/attestationNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            },
+            "description": "The attestation parameters."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated attestation.",
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            }
+          },
+          "201": {
+            "description": "The created attestation.",
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Create attestation at individual resource scope": {
+            "$ref": "./examples/Attestations_CreateResourceScope.json"
+          }
+        }
+      },
+      "get": {
+        "operationId": "Attestations_GetAtResource",
+        "description": "Gets an existing attestation at resource scope.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceIdParameter"
+          },
+          {
+            "$ref": "#/parameters/attestationNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The retrieved attestation.",
+            "schema": {
+              "$ref": "#/definitions/Attestation"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get attestation at individual resource scope": {
+            "$ref": "./examples/Attestations_GetResourceScope.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Attestations_DeleteAtResource",
+        "description": "Deletes an existing attestation at individual resource scope.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceIdParameter"
+          },
+          {
+            "$ref": "#/parameters/attestationNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The attestation was successfully deleted."
+          },
+          "204": {
+            "description": "The attestation did not exist."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete attestation at individual resource scope": {
+            "$ref": "./examples/Attestations_DeleteResourceScope.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AttestationListResult": {
+      "description": "List of attestations.",
+      "properties": {
+        "value": {
+          "description": "Array of attestation definitions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Attestation"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results.",
+          "readOnly": true
+        }
+      }
+    },
+    "Attestation": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AttestationProperties",
+          "description": "Properties for the attestation."
+        },
+        "systemData": {
+          "readOnly": true,
+          "type": "object",
+          "description": "Azure Resource Manager metadata containing createdBy and modifiedBy information.",
+          "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/systemData"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v1/types.json#/definitions/Resource"
+        }
+      ],
+      "required": [
+        "properties"
+      ],
+      "description": "An attestation resource."
+    },
+    "AttestationProperties": {
+      "properties": {
+        "policyAssignmentId": {
+          "type": "string",
+          "description": "The resource ID of the policy assignment that the attestation is setting the state for."
+        },
+        "policyDefinitionReferenceId": {
+          "type": "string",
+          "description": "The policy definition reference ID from a policy set definition that the attestation is setting the state for."
+        },
+        "complianceState": {
+          "type": "string",
+          "enum": [
+            "Compliant",
+            "NonCompliant",
+            "Unknown"
+          ],
+          "x-ms-enum": {
+            "name": "ComplianceState",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "Compliant",
+                "description": "The resource is in compliance with the policy."
+              },
+              {
+                "value": "NonCompliant",
+                "description": "The resource is not in compliance with the policy."
+              },
+              {
+                "value": "Unknown",
+                "description": "The compliance state of the resource is not known."
+              }
+            ]
+          },
+          "description": "The compliance state that should be set on the resource."
+        },
+        "expiresOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the compliance state should expire."
+        },
+        "owner": {
+          "type": "string",
+          "description": "The person responsible for setting the state of the resource."
+        },
+        "comments": {
+          "type": "string",
+          "description": "Comments describing why this attestation was created."
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AttestationEvidence"
+          },
+          "description": "The evidence supporting the compliance state set in this attestation."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The status of the attestation.",
+          "readOnly": true
+        },
+        "lastComplianceStateChangeAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the compliance state was last changed in this attestation.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "policyAssignmentId"
+      ],
+      "description": "The properties of an attestation resource."
+    },
+    "AttestationEvidence": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The description for this piece of evidence."
+        },
+        "sourceUri": {
+          "type": "string",
+          "description": "The URI location of the evidence."
+        }
+      },
+      "description": "A piece of evidence supporting the compliance state set in the attestation."
+    },
+    "ErrorResponse": {
+      "description": "Error response.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorDefinition",
+          "description": "The error details."
+        }
+      }
+    },
+    "ErrorDefinition": {
+      "description": "Error definition.",
+      "properties": {
+        "code": {
+          "description": "Service specific error code which serves as the substatus for the HTTP error code.",
+          "type": "string",
+          "readOnly": true
+        },
+        "message": {
+          "description": "Description of the error.",
+          "type": "string",
+          "readOnly": true
+        },
+        "target": {
+          "description": "The target of the error.",
+          "type": "string",
+          "readOnly": true
+        },
+        "details": {
+          "description": "Internal error details.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorDefinition"
+          },
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "description": "Additional scenario specific error details.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TypedErrorInfo"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "TypedErrorInfo": {
+      "description": "Scenario specific error details.",
+      "properties": {
+        "type": {
+          "description": "The type of included error details.",
+          "type": "string",
+          "readOnly": true
+        },
+        "info": {
+          "description": "The scenario specific error details.",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "attestationNameParameter": {
+      "name": "attestationName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the attestation.",
+      "x-ms-parameter-location": "method"
+    },
+    "resourceIdParameter": {
+      "name": "resourceId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Resource ID.",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "topParameter": {
+      "name": "$top",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32",
+      "minimum": 0,
+      "description": "Maximum number of records to return.",
+      "x-ms-parameter-location": "method",
+      "x-ms-parameter-grouping": {
+        "name": "QueryOptions"
+      },
+      "x-ms-client-name": "Top"
+    },
+    "filterParameter": {
+      "name": "$filter",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "OData filter expression.",
+      "x-ms-parameter-location": "method",
+      "x-ms-parameter-grouping": {
+        "name": "QueryOptions"
+      },
+      "x-ms-client-name": "Filter"
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/attestations.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/attestations.json
@@ -592,7 +592,7 @@
         },
         "policyDefinitionReferenceId": {
           "type": "string",
-          "description": "The policy definition reference ID from a policy set definition that the attestation is setting the state for."
+          "description": "The policy definition reference ID from a policy set definition that the attestation is setting the state for. If the policy assignment assigns a policy set definition the attestation can choose a definition within the set definition with this property or omit this and set the state for the entire set definition."
         },
         "complianceState": {
           "type": "string",

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_CreateResourceGroupScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_CreateResourceGroupScope.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "api-version": "2019-10-01",
+    "resourceGroupName": "myRg",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+    "parameters": {
+      "properties": {
+        "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+        "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+        "complianceState": "Compliant",
+        "expiresOn": "2021-06-15T00:00:00Z",
+        "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+        "comments": "This subscription has passed a security audit.",
+        "evidence": [
+          {
+            "description": "The results of the security audit.",
+            "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "expiresOn": "2021-06-15T00:00:00Z",
+          "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+          "comments": "This subscription has passed a security audit.",
+          "evidence": [
+            {
+              "description": "The results of the security audit.",
+              "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    },
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "expiresOn": "2021-06-15T00:00:00Z",
+          "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+          "comments": "This subscription has passed a security audit.",
+          "evidence": [
+            {
+              "description": "The results of the security audit.",
+              "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_CreateResourceScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_CreateResourceScope.json
@@ -1,0 +1,89 @@
+{
+  "parameters": {
+    "resourceId": "subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM",
+    "api-version": "2019-10-01",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+    "parameters": {
+      "properties": {
+        "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+        "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+        "complianceState": "Compliant",
+        "expiresOn": "2021-06-15T00:00:00Z",
+        "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+        "comments": "This subscription has passed a security audit.",
+        "evidence": [
+          {
+            "description": "The results of the security audit.",
+            "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "expiresOn": "2021-06-15T00:00:00Z",
+          "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+          "comments": "This subscription has passed a security audit.",
+          "evidence": [
+            {
+              "description": "The results of the security audit.",
+              "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    },
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "expiresOn": "2021-06-15T00:00:00Z",
+          "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+          "comments": "This subscription has passed a security audit.",
+          "evidence": [
+            {
+              "description": "The results of the security audit.",
+              "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_CreateSubscriptionScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_CreateSubscriptionScope.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "api-version": "2019-10-01",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+    "parameters": {
+      "properties": {
+        "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+        "complianceState": "Compliant"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    },
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_CreateSubscriptionScope_AllProperties.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_CreateSubscriptionScope_AllProperties.json
@@ -1,0 +1,89 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "api-version": "2019-10-01",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+    "parameters": {
+      "properties": {
+        "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+        "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+        "complianceState": "Compliant",
+        "expiresOn": "2021-06-15T00:00:00Z",
+        "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+        "comments": "This subscription has passed a security audit.",
+        "evidence": [
+          {
+            "description": "The results of the security audit.",
+            "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "expiresOn": "2021-06-15T00:00:00Z",
+          "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+          "comments": "This subscription has passed a security audit.",
+          "evidence": [
+            {
+              "description": "The results of the security audit.",
+              "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    },
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "expiresOn": "2021-06-15T00:00:00Z",
+          "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+          "comments": "This subscription has passed a security audit.",
+          "evidence": [
+            {
+              "description": "The results of the security audit.",
+              "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_DeleteResourceGroupScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_DeleteResourceGroupScope.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "resourceGroupName": "myRg",
+    "api-version": "2019-10-01",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_DeleteResourceScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_DeleteResourceScope.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "resourceId": "subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM",
+    "api-version": "2019-10-01",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_DeleteSubscriptionScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_DeleteSubscriptionScope.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "api-version": "2019-10-01",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_GetResourceGroupScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_GetResourceGroupScope.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "resourceGroupName": "myRg",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+    "api-version": "2019-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "expiresOn": "2021-06-15T00:00:00Z",
+          "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+          "comments": "This subscription has passed a security audit.",
+          "evidence": [
+            {
+              "description": "The results of the security audit.",
+              "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_GetResourceScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_GetResourceScope.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "resourceId": "subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+    "api-version": "2019-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "expiresOn": "2021-06-15T00:00:00Z",
+          "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+          "comments": "This subscription has passed a security audit.",
+          "evidence": [
+            {
+              "description": "The results of the security audit.",
+              "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_GetSubscriptionScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_GetSubscriptionScope.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "attestationName": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+    "api-version": "2019-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+          "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+          "complianceState": "Compliant",
+          "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+          "expiresOn": "2021-06-15T00:00:00Z",
+          "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+          "comments": "This subscription has passed a security audit.",
+          "evidence": [
+            {
+              "description": "The results of the security audit.",
+              "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "createdByType": "User",
+          "createdAt": "2020-06-15T18:52:27Z",
+          "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2020-06-15T18:52:27Z"
+        },
+        "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+        "type": "Microsoft.PolicyInsights/attestations"
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListResourceGroupScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListResourceGroupScope.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "resourceGroupName": "myRg",
+    "api-version": "2019-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+              "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+              "complianceState": "Compliant",
+              "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+              "expiresOn": "2021-06-15T00:00:00Z",
+              "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+              "comments": "This subscription has passed a security audit.",
+              "evidence": [
+                {
+                  "description": "The results of the security audit.",
+                  "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "createdByType": "User",
+              "createdAt": "2020-06-15T18:52:27Z",
+              "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2020-06-15T18:52:27Z"
+            },
+            "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "type": "Microsoft.PolicyInsights/attestations"
+          },
+          {
+            "properties": {
+              "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/090a47f8-13e9-441e-ad90-dc666cc5d487",
+              "complianceState": "Compliant",
+              "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "34709f31-f267-4eee-8479-0da11925f2f2",
+              "createdByType": "User",
+              "createdAt": "2020-06-15T18:52:27Z",
+              "lastModifiedBy": "34709f31-f267-4eee-8479-0da11925f2f2",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2020-06-15T18:52:27Z"
+            },
+            "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.policyinsights/attestations/689bfc0c-a012-49fc-af40-3ebea35ff3ed",
+            "name": "689bfc0c-a012-49fc-af40-3ebea35ff3ed",
+            "type": "Microsoft.PolicyInsights/attestations"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListResourceGroupScope_WithQuery.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListResourceGroupScope_WithQuery.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "resourceGroupName": "myRg",
+    "$filter": "PolicyAssignmentId eq '/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5' AND PolicyDefinitionReferenceId eq '0b158b46-ff42-4799-8e39-08a5c23b4551'",
+    "$top": 1,
+    "api-version": "2019-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+              "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+              "complianceState": "Compliant",
+              "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+              "expiresOn": "2021-06-15T00:00:00Z",
+              "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+              "comments": "This subscription has passed a security audit.",
+              "evidence": [
+                {
+                  "description": "The results of the security audit.",
+                  "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "createdByType": "User",
+              "createdAt": "2020-06-15T18:52:27Z",
+              "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2020-06-15T18:52:27Z"
+            },
+            "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "type": "Microsoft.PolicyInsights/attestations"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListResourceScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListResourceScope.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "resourceId": "subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM",
+    "api-version": "2019-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+              "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+              "complianceState": "Compliant",
+              "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+              "expiresOn": "2021-06-15T00:00:00Z",
+              "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+              "comments": "This subscription has passed a security audit.",
+              "evidence": [
+                {
+                  "description": "The results of the security audit.",
+                  "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "createdByType": "User",
+              "createdAt": "2020-06-15T18:52:27Z",
+              "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2020-06-15T18:52:27Z"
+            },
+            "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "type": "Microsoft.PolicyInsights/attestations"
+          },
+          {
+            "properties": {
+              "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/090a47f8-13e9-441e-ad90-dc666cc5d487",
+              "complianceState": "Compliant",
+              "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "34709f31-f267-4eee-8479-0da11925f2f2",
+              "createdByType": "User",
+              "createdAt": "2020-06-15T18:52:27Z",
+              "lastModifiedBy": "34709f31-f267-4eee-8479-0da11925f2f2",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2020-06-15T18:52:27Z"
+            },
+            "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM/providers/microsoft.policyinsights/attestations/689bfc0c-a012-49fc-af40-3ebea35ff3ed",
+            "name": "689bfc0c-a012-49fc-af40-3ebea35ff3ed",
+            "type": "Microsoft.PolicyInsights/attestations"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListResourceScope_WithQuery.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListResourceScope_WithQuery.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "resourceId": "subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM",
+    "$filter": "PolicyAssignmentId eq '/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5' AND PolicyDefinitionReferenceId eq '0b158b46-ff42-4799-8e39-08a5c23b4551'",
+    "$top": 1,
+    "api-version": "2019-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+              "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+              "complianceState": "Compliant",
+              "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+              "expiresOn": "2021-06-15T00:00:00Z",
+              "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+              "comments": "This subscription has passed a security audit.",
+              "evidence": [
+                {
+                  "description": "The results of the security audit.",
+                  "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "createdByType": "User",
+              "createdAt": "2020-06-15T18:52:27Z",
+              "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2020-06-15T18:52:27Z"
+            },
+            "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.compute/virtualMachines/devVM/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "type": "Microsoft.PolicyInsights/attestations"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListSubscriptionScope.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListSubscriptionScope.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "api-version": "2019-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+              "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+              "complianceState": "Compliant",
+              "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+              "expiresOn": "2021-06-15T00:00:00Z",
+              "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+              "comments": "This subscription has passed a security audit.",
+              "evidence": [
+                {
+                  "description": "The results of the security audit.",
+                  "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "createdByType": "User",
+              "createdAt": "2020-06-15T18:52:27Z",
+              "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2020-06-15T18:52:27Z"
+            },
+            "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "type": "Microsoft.PolicyInsights/attestations"
+          },
+          {
+            "properties": {
+              "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/090a47f8-13e9-441e-ad90-dc666cc5d487",
+              "complianceState": "Compliant",
+              "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "34709f31-f267-4eee-8479-0da11925f2f2",
+              "createdByType": "User",
+              "createdAt": "2020-06-15T18:52:27Z",
+              "lastModifiedBy": "34709f31-f267-4eee-8479-0da11925f2f2",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2020-06-15T18:52:27Z"
+            },
+            "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/resourcegroups/myrg/providers/microsoft.policyinsights/attestations/689bfc0c-a012-49fc-af40-3ebea35ff3ed",
+            "name": "689bfc0c-a012-49fc-af40-3ebea35ff3ed",
+            "type": "Microsoft.PolicyInsights/attestations"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListSubscriptionScope_WithQuery.json
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/stable/2019-10-01/examples/Attestations_ListSubscriptionScope_WithQuery.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "subscriptionId": "35ee058e-5fa0-414c-8145-3ebb8d09b6e2",
+    "$filter": "PolicyAssignmentId eq '/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5' AND PolicyDefinitionReferenceId eq '0b158b46-ff42-4799-8e39-08a5c23b4551'",
+    "$top": 1,
+    "api-version": "2019-10-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "policyAssignmentId": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.authorization/policyassignments/b101830944f246d8a14088c5",
+              "policyDefinitionReferenceId": "0b158b46-ff42-4799-8e39-08a5c23b4551",
+              "complianceState": "Compliant",
+              "lastComplianceStateChangeAt": "2020-06-15T18:52:27Z",
+              "expiresOn": "2021-06-15T00:00:00Z",
+              "owner": "55a32e28-3aa5-4eea-9b5a-4cd85153b966",
+              "comments": "This subscription has passed a security audit.",
+              "evidence": [
+                {
+                  "description": "The results of the security audit.",
+                  "sourceUri": "https://gist.github.com/contoso/9573e238762c60166c090ae16b814011"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "createdByType": "User",
+              "createdAt": "2020-06-15T18:52:27Z",
+              "lastModifiedBy": "b69a9388-9488-4534-b470-7ec6d41beef6",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2020-06-15T18:52:27Z"
+            },
+            "id": "/subscriptions/35ee058e-5fa0-414c-8145-3ebb8d09b6e2/providers/microsoft.policyinsights/attestations/790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "name": "790996e6-9871-4b1f-9cd9-ec42cd6ced1e",
+            "type": "Microsoft.PolicyInsights/attestations"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/policyinsights/resource-manager/readme.md
+++ b/specification/policyinsights/resource-manager/readme.md
@@ -66,6 +66,10 @@ directive:
     where:
       - $.paths["/providers/Microsoft.PolicyInsights/operations"].get
 
+  - suppress: BodyTopLevelProperties
+    reason: systemData should be supported by all new resources
+    where:
+      - $.definitions.Attestation.properties
 ```
 
 ### Tag: package-2019-10
@@ -79,6 +83,7 @@ input-file:
 - Microsoft.PolicyInsights/stable/2019-10-01/policyEvents.json
 - Microsoft.PolicyInsights/stable/2019-10-01/policyStates.json
 - Microsoft.PolicyInsights/stable/2019-10-01/policyMetadata.json
+- Microsoft.PolicyInsights/stable/2019-10-01/attestations.json
 ```
 
 


### PR DESCRIPTION
This is a new resource type in Microsoft.PolicyInsights to facilitate manual policies.  Manual policies are policies where a user manually sets the compliance state of applicable resources.  This attestations resource is how they set the state of a subscription, resource group, or individual resource.

### Contribution checklist:
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [x] Service team MUST add the "**WaitForARMFeedback**" label if the management plane API changes fall into one of the below categories. 
  - adding/removing APIs.
  - adding/removing properties.
  - adding/removing API-version. 
  - adding a new service in Azure.

<i>Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.</i>

- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://aka.ms/SwaggerPRReview).
