### PR TITLE
add Java to AVS

### DIFF
--- a/specification/vmware/resource-manager/readme.java.md
+++ b/specification/vmware/resource-manager/readme.java.md
@@ -11,3 +11,23 @@ java:
   license-header: MICROSOFT_MIT_NO_CODEGEN
   output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-avs
 ```
+
+### Java multi-api
+
+``` yaml $(java) && $(multiapi)
+batch:
+  - tag: package-2019-08-09-preview
+```
+
+### Tag: package-2019-08-09-preview and java
+
+These settings apply only when `--tag=package-2019-08-09 --java` is specified on the command line.
+Please also specify the `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+``` yaml $(tag) == 'package-2019-08-09-preview' && $(java) && $(multiapi)
+java:
+  namespace: com.microsoft.azure.management.avs.v2019_08_09_preview
+  output-folder: $(azure-libraries-for-java-folder)/sdk/avs/mgmt-v2019_08_09_preview
+regenerate-manager: true
+generate-interface: true
+```

--- a/specification/vmware/resource-manager/readme.java.md
+++ b/specification/vmware/resource-manager/readme.java.md
@@ -1,0 +1,13 @@
+## Java
+
+These settings apply only when `--java` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-libraries-for-java clone>`.
+
+``` yaml $(java)
+java:
+  azure-arm: true
+  namespace: com.microsoft.azure.management.avs
+  override-client-name: AvsClient
+  license-header: MICROSOFT_MIT_NO_CODEGEN
+  output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-avs
+```

--- a/specification/vmware/resource-manager/readme.md
+++ b/specification/vmware/resource-manager/readme.md
@@ -57,6 +57,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
+  - repo: azure-sdk-for-java
 ```
 
 ## TypeScript
@@ -74,6 +75,10 @@ See configuration in [readme.csharp.md](./readme.csharp.md)
 ## Go
 
 See configuration in [readme.go.md](./readme.go.md)
+
+## Java
+
+See configuration in [readme.java.md](./readme.java.md)
 
 ## Multi-API/Profile support for AutoRest v3 generators 
 


### PR DESCRIPTION
This just requests the Java SDK be built for Microsoft.AVS. It has already been requested from the OpenAPI Hub.