### PR TITLE
<QnAMaker> For new Metadata OR operation

### DIFF
--- a/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMakerRuntime.json
+++ b/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMakerRuntime.json
@@ -370,7 +370,7 @@
         },
         "strictFiltersCompoundOperationType": {
           "type": "string",
-          "description": "Optional field. Set to 'OR' for using OR as Operation for Strict Filters.",
+          "description": "Optional field. Set to OR for using OR as Operation for Strict Filters.",
           "x-ms-enum": {
             "name": "StrictFiltersCompoundOperationType",
             "modelAsString": true

--- a/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMakerRuntime.json
+++ b/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMakerRuntime.json
@@ -370,17 +370,16 @@
         },
         "strictFiltersCompoundOperationType": {
           "type": "string",
-          "description": "Optional field. Set to "OR" for using OR as Operation for Strict Filters.",
-	      "x-ms-enum": {
-				"name": "StrictFiltersCompoundOperationType",
-				"modelAsString": true
-			  },
-		  "enum": [
-		  "AND",
-		  "OR"
-		  ]
+          "description": "Optional field. Set to 'OR' for using OR as Operation for Strict Filters.",
+          "x-ms-enum": {
+            "name": "StrictFiltersCompoundOperationType",
+            "modelAsString": true
+          },
+          "enum": [
+            "AND",
+            "OR"
+          ]
         }
-      }
       }
     },
     "QueryContextDTO": {

--- a/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMakerRuntime.json
+++ b/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMakerRuntime.json
@@ -369,9 +369,18 @@
           }
         },
         "strictFiltersCompoundOperationType": {
-          "type": "integer",
-          "description": "Optional field. Set to 1 for using OR as Operation for Strict Filters."
+          "type": "string",
+          "description": "Optional field. Set to "OR" for using OR as Operation for Strict Filters.",
+	      "x-ms-enum": {
+				"name": "StrictFiltersCompoundOperationType",
+				"modelAsString": true
+			  },
+		  "enum": [
+		  "AND",
+		  "OR"
+		  ]
         }
+      }
       }
     },
     "QueryContextDTO": {

--- a/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMakerRuntime.json
+++ b/specification/cognitiveservices/data-plane/QnAMaker/stable/v4.0/QnAMakerRuntime.json
@@ -367,6 +367,10 @@
           "items": {
             "$ref": "#/definitions/MetadataDTO"
           }
+        },
+        "strictFiltersCompoundOperationType": {
+          "type": "integer",
+          "description": "Optional field. Set to 1 for using OR as Operation for Strict Filters."
         }
       }
     },


### PR DESCRIPTION
QueryDTO updates for supporting new parameter in GenerateAnswer Request. The "strictFiltersCompoundOperationType" , when set to 'OR', can be used for "OR' operation , on a set of strict filters.