### PR TITLE
Switching sample since Ink Recognizer is global.

### DIFF
--- a/specification/cognitiveservices/data-plane/InkRecognizer/preview/v1.0/InkRecognizer.json
+++ b/specification/cognitiveservices/data-plane/InkRecognizer/preview/v1.0/InkRecognizer.json
@@ -677,7 +677,7 @@
   "parameters": {
     "Endpoint": {
       "name": "Endpoint",
-      "description": "Supported Cognitive Services endpoints (protocol and hostname, for example: https://westus2.api.cognitive.microsoft.com).",
+      "description": "Supported Cognitive Services endpoints (protocol and hostname, for example: https://api.cognitive.microsoft.com).",
       "x-ms-parameter-location": "client",
       "required": true,
       "type": "string",


### PR DESCRIPTION
Simple update to the sample Url we use in the Ink recognizer documentation to fix an issue filed by a customer.   