### PR TITLE
[Synapse DataPlane]Add a property as required and Remove AccessControl's operation id

### DIFF
--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/artifacts.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/artifacts.json
@@ -2716,7 +2716,8 @@
         }
       },
       "required": [
-        "sessionId"
+        "sessionId",
+        "commandPayload"
       ]
     },
     "DataFlowDebugQueryResponse": {

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2020-02-01-preview/roleAssignments.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2020-02-01-preview/roleAssignments.json
@@ -22,7 +22,7 @@
         "tags": [
           "RoleAssignments"
         ],
-        "operationId": "AccessControl_CreateRoleAssignment",
+        "operationId": "CreateRoleAssignment",
         "description": "Create role assignment.",
         "x-ms-examples": {
           "Create role assignment": {
@@ -68,7 +68,7 @@
         "tags": [
           "RoleAssignments"
         ],
-        "operationId": "AccessControl_GetRoleAssignments",
+        "operationId": "GetRoleAssignments",
         "description": "List role assignments.",
         "x-ms-examples": {
           "Get role assignment information": {
@@ -120,7 +120,7 @@
         "tags": [
           "RoleAssignments"
         ],
-        "operationId": "AccessControl_GetRoleAssignmentById",
+        "operationId": "GetRoleAssignmentById",
         "description": "Get role assignment by role assignment Id.",
         "x-ms-examples": {
           "Get role assignment information": {
@@ -158,7 +158,7 @@
         "tags": [
           "RoleAssignments"
         ],
-        "operationId": "AccessControl_DeleteRoleAssignmentById",
+        "operationId": "DeleteRoleAssignmentById",
         "description": "Delete role assignment by role assignment Id.",
         "x-ms-examples": {
           "Delete role assignment": {
@@ -198,7 +198,7 @@
         "tags": [
           "RoleAssignments"
         ],
-        "operationId": "AccessControl_GetCallerRoleAssignments",
+        "operationId": "GetCallerRoleAssignments",
         "description": "List role assignments of the caller.",
         "x-ms-examples": {
           "Get caller role assignments": {

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2020-02-01-preview/roles.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2020-02-01-preview/roles.json
@@ -22,7 +22,7 @@
         "tags": [
           "SynapseRoles"
         ],
-        "operationId": "AccessControl_GetRoleDefinitions",
+        "operationId": "GetRoleDefinitions",
         "description": "List roles.",
         "x-ms-examples": {
           "Get access control information": {
@@ -62,7 +62,7 @@
         "tags": [
           "SynapseRoles"
         ],
-        "operationId": "AccessControl_GetRoleDefinitionById",
+        "operationId": "GetRoleDefinitionById",
         "description": "Get role by role Id.",
         "x-ms-examples": {
           "Get access control information": {


### PR DESCRIPTION
1. Add a property as required
2. Remove AccessControl's operation id to elevate methods to client

<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Contribution checklist:
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Service team MUST add the "**WaitForARMFeedback**" label if the management plane API changes fall into one of the below categories. 
  - adding/removing APIs.
  - adding/removing properties.
  - adding/removing API-version. 
  - adding a new service in Azure.

<i>Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.</i>

- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://aka.ms/SwaggerPRReview).
