### PR TITLE
[T2] fixed track2 generation

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/gallery.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2019-07-01/gallery.json
@@ -2542,21 +2542,6 @@
     "UpdateResource": {
       "description": "The Update Resource model definition.",
       "properties": {
-        "id": {
-          "readOnly": true,
-          "type": "string",
-          "description": "Resource Id"
-        },
-        "name": {
-          "readOnly": true,
-          "type": "string",
-          "description": "Resource name"
-        },
-        "type": {
-          "readOnly": true,
-          "type": "string",
-          "description": "Resource type"
-        },
         "tags": {
           "type": "object",
           "additionalProperties": {


### PR DESCRIPTION
Gallery.json had different definition of "UpdateResource".
Seems like these readonly properties shouldn't be there, as this definition is used in Update operation.