### PR TITLE
updated 2019-01-01, 2019-12-01

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimanagement.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimanagement.json
@@ -198,6 +198,33 @@
       "pattern": "^[^*#&+:<>?]+$",
       "x-ms-parameter-location": "method"
     },
+    "AppTypeParameter": {
+      "name": "appType",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "Determines the type of application which send the create user request. Default is legacy publisher portal.",
+      "enum": [
+        "portal",
+        "developerPortal"
+      ],
+      "x-ms-enum": {
+        "name": "AppType",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "portal",
+            "description": "User create request was sent by legacy developer portal."
+          },
+          {
+            "value": "developerPortal",
+            "description": "User create request was sent by new developer portal."
+          }
+        ]
+      },
+      "default": "portal",
+      "x-ms-parameter-location": "method"
+    },
     "AttachmentIdParameter": {
       "name": "attachmentId",
       "in": "path",

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimsubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimsubscriptions.json
@@ -230,6 +230,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {
@@ -306,6 +309,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimusers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimusers.json
@@ -233,6 +233,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {
@@ -363,6 +366,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {
@@ -681,6 +687,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimusers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimusers.json
@@ -226,6 +226,13 @@
             "description": "Create or update parameters."
           },
           {
+            "name": "notify",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Send an Email notification to the User."
+          },
+          {
             "$ref": "./apimanagement.json#/parameters/IfMatchOptionalParameter"
           },
           {

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimusers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/apimusers.json
@@ -240,9 +240,6 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/definitions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/definitions.json
@@ -4506,28 +4506,6 @@
         "allowTracing": {
           "type": "boolean",
           "description": "Determines whether tracing can be enabled"
-        },
-        "appType": {
-          "type": "string",
-          "description": "Determines the type of application which send the create subscription request. Default is legacy portal.",
-          "enum": [
-            "portal",
-            "developerPortal"
-          ],
-          "x-ms-enum": {
-            "name": "AppType",
-            "modelAsString": true,
-            "values": [
-              {
-                "value": "portal",
-                "description": "User create request was sent by legacy developer portal."
-              },
-              {
-                "value": "developerPortal",
-                "description": "User create request was sent by new developer portal."
-              }
-            ]
-          }
         }
       },
       "required": [
@@ -4628,28 +4606,6 @@
         "allowTracing": {
           "type": "boolean",
           "description": "Determines whether tracing can be enabled"
-        },
-        "appType": {
-          "type": "string",
-          "description": "Determines the type of application which send the update subscription request. Default is legacy portal.",
-          "enum": [
-            "portal",
-            "developerPortal"
-          ],
-          "x-ms-enum": {
-            "name": "AppType",
-            "modelAsString": true,
-            "values": [
-              {
-                "value": "portal",
-                "description": "User create request was sent by legacy developer portal."
-              },
-              {
-                "value": "developerPortal",
-                "description": "User create request was sent by new developer portal."
-              }
-            ]
-          }
         }
       },
       "description": "Parameters supplied to the Update subscription operation."
@@ -5007,6 +4963,28 @@
         "password": {
           "type": "string",
           "description": "User Password. If no value is provided, a default password is generated."
+        },
+        "appType": {
+          "type": "string",
+          "description": "Determines the type of application which send the create subscription request. Default is legacy portal.",
+          "enum": [
+            "portal",
+            "developerPortal"
+          ],
+          "x-ms-enum": {
+            "name": "AppType",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "portal",
+                "description": "User create request was sent by legacy developer portal."
+              },
+              {
+                "value": "developerPortal",
+                "description": "User create request was sent by new developer portal."
+              }
+            ]
+          }
         },
         "confirmation": {
           "type": "string",

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/definitions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/definitions.json
@@ -4966,7 +4966,7 @@
         },
         "appType": {
           "type": "string",
-          "description": "Determines the type of application which send the create subscription request. Default is legacy portal.",
+          "description": "Determines the type of application which send the create user request. Default is legacy portal.",
           "enum": [
             "portal",
             "developerPortal"

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/definitions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/definitions.json
@@ -4506,6 +4506,28 @@
         "allowTracing": {
           "type": "boolean",
           "description": "Determines whether tracing can be enabled"
+        },
+        "appType": {
+          "type": "string",
+          "description": "Determines the type of application which send the create subscription request. Default is legacy portal.",
+          "enum": [
+            "portal",
+            "developerPortal"
+          ],
+          "x-ms-enum": {
+            "name": "AppType",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "portal",
+                "description": "User create request was sent by legacy developer portal."
+              },
+              {
+                "value": "developerPortal",
+                "description": "User create request was sent by new developer portal."
+              }
+            ]
+          }
         }
       },
       "required": [
@@ -4606,6 +4628,28 @@
         "allowTracing": {
           "type": "boolean",
           "description": "Determines whether tracing can be enabled"
+        },
+        "appType": {
+          "type": "string",
+          "description": "Determines the type of application which send the update subscription request. Default is legacy portal.",
+          "enum": [
+            "portal",
+            "developerPortal"
+          ],
+          "x-ms-enum": {
+            "name": "AppType",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "portal",
+                "description": "User create request was sent by legacy developer portal."
+              },
+              {
+                "value": "developerPortal",
+                "description": "User create request was sent by new developer portal."
+              }
+            ]
+          }
         }
       },
       "description": "Parameters supplied to the Update subscription operation."
@@ -4963,23 +5007,6 @@
         "password": {
           "type": "string",
           "description": "User Password. If no value is provided, a default password is generated."
-        },
-        "appType": {
-          "type": "string",
-          "description": "Determines the type of application which send the create user request. Default is old publisher portal.",
-          "enum": [
-            "developerPortal"
-          ],
-          "x-ms-enum": {
-            "name": "AppType",
-            "modelAsString": true,
-            "values": [
-              {
-                "value": "developerPortal",
-                "description": "User create request was sent by new developer portal."
-              }
-            ]
-          }
         },
         "confirmation": {
           "type": "string",

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimanagement.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimanagement.json
@@ -198,6 +198,33 @@
       "pattern": "^[^*#&+:<>?]+$",
       "x-ms-parameter-location": "method"
     },
+    "AppTypeParameter": {
+      "name": "appType",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "Determines the type of application which send the create user request. Default is legacy publisher portal.",
+      "enum": [
+        "portal",
+        "developerPortal"
+      ],
+      "x-ms-enum": {
+        "name": "AppType",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "portal",
+            "description": "User create request was sent by legacy developer portal."
+          },
+          {
+            "value": "developerPortal",
+            "description": "User create request was sent by new developer portal."
+          }
+        ]
+      },
+      "default": "portal",
+      "x-ms-parameter-location": "method"
+    },
     "AttachmentIdParameter": {
       "name": "attachmentId",
       "in": "path",

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimsubscriptions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimsubscriptions.json
@@ -230,6 +230,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {
@@ -306,6 +309,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimusers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimusers.json
@@ -233,6 +233,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {
@@ -363,6 +366,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {
@@ -681,6 +687,9 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimusers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimusers.json
@@ -226,6 +226,13 @@
             "description": "Create or update parameters."
           },
           {
+            "name": "notify",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "description": "Send an Email notification to the User."
+          },
+          {
             "$ref": "./apimanagement.json#/parameters/IfMatchOptionalParameter"
           },
           {

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimusers.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimusers.json
@@ -240,9 +240,6 @@
           },
           {
             "$ref": "./apimanagement.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "./apimanagement.json#/parameters/AppTypeParameter"
           }
         ],
         "responses": {

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/definitions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/definitions.json
@@ -4590,28 +4590,6 @@
         "allowTracing": {
           "type": "boolean",
           "description": "Determines whether tracing can be enabled"
-        },
-        "appType": {
-          "type": "string",
-          "description": "Determines the type of application which send the create subscription request. Default is legacy portal.",
-          "enum": [
-            "portal",
-            "developerPortal"
-          ],
-          "x-ms-enum": {
-            "name": "AppType",
-            "modelAsString": true,
-            "values": [
-              {
-                "value": "portal",
-                "description": "User create request was sent by legacy developer portal."
-              },
-              {
-                "value": "developerPortal",
-                "description": "User create request was sent by new developer portal."
-              }
-            ]
-          }
         }
       },
       "required": [
@@ -4712,28 +4690,6 @@
         "allowTracing": {
           "type": "boolean",
           "description": "Determines whether tracing can be enabled"
-        },
-        "appType": {
-          "type": "string",
-          "description": "Determines the type of application which send the update subscription request. Default is legacy portal.",
-          "enum": [
-            "portal",
-            "developerPortal"
-          ],
-          "x-ms-enum": {
-            "name": "AppType",
-            "modelAsString": true,
-            "values": [
-              {
-                "value": "portal",
-                "description": "User create request was sent by legacy developer portal."
-              },
-              {
-                "value": "developerPortal",
-                "description": "User create request was sent by new developer portal."
-              }
-            ]
-          }
         }
       },
       "description": "Parameters supplied to the Update subscription operation."
@@ -5095,6 +5051,28 @@
         "password": {
           "type": "string",
           "description": "User Password. If no value is provided, a default password is generated."
+        },
+        "appType": {
+          "type": "string",
+          "description": "Determines the type of application which send the create subscription request. Default is legacy portal.",
+          "enum": [
+            "portal",
+            "developerPortal"
+          ],
+          "x-ms-enum": {
+            "name": "AppType",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "portal",
+                "description": "User create request was sent by legacy developer portal."
+              },
+              {
+                "value": "developerPortal",
+                "description": "User create request was sent by new developer portal."
+              }
+            ]
+          }
         },
         "confirmation": {
           "type": "string",

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/definitions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/definitions.json
@@ -4590,6 +4590,28 @@
         "allowTracing": {
           "type": "boolean",
           "description": "Determines whether tracing can be enabled"
+        },
+        "appType": {
+          "type": "string",
+          "description": "Determines the type of application which send the create subscription request. Default is legacy portal.",
+          "enum": [
+            "portal",
+            "developerPortal"
+          ],
+          "x-ms-enum": {
+            "name": "AppType",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "portal",
+                "description": "User create request was sent by legacy developer portal."
+              },
+              {
+                "value": "developerPortal",
+                "description": "User create request was sent by new developer portal."
+              }
+            ]
+          }
         }
       },
       "required": [
@@ -4690,6 +4712,28 @@
         "allowTracing": {
           "type": "boolean",
           "description": "Determines whether tracing can be enabled"
+        },
+        "appType": {
+          "type": "string",
+          "description": "Determines the type of application which send the update subscription request. Default is legacy portal.",
+          "enum": [
+            "portal",
+            "developerPortal"
+          ],
+          "x-ms-enum": {
+            "name": "AppType",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "portal",
+                "description": "User create request was sent by legacy developer portal."
+              },
+              {
+                "value": "developerPortal",
+                "description": "User create request was sent by new developer portal."
+              }
+            ]
+          }
         }
       },
       "description": "Parameters supplied to the Update subscription operation."
@@ -5051,23 +5095,6 @@
         "password": {
           "type": "string",
           "description": "User Password. If no value is provided, a default password is generated."
-        },
-        "appType": {
-          "type": "string",
-          "description": "Determines the type of application which send the create user request. Default is old publisher portal.",
-          "enum": [
-            "developerPortal"
-          ],
-          "x-ms-enum": {
-            "name": "AppType",
-            "modelAsString": true,
-            "values": [
-              {
-                "value": "developerPortal",
-                "description": "User create request was sent by new developer portal."
-              }
-            ]
-          }
         },
         "confirmation": {
           "type": "string",

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/definitions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/definitions.json
@@ -5054,7 +5054,7 @@
         },
         "appType": {
           "type": "string",
-          "description": "Determines the type of application which send the create subscription request. Default is legacy portal.",
+          "description": "Determines the type of application which send the create user request. Default is legacy portal.",
           "enum": [
             "portal",
             "developerPortal"


### PR DESCRIPTION
Removed unused appType from UserCreateParameterProperties
Added appType as query parameter for Users create/delete/confirmations password send
Added appType as payload parameter for Subscription create/update

<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Contribution checklist:
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [x] Service team MUST add the "**WaitForARMFeedback**" label if the management plane API changes fall into one of the below categories. 
  - adding/removing APIs.
  - adding/removing properties.
  - adding/removing API-version. 
  - adding a new service in Azure.

<i>Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.</i>

- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://aka.ms/SwaggerPRReview).
