### PR TITLE
MSI/ClientCert support in SignalR service

### DIFF
--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/Operations_List.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/Operations_List.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.SignalRService/SignalR/read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.SignalRService",
+              "resource": "SignalR",
+              "operation": "Manage SignalR (read-only)",
+              "description": "View the SignalR's settings and configurations in the management portal or through API"
+            },
+            "properties": {}
+          }
+        ],
+        "nextLink": "providers/Microsoft.SignalRService?$skipToken={opaqueString}"
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/Operations_List.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/Operations_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01"
+    "api-version": "2020-07-01-preview"
   },
   "responses": {
     "200": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Delete.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Delete.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService",
+    "privateEndpointConnectionName": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult...",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationStatus..."
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Delete.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService",

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Get.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService",
+    "privateEndpointConnectionName": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved",
+            "description": null,
+            "actionsRequired": "None"
+          }
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService/privateEndpointConnections/mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+        "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+        "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Get.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService",

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Update.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Update.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "parameters": {
+      "properties": {
+        "privateEndpoint": {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+        },
+        "privateLinkServiceConnectionState": {
+          "status": "Approved",
+          "description": null,
+          "actionsRequired": "None"
+        }
+      }
+    },
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService",
+    "privateEndpointConnectionName": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved",
+            "description": null,
+            "actionsRequired": "None"
+          }
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService/privateEndpointConnections/mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+        "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+        "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult...",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationStatus..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Update.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateEndpointConnections_Update.json
@@ -12,7 +12,7 @@
         }
       }
     },
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService",

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateLinkResources_List.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateLinkResources_List.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "groupId": "signalr",
+              "requiredMembers": [
+                "signalr"
+              ],
+              "requiredZoneNames": [
+                "privatelink.service.signalr.net"
+              ]
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/privateLinkResources",
+            "name": "signalr",
+            "type": "privateLinkResources"
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToMoreResults..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateLinkResources_List.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalRPrivateLinkResources_List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_CheckNameAvailability.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_CheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "location": "eastus",
+    "parameters": {
+      "type": "Microsoft.SignalRService/SignalR",
+      "name": "my-signalr-service"
+    },
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nameAvailable": false,
+        "reason": "AlreadyExists",
+        "message": "The leaf is already used by other people"
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_CheckNameAvailability.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_CheckNameAvailability.json
@@ -5,7 +5,7 @@
       "type": "Microsoft.SignalRService/SignalR",
       "name": "my-signalr-service"
     },
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_CreateOrUpdate.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_CreateOrUpdate.json
@@ -1,0 +1,278 @@
+{
+  "parameters": {
+    "parameters": {
+      "sku": {
+        "name": "Standard_S1",
+        "tier": "Standard",
+        "capacity": 1
+      },
+      "properties": {
+        "hostNamePrefix": null,
+        "features": [
+          {
+            "flag": "ServiceMode",
+            "value": "Serverless",
+            "properties": {}
+          },
+          {
+            "flag": "EnableConnectivityLogs",
+            "value": "True",
+            "properties": {}
+          },
+          {
+            "flag": "EnableMessagingLogs",
+            "value": "False",
+            "properties": {}
+          }
+        ],
+        "cors": {
+          "allowedOrigins": [
+            "https://foo.com",
+            "https://bar.com"
+          ]
+        },
+        "upstream": {
+          "templates": [
+            {
+              "hubPattern": "*",
+              "eventPattern": "connect,disconnect",
+              "categoryPattern": "*",
+              "urlTemplate": "https://example.com/chat/api/connect"
+            }
+          ]
+        },
+        "networkACLs": {
+          "defaultAction": "Deny",
+          "publicNetwork": {
+            "allow": [
+              "ClientConnection"
+            ],
+            "deny": null
+          },
+          "privateEndpoints": [
+            {
+              "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "allow": [
+                "ServerConnection"
+              ],
+              "deny": null
+            }
+          ]
+        }
+      },
+      "kind": "SignalR",
+      "location": "eastus",
+      "tags": {
+        "key1": "value1"
+      }
+    },
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sku": {
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "externalIP": "10.0.0.1",
+          "hostName": "mysignalrservice.service.signalr.net",
+          "publicPort": 443,
+          "serverPort": 443,
+          "version": "1.0",
+          "privateEndpointConnections": [
+            {
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateEndpoint": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                },
+                "privateLinkServiceConnectionState": {
+                  "status": "Approved",
+                  "description": null,
+                  "actionsRequired": "None"
+                }
+              },
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService/privateEndpointConnections/mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
+            }
+          ],
+          "hostNamePrefix": "mysignalrservice",
+          "features": [
+            {
+              "flag": "ServiceMode",
+              "value": "Serverless",
+              "properties": {}
+            },
+            {
+              "flag": "EnableConnectivityLogs",
+              "value": "True",
+              "properties": {}
+            },
+            {
+              "flag": "EnableMessagingLogs",
+              "value": "False",
+              "properties": {}
+            }
+          ],
+          "cors": {
+            "allowedOrigins": [
+              "https://foo.com",
+              "https://bar.com"
+            ]
+          },
+          "upstream": {
+            "templates": [
+              {
+                "hubPattern": null,
+                "eventPattern": null,
+                "categoryPattern": null,
+                "urlTemplate": "http://foo.com"
+              }
+            ]
+          },
+          "networkACLs": {
+            "defaultAction": "Deny",
+            "publicNetwork": {
+              "allow": [
+                "ClientConnection"
+              ],
+              "deny": null
+            },
+            "privateEndpoints": [
+              {
+                "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                "allow": [
+                  "ServerConnection"
+                ],
+                "deny": null
+              }
+            ]
+          }
+        },
+        "kind": "SignalR",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+        "name": "mySignalRService",
+        "type": "Microsoft.SignalRService/SignalR"
+      }
+    },
+    "201": {
+      "body": {
+        "sku": {
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "externalIP": "10.0.0.1",
+          "hostName": "mysignalrservice.service.signalr.net",
+          "publicPort": 443,
+          "serverPort": 443,
+          "version": "1.0",
+          "privateEndpointConnections": [
+            {
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateEndpoint": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                },
+                "privateLinkServiceConnectionState": {
+                  "status": "Approved",
+                  "description": null,
+                  "actionsRequired": "None"
+                }
+              },
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService/privateEndpointConnections/mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
+            }
+          ],
+          "hostNamePrefix": "mysignalrservice",
+          "features": [
+            {
+              "flag": "ServiceMode",
+              "value": "Serverless",
+              "properties": {}
+            },
+            {
+              "flag": "EnableConnectivityLogs",
+              "value": "True",
+              "properties": {}
+            },
+            {
+              "flag": "EnableMessagingLogs",
+              "value": "False",
+              "properties": {}
+            }
+          ],
+          "cors": {
+            "allowedOrigins": [
+              "https://foo.com",
+              "https://bar.com"
+            ]
+          },
+          "upstream": {
+            "templates": [
+              {
+                "hubPattern": null,
+                "eventPattern": null,
+                "categoryPattern": null,
+                "urlTemplate": "http://foo.com"
+              }
+            ]
+          },
+          "networkACLs": {
+            "defaultAction": "Deny",
+            "publicNetwork": {
+              "allow": [
+                "ClientConnection"
+              ],
+              "deny": null
+            },
+            "privateEndpoints": [
+              {
+                "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                "allow": [
+                  "ServerConnection"
+                ],
+                "deny": null
+              }
+            ]
+          }
+        },
+        "kind": "SignalR",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+        "name": "mySignalRService",
+        "type": "Microsoft.SignalRService/SignalR"
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult...",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationStatus..."
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult...",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationStatus..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_CreateOrUpdate.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_CreateOrUpdate.json
@@ -7,7 +7,9 @@
         "capacity": 1
       },
       "properties": {
-        "hostNamePrefix": null,
+        "tls": {
+          "clientCertEnabled": false
+        },
         "features": [
           {
             "flag": "ServiceMode",
@@ -37,7 +39,13 @@
               "hubPattern": "*",
               "eventPattern": "connect,disconnect",
               "categoryPattern": "*",
-              "urlTemplate": "https://example.com/chat/api/connect"
+              "urlTemplate": "https://example.com/chat/api/connect",
+              "auth": {
+                "type": "ManagedIdentity",
+                "managedIdentity": {
+                  "resource": "api://example"
+                }
+              }
             }
           ]
         },
@@ -61,12 +69,15 @@
         }
       },
       "kind": "SignalR",
+      "identity": {
+        "type": "SystemAssigned"
+      },
       "location": "eastus",
       "tags": {
         "key1": "value1"
       }
     },
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"
@@ -105,7 +116,9 @@
               "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
             }
           ],
-          "hostNamePrefix": "mysignalrservice",
+          "tls": {
+            "clientCertEnabled": true
+          },
           "features": [
             {
               "flag": "ServiceMode",
@@ -135,7 +148,8 @@
                 "hubPattern": null,
                 "eventPattern": null,
                 "categoryPattern": null,
-                "urlTemplate": "http://foo.com"
+                "urlTemplate": "http://foo.com",
+                "auth": null
               }
             ]
           },
@@ -159,6 +173,11 @@
           }
         },
         "kind": "SignalR",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
         "location": "eastus",
         "tags": {
           "key1": "value1"
@@ -201,7 +220,9 @@
               "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
             }
           ],
-          "hostNamePrefix": "mysignalrservice",
+          "tls": {
+            "clientCertEnabled": true
+          },
           "features": [
             {
               "flag": "ServiceMode",
@@ -231,7 +252,8 @@
                 "hubPattern": null,
                 "eventPattern": null,
                 "categoryPattern": null,
-                "urlTemplate": "http://foo.com"
+                "urlTemplate": "http://foo.com",
+                "auth": null
               }
             ]
           },
@@ -255,6 +277,11 @@
           }
         },
         "kind": "SignalR",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
         "location": "eastus",
         "tags": {
           "key1": "value1"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Delete.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Delete.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult...",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationStatus..."
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Delete.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Delete.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Get.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Get.json
@@ -1,0 +1,106 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sku": {
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "externalIP": "10.0.0.1",
+          "hostName": "mysignalrservice.service.signalr.net",
+          "publicPort": 443,
+          "serverPort": 443,
+          "version": "1.0",
+          "privateEndpointConnections": [
+            {
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateEndpoint": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                },
+                "privateLinkServiceConnectionState": {
+                  "status": "Approved",
+                  "description": null,
+                  "actionsRequired": "None"
+                }
+              },
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService/privateEndpointConnections/mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
+            }
+          ],
+          "hostNamePrefix": "mysignalrservice",
+          "features": [
+            {
+              "flag": "ServiceMode",
+              "value": "Serverless",
+              "properties": {}
+            },
+            {
+              "flag": "EnableConnectivityLogs",
+              "value": "True",
+              "properties": {}
+            },
+            {
+              "flag": "EnableMessagingLogs",
+              "value": "False",
+              "properties": {}
+            }
+          ],
+          "cors": {
+            "allowedOrigins": [
+              "https://foo.com",
+              "https://bar.com"
+            ]
+          },
+          "upstream": {
+            "templates": [
+              {
+                "hubPattern": null,
+                "eventPattern": null,
+                "categoryPattern": null,
+                "urlTemplate": "http://foo.com"
+              }
+            ]
+          },
+          "networkACLs": {
+            "defaultAction": "Deny",
+            "publicNetwork": {
+              "allow": [
+                "ClientConnection"
+              ],
+              "deny": null
+            },
+            "privateEndpoints": [
+              {
+                "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                "allow": [
+                  "ServerConnection"
+                ],
+                "deny": null
+              }
+            ]
+          }
+        },
+        "kind": "SignalR",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+        "name": "mySignalRService",
+        "type": "Microsoft.SignalRService/SignalR"
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Get.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Get.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"
@@ -39,7 +39,9 @@
               "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
             }
           ],
-          "hostNamePrefix": "mysignalrservice",
+          "tls": {
+            "clientCertEnabled": true
+          },
           "features": [
             {
               "flag": "ServiceMode",
@@ -69,7 +71,8 @@
                 "hubPattern": null,
                 "eventPattern": null,
                 "categoryPattern": null,
-                "urlTemplate": "http://foo.com"
+                "urlTemplate": "http://foo.com",
+                "auth": null
               }
             ]
           },
@@ -93,6 +96,11 @@
           }
         },
         "kind": "SignalR",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
         "location": "eastus",
         "tags": {
           "key1": "value1"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListByResourceGroup.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListByResourceGroup.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "sku": {
+              "name": "Standard_S1",
+              "tier": "Standard",
+              "size": "S1",
+              "capacity": 1
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "externalIP": "10.0.0.1",
+              "hostName": "mysignalrservice.service.signalr.net",
+              "publicPort": 443,
+              "serverPort": 443,
+              "version": "1.0",
+              "privateEndpointConnections": [
+                {
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateEndpoint": {
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                    },
+                    "privateLinkServiceConnectionState": {
+                      "status": "Approved",
+                      "description": null,
+                      "actionsRequired": "None"
+                    }
+                  },
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService/privateEndpointConnections/mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                  "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                  "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
+                }
+              ],
+              "hostNamePrefix": "mysignalrservice",
+              "features": [
+                {
+                  "flag": "ServiceMode",
+                  "value": "Serverless",
+                  "properties": {}
+                },
+                {
+                  "flag": "EnableConnectivityLogs",
+                  "value": "True",
+                  "properties": {}
+                },
+                {
+                  "flag": "EnableMessagingLogs",
+                  "value": "False",
+                  "properties": {}
+                }
+              ],
+              "cors": {
+                "allowedOrigins": [
+                  "https://foo.com",
+                  "https://bar.com"
+                ]
+              },
+              "upstream": {
+                "templates": [
+                  {
+                    "hubPattern": null,
+                    "eventPattern": null,
+                    "categoryPattern": null,
+                    "urlTemplate": "http://foo.com"
+                  }
+                ]
+              },
+              "networkACLs": {
+                "defaultAction": "Deny",
+                "publicNetwork": {
+                  "allow": [
+                    "ClientConnection"
+                  ],
+                  "deny": null
+                },
+                "privateEndpoints": [
+                  {
+                    "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                    "allow": [
+                      "ServerConnection"
+                    ],
+                    "deny": null
+                  }
+                ]
+              }
+            },
+            "kind": "SignalR",
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+            "name": "mySignalRService",
+            "type": "Microsoft.SignalRService/SignalR"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListByResourceGroup.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListByResourceGroup.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup"
   },
@@ -40,7 +40,9 @@
                   "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
                 }
               ],
-              "hostNamePrefix": "mysignalrservice",
+              "tls": {
+                "clientCertEnabled": true
+              },
               "features": [
                 {
                   "flag": "ServiceMode",
@@ -70,7 +72,8 @@
                     "hubPattern": null,
                     "eventPattern": null,
                     "categoryPattern": null,
-                    "urlTemplate": "http://foo.com"
+                    "urlTemplate": "http://foo.com",
+                    "auth": null
                   }
                 ]
               },
@@ -94,6 +97,11 @@
               }
             },
             "kind": "SignalR",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000"
+            },
             "location": "eastus",
             "tags": {
               "key1": "value1"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListBySubscription.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListBySubscription.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "sku": {
+              "name": "Standard_S1",
+              "tier": "Standard",
+              "size": "S1",
+              "capacity": 1
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "externalIP": "10.0.0.1",
+              "hostName": "mysignalrservice.service.signalr.net",
+              "publicPort": 443,
+              "serverPort": 443,
+              "version": "1.0",
+              "privateEndpointConnections": [
+                {
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateEndpoint": {
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                    },
+                    "privateLinkServiceConnectionState": {
+                      "status": "Approved",
+                      "description": null,
+                      "actionsRequired": "None"
+                    }
+                  },
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService/privateEndpointConnections/mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                  "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                  "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
+                }
+              ],
+              "hostNamePrefix": "mysignalrservice",
+              "features": [
+                {
+                  "flag": "ServiceMode",
+                  "value": "Serverless",
+                  "properties": {}
+                },
+                {
+                  "flag": "EnableConnectivityLogs",
+                  "value": "True",
+                  "properties": {}
+                },
+                {
+                  "flag": "EnableMessagingLogs",
+                  "value": "False",
+                  "properties": {}
+                }
+              ],
+              "cors": {
+                "allowedOrigins": [
+                  "https://foo.com",
+                  "https://bar.com"
+                ]
+              },
+              "upstream": {
+                "templates": [
+                  {
+                    "hubPattern": null,
+                    "eventPattern": null,
+                    "categoryPattern": null,
+                    "urlTemplate": "http://foo.com"
+                  }
+                ]
+              },
+              "networkACLs": {
+                "defaultAction": "Deny",
+                "publicNetwork": {
+                  "allow": [
+                    "ClientConnection"
+                  ],
+                  "deny": null
+                },
+                "privateEndpoints": [
+                  {
+                    "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                    "allow": [
+                      "ServerConnection"
+                    ],
+                    "deny": null
+                  }
+                ]
+              }
+            },
+            "kind": "SignalR",
+            "location": "eastus",
+            "tags": {
+              "key1": "value1"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+            "name": "mySignalRService",
+            "type": "Microsoft.SignalRService/SignalR"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListBySubscription.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListBySubscription.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {
@@ -39,7 +39,9 @@
                   "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
                 }
               ],
-              "hostNamePrefix": "mysignalrservice",
+              "tls": {
+                "clientCertEnabled": true
+              },
               "features": [
                 {
                   "flag": "ServiceMode",
@@ -69,7 +71,8 @@
                     "hubPattern": null,
                     "eventPattern": null,
                     "categoryPattern": null,
-                    "urlTemplate": "http://foo.com"
+                    "urlTemplate": "http://foo.com",
+                    "auth": null
                   }
                 ]
               },
@@ -93,6 +96,11 @@
               }
             },
             "kind": "SignalR",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000"
+            },
             "location": "eastus",
             "tags": {
               "key1": "value1"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListKeys.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "primaryAccessKey",
+        "secondaryKey": "secondaryAccessKey",
+        "primaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=primaryAccessKey;Version=1.0",
+        "secondaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=secondaryAccessKey;Version=1.0"
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListKeys.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_ListKeys.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_RegenerateKey.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_RegenerateKey.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "parameters": {
+      "keyType": "Primary"
+    },
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "primaryKey": "primaryAccessKey",
+        "secondaryKey": "secondaryAccessKey",
+        "primaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=primaryAccessKey;Version=1.0;",
+        "secondaryConnectionString": "Endpoint=https://yourServiceName.service.signalr.net;AccessKey=secondaryAccessKey;Version=1.0;"
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult...",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationStatus..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_RegenerateKey.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_RegenerateKey.json
@@ -3,7 +3,7 @@
     "parameters": {
       "keyType": "Primary"
     },
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Restart.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Restart.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult...",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationStatus..."
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Restart.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Restart.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Update.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Update.json
@@ -1,0 +1,178 @@
+{
+  "parameters": {
+    "parameters": {
+      "sku": {
+        "name": "Standard_S1",
+        "tier": "Standard",
+        "capacity": 1
+      },
+      "properties": {
+        "hostNamePrefix": null,
+        "features": [
+          {
+            "flag": "ServiceMode",
+            "value": "Serverless",
+            "properties": {}
+          },
+          {
+            "flag": "EnableConnectivityLogs",
+            "value": "True",
+            "properties": {}
+          },
+          {
+            "flag": "EnableMessagingLogs",
+            "value": "False",
+            "properties": {}
+          }
+        ],
+        "cors": {
+          "allowedOrigins": [
+            "https://foo.com",
+            "https://bar.com"
+          ]
+        },
+        "upstream": {
+          "templates": [
+            {
+              "hubPattern": "*",
+              "eventPattern": "connect,disconnect",
+              "categoryPattern": "*",
+              "urlTemplate": "https://example.com/chat/api/connect"
+            }
+          ]
+        },
+        "networkACLs": {
+          "defaultAction": "Deny",
+          "publicNetwork": {
+            "allow": [
+              "ClientConnection"
+            ],
+            "deny": null
+          },
+          "privateEndpoints": [
+            {
+              "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "allow": [
+                "ServerConnection"
+              ],
+              "deny": null
+            }
+          ]
+        }
+      },
+      "kind": "SignalR",
+      "location": "eastus",
+      "tags": {
+        "key1": "value1"
+      }
+    },
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "mySignalRService"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sku": {
+          "name": "Standard_S1",
+          "tier": "Standard",
+          "size": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "externalIP": "10.0.0.1",
+          "hostName": "mysignalrservice.service.signalr.net",
+          "publicPort": 443,
+          "serverPort": 443,
+          "version": "1.0",
+          "privateEndpointConnections": [
+            {
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateEndpoint": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                },
+                "privateLinkServiceConnectionState": {
+                  "status": "Approved",
+                  "description": null,
+                  "actionsRequired": "None"
+                }
+              },
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService/privateEndpointConnections/mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
+            }
+          ],
+          "hostNamePrefix": "mysignalrservice",
+          "features": [
+            {
+              "flag": "ServiceMode",
+              "value": "Serverless",
+              "properties": {}
+            },
+            {
+              "flag": "EnableConnectivityLogs",
+              "value": "True",
+              "properties": {}
+            },
+            {
+              "flag": "EnableMessagingLogs",
+              "value": "False",
+              "properties": {}
+            }
+          ],
+          "cors": {
+            "allowedOrigins": [
+              "https://foo.com",
+              "https://bar.com"
+            ]
+          },
+          "upstream": {
+            "templates": [
+              {
+                "hubPattern": null,
+                "eventPattern": null,
+                "categoryPattern": null,
+                "urlTemplate": "http://foo.com"
+              }
+            ]
+          },
+          "networkACLs": {
+            "defaultAction": "Deny",
+            "publicNetwork": {
+              "allow": [
+                "ClientConnection"
+              ],
+              "deny": null
+            },
+            "privateEndpoints": [
+              {
+                "name": "mySignalRService.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+                "allow": [
+                  "ServerConnection"
+                ],
+                "deny": null
+              }
+            ]
+          }
+        },
+        "kind": "SignalR",
+        "location": "eastus",
+        "tags": {
+          "key1": "value1"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.SignalRService/SignalR/mySignalRService",
+        "name": "mySignalRService",
+        "type": "Microsoft.SignalRService/SignalR"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationResult...",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToOperationStatus..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Update.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/SignalR_Update.json
@@ -7,7 +7,9 @@
         "capacity": 1
       },
       "properties": {
-        "hostNamePrefix": null,
+        "tls": {
+          "clientCertEnabled": false
+        },
         "features": [
           {
             "flag": "ServiceMode",
@@ -37,7 +39,13 @@
               "hubPattern": "*",
               "eventPattern": "connect,disconnect",
               "categoryPattern": "*",
-              "urlTemplate": "https://example.com/chat/api/connect"
+              "urlTemplate": "https://example.com/chat/api/connect",
+              "auth": {
+                "type": "ManagedIdentity",
+                "managedIdentity": {
+                  "resource": "api://example"
+                }
+              }
             }
           ]
         },
@@ -61,12 +69,15 @@
         }
       },
       "kind": "SignalR",
+      "identity": {
+        "type": "SystemAssigned"
+      },
       "location": "eastus",
       "tags": {
         "key1": "value1"
       }
     },
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "resourceName": "mySignalRService"
@@ -105,7 +116,9 @@
               "type": "Microsoft.SignalRService/SignalR/privateEndpointConnections"
             }
           ],
-          "hostNamePrefix": "mysignalrservice",
+          "tls": {
+            "clientCertEnabled": true
+          },
           "features": [
             {
               "flag": "ServiceMode",
@@ -135,7 +148,8 @@
                 "hubPattern": null,
                 "eventPattern": null,
                 "categoryPattern": null,
-                "urlTemplate": "http://foo.com"
+                "urlTemplate": "http://foo.com",
+                "auth": null
               }
             ]
           },
@@ -159,6 +173,11 @@
           }
         },
         "kind": "SignalR",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
         "location": "eastus",
         "tags": {
           "key1": "value1"

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/Usages_List.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/Usages_List.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "location": "eastus",
+    "api-version": "2020-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SignalRService/locations/eastus/usages/Usage1",
+            "currentValue": 0,
+            "limit": 100,
+            "name": {
+              "value": "Usage1",
+              "localizedValue": "Usage1"
+            },
+            "unit": "Count"
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.SignalRService/locations/eastus/usages/Usage2",
+            "currentValue": 0,
+            "limit": 100,
+            "name": {
+              "value": "Usage2",
+              "localizedValue": "Usage2"
+            },
+            "unit": "Count"
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/subid/providers/Microsoft.SignalRService/...pathToMoreResults..."
+      }
+    }
+  }
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/Usages_List.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/examples/Usages_List.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "location": "eastus",
-    "api-version": "2020-05-01",
+    "api-version": "2020-07-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/signalr.json
@@ -1,0 +1,1741 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2020-05-01",
+    "title": "SignalRManagementClient",
+    "description": "REST API for Azure SignalR Service"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/providers/Microsoft.SignalRService/operations": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Lists all of the available REST API operations of the Microsoft.SignalRService provider.",
+        "operationId": "Operations_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the list of operations.",
+            "schema": {
+              "$ref": "#/definitions/OperationList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/locations/{location}/checkNameAvailability": {
+      "post": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Checks that the SignalR name is valid and is not already in use.",
+        "operationId": "SignalR_CheckNameAvailability",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "path",
+            "description": "the region",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the operation.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/NameAvailabilityParameters"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the name availability.",
+            "schema": {
+              "$ref": "#/definitions/NameAvailability"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SignalR_CheckNameAvailability": {
+            "$ref": "./examples/SignalR_CheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/signalR": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Handles requests to list all resources in a subscription.",
+        "operationId": "SignalR_ListBySubscription",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the list of SignalR services in the subscription.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "SignalR_ListBySubscription": {
+            "$ref": "./examples/SignalR_ListBySubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Handles requests to list all resources in a resource group.",
+        "operationId": "SignalR_ListByResourceGroup",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the list of SignalR services in a resourceGroup.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "SignalR_ListByResourceGroup": {
+            "$ref": "./examples/SignalR_ListByResourceGroup.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Get the specified private endpoint connection associated with a SignalR resource.",
+        "operationId": "SignalRPrivateEndpointConnections_Get",
+        "parameters": [
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the SignalR resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes a list of private link resources.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SignalRPrivateEndpointConnections_Get": {
+            "$ref": "./examples/SignalRPrivateEndpointConnections_Get.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Update the state of specified private endpoint connection associated with a SignalR resource.",
+        "operationId": "SignalRPrivateEndpointConnections_Update",
+        "parameters": [
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the SignalR resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The resource of private endpoint and its properties.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The response indicates the private endpoint connection is updated successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SignalRPrivateEndpointConnections_Update": {
+            "$ref": "./examples/SignalRPrivateEndpointConnections_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Delete the specified private endpoint connection associated with a SignalR resource.",
+        "operationId": "SignalRPrivateEndpointConnections_Delete",
+        "parameters": [
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the SignalR resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Success"
+          },
+          "204": {
+            "description": "Success. The response indicates the private endpoint connection is already deleted."
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "SignalRPrivateEndpointConnections_Delete": {
+            "$ref": "./examples/SignalRPrivateEndpointConnections_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/privateLinkResources": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Get the private link resources that need to be created for a SignalR resource.",
+        "operationId": "SignalRPrivateLinkResources_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes a list of private link resources.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "SignalRPrivateLinkResources_List": {
+            "$ref": "./examples/SignalRPrivateLinkResources_List.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/listKeys": {
+      "post": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Get the access keys of the SignalR resource.",
+        "operationId": "SignalR_ListKeys",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes SignalR service access keys.",
+            "schema": {
+              "$ref": "#/definitions/SignalRKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SignalR_ListKeys": {
+            "$ref": "./examples/SignalR_ListKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/regenerateKey": {
+      "post": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Regenerate SignalR service access key. PrimaryKey and SecondaryKey cannot be regenerated at the same time.",
+        "operationId": "SignalR_RegenerateKey",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameter that describes the Regenerate Key Operation.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/RegenerateKeyParameters"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created and an async operation is executing in background to make the new key to take effect. The response contains new keys and a Location header to query the async operation result.",
+            "schema": {
+              "$ref": "#/definitions/SignalRKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-examples": {
+          "SignalR_RegenerateKey": {
+            "$ref": "./examples/SignalR_RegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Get the SignalR service and its properties.",
+        "operationId": "SignalR_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes the corresponding SignalR service.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SignalR_Get": {
+            "$ref": "./examples/SignalR_Get.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Create a new SignalR service and update an exiting SignalR service.",
+        "operationId": "SignalR_CreateOrUpdate",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for the create or update operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes a SignalR service.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          },
+          "201": {
+            "description": "Created. The response describes the new service and contains a Location header to query the operation result.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          },
+          "202": {
+            "description": "Accepted. The response indicates the exiting SignalR service is now updating and contains a Location header to query the operation result.."
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "SignalR_CreateOrUpdate": {
+            "$ref": "./examples/SignalR_CreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Operation to delete a SignalR service.",
+        "operationId": "SignalR_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted. The response indicates the delete operation is performed in the background."
+          },
+          "204": {
+            "description": "Success. The response indicates the resource is already deleted."
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "SignalR_Delete": {
+            "$ref": "./examples/SignalR_Delete.json"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Operation to update an exiting SignalR service.",
+        "operationId": "SignalR_Update",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for the update operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describes a SignalR service.",
+            "schema": {
+              "$ref": "#/definitions/SignalRResource"
+            }
+          },
+          "202": {
+            "description": "Accepted. The response indicates the exiting SignalR service is now updating  and contains a Location header to query the operation result.."
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "SignalR_Update": {
+            "$ref": "./examples/SignalR_Update.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/restart": {
+      "post": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "Operation to restart a SignalR service.",
+        "operationId": "SignalR_Restart",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupParameter"
+          },
+          {
+            "$ref": "#/parameters/SignalRServiceName"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted. The response indicates the restart operation is performed in the background."
+          },
+          "204": {
+            "description": "Success. The response indicates the operation is successful and no content will be returned."
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-examples": {
+          "SignalR_Restart": {
+            "$ref": "./examples/SignalR_Restart.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.SignalRService/locations/{location}/usages": {
+      "get": {
+        "tags": [
+          "SignalR"
+        ],
+        "description": "List usage quotas for Azure SignalR service by location.",
+        "operationId": "Usages_List",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "path",
+            "description": "the location like \"eastus\"",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The response describe the usage quotas of a subscription in specified region.",
+            "schema": {
+              "$ref": "#/definitions/SignalRUsageList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error occurred during the operation.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Usages_List": {
+            "$ref": "./examples/Usages_List.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "OperationList": {
+      "description": "Result of the request to list REST API operations. It contains a list of operations.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of operations supported by the resource provider.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "nextLink": {
+          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+          "type": "string"
+        }
+      }
+    },
+    "Operation": {
+      "description": "REST API operation supported by SignalR resource provider.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the operation with format: {provider}/{resource}/{operation}",
+          "type": "string"
+        },
+        "isDataAction": {
+          "description": "If the operation is a data action. (for data plane rbac)",
+          "type": "boolean"
+        },
+        "display": {
+          "$ref": "#/definitions/OperationDisplay",
+          "description": "The object that describes the operation."
+        },
+        "origin": {
+          "description": "Optional. The intended executor of the operation; governs the display of the operation in the RBAC UX and the audit logs UX.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/OperationProperties",
+          "description": "Extra properties for the operation.",
+          "x-ms-client-flatten": false
+        }
+      }
+    },
+    "OperationDisplay": {
+      "description": "The object that describes a operation.",
+      "type": "object",
+      "properties": {
+        "provider": {
+          "description": "Friendly name of the resource provider",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Resource type on which the operation is performed.",
+          "type": "string"
+        },
+        "operation": {
+          "description": "The localized friendly name for the operation.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The localized friendly description for the operation",
+          "type": "string"
+        }
+      }
+    },
+    "OperationProperties": {
+      "description": "Extra Operation properties.",
+      "type": "object",
+      "properties": {
+        "serviceSpecification": {
+          "$ref": "#/definitions/ServiceSpecification",
+          "description": "The service specifications."
+        }
+      }
+    },
+    "ServiceSpecification": {
+      "description": "An object that describes a specification.",
+      "type": "object",
+      "properties": {
+        "metricSpecifications": {
+          "description": "Specifications of the Metrics for Azure Monitoring.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MetricSpecification"
+          }
+        },
+        "logSpecifications": {
+          "description": "Specifications of the Logs for Azure Monitoring.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LogSpecification"
+          }
+        }
+      }
+    },
+    "MetricSpecification": {
+      "description": "Specifications of the Metrics for Azure Monitoring.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the metric.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Localized friendly display name of the metric.",
+          "type": "string"
+        },
+        "displayDescription": {
+          "description": "Localized friendly description of the metric.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The unit that makes sense for the metric.",
+          "type": "string"
+        },
+        "aggregationType": {
+          "description": "Only provide one value for this field. Valid values: Average, Minimum, Maximum, Total, Count.",
+          "type": "string"
+        },
+        "fillGapWithZero": {
+          "description": "Optional. If set to true, then zero will be returned for time duration where no metric is emitted/published. \r\nEx. a metric that returns the number of times a particular error code was emitted. The error code may not appear \r\noften, instead of the RP publishing 0, Shoebox can auto fill in 0s for time periods where nothing was emitted.",
+          "type": "string"
+        },
+        "category": {
+          "description": "The name of the metric category that the metric belongs to. A metric can only belong to a single category.",
+          "type": "string"
+        },
+        "dimensions": {
+          "description": "The dimensions of the metrics.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Dimension"
+          }
+        }
+      }
+    },
+    "LogSpecification": {
+      "description": "Specifications of the Logs for Azure Monitoring.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the log.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Localized friendly display name of the log.",
+          "type": "string"
+        }
+      }
+    },
+    "Dimension": {
+      "description": "Specifications of the Dimension of metrics.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The public facing name of the dimension.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Localized friendly display name of the dimension.",
+          "type": "string"
+        },
+        "internalName": {
+          "description": "Name of the dimension as it appears in MDM.",
+          "type": "string"
+        },
+        "toBeExportedForShoebox": {
+          "description": "A Boolean flag indicating whether this dimension should be included for the shoebox export scenario.",
+          "type": "boolean"
+        }
+      }
+    },
+    "ErrorResponse": {
+      "description": "Contains information about an API error.",
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorResponseBody",
+          "description": "Describes a particular API error with an error code and a message."
+        }
+      }
+    },
+    "ErrorResponseBody": {
+      "description": "Describes a particular API error with an error code and a message.",
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "An error code that describes the error condition more precisely than an HTTP status code. \r\nCan be used to programmatically handle specific error cases.",
+          "type": "string"
+        },
+        "message": {
+          "description": "A message that describes the error in detail and provides debugging information.",
+          "type": "string"
+        },
+        "target": {
+          "description": "The target of the particular error (for example, the name of the property in error).",
+          "type": "string"
+        },
+        "details": {
+          "description": "Contains nested errors that are related to this error.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorResponseBody"
+          }
+        }
+      }
+    },
+    "NameAvailabilityParameters": {
+      "description": "Data POST-ed to the nameAvailability action",
+      "required": [
+        "type",
+        "name"
+      ],
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The resource type. Should be always \"Microsoft.SignalRService/SignalR\".",
+          "type": "string"
+        },
+        "name": {
+          "description": "The SignalR service name to validate. e.g.\"my-signalR-name-here\"",
+          "type": "string"
+        }
+      }
+    },
+    "NameAvailability": {
+      "description": "Result of the request to check name availability. It contains a flag and possible reason of failure.",
+      "type": "object",
+      "properties": {
+        "nameAvailable": {
+          "description": "Indicates whether the name is available or not.",
+          "type": "boolean"
+        },
+        "reason": {
+          "description": "The reason of the availability. Required if name is not available.",
+          "type": "string"
+        },
+        "message": {
+          "description": "The message of the operation.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRResourceList": {
+      "description": "Object that includes an array of SignalR services and a possible link for next set.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of SignalR services",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SignalRResource"
+          }
+        },
+        "nextLink": {
+          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRResource": {
+      "description": "A class represent a SignalR service resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResource"
+        }
+      ],
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/ResourceSku",
+          "description": "The billing information of the resource.(e.g. Free, Standard)"
+        },
+        "properties": {
+          "$ref": "#/definitions/SignalRProperties",
+          "description": "Settings used to provision or configure the resource",
+          "x-ms-client-flatten": true
+        },
+        "kind": {
+          "$ref": "#/definitions/ServiceKind",
+          "description": "The kind of the service - e.g. \"SignalR\", or \"RawWebSockets\" for \"Microsoft.SignalRService/SignalR\"",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "ServiceKind": {
+      "description": "The kind of the service - e.g. \"SignalR\", or \"RawWebSockets\" for \"Microsoft.SignalRService/SignalR\"",
+      "enum": [
+        "SignalR",
+        "RawWebSockets"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ServiceKind",
+        "modelAsString": true
+      }
+    },
+    "TrackedResource": {
+      "description": "The resource model definition for a ARM tracked top level resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "location": {
+          "description": "The GEO location of the SignalR service. e.g. West US | East US | North Central US | South Central US.",
+          "type": "string",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "description": "Tags of the service which is a list of key value pairs that describe the resource.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Resource": {
+      "description": "The core properties of ARM resources.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Fully qualified resource Id for the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "The name of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "The type of the resource - e.g. \"Microsoft.SignalRService/SignalR\"",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ResourceSku": {
+      "description": "The billing information of the SignalR resource.",
+      "required": [
+        "name"
+      ],
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the SKU. Required.\r\n\r\nAllowed values: Standard_S1, Free_F1",
+          "type": "string"
+        },
+        "tier": {
+          "$ref": "#/definitions/SignalRSkuTier",
+          "description": "Optional tier of this particular SKU. 'Standard' or 'Free'. \r\n\r\n`Basic` is deprecated, use `Standard` instead."
+        },
+        "size": {
+          "description": "Optional string. For future use.",
+          "type": "string"
+        },
+        "family": {
+          "description": "Optional string. For future use.",
+          "type": "string"
+        },
+        "capacity": {
+          "format": "int32",
+          "description": "Optional, integer. The unit count of SignalR resource. 1 by default.\r\n\r\nIf present, following values are allowed:\r\n    Free: 1\r\n    Standard: 1,2,5,10,20,50,100",
+          "type": "integer"
+        }
+      }
+    },
+    "SignalRSkuTier": {
+      "description": "Optional tier of this particular SKU. 'Standard' or 'Free'. \r\n\r\n`Basic` is deprecated, use `Standard` instead.",
+      "enum": [
+        "Free",
+        "Basic",
+        "Standard",
+        "Premium"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "SignalRSkuTier",
+        "modelAsString": true
+      }
+    },
+    "SignalRProperties": {
+      "description": "A class that describes the properties of the SignalR service that should contain more read-only properties than AzSignalR.Models.SignalRCreateOrUpdateProperties",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalRCreateOrUpdateProperties"
+        }
+      ],
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Provisioning state of the resource.",
+          "readOnly": true
+        },
+        "externalIP": {
+          "description": "The publicly accessible IP of the SignalR service.",
+          "type": "string",
+          "readOnly": true
+        },
+        "hostName": {
+          "description": "FQDN of the SignalR service instance. Format: xxx.service.signalr.net",
+          "type": "string",
+          "readOnly": true
+        },
+        "publicPort": {
+          "format": "int32",
+          "description": "The publicly accessible port of the SignalR service which is designed for browser/client side usage.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "serverPort": {
+          "format": "int32",
+          "description": "The publicly accessible port of the SignalR service which is designed for customer server side usage.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "version": {
+          "description": "Version of the SignalR resource. Probably you need the same or higher version of client SDKs.",
+          "type": "string",
+          "readOnly": true
+        },
+        "privateEndpointConnections": {
+          "description": "Private endpoint connections to the SignalR resource.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ProvisioningState": {
+      "description": "Provisioning state of the resource.",
+      "enum": [
+        "Unknown",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Running",
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Moving"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true
+      }
+    },
+    "SignalRCreateOrUpdateProperties": {
+      "description": "Settings used to provision or configure the resource.",
+      "type": "object",
+      "properties": {
+        "hostNamePrefix": {
+          "description": "Prefix for the hostName of the SignalR service. Retained for future use.\r\nThe hostname will be of format: &lt;hostNamePrefix&gt;.service.signalr.net.",
+          "type": "string"
+        },
+        "features": {
+          "description": "List of SignalR featureFlags. e.g. ServiceMode.\r\n\r\nFeatureFlags that are not included in the parameters for the update operation will not be modified.\r\nAnd the response will only include featureFlags that are explicitly set. \r\nWhen a featureFlag is not explicitly set, SignalR service will use its globally default value. \r\nBut keep in mind, the default value doesn't mean \"false\". It varies in terms of different FeatureFlags.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SignalRFeature"
+          }
+        },
+        "cors": {
+          "$ref": "#/definitions/SignalRCorsSettings",
+          "description": "Cross-Origin Resource Sharing (CORS) settings."
+        },
+        "upstream": {
+          "$ref": "#/definitions/ServerlessUpstreamSettings",
+          "description": "Upstream settings when the Azure SignalR is in server-less mode."
+        },
+        "networkACLs": {
+          "$ref": "#/definitions/SignalRNetworkACLs",
+          "description": "Network ACLs"
+        }
+      }
+    },
+    "SignalRFeature": {
+      "description": "Feature of a SignalR resource, which controls the SignalR runtime behavior.",
+      "required": [
+        "flag",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "flag": {
+          "$ref": "#/definitions/FeatureFlags",
+          "description": "FeatureFlags is the supported features of Azure SignalR service.\r\n- ServiceMode: Flag for backend server for SignalR service. Values allowed: \"Default\": have your own backend server; \"Serverless\": your application doesn't have a backend server; \"Classic\": for backward compatibility. Support both Default and Serverless mode but not recommended; \"PredefinedOnly\": for future use.\r\n- EnableConnectivityLogs: \"true\"/\"false\", to enable/disable the connectivity log category respectively."
+        },
+        "value": {
+          "description": "Value of the feature flag. See Azure SignalR service document https://docs.microsoft.com/azure/azure-signalr/ for allowed values.",
+          "maxLength": 128,
+          "minLength": 1,
+          "type": "string"
+        },
+        "properties": {
+          "description": "Optional properties related to this feature.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FeatureFlags": {
+      "description": "FeatureFlags is the supported features of Azure SignalR service.\r\n- ServiceMode: Flag for backend server for SignalR service. Values allowed: \"Default\": have your own backend server; \"Serverless\": your application doesn't have a backend server; \"Classic\": for backward compatibility. Support both Default and Serverless mode but not recommended; \"PredefinedOnly\": for future use.\r\n- EnableConnectivityLogs: \"true\"/\"false\", to enable/disable the connectivity log category respectively.",
+      "enum": [
+        "ServiceMode",
+        "EnableConnectivityLogs",
+        "EnableMessagingLogs"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "FeatureFlags",
+        "modelAsString": true
+      }
+    },
+    "SignalRCorsSettings": {
+      "description": "Cross-Origin Resource Sharing (CORS) settings.",
+      "type": "object",
+      "properties": {
+        "allowedOrigins": {
+          "description": "Gets or sets the list of origins that should be allowed to make cross-origin calls (for example: http://example.com:12345). Use \"*\" to allow all. If omitted, allow all by default.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ServerlessUpstreamSettings": {
+      "description": "The settings for the Upstream when the Azure SignalR is in server-less mode.",
+      "type": "object",
+      "properties": {
+        "templates": {
+          "description": "Gets or sets the list of Upstream URL templates. Order matters, and the first matching template takes effects.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UpstreamTemplate"
+          }
+        }
+      }
+    },
+    "SignalRNetworkACLs": {
+      "description": "Network ACLs for SignalR",
+      "type": "object",
+      "properties": {
+        "defaultAction": {
+          "$ref": "#/definitions/ACLAction",
+          "description": "Default action when no other rule matches"
+        },
+        "publicNetwork": {
+          "$ref": "#/definitions/NetworkACL",
+          "description": "ACL for requests from public network"
+        },
+        "privateEndpoints": {
+          "description": "ACLs for requests from private endpoints",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointACL"
+          }
+        }
+      }
+    },
+    "ACLAction": {
+      "description": "Default action when no other rule matches",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ACLAction",
+        "modelAsString": true
+      }
+    },
+    "UpstreamTemplate": {
+      "description": "Upstream template item settings. It defines the Upstream URL of the incoming requests.\r\nThe template defines the pattern of the event, the hub or the category of the incoming request that matches current URL template.",
+      "required": [
+        "urlTemplate"
+      ],
+      "type": "object",
+      "properties": {
+        "hubPattern": {
+          "description": "Gets or sets the matching pattern for hub names. If not set, it matches any hub.\r\nThere are 3 kind of patterns supported:\r\n    1. \"*\", it to matches any hub name\r\n    2. Combine multiple hubs with \",\", for example \"hub1,hub2\", it matches \"hub1\" and \"hub2\"\r\n    3. The single hub name, for example, \"hub1\", it matches \"hub1\"",
+          "type": "string"
+        },
+        "eventPattern": {
+          "description": "Gets or sets the matching pattern for event names. If not set, it matches any event.\r\nThere are 3 kind of patterns supported:\r\n    1. \"*\", it to matches any event name\r\n    2. Combine multiple events with \",\", for example \"connect,disconnect\", it matches event \"connect\" and \"disconnect\"\r\n    3. The single event name, for example, \"connect\", it matches \"connect\"",
+          "type": "string"
+        },
+        "categoryPattern": {
+          "description": "Gets or sets the matching pattern for category names. If not set, it matches any category.\r\nThere are 3 kind of patterns supported:\r\n    1. \"*\", it to matches any category name\r\n    2. Combine multiple categories with \",\", for example \"connections,messages\", it matches category \"connections\" and \"messages\"\r\n    3. The single category name, for example, \"connections\", it matches the category \"connections\"",
+          "type": "string"
+        },
+        "urlTemplate": {
+          "description": "Gets or sets the Upstream URL template. You can use 3 predefined parameters {hub}, {category} {event} inside the template, the value of the Upstream URL is dynamically calculated when the client request comes in.\r\nFor example, if the urlTemplate is `http://example.com/{hub}/api/{event}`, with a client request from hub `chat` connects, it will first POST to this URL: `http://example.com/chat/api/connect`.",
+          "type": "string"
+        }
+      }
+    },
+    "NetworkACL": {
+      "description": "Network ACL",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SignalRRequestType"
+          }
+        },
+        "deny": {
+          "description": "Denied request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SignalRRequestType"
+          }
+        }
+      }
+    },
+    "SignalRRequestType": {
+      "description": "Allowed request types. The value can be one or more of: ClientConnection, ServerConnection, RESTAPI.",
+      "enum": [
+        "ClientConnection",
+        "ServerConnection",
+        "RESTAPI"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "SignalRRequestType",
+        "modelAsString": true
+      }
+    },
+    "PrivateEndpointACL": {
+      "description": "ACL for a private endpoint",
+      "required": [
+        "name"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NetworkACL"
+        }
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the private endpoint connection",
+          "type": "string"
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "description": "A private endpoint connection to SignalR resource",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Properties of the private endpoint connection",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "ProxyResource": {
+      "description": "The resource model definition for a ARM proxy resource. It will have everything other than required location and tags",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {}
+    },
+    "PrivateEndpointConnectionProperties": {
+      "description": "Private endpoint connection properties",
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Provisioning state of the private endpoint connection",
+          "readOnly": true
+        },
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "Private endpoint associated with the private endpoint connection"
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "Connection state"
+        }
+      }
+    },
+    "PrivateEndpoint": {
+      "description": "Private endpoint",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Full qualified Id of the private endpoint",
+          "type": "string"
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "description": "Connection state of the private endpoint connection",
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionStatus",
+          "description": "Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service."
+        },
+        "description": {
+          "description": "The reason for approval/rejection of the connection.",
+          "type": "string"
+        },
+        "actionsRequired": {
+          "description": "A message indicating if changes on the service provider require any updates on the consumer.",
+          "type": "string"
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionStatus": {
+      "description": "Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "PrivateLinkServiceConnectionStatus",
+        "modelAsString": true
+      }
+    },
+    "PrivateLinkResourceList": {
+      "description": "Contains a list of AzSignalR.Models.Response.PrivateLink.PrivateLinkResource and a possible link to query more results",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of PrivateLinkResource",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+          "type": "string"
+        }
+      }
+    },
+    "PrivateLinkResource": {
+      "description": "Private link resource",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "Properties of a private link resource",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "PrivateLinkResourceProperties": {
+      "description": "Private link resource properties",
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "description": "Group Id of the private link resource",
+          "type": "string"
+        },
+        "requiredMembers": {
+          "description": "Required members of the private link resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requiredZoneNames": {
+          "description": "Required private DNS zone names",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SignalRKeys": {
+      "description": "A class represents the access keys of SignalR service.",
+      "type": "object",
+      "properties": {
+        "primaryKey": {
+          "description": "The primary access key.",
+          "type": "string"
+        },
+        "secondaryKey": {
+          "description": "The secondary access key.",
+          "type": "string"
+        },
+        "primaryConnectionString": {
+          "description": "SignalR connection string constructed via the primaryKey",
+          "type": "string"
+        },
+        "secondaryConnectionString": {
+          "description": "SignalR connection string constructed via the secondaryKey",
+          "type": "string"
+        }
+      }
+    },
+    "RegenerateKeyParameters": {
+      "description": "Parameters describes the request to regenerate access keys",
+      "type": "object",
+      "properties": {
+        "keyType": {
+          "$ref": "#/definitions/KeyType",
+          "description": "The keyType to regenerate. Must be either 'primary' or 'secondary'(case-insensitive)."
+        }
+      }
+    },
+    "KeyType": {
+      "description": "The keyType to regenerate. Must be either 'primary' or 'secondary'(case-insensitive).",
+      "enum": [
+        "Primary",
+        "Secondary"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "KeyType",
+        "modelAsString": true
+      }
+    },
+    "SignalRUsageList": {
+      "description": "Object that includes an array of SignalR resource usages and a possible link for next set.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of SignalR usages",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SignalRUsage"
+          }
+        },
+        "nextLink": {
+          "description": "The URL the client should use to fetch the next page (per server side paging).\r\nIt's null for now, added for future use.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRUsage": {
+      "description": "Object that describes a specific usage of SignalR resources.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Fully qualified ARM resource id",
+          "type": "string"
+        },
+        "currentValue": {
+          "format": "int64",
+          "description": "Current value for the usage quota.",
+          "type": "integer"
+        },
+        "limit": {
+          "format": "int64",
+          "description": "The maximum permitted value for the usage quota. If there is no limit, this value will be -1.",
+          "type": "integer"
+        },
+        "name": {
+          "$ref": "#/definitions/SignalRUsageName",
+          "description": "Localizable String object containing the name and a localized value."
+        },
+        "unit": {
+          "description": "Representing the units of the usage quota. Possible values are: Count, Bytes, Seconds, Percent, CountPerSecond, BytesPerSecond.",
+          "type": "string"
+        }
+      }
+    },
+    "SignalRUsageName": {
+      "description": "Localizable String object containing the name and a localized value.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The identifier of the usage.",
+          "type": "string"
+        },
+        "localizedValue": {
+          "description": "Localized name of the usage.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "Client Api Version.",
+      "required": true,
+      "type": "string"
+    },
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Gets subscription Id which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+      "required": true,
+      "type": "string"
+    },
+    "ResourceGroupParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group that contains the resource. You can obtain this value from the Azure Resource Manager API or the portal.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "SignalRServiceName": {
+      "name": "resourceName",
+      "in": "path",
+      "description": "The name of the SignalR resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      },
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow"
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ]
+}

--- a/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/signalr.json
+++ b/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2020-07-01-preview/signalr.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2020-05-01",
+    "version": "2020-07-01-preview",
     "title": "SignalRManagementClient",
     "description": "REST API for Azure SignalR Service"
   },
@@ -1059,6 +1059,10 @@
             "read",
             "create"
           ]
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedIdentity",
+          "description": "The managed identity response"
         }
       }
     },
@@ -1214,6 +1218,10 @@
             "$ref": "#/definitions/PrivateEndpointConnection"
           },
           "readOnly": true
+        },
+        "tls": {
+          "$ref": "#/definitions/SignalRTlsSettings",
+          "description": "TLS settings."
         }
       }
     },
@@ -1240,10 +1248,6 @@
       "description": "Settings used to provision or configure the resource.",
       "type": "object",
       "properties": {
-        "hostNamePrefix": {
-          "description": "Prefix for the hostName of the SignalR service. Retained for future use.\r\nThe hostname will be of format: &lt;hostNamePrefix&gt;.service.signalr.net.",
-          "type": "string"
-        },
         "features": {
           "description": "List of SignalR featureFlags. e.g. ServiceMode.\r\n\r\nFeatureFlags that are not included in the parameters for the update operation will not be modified.\r\nAnd the response will only include featureFlags that are explicitly set. \r\nWhen a featureFlag is not explicitly set, SignalR service will use its globally default value. \r\nBut keep in mind, the default value doesn't mean \"false\". It varies in terms of different FeatureFlags.",
           "type": "array",
@@ -1386,6 +1390,10 @@
         "urlTemplate": {
           "description": "Gets or sets the Upstream URL template. You can use 3 predefined parameters {hub}, {category} {event} inside the template, the value of the Upstream URL is dynamically calculated when the client request comes in.\r\nFor example, if the urlTemplate is `http://example.com/{hub}/api/{event}`, with a client request from hub `chat` connects, it will first POST to this URL: `http://example.com/chat/api/connect`.",
           "type": "string"
+        },
+        "auth": {
+          "$ref": "#/definitions/UpstreamAuthSettings",
+          "description": "Gets or sets the auth settings for an upstream. If not set, no auth is used for upstream messages."
         }
       }
     },
@@ -1440,6 +1448,82 @@
         }
       }
     },
+    "UpstreamAuthSettings": {
+      "description": "Upstream auth settings.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/UpstreamAuthType",
+          "description": "Gets or sets the type of auth. None or ManagedIdentity is supported now."
+        },
+        "managedIdentity": {
+          "$ref": "#/definitions/ManagedIdentitySettings",
+          "description": "Gets or sets the managed identity settings. It's required if the auth type is set to ManagedIdentity."
+        }
+      }
+    },
+    "UpstreamAuthType": {
+      "description": "Gets or sets the type of auth. None or ManagedIdentity is supported now.",
+      "enum": [
+        "None",
+        "ManagedIdentity"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "UpstreamAuthType",
+        "modelAsString": true
+      }
+    },
+    "ManagedIdentitySettings": {
+      "description": "Managed identity settings for upstream.",
+      "type": "object",
+      "properties": {
+        "resource": {
+          "description": "The Resource indicating the App ID URI of the target resource.\r\nIt also appears in the aud (audience) claim of the issued token.",
+          "type": "string"
+        }
+      }
+    },
+    "ManagedIdentity": {
+      "description": "A class represent managed identities used for request and response",
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ManagedIdentityType",
+          "description": "Represent the identity type: systemAssigned, userAssigned, None"
+        },
+        "userAssignedIdentities": {
+          "description": "Get or set the user assigned identities",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentityProperty"
+          }
+        },
+        "principalId": {
+          "description": "Get the principal id for the system assigned identity.\r\nOnly be used in response.",
+          "type": "string",
+          "readOnly": true
+        },
+        "tenantId": {
+          "description": "Get the tenant id for the system assigned identity.\r\nOnly be used in response",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ManagedIdentityType": {
+      "description": "Represent the identity type: systemAssigned, userAssigned, None",
+      "enum": [
+        "None",
+        "SystemAssigned",
+        "UserAssigned"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ManagedIdentityType",
+        "modelAsString": true
+      }
+    },
     "PrivateEndpointConnection": {
       "description": "A private endpoint connection to SignalR resource",
       "type": "object",
@@ -1465,6 +1549,32 @@
         }
       ],
       "properties": {}
+    },
+    "SignalRTlsSettings": {
+      "description": "TLS settings for SignalR",
+      "type": "object",
+      "properties": {
+        "clientCertEnabled": {
+          "description": "Request client certificate during TLS handshake if enabled",
+          "type": "boolean"
+        }
+      }
+    },
+    "UserAssignedIdentityProperty": {
+      "description": "Properties of user assigned identity.",
+      "type": "object",
+      "properties": {
+        "principalId": {
+          "description": "Get the principal id for the user assigned identity",
+          "type": "string",
+          "readOnly": true
+        },
+        "clientId": {
+          "description": "Get the client id for the user assigned identity",
+          "type": "string",
+          "readOnly": true
+        }
+      }
     },
     "PrivateEndpointConnectionProperties": {
       "description": "Private endpoint connection properties",

--- a/specification/signalr/resource-manager/readme.go.md
+++ b/specification/signalr/resource-manager/readme.go.md
@@ -52,5 +52,5 @@ These settings apply only when `--tag=package-2020-07-01-preview --go` is specif
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag) == 'package-2020-07-01-preview' && $(go)
-output-folder: $(go-sdk-folder)/services/$(namespace)/mgmt/2020-07-01-preview/$(namespace)
+output-folder: $(go-sdk-folder)/services/preview/$(namespace)/mgmt/2020-07-01-preview/$(namespace)
 ```

--- a/specification/signalr/resource-manager/readme.go.md
+++ b/specification/signalr/resource-manager/readme.go.md
@@ -16,6 +16,7 @@ batch:
   - tag: package-2018-03-01-preview
   - tag: package-2018-10-01
   - tag: package-2020-05-01
+  - tag: package-2020-07-01-preview
 ```
 
 ### Tag: package-2018-03-01-preview and go
@@ -43,4 +44,13 @@ Please also specify `--go-sdk-folder=<path to the root directory of your azure-s
 
 ``` yaml $(tag) == 'package-2020-05-01' && $(go)
 output-folder: $(go-sdk-folder)/services/$(namespace)/mgmt/2020-05-01/$(namespace)
+```
+
+### Tag: package-2020-07-01-preview and go
+
+These settings apply only when `--tag=package-2020-07-01-preview --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag) == 'package-2020-07-01-preview' && $(go)
+output-folder: $(go-sdk-folder)/services/$(namespace)/mgmt/2020-07-01-preview/$(namespace)
 ```

--- a/specification/signalr/resource-manager/readme.java.md
+++ b/specification/signalr/resource-manager/readme.java.md
@@ -19,6 +19,20 @@ batch:
   - tag: package-2018-03-01-preview
   - tag: package-2018-10-01
   - tag: package-2020-05-01
+  - tag: package-2020-07-01-preview
+```
+
+### Tag: package-2020-07-01-preview and java
+
+These settings apply only when `--tag=package-2020-07-01-preview --java` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+``` yaml $(tag) == 'package-2020-07-01-preview' && $(java) && $(multiapi)
+java:
+  namespace: com.microsoft.azure.management.signalr.v2020_07_01_preview
+  output-folder: $(azure-libraries-for-java-folder)/sdk/signalr/mgmt-v2020_07_01_preview
+regenerate-manager: true
+generate-interface: true
 ```
 
 ### Tag: package-2020-05-01 and java

--- a/specification/signalr/resource-manager/readme.md
+++ b/specification/signalr/resource-manager/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the SignalR API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2020-05-01
+tag: package-2020-07-01-preview
 ```
 
 ### Suppression
@@ -53,6 +53,15 @@ directive:
     - $.definitions.SignalRFeature.properties.properties
     - $.definitions.PrivateEndpointConnection.properties.properties
     reason:  The 'properties' is a user-defined dictionary, cannot be flattened.
+```
+
+### Tag: package-2020-07-01-preview
+
+These settings apply only when `--tag=package-2020-07-01-preview` is specified on the command line.
+
+``` yaml $(tag) == 'package-2020-07-01-preview'
+input-file:
+- Microsoft.SignalRService/preview/2020-07-01-preview/signalr.json
 ```
 
 ### Tag: package-2020-05-01

--- a/specification/signalr/resource-manager/readme.ruby.md
+++ b/specification/signalr/resource-manager/readme.ruby.md
@@ -15,6 +15,17 @@ batch:
   - tag: package-2018-03-01-preview
   - tag: package-2018-10-01
   - tag: package-2020-05-01
+  - tag: package-2020-07-01-preview
+```
+
+### Tag: package-2020-07-01-preview and ruby
+
+These settings apply only when `--tag=package-2020-07-01-preview --ruby` is specified on the command line.
+Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
+
+``` yaml $(tag) == 'package-2020-07-01-preview' && $(ruby)
+namespace: "Azure::Signalr::Mgmt::V2020_07_01_preview"
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_signalr/lib
 ```
 
 ### Tag: package-2020-05-01 and ruby


### PR DESCRIPTION
- Adding MSI support in SignalR Service
- Allow customer to enable client certificate for SignalR data plane auth.
- Adding new api-version `2020-07-01-preview`

More comments and context can be found at https://github.com/Azure/azure-rest-api-specs/pull/9908. 

<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Contribution checklist:
- [ ] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [ ] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Service team MUST add the "**WaitForARMFeedback**" label if the management plane API changes fall into one of the below categories. 
  - adding/removing APIs.
  - adding/removing properties.
  - adding/removing API-version. 
  - adding a new service in Azure.

<i>Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.</i>

- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://aka.ms/SwaggerPRReview).
