### PR TITLE
Add Accept headers for cosmos endpoint requirements

### DIFF
--- a/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableCreate.json
+++ b/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableCreate.json
@@ -1,5 +1,6 @@
 {
   "parameters": {
+    "Accept": "application/json",
     "x-ms-version": "2019-02-02",
     "DataServiceVersion": "3.0",
     "url": "myaccount.table.core.windows.net",

--- a/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableDelete.json
+++ b/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableDelete.json
@@ -1,5 +1,6 @@
 {
   "parameters": {
+    "Accept": "application/json",
     "x-ms-version": "2019-02-02",
     "url": "myaccount.table.core.windows.net",
     "table": "mytable"

--- a/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableGet.json
+++ b/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableGet.json
@@ -1,5 +1,6 @@
 {
   "parameters": {
+    "Accept": "application/json",
     "x-ms-version": "2019-02-02",
     "DataServiceVersion": "3.0",
     "$top": 1,

--- a/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableInsertEntity.json
+++ b/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableInsertEntity.json
@@ -1,5 +1,6 @@
 {
   "parameters": {
+    "Accept": "application/json",
     "x-ms-version": "2019-02-02",
     "DataServiceVersion": "3.0",
     "table": "Customer",

--- a/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableQueryEntities.json
+++ b/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableQueryEntities.json
@@ -1,5 +1,6 @@
 {
   "parameters": {
+    "Accept": "application/json",
     "x-ms-version": "2019-02-02",
     "DataServiceVersion": "3.0",
     "url": "myaccount.table.core.windows.net",

--- a/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableQueryEntitiesWithPartitionAndRowKey.json
+++ b/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableQueryEntitiesWithPartitionAndRowKey.json
@@ -1,5 +1,6 @@
 {
   "parameters": {
+    "Accept": "application/json",
     "x-ms-version": "2019-02-02",
     "DataServiceVersion": "3.0",
     "url": "myaccount.table.core.windows.net",

--- a/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableUpdateEntity.json
+++ b/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/examples/TableUpdateEntity.json
@@ -1,5 +1,6 @@
 {
   "parameters": {
+    "Accept": "application/json",
     "x-ms-version": "2019-02-02",
     "DataServiceVersion": "3.0",
     "url": "myaccount.table.core.windows.net",

--- a/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/table.json
+++ b/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/table.json
@@ -75,6 +75,9 @@
             "required": false,
             "type": "string",
             "description": "A table query continuation token from a previous call."
+          },
+          {
+            "$ref": "#/parameters/acceptJsonParameter"
           }
         ],
         "responses": {
@@ -141,6 +144,9 @@
           },
           {
             "$ref": "#/parameters/PreferParameter"
+          },
+          {
+            "$ref": "#/parameters/acceptJsonParameter"
           }
         ],
         "responses": {
@@ -247,6 +253,9 @@
           },
           {
             "$ref": "#/parameters/tableNameParameter"
+          },
+          {
+            "$ref": "#/parameters/acceptJsonParameter"
           }
         ],
         "responses": {
@@ -343,6 +352,9 @@
             "required": false,
             "type": "string",
             "description": "An entity query continuation token from a previous call."
+          },
+          {
+            "$ref": "#/parameters/acceptJsonParameter"
           }
         ],
         "responses": {
@@ -439,6 +451,9 @@
           },
           {
             "$ref": "#/parameters/rowKeyParameter"
+          },
+          {
+            "$ref": "#/parameters/acceptJsonParameter"
           }
         ],
         "responses": {
@@ -548,6 +563,9 @@
             "type": "string",
             "description": "Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised. To force an unconditional update, set to the wildcard character (*). If not specified, an insert will be performed when no existing entity is found to update and a replace will be performed if an existing entity is found.",
             "x-ms-client-name": "IfMatch"
+          },
+          {
+            "$ref": "#/parameters/acceptJsonParameter"
           }
         ],
         "responses": {
@@ -814,6 +832,9 @@
           },
           {
             "$ref": "#/parameters/PreferParameter"
+          },
+          {
+            "$ref": "#/parameters/acceptJsonParameter"
           }
         ],
         "responses": {
@@ -1010,6 +1031,9 @@
           },
           {
             "$ref": "#/parameters/compAclParameter"
+          },
+          {
+            "$ref": "#/parameters/acceptXmlParameter"
           }
         ],
         "responses": {
@@ -1908,6 +1932,28 @@
       "type": "string",
       "x-ms-parameter-location": "method",
       "description": "The row key of the entity."
+    },
+    "acceptJsonParameter": {
+      "description": "",
+      "name": "Accept",
+      "in": "header",
+      "type": "string",
+      "enum": [
+        "application/json"
+      ],
+      "required": true,
+      "x-ms-parameter-location": "method"
+    },
+    "acceptXmlParameter": {
+      "description": "",
+      "name": "Accept",
+      "in": "header",
+      "type": "string",
+      "enum": [
+        "application/xml"
+      ],
+      "required": true,
+      "x-ms-parameter-location": "method"
     }
   }
 }


### PR DESCRIPTION
Some Cosmos Tables endpoints return 415 Unsupported Media Type without an explicit Accept header

Examples:

- CreateTable: returns 415 without Accept: application/json
- DeleteTable: returns 415 without Accept: application/json
- InsertEntity: returns 415 without Accept: application/json
- QueryEntity: returns 415 without Accept: application/json
- QueryEntitiesWithPartitionAndRowKey: returns 415 without Accept: application/json
- QueryTable: returns 415 without Accept: application/json
- SetAccessPolicy: returns 415 without Accept: application/xml

### Contribution checklist:
- [ ] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of “no breaking changes
- [ ] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [ ] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).