### PR TITLE
Template Specs: Dropping "Model" suffix from TemplateSpec and TemplateSpecVersion

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/preview/2019-06-01-preview/templateSpecs.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/preview/2019-06-01-preview/templateSpecs.json
@@ -64,7 +64,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/TemplateSpecModel"
+              "$ref": "#/definitions/TemplateSpec"
             },
             "description": "Template Spec supplied to the operation."
           }
@@ -73,13 +73,13 @@
           "200": {
             "description": "OK - The Template Spec update request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/TemplateSpecModel"
+              "$ref": "#/definitions/TemplateSpec"
             }
           },
           "201": {
             "description": "Template Spec created.",
             "schema": {
-              "$ref": "#/definitions/TemplateSpecModel"
+              "$ref": "#/definitions/TemplateSpec"
             }
           },
           "default": {
@@ -127,7 +127,7 @@
           "200": {
             "description": "OK -- Template Spec tags are updated.",
             "schema": {
-              "$ref": "#/definitions/TemplateSpecModel"
+              "$ref": "#/definitions/TemplateSpec"
             }
           },
           "default": {
@@ -167,7 +167,7 @@
           "200": {
             "description": "OK - Returns information about the Template Spec.",
             "schema": {
-              "$ref": "#/definitions/TemplateSpecModel"
+              "$ref": "#/definitions/TemplateSpec"
             }
           },
           "default": {
@@ -333,7 +333,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/TemplateSpecVersionModel"
+              "$ref": "#/definitions/TemplateSpecVersion"
             },
             "description": "Template Spec Version supplied to the operation."
           }
@@ -342,13 +342,13 @@
           "200": {
             "description": "OK - The Template Spec Version has been successfully updated.",
             "schema": {
-              "$ref": "#/definitions/TemplateSpecVersionModel"
+              "$ref": "#/definitions/TemplateSpecVersion"
             }
           },
           "201": {
             "description": "Template Spec Version created.",
             "schema": {
-              "$ref": "#/definitions/TemplateSpecVersionModel"
+              "$ref": "#/definitions/TemplateSpecVersion"
             }
           },
           "default": {
@@ -399,7 +399,7 @@
           "200": {
             "description": "OK -- Template Spec Version tags are updated.",
             "schema": {
-              "$ref": "#/definitions/TemplateSpecVersionModel"
+              "$ref": "#/definitions/TemplateSpecVersion"
             }
           },
           "default": {
@@ -442,7 +442,7 @@
           "200": {
             "description": "OK - Returns information about the Template Spec version.",
             "schema": {
-              "$ref": "#/definitions/TemplateSpecVersionModel"
+              "$ref": "#/definitions/TemplateSpecVersion"
             }
           },
           "default": {
@@ -544,7 +544,7 @@
     }
   },
   "definitions": {
-    "TemplateSpecModel": {
+    "TemplateSpec": {
       "required": [
         "location"
       ],
@@ -600,7 +600,7 @@
         "value": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/TemplateSpecModel"
+            "$ref": "#/definitions/TemplateSpec"
           },
           "description": "An array of Template Specs."
         },
@@ -675,7 +675,7 @@
         }
       }
     },
-    "TemplateSpecVersionModel": {
+    "TemplateSpecVersion": {
       "required": [
         "properties",
         "location"
@@ -738,7 +738,7 @@
         "value": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/TemplateSpecVersionModel"
+            "$ref": "#/definitions/TemplateSpecVersion"
           },
           "description": "An array of Template Spec versions."
         },

--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -580,8 +580,8 @@ directive:
   - suppress: R3006 #BodyTopLevelProperties
     from: templateSpecs.json
     where: 
-    - $.definitions.TemplateSpecModel.properties
-    - $.definitions.TemplateSpecVersionModel.properties
+    - $.definitions.TemplateSpec.properties
+    - $.definitions.TemplateSpecVersion.properties
     - $.definitions.TemplateSpecUpdateModel.properties
     - $.definitions.TemplateSpecVersionUpdateModel.properties
     reason: Currently systemData is not allowed
@@ -591,7 +591,7 @@ directive:
     reason: Tooling issue
   - suppress: TrackedResourceListByResourceGroup
     from: templateSpecs.json
-    where: $.definitions.TemplateSpecVersionModel
+    where: $.definitions.TemplateSpecVersion
     reason: Tooling issue
 ```
 


### PR DESCRIPTION
No functionality changes... simply drops the "Model" suffix from the definitions of two existing models. Results in cleaner/more consistent SDK.

<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Contribution checklist:
- [X] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [X] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Service team MUST add the "**WaitForARMFeedback**" label if the management plane API changes fall into one of the below categories. 
  - adding/removing APIs.
  - adding/removing properties.
  - adding/removing API-version. 
  - adding a new service in Azure.

<i>Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.</i>

- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://aka.ms/SwaggerPRReview).
