### PR TITLE
Addendum | Access Reviews reviewer and stats APIs

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/authorization-AccessReviewCalls.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/authorization-AccessReviewCalls.json
@@ -1,0 +1,1429 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2018-05-01-preview",
+    "title": "AuthorizationManagementClient",
+    "description": "Access reviews service provides the workflow for running access reviews on different kind of resources."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/providers/Microsoft.Authorization/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "x-ms-examples": {},
+        "description": "Lists the operations available from this provider.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions": {
+      "get": {
+        "tags": [
+          "GetAccessReviewScheduleDefinitions"
+        ],
+        "operationId": "AccessReviewScheduleDefinitions_List",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/GetAccessReviewScheduleDefinitions.json"
+          }
+        },
+        "description": "Get access review schedule definitions",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewScheduleDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}": {
+      "get": {
+        "tags": [
+          "GetAccessReviewScheduleDefinition"
+        ],
+        "operationId": "AccessReviewScheduleDefinitions_GetById",
+        "x-ms-examples": {
+          "GetAccessReview": {
+            "$ref": "./examples/GetAccessReviewScheduleDefinition.json"
+          }
+        },
+        "description": "Get single access review definition",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewScheduleDefinition"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DeleteAccessReviewScheduleDefinition"
+        ],
+        "operationId": "AccessReviewScheduleDefinitions_DeleteById",
+        "x-ms-examples": {
+          "DeleteAccessReview": {
+            "$ref": "./examples/DeleteAccessReviewScheduleDefinition.json"
+          }
+        },
+        "description": "Delete access review schedule definition",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Request is well formed but the resource does not exist"
+          },
+          "200": {
+            "description": "Resource deleted successfully"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "PutAccessReviewScheduleDefinition"
+        ],
+        "operationId": "AccessReviewScheduleDefinitions_CreateOrUpdateById",
+        "x-ms-examples": {
+          "PutAccessReview": {
+            "$ref": "./examples/PutAccessReviewScheduleDefinition.json"
+          }
+        },
+        "description": "Create or Update access review schedule definition.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AccessReviewScheduleDefinitionProperties"
+            },
+            "description": "Access review schedule definition properties."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful update",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewScheduleDefinition"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/stop": {
+      "post": {
+        "tags": [
+          "AccessReviewScheduleDefinitionStop"
+        ],
+        "operationId": "AccessReviewScheduleDefinitions_Stop",
+        "x-ms-examples": {
+          "GetAccessReview": {
+            "$ref": "./examples/StopAccessReviewScheduleDefinition.json"
+          }
+        },
+        "description": "Stop access review definition",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Describe the result of a successful operation."
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances": {
+      "get": {
+        "tags": [
+          "GetAccessReviewInstances"
+        ],
+        "operationId": "AccessReviewInstances_List",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/GetAccessReviewInstances.json"
+          }
+        },
+        "description": "Get access review instances",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewInstanceListResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}": {
+      "get": {
+        "tags": [
+          "GetAccessReviewInstance"
+        ],
+        "operationId": "AccessReviewInstances_GetById",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/GetAccessReviewInstance.json"
+          }
+        },
+        "description": "Get access review instances",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewInstance"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}/stop": {
+      "post": {
+        "tags": [
+          "AccessReviewInstanceStop"
+        ],
+        "operationId": "AccessReviewInstance_Stop",
+        "x-ms-examples": {
+          "GetAccessReview": {
+            "$ref": "./examples/StopAccessReviewInstance.json"
+          }
+        },
+        "description": "An action to stop an access review instance.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Describe the result of a successful operation."
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}/resetDecisions": {
+      "post": {
+        "tags": [
+          "AccessReviewInstanceResetDecisions"
+        ],
+        "operationId": "AccessReviewInstance_ResetDecisions",
+        "x-ms-examples": {
+          "GetAccessReview": {
+            "$ref": "./examples/AccessReviewInstanceResetDecisions.json"
+          }
+        },
+        "description": "An action to reset all decisions for an access review instance.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Describe the result of a successful operation."
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}/applyDecisions": {
+      "post": {
+        "tags": [
+          "AccessReviewInstanceApplyDecisions"
+        ],
+        "operationId": "AccessReviewInstance_ApplyDecisions",
+        "x-ms-examples": {
+          "GetAccessReview": {
+            "$ref": "./examples/AccessReviewInstanceApplyDecisions.json"
+          }
+        },
+        "description": "An action to apply all decisions for an access review instance.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Describe the result of a successful operation."
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}/sendReminders": {
+      "post": {
+        "tags": [
+          "AccessReviewInstanceSendReminders"
+        ],
+        "operationId": "AccessReviewInstance_SendReminders",
+        "x-ms-examples": {
+          "GetAccessReview": {
+            "$ref": "./examples/AccessReviewInstanceSendReminders.json"
+          }
+        },
+        "description": "An action to send reminders for an access review instance.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Describe the result of a successful operation."
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}/decisions": {
+      "get": {
+        "tags": [
+          "GetAccessReviewInstanceDecisions"
+        ],
+        "operationId": "AccessReviewInstanceDecisions_List",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/GetAccessReviewInstanceDecisions.json"
+          }
+        },
+        "description": "Get access review instance decisions",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewDecisionListResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/accessReviewScheduleSettings/default": {
+      "get": {
+        "tags": [
+          "GetAccessReviewDefaultSettings"
+        ],
+        "operationId": "AccessReviewDefaultSettings_Get",
+        "x-ms-examples": {
+          "GetAccessReviewDefaultSettings": {
+            "$ref": "./examples/GetAccessReviewDefaultSettings.json"
+          }
+        },
+        "description": "Get access review default settings for the subscription",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewDefaultSettings"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "PutAccessReviewDefaultSettings"
+        ],
+        "operationId": "AccessReviewDefaultSettings_Put",
+        "x-ms-examples": {
+          "GetAccessReviewDefaultSettings": {
+            "$ref": "./examples/PutAccessReviewDefaultSettings.json"
+          }
+        },
+        "description": "Get access review default settings for the subscription",
+        "parameters": [
+          {
+            "name": "properties",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AccessReviewScheduleSettings"
+            },
+            "description": "Access review schedule settings."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewDefaultSettings"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessReviewScheduleDefinition": {
+      "x-ms-azure-resource": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The access review schedule definition id."
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The access review schedule definition unique id."
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The resource type."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewScheduleDefinitionProperties",
+          "description": "Access Review properties."
+        }
+      },
+      "description": "Access Review Schedule Definition."
+    },
+    "AccessReviewScheduleDefinitionProperties": {
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "The display name for the schedule definition."
+        },
+        "status": {
+          "type": "string",
+          "readOnly": true,
+          "description": "This read-only field specifies the status of an accessReview.",
+          "enum": [
+            "NotStarted",
+            "InProgress",
+            "Completed",
+            "Applied",
+            "Initializing",
+            "Applying",
+            "Completing",
+            "Scheduled",
+            "AutoReviewing",
+            "AutoReviewed",
+            "Starting"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewScheduleDefinitionStatus",
+            "modelAsString": true
+          }
+        },
+        "descriptionForAdmins": {
+          "type": "string",
+          "description": "The description provided by the access review creator and visible to admins."
+        },
+        "descriptionForReviewers": {
+          "type": "string",
+          "description": "The description provided by the access review creator to be shown to reviewers."
+        },
+        "createdBy": {
+          "readOnly": true,
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewActorIdentity",
+          "description": "The user or other identity who created this review."
+        },
+        "settings": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewScheduleSettings",
+          "description": "Access Review Settings."
+        },
+        "scope": {
+          "readOnly": true,
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewScope",
+          "description": "This is used to define what to include in scope of the review. The scope definition includes the resourceId and roleDefinitionId."
+        },
+        "reviewers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AccessReviewReviewer"
+          },
+          "description": "This is the collection of reviewers."
+        }
+      },
+      "description": "Access Review."
+    },
+    "AccessReviewInstance": {
+      "x-ms-azure-resource": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The access review instance id."
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The access review instance name."
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The resource type."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewInstanceProperties",
+          "description": "Access Review properties."
+        }
+      },
+      "description": "Access Review Instance."
+    },
+    "AccessReviewInstanceProperties": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "readOnly": true,
+          "description": "This read-only field specifies the status of an access review instance.",
+          "enum": [
+            "NotStarted",
+            "InProgress",
+            "Completed",
+            "Applied",
+            "Initializing",
+            "Applying",
+            "Completing",
+            "Scheduled",
+            "AutoReviewing",
+            "AutoReviewed",
+            "Starting"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewInstanceStatus",
+            "modelAsString": true
+          }
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to be start.",
+          "x-nullable": false
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to end.",
+          "x-nullable": false
+        }
+      },
+      "description": "Access Review Instance properties."
+    },
+    "AccessReviewScheduleSettings": {
+      "properties": {
+        "mailNotificationsEnabled": {
+          "type": "boolean",
+          "description": "Flag to indicate whether sending mails to reviewers and the review creator is enabled."
+        },
+        "reminderNotificationsEnabled": {
+          "type": "boolean",
+          "description": "Flag to indicate whether sending reminder emails to reviewers are enabled."
+        },
+        "defaultDecisionEnabled": {
+          "type": "boolean",
+          "description": "Flag to indicate whether reviewers are required to provide a justification when reviewing access."
+        },
+        "justificationRequiredOnApproval": {
+          "type": "boolean",
+          "description": "Flag to indicate whether the reviewer is required to pass justification when recording a decision."
+        },
+        "defaultDecision": {
+          "type": "string",
+          "description": "This specifies the behavior for the autoReview feature when an access review completes.",
+          "enum": [
+            "Approve",
+            "Deny",
+            "Recommendation"
+          ],
+          "x-ms-enum": {
+            "name": "DefaultDecisionType",
+            "modelAsString": true
+          }
+        },
+        "autoApplyDecisionsEnabled": {
+          "type": "boolean",
+          "description": "Flag to indicate whether auto-apply capability, to automatically change the target object access resource, is enabled. If not enabled, a user must, after the review completes, apply the access review."
+        },
+        "recommendationsEnabled": {
+          "type": "boolean",
+          "description": "Flag to indicate whether showing recommendations to reviewers is enabled."
+        },
+        "instanceDurationInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The duration in days for an instance."
+        },
+        "recurrence": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewRecurrenceSettings",
+          "description": "Access Review Settings."
+        }
+      },
+      "description": "Settings of an Access Review."
+    },
+    "AccessReviewDefaultSettings": {
+      "x-ms-azure-resource": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The access review default settings id. This is only going to be default"
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The access review default settings name. This is always going to be Access Review Default Settings"
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The resource type."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewScheduleSettings",
+          "description": "Access Review properties."
+        }
+      },
+      "description": "Access Review Default Settings."
+    },
+    "AccessReviewRecurrenceSettings": {
+      "properties": {
+        "pattern": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewRecurrencePattern",
+          "description": "Access Review schedule definition recurrence pattern."
+        },
+        "range": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewRecurrenceRange",
+          "description": "Access Review schedule definition recurrence range."
+        }
+      },
+      "description": "Recurrence Settings of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrencePattern": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The recurrence type : weekly, monthly, etc.",
+          "enum": [
+            "weekly",
+            "absoluteMonthly"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewRecurrencePatternType",
+            "modelAsString": true
+          }
+        },
+        "interval": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The interval for recurrence. For a quarterly review, the interval is 3 for type : absoluteMonthly."
+        }
+      },
+      "description": "Recurrence Pattern of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrenceRange": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The recurrence range type. The possible values are: endDate, noEnd, numbered.",
+          "enum": [
+            "endDate",
+            "noEnd",
+            "numbered"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewRecurrenceRangeType",
+            "modelAsString": true
+          }
+        },
+        "numberOfOccurrences": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of times to repeat the access review. Required and must be positive if type is numbered."
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to be start. This could be a date in the future. Required on create.",
+          "x-nullable": false
+        },
+        "endDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to end. Required if type is endDate",
+          "x-nullable": false
+        }
+      },
+      "description": "Recurrence Range of an Access Review Schedule Definition."
+    },
+    "AccessReviewScope": {
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "ResourceId in which this review is getting created"
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "This is used to indicate the role being reviewed"
+        },
+        "principalType": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The identity type user/servicePrincipal to review",
+          "enum": [
+            "user",
+            "servicePrincipal"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewScopePrincipalType",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "Descriptor for what needs to be reviewed"
+    },
+    "AccessReviewReviewer": {
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The id of the reviewer(user/servicePrincipal)"
+        },
+        "principalType": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The identity type : user/servicePrincipal",
+          "enum": [
+            "user",
+            "servicePrincipal"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewReviewerType",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "Descriptor for what needs to be reviewed"
+    },
+    "AccessReviewDecision": {
+      "x-ms-azure-resource": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The access review decision id."
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The access review decision name."
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The resource type."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewDecisionProperties",
+          "description": "Access Review Decision properties."
+        }
+      },
+      "description": "Access Review."
+    },
+    "AccessReviewDecisionProperties": {
+      "properties": {
+        "target": {
+          "readOnly": true,
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewDecisionTarget",
+          "description": "Target of this decision record. Can be UserDecisionTarget or ServicePrincipalDecisionTarget"
+        },
+        "recommendation": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The feature- generated recommendation shown to the reviewer.",
+          "enum": [
+            "Approve",
+            "Deny",
+            "NoInfoAvailable"
+          ],
+          "x-ms-enum": {
+            "name": "AccessRecommendationType",
+            "modelAsString": true
+          }
+        },
+        "decision": {
+          "type": "string",
+          "description": "The decision on the approval step. This value is initially set to NotReviewed. Approvers can take action of Approve/Deny",
+          "enum": [
+            "Approve",
+            "Deny",
+            "NotReviewed",
+            "DontKnow",
+            "NotNotified"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewResult",
+            "modelAsString": true
+          }
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justification provided by approvers for their action"
+        },
+        "reviewedDateTime": {
+          "type": "string",
+          "readOnly": true,
+          "format": "date-time",
+          "description": "Date Time when a decision was taken.",
+          "x-nullable": false
+        },
+        "reviewedBy": {
+          "readOnly": true,
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewActorIdentity",
+          "description": "Details of the approver."
+        },
+        "applyResult": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The outcome of applying the decision.",
+          "enum": [
+            "New",
+            "Applying",
+            "AppliedSuccessfully",
+            "AppliedWithUnknownFailure",
+            "AppliedSuccessfullyButObjectNotFound",
+            "ApplyNotSupported"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewApplyResult",
+            "modelAsString": true
+          }
+        },
+        "appliedDateTime": {
+          "type": "string",
+          "readOnly": true,
+          "format": "date-time",
+          "description": "The date and time when the review decision was applied.",
+          "x-nullable": false
+        },
+        "appliedBy": {
+          "readOnly": true,
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AccessReviewActorIdentity",
+          "description": "Details of the approver."
+        }
+      },
+      "description": "Approval Step."
+    },
+    "AccessReviewDecisionTarget": {
+      "discriminator": "type",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of decision target : User/ServicePrincipal",
+          "enum": [
+            "user",
+            "servicePrincipal"
+          ],
+          "x-ms-enum": {
+            "name": "DecisionTargetType",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "Target of the decision."
+    },
+    "UserDecisionTarget": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AccessReviewDecisionTarget"
+        },
+        {
+          "type": "object",
+          "description": "UserDecisionTarget"
+        }
+      ],
+      "x-ms-discriminator-value": "user",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The id of user whose access was reviewed."
+        },
+        "principalName": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The display name of the user whose access was reviewed."
+        },
+        "userPrincipalName": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The user principal name of the user whose access was reviewed."
+        }
+      },
+      "description": "User Decision Target"
+    },
+    "ServicePrincipalDecisionTarget": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AccessReviewDecisionTarget"
+        },
+        {
+          "type": "object",
+          "description": "ServicePrincipalDecisionTarget"
+        }
+      ],
+      "x-ms-discriminator-value": "servicePrincipal",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The id of service principal whose access is reviewed."
+        },
+        "principalName": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The display name of the service principal whose access was reviewed."
+        },
+        "appId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The appId for the service principal entity being reviewed"
+        }
+      },
+      "description": "Service Principal Decision Target"
+    },
+    "AccessReviewActorIdentity": {
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The identity id"
+        },
+        "principalType": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The identity type : user/servicePrincipal",
+          "enum": [
+            "user",
+            "servicePrincipal"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewActorIdentityType",
+            "modelAsString": true
+          }
+        },
+        "principalName": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The identity display name"
+        },
+        "userPrincipalName": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The user principal name(if valid)"
+        }
+      },
+      "description": "Details of the actor identity"
+    },
+    "AccessReviewScheduleDefinitionListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AccessReviewScheduleDefinition"
+          },
+          "description": "Access Review Schedule Definition list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "List of Access Review Schedule Definitions."
+    },
+    "AccessReviewInstanceListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AccessReviewInstance"
+          },
+          "description": "Access Review Instance list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "List of Access Review Instances."
+    },
+    "AccessReviewDecisionListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AccessReviewDecision"
+          },
+          "description": "Access Review Decision list."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "List of access review decisions."
+    },
+    "ErrorDefinition": {
+      "type": "object",
+      "title": "Error",
+      "description": "Error description and code explaining why an operation failed.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorDefinitionProperties",
+          "description": "Error of the list gateway status."
+        }
+      }
+    },
+    "ErrorDefinitionProperties": {
+      "type": "object",
+      "title": "Error",
+      "description": "Error description and code explaining why an operation failed.",
+      "properties": {
+        "message": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Description of the error."
+        },
+        "code": {
+          "type": "string",
+          "description": "Error code of list gateway."
+        }
+      }
+    },
+    "Operation": {
+      "description": "The definition of a Microsoft.Authorization operation.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Operation name: {provider}/{resource}/{operation}.",
+          "type": "string",
+          "readOnly": true
+        },
+        "display": {
+          "readOnly": true,
+          "$ref": "#/definitions/OperationDisplay",
+          "description": "The display information for the Microsoft.Authorization operation."
+        }
+      }
+    },
+    "OperationDisplay": {
+      "description": "The display information for a Microsoft.Authorization operation.",
+      "type": "object",
+      "properties": {
+        "provider": {
+          "description": "The resource provider name: Microsoft.Authorization.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resource": {
+          "description": "The resource on which the operation is performed.",
+          "type": "string",
+          "readOnly": true
+        },
+        "operation": {
+          "description": "The operation that users can perform.",
+          "type": "string",
+          "readOnly": true
+        },
+        "description": {
+          "description": "The description for the operation.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "OperationListResult": {
+      "description": "The result of a request to list Microsoft.Authorization operations.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The collection value.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "nextLink": {
+          "description": "The URI that can be used to request the next set of paged results.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The ID of the target subscription."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The API version to be used with the HTTP request."
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/authorization-AccessReviewCalls.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/authorization-AccessReviewCalls.json
@@ -691,6 +691,341 @@
           }
         }
       }
+    },
+    "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions": {
+      "get": {
+        "tags": [
+          "GetAccessReviewScheduleDefinitionsAssignedForMyApproval"
+        ],
+        "operationId": "AccessReviewScheduleDefinitionsAssignedForMyApproval_List",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/GetAccessReviewScheduleDefinitionsAssignedForMyApproval.json"
+          }
+        },
+        "description": "Get access review instances assigned for my approval.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewScheduleDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances": {
+      "get": {
+        "tags": [
+          "GetAccessReviewInstancesAssignedForMyApproval"
+        ],
+        "operationId": "AccessReviewInstancesAssignedForMyApproval_List",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/GetAccessReviewInstancesAssignedForMyApproval.json"
+          }
+        },
+        "description": "Get access review instances assigned for my approval.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewInstanceListResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}": {
+      "get": {
+        "tags": [
+          "GetAccessReviewInstance"
+        ],
+        "operationId": "AccessReviewInstancesAssignedForMyApproval_GetById",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/GetAccessReviewInstanceAssignedForMyApproval.json"
+          }
+        },
+        "description": "Get single access review instance assigned for my approval.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewInstance"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}/acceptRecommendations": {
+      "post": {
+        "tags": [
+          "AccessReviewInstanceAcceptRecommmendations"
+        ],
+        "operationId": "AccessReviewInstance_AcceptRecommendations",
+        "x-ms-examples": {
+          "GetAccessReview": {
+            "$ref": "./examples/AccessReviewInstanceAcceptRecommendations.json"
+          }
+        },
+        "description": "An action to accept recommendations for decision in an access review instance.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Describe the result of a successful operation."
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}/decisions": {
+      "get": {
+        "tags": [
+          "GetAccessReviewMyInstanceDecisions"
+        ],
+        "operationId": "AccessReviewInstanceMyDecisions_List",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/GetAccessReviewInstanceMyDecisions.json"
+          }
+        },
+        "description": "Get my access review instance decisions.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewDecisionListResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/{scheduleDefinitionId}/instances/{id}/decisions/{decisionId}": {
+      "get": {
+        "tags": [
+          "GetAccessReviewMyInstanceDecision"
+        ],
+        "operationId": "AccessReviewInstanceMyDecisions_GetById",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/GetAccessReviewInstanceMyDecisionById.json"
+          }
+        },
+        "description": "Get my single access review instance decision.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "name": "decisionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the decision record."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewDecision"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "PatchAccessReviewMyInstanceDecision"
+        ],
+        "operationId": "AccessReviewInstanceMyDecisions_Patch",
+        "x-ms-examples": {
+          "GetAccessReviews": {
+            "$ref": "./examples/PatchAccessReviewInstanceMyDecisionById.json"
+          }
+        },
+        "description": "Record a decision.",
+        "parameters": [
+          {
+            "name": "scheduleDefinitionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review schedule definition."
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the access review instance."
+          },
+          {
+            "name": "decisionId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The id of the decision record."
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AccessReviewDecisionProperties"
+            },
+            "description": "Access review decision properties to patch."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describe the result of a successful operation.",
+            "schema": {
+              "$ref": "#/definitions/AccessReviewDecision"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorDefinition"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -779,6 +1114,27 @@
             "$ref": "#/definitions/AccessReviewReviewer"
           },
           "description": "This is the collection of reviewers."
+        },
+        "reviewersType": {
+          "type": "string",
+          "readOnly": true,
+          "description": "This field specifies the type of reviewers for a review. Usually for a review, reviewers are explicitly assigned. However, in some cases, the reviewers may not be assigned and instead be chosen dynamically. For example managers review or self review.",
+          "enum": [
+            "Assigned",
+            "Self",
+            "Managers"
+          ],
+          "x-ms-enum": {
+            "name": "AccessReviewScheduleDefinitionReviewersType",
+            "modelAsString": true
+          }
+        },
+        "instances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AccessReviewInstance"
+          },
+          "description": "This is the collection of instances returned when one does an expand on it."
         }
       },
       "description": "Access Review."
@@ -1355,14 +1711,20 @@
       "type": "object",
       "properties": {
         "name": {
-          "description": "Operation name: {provider}/{resource}/{operation}.",
-          "type": "string",
-          "readOnly": true
+          "description": "Name of the operation",
+          "type": "string"
+        },
+        "isDataAction": {
+          "description": "Indicates whether the operation is a data action",
+          "type": "boolean"
         },
         "display": {
-          "readOnly": true,
           "$ref": "#/definitions/OperationDisplay",
-          "description": "The display information for the Microsoft.Authorization operation."
+          "description": "Display of the operation"
+        },
+        "origin": {
+          "description": "Origin of the operation",
+          "type": "string"
         }
       }
     },

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/AccessReviewInstanceAcceptRecommendations.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/AccessReviewInstanceAcceptRecommendations.json
@@ -1,0 +1,10 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "scheduleDefinitionId": "488a6d0e-0a63-4946-86e3-1f5bbc934661",
+    "id": "d9b9e056-7004-470b-bf21-1635e98487da"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/AccessReviewInstanceApplyDecisions.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/AccessReviewInstanceApplyDecisions.json
@@ -1,0 +1,11 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "id": "d9b9e056-7004-470b-bf21-1635e98487da"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/AccessReviewInstanceResetDecisions.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/AccessReviewInstanceResetDecisions.json
@@ -1,0 +1,11 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "id": "d9b9e056-7004-470b-bf21-1635e98487da"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/AccessReviewInstanceSendReminders.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/AccessReviewInstanceSendReminders.json
@@ -1,0 +1,11 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "id": "d9b9e056-7004-470b-bf21-1635e98487da"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/DeleteAccessReviewScheduleDefinition.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/DeleteAccessReviewScheduleDefinition.json
@@ -1,0 +1,11 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewDefaultSettings.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewDefaultSettings.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/accessReviewSettings/default",
+        "type": "Microsoft.Authorization/accessReviewSettings",
+        "name": "default",
+        "properties": {
+          "mailNotificationsEnabled": true,
+          "reminderNotificationsEnabled": true,
+          "justificationRequiredOnApproval": true,
+          "recommendationsEnabled": true,
+          "instanceDurationInDays": 30,
+          "recurrence": {
+            "range": {
+              "type": "endDate",
+              "numberOfOccurrences": 1,
+              "startDate": "2018-08-03T21:02:30.667Z",
+              "endDate": "2018-08-03T21:17:30.513Z"
+            }
+          },
+          "defaultDecisionEnabled": true,
+          "defaultDecision": "Approve",
+          "autoApplyDecisionsEnabled": true
+        }
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstance.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstance.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "id": "4135f961-be78-4005-8101-c72a5af307a2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/instances/4135f961-be78-4005-8101-c72a5af307a2",
+        "type": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances",
+        "name": "4135f961-be78-4005-8101-c72a5af307a2",
+        "properties": {
+          "status": "Applied",
+          "startDateTime": "2018-08-03T21:02:30.667Z",
+          "endDateTime": "2018-08-03T21:17:30.513Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstanceAssignedForMyApproval.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstanceAssignedForMyApproval.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "scheduleDefinitionId": "488a6d0e-0a63-4946-86e3-1f5bbc934661",
+    "id": "4135f961-be78-4005-8101-c72a5af307a2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/488a6d0e-0a63-4946-86e3-1f5bbc934661/instances/4135f961-be78-4005-8101-c72a5af307a2",
+        "type": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances",
+        "name": "4135f961-be78-4005-8101-c72a5af307a2",
+        "properties": {
+          "status": "Applied",
+          "startDateTime": "2018-08-03T21:02:30.667Z",
+          "endDateTime": "2018-08-03T21:17:30.513Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstanceDecisions.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstanceDecisions.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "265785a7-a81f-4201-8a18-bb0db95982b7",
+    "id": "f25ed880-9c31-4101-bc57-825d8df3b58c"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/instances/f8882fec-7d56-4e97-ad6d-5e3f4557971d/decisions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+            "type": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions",
+            "name": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+            "properties": {
+              "reviewedBy": {
+                "principalType": "user",
+                "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+                "principalName": "Shubham Gupta",
+                "userPrincipalName": "shugup@microsoft.com"
+              },
+              "reviewedDateTime": "2018-08-03T21:02:30.667Z",
+              "decision": "Deny",
+              "justification": "This person has left this team",
+              "appliedBy": {
+                "principalType": "user",
+                "principalId": "36777fc8-4ec2-49ea-a56c-cec0bd47d83a",
+                "principalName": "Amit Ghosh",
+                "userPrincipalName": "amitgho@microsoft.com"
+              },
+              "appliedDateTime": "2018-10-03T21:02:30.667Z",
+              "applyResult": "Success",
+              "recommendation": "Deny",
+              "target": {
+                "type": "user",
+                "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+                "principalName": "Shubham Gupta",
+                "userPrincipalName": "shugup@microsoft.com"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstanceMyDecisionById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstanceMyDecisionById.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "id": "4135f961-be78-4005-8101-c72a5af307a2",
+    "scheduleDefinitionId": "488a6d0e-0a63-4946-86e3-1f5bbc934661",
+    "decisionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/488a6d0e-0a63-4946-86e3-1f5bbc934661/instances/4135f961-be78-4005-8101-c72a5af307a2/decisions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+        "type": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions",
+        "name": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+        "properties": {
+          "reviewedBy": {
+            "principalType": "user",
+            "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+            "principalName": "Shubham Gupta",
+            "userPrincipalName": "shugup@microsoft.com"
+          },
+          "reviewedDateTime": "2018-08-03T21:02:30.667Z",
+          "decision": "Deny",
+          "justification": "This person has left this team",
+          "appliedBy": {
+            "principalType": "user",
+            "principalId": "36777fc8-4ec2-49ea-a56c-cec0bd47d83a",
+            "principalName": "Amit Ghosh",
+            "userPrincipalName": "amitgho@microsoft.com"
+          },
+          "appliedDateTime": "2018-10-03T21:02:30.667Z",
+          "applyResult": "Success",
+          "recommendation": "Deny",
+          "target": {
+            "type": "user",
+            "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+            "principalName": "Shubham Gupta",
+            "userPrincipalName": "shugup@microsoft.com"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstanceMyDecisions.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstanceMyDecisions.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "scheduleDefinitionId": "488a6d0e-0a63-4946-86e3-1f5bbc934661",
+    "id": "4135f961-be78-4005-8101-c72a5af307a2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/488a6d0e-0a63-4946-86e3-1f5bbc934661/instances/4135f961-be78-4005-8101-c72a5af307a2/decisions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+            "type": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions",
+            "name": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+            "properties": {
+              "reviewedBy": {
+                "principalType": "user",
+                "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+                "principalName": "Shubham Gupta",
+                "userPrincipalName": "shugup@microsoft.com"
+              },
+              "reviewedDateTime": "2018-08-03T21:02:30.667Z",
+              "decision": "Deny",
+              "justification": "This person has left this team",
+              "appliedBy": {
+                "principalType": "user",
+                "principalId": "36777fc8-4ec2-49ea-a56c-cec0bd47d83a",
+                "principalName": "Amit Ghosh",
+                "userPrincipalName": "amitgho@microsoft.com"
+              },
+              "appliedDateTime": "2018-10-03T21:02:30.667Z",
+              "applyResult": "Success",
+              "recommendation": "Deny",
+              "target": {
+                "type": "user",
+                "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+                "principalName": "Shubham Gupta",
+                "userPrincipalName": "shugup@microsoft.com"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstances.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstances.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "265785a7-a81f-4201-8a18-bb0db95982b7"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/instances/4135f961-be78-4005-8101-c72a5af307a2",
+            "type": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances",
+            "name": "4135f961-be78-4005-8101-c72a5af307a2",
+            "properties": {
+              "status": "Applied",
+              "startDateTime": "2018-08-03T21:02:30.667Z",
+              "endDateTime": "2018-08-03T21:17:30.513Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstancesAssignedForMyApproval.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewInstancesAssignedForMyApproval.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "scheduleDefinitionId": "488a6d0e-0a63-4946-86e3-1f5bbc934661"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/488a6d0e-0a63-4946-86e3-1f5bbc934661/instances/4135f961-be78-4005-8101-c72a5af307a2",
+            "type": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances",
+            "name": "4135f961-be78-4005-8101-c72a5af307a2",
+            "properties": {
+              "status": "Applied",
+              "startDateTime": "2018-08-03T21:02:30.667Z",
+              "endDateTime": "2018-08-03T21:17:30.513Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewScheduleDefinition.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewScheduleDefinition.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+        "type": "Microsoft.Authorization/accessReviewScheduleDefinitions",
+        "name": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+        "properties": {
+          "displayName": "Hello world",
+          "status": "InProgress",
+          "descriptionForAdmins": "asdfasdf",
+          "descriptionForReviewers": "asdfasdf",
+          "createdBy": {
+            "principalType": "user",
+            "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+            "principalName": "Shubham Gupta",
+            "userPrincipalName": "shugup@microsoft.com"
+          },
+          "scope": {
+            "resourceId": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+            "roleDefinitionId": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/roleDefinitions/b225c7ff-4338-4cdc-a790-6b34d987f7cd"
+          },
+          "reviewers": [
+            {
+              "principalId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d ",
+              "principalType": "user"
+            }
+          ],
+          "settings": {
+            "mailNotificationsEnabled": true,
+            "reminderNotificationsEnabled": true,
+            "justificationRequiredOnApproval": true,
+            "recommendationsEnabled": true,
+            "instanceDurationInDays": 30,
+            "recurrence": {
+              "range": {
+                "type": "endDate",
+                "numberOfOccurrences": 1,
+                "startDate": "2018-08-03T21:02:30.667Z",
+                "endDate": "2018-08-03T21:17:30.513Z"
+              }
+            },
+            "defaultDecisionEnabled": true,
+            "defaultDecision": "Approve",
+            "autoApplyDecisionsEnabled": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewScheduleDefinition.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewScheduleDefinition.json
@@ -31,6 +31,7 @@
               "principalType": "user"
             }
           ],
+          "reviewersType": "Assigned",
           "settings": {
             "mailNotificationsEnabled": true,
             "reminderNotificationsEnabled": true,

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewScheduleDefinitions.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewScheduleDefinitions.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+            "type": "Microsoft.Authorization/accessReviewScheduleDefinitions",
+            "name": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+            "properties": {
+              "displayName": "Hello world",
+              "status": "InProgress",
+              "descriptionForAdmins": "asdfasdf",
+              "descriptionForReviewers": "asdfasdf",
+              "createdBy": {
+                "principalType": "user",
+                "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+                "principalName": "Shubham Gupta",
+                "userPrincipalName": "shugup@microsoft.com"
+              },
+              "scope": {
+                "resourceId": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+                "roleDefinitionId": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/roleDefinitions/b225c7ff-4338-4cdc-a790-6b34d987f7cd"
+              },
+              "reviewers": [
+                {
+                  "principalId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d ",
+                  "principalType": "user"
+                }
+              ],
+              "settings": {
+                "mailNotificationsEnabled": true,
+                "reminderNotificationsEnabled": true,
+                "justificationRequiredOnApproval": true,
+                "recommendationsEnabled": true,
+                "instanceDurationInDays": 30,
+                "recurrence": {
+                  "range": {
+                    "type": "endDate",
+                    "numberOfOccurrences": 1,
+                    "startDate": "2018-08-03T21:02:30.667Z",
+                    "endDate": "2018-08-03T21:17:30.513Z"
+                  }
+                },
+                "defaultDecisionEnabled": true,
+                "defaultDecision": "Approve",
+                "autoApplyDecisionsEnabled": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewScheduleDefinitionsAssignedForMyApproval.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/GetAccessReviewScheduleDefinitionsAssignedForMyApproval.json
@@ -1,14 +1,13 @@
 {
   "parameters": {
-    "api-version": "2018-05-01-preview",
-    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d"
+    "api-version": "2018-05-01-preview"
   },
   "responses": {
     "200": {
       "body": {
         "value": [
           {
-            "id": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+            "id": "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
             "type": "Microsoft.Authorization/accessReviewScheduleDefinitions",
             "name": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
             "properties": {
@@ -50,7 +49,19 @@
                 "defaultDecisionEnabled": true,
                 "defaultDecision": "Approve",
                 "autoApplyDecisionsEnabled": true
-              }
+              },
+              "instances": [
+                {
+                  "id": "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/488a6d0e-0a63-4946-86e3-1f5bbc934661/instances/4135f961-be78-4005-8101-c72a5af307a2",
+                  "type": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances",
+                  "name": "4135f961-be78-4005-8101-c72a5af307a2",
+                  "properties": {
+                    "status": "Applied",
+                    "startDateTime": "2018-08-03T21:02:30.667Z",
+                    "endDateTime": "2018-08-03T21:17:30.513Z"
+                  }
+                }
+              ]
             }
           }
         ]

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/PatchAccessReviewInstanceMyDecisionById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/PatchAccessReviewInstanceMyDecisionById.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "scheduleDefinitionId": "488a6d0e-0a63-4946-86e3-1f5bbc934661",
+    "id": "4135f961-be78-4005-8101-c72a5af307a2",
+    "decisionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "properties": {},
+    "body": {
+      "properties": {
+        "decision": "Approve",
+        "justification": "I trust this person."
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/488a6d0e-0a63-4946-86e3-1f5bbc934661/instances/4135f961-be78-4005-8101-c72a5af307a2/decisions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+        "type": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions",
+        "name": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+        "properties": {
+          "reviewedBy": {
+            "principalType": "user",
+            "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+            "principalName": "Shubham Gupta",
+            "userPrincipalName": "shugup@microsoft.com"
+          },
+          "reviewedDateTime": "2018-08-03T21:02:30.667Z",
+          "decision": "Deny",
+          "justification": "This person has left this team",
+          "appliedBy": {
+            "principalType": "user",
+            "principalId": "36777fc8-4ec2-49ea-a56c-cec0bd47d83a",
+            "principalName": "Amit Ghosh",
+            "userPrincipalName": "amitgho@microsoft.com"
+          },
+          "appliedDateTime": "2018-10-03T21:02:30.667Z",
+          "applyResult": "Success",
+          "recommendation": "Deny",
+          "target": {
+            "type": "user",
+            "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+            "principalName": "Shubham Gupta",
+            "userPrincipalName": "shugup@microsoft.com"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/PutAccessReviewDefaultSettings.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/PutAccessReviewDefaultSettings.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "id": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "properties": {},
+    "body": {
+      "properties": {
+        "mailNotificationsEnabled": true,
+        "remindersEnabled": true,
+        "justificationRequiredOnApproval": true,
+        "accessRecommendationsEnabled": true,
+        "recurrenceSettings": {
+          "recurrenceType": "weekly",
+          "recurrenceEndType": "never",
+          "durationInDays": 5,
+          "recurrenceCount": 0
+        },
+        "autoReviewEnabled": true,
+        "autoReviewNotReviewedResult": "Approve",
+        "autoApplyReviewResultsEnabled": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/accessReviewSettings/default",
+        "type": "Microsoft.Authorization/accessReviewSettings",
+        "name": "default",
+        "properties": {
+          "mailNotificationsEnabled": true,
+          "reminderNotificationsEnabled": true,
+          "justificationRequiredOnApproval": true,
+          "recommendationsEnabled": true,
+          "instanceDurationInDays": 30,
+          "recurrence": {
+            "range": {
+              "type": "endDate",
+              "numberOfOccurrences": 1,
+              "startDate": "2018-08-03T21:02:30.667Z",
+              "endDate": "2018-08-03T21:17:30.513Z"
+            }
+          },
+          "defaultDecisionEnabled": true,
+          "defaultDecision": "Approve",
+          "autoApplyDecisionsEnabled": true
+        }
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/PutAccessReviewScheduleDefinition.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/PutAccessReviewScheduleDefinition.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "properties": {},
+    "body": {
+      "properties": {
+        "displayName": "Hello world",
+        "status": "InProgress",
+        "descriptionForAdmins": "asdfasdf",
+        "descriptionForReviewers": "asdfasdf",
+        "createdBy": {
+          "principalType": "user",
+          "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+          "principalName": "Shubham Gupta",
+          "userPrincipalName": "shugup@microsoft.com"
+        },
+        "scope": {
+          "resourceId": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+          "roleDefinitionId": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/roleDefinitions/b225c7ff-4338-4cdc-a790-6b34d987f7cd"
+        },
+        "reviewers": [
+          {
+            "principalId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d ",
+            "principalType": "user"
+          }
+        ],
+        "settings": {
+          "mailNotificationsEnabled": true,
+          "reminderNotificationsEnabled": true,
+          "justificationRequiredOnApproval": true,
+          "recommendationsEnabled": true,
+          "instanceDurationInDays": 30,
+          "recurrence": {
+            "range": {
+              "type": "endDate",
+              "numberOfOccurrences": 1,
+              "startDate": "2018-08-03T21:02:30.667Z",
+              "endDate": "2018-08-03T21:17:30.513Z"
+            }
+          },
+          "defaultDecisionEnabled": true,
+          "defaultDecision": "Approve",
+          "autoApplyDecisionsEnabled": true
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/accessReviewScheduleDefinitions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+        "type": "Microsoft.Authorization/accessReviewScheduleDefinitions",
+        "name": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+        "properties": {
+          "displayName": "Hello world",
+          "status": "InProgress",
+          "descriptionForAdmins": "asdfasdf",
+          "descriptionForReviewers": "asdfasdf",
+          "createdBy": {
+            "principalType": "user",
+            "principalId": "a6c7aecb-cbfd-4763-87ef-e91b4bd509d9",
+            "principalName": "Shubham Gupta",
+            "userPrincipalName": "shugup@microsoft.com"
+          },
+          "scope": {
+            "resourceId": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+            "roleDefinitionId": "/subscriptions/fa73e90b-5bf1-45fd-a182-35ce5fc0674d/providers/Microsoft.Authorization/roleDefinitions/b225c7ff-4338-4cdc-a790-6b34d987f7cd"
+          },
+          "reviewers": [
+            {
+              "principalId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d ",
+              "principalType": "user"
+            }
+          ],
+          "settings": {
+            "mailNotificationsEnabled": true,
+            "reminderNotificationsEnabled": true,
+            "justificationRequiredOnApproval": true,
+            "recommendationsEnabled": true,
+            "instanceDurationInDays": 30,
+            "recurrence": {
+              "range": {
+                "type": "endDate",
+                "numberOfOccurrences": 1,
+                "startDate": "2018-08-03T21:02:30.667Z",
+                "endDate": "2018-08-03T21:17:30.513Z"
+              }
+            },
+            "defaultDecisionEnabled": true,
+            "defaultDecision": "Approve",
+            "autoApplyDecisionsEnabled": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/PutAccessReviewScheduleDefinition.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/PutAccessReviewScheduleDefinition.json
@@ -26,6 +26,7 @@
             "principalType": "user"
           }
         ],
+        "reviewersType": "Assigned",
         "settings": {
           "mailNotificationsEnabled": true,
           "reminderNotificationsEnabled": true,
@@ -74,6 +75,7 @@
               "principalType": "user"
             }
           ],
+          "reviewersType": "Assigned",
           "settings": {
             "mailNotificationsEnabled": true,
             "reminderNotificationsEnabled": true,

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/StopAccessReviewInstance.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/StopAccessReviewInstance.json
@@ -1,0 +1,11 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "id": "d9b9e056-7004-470b-bf21-1635e98487da"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/StopAccessReviewScheduleDefinition.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/preview/2018-05-01-preview/examples/StopAccessReviewScheduleDefinition.json
@@ -1,0 +1,10 @@
+{
+  "parameters": {
+    "api-version": "2018-05-01-preview",
+    "subscriptionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d",
+    "scheduleDefinitionId": "fa73e90b-5bf1-45fd-a182-35ce5fc0674d"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/authorization/resource-manager/readme.azureresourceschema.md
+++ b/specification/authorization/resource-manager/readme.azureresourceschema.md
@@ -13,6 +13,7 @@ batch:
   - tag: schema-authorization-2017-10-01-preview
   - tag: schema-authorization-2015-07-01
   - tag: schema-authorization-2015-06-01
+  - tag: schema-authorization-2018-05-01-preview
 
 ```
 
@@ -48,6 +49,17 @@ output-folder: $(azureresourceschema-folder)/schemas
 # all the input files in this apiVersion
 input-file:
   - Microsoft.Authorization/preview/2018-07-01-preview/authorization-DenyAssignmentGetCalls.json
+
+```
+
+### Tag: schema-authorization-2018-05-01-preview and azureresourceschema
+
+``` yaml $(tag) == 'schema-authorization-2018-05-01-preview' && $(azureresourceschema)
+output-folder: $(azureresourceschema-folder)/schemas
+
+# all the input files in this apiVersion
+input-file:
+  - Microsoft.Authorization/preview/2018-05-01-preview/authorization-AccessReviewCalls.json
 
 ```
 

--- a/specification/authorization/resource-manager/readme.java.md
+++ b/specification/authorization/resource-manager/readme.java.md
@@ -47,6 +47,19 @@ regenerate-manager: true
 generate-interface: true
 ```
 
+### Tag: package-2018-05-01-preview-only and java
+
+These settings apply only when `--tag=package-2018-05-01-preview-only --java` is specified on he command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+``` yaml $(tag) == 'package-2018-05-01-preview-only' && $(java) && $(multiapi)
+java:
+  namespace: com.microsoft.azure.management.authorization.v2018_05_01_preview
+  output-folder: $(azure-libraries-for-java-folder)/sdk/authorization/mgmt-v2018_05_01_preview
+regenerate-manager: true
+generate-interface: true
+```
+
 ### Tag: package-2015-07-01 and java
 
 These settings apply only when `--tag=package-2015-07-01 --java` is specified on he command line.

--- a/specification/authorization/resource-manager/readme.java.md
+++ b/specification/authorization/resource-manager/readme.java.md
@@ -19,6 +19,7 @@ batch:
   - tag: package-2018-09-01-preview
   - tag: package-2018-07-01-preview-only
   - tag: package-2015-06-01-preview
+  - tag: package-2018-05-01-preview
 ```
 
 ### Tag: package-2018-09-01-preview and java
@@ -47,12 +48,12 @@ regenerate-manager: true
 generate-interface: true
 ```
 
-### Tag: package-2018-05-01-preview-only and java
+### Tag: package-2018-05-01-preview and java
 
-These settings apply only when `--tag=package-2018-05-01-preview-only --java` is specified on he command line.
+These settings apply only when `--tag=package-2018-05-01-preview --java` is specified on he command line.
 Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
 
-``` yaml $(tag) == 'package-2018-05-01-preview-only' && $(java) && $(multiapi)
+``` yaml $(tag) == 'package-2018-05-01-preview' && $(java) && $(multiapi)
 java:
   namespace: com.microsoft.azure.management.authorization.v2018_05_01_preview
   output-folder: $(azure-libraries-for-java-folder)/sdk/authorization/mgmt-v2018_05_01_preview

--- a/specification/authorization/resource-manager/readme.md
+++ b/specification/authorization/resource-manager/readme.md
@@ -35,6 +35,8 @@ tag: package-2020-04-preview
 directive:
   - suppress: OperationsAPIImplementation
     reason: we do have a operations api as "/providers/Microsoft.Authorization/operations"
+  - suppress: TopLevelResourcesListByResourceGroup
+    reason: proxy resources don't require list by resource group(Suppresion confirmed by API council)
   - suppress: OperationIdNounConflictingModelNames
     where: '$.paths["/providers/Microsoft.Authorization/providerOperations/{resourceProviderNamespace}"].get.operationId'
     from: authorization-ProviderOperationsCalls.json
@@ -190,6 +192,15 @@ input-file:
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-RoleAssignmentsCalls.json
 - Microsoft.Authorization/preview/2018-01-01-preview/authorization-RoleDefinitionsCalls.json
 - Microsoft.Authorization/preview/2018-07-01-preview/authorization-DenyAssignmentGetCalls.json
+```
+
+### Tag: package-2018-05-01-preview
+
+These settings apply only when `--tag=package-2018-05-01-preview` is specified on the command line.
+
+``` yaml $(tag) == 'package-2018-05-01-preview'
+input-file:
+- Microsoft.Authorization/preview/2018-05-01-preview/authorization-AccessReviewCalls.json
 ```
 
 ### Tag: package-2018-09-01-preview

--- a/specification/authorization/resource-manager/readme.python.md
+++ b/specification/authorization/resource-manager/readme.python.md
@@ -27,6 +27,7 @@ batch:
   - tag: package-2018-01-01-preview-only
   - tag: package-2015-07-01
   - tag: package-2015-06-01-preview
+  - tag: package-2018-05-01-preview-only
 ```
 
 ### Tag: package-2020-04-01-preview-only and python
@@ -57,6 +58,16 @@ These settings apply only when `--tag=package-2018-07-01-preview-only --python` 
 python:
   namespace: azure.mgmt.authorization.v2018_07_01_preview
   output-folder: $(python-sdks-folder)/authorization/azure-mgmt-authorization/azure/mgmt/authorization/v2018_07_01_preview
+```
+
+### Tag: package-2018-05-01-preview-only and python
+
+These settings apply only when `--tag=package-2018-05-01-preview-only --python` is specified on the command line.
+
+``` yaml $(tag) == 'package-2018-05-01-preview-only' && $(python)
+python:
+  namespace: azure.mgmt.authorization.v2018_05_01_preview
+  output-folder: $(python-sdks-folder)/authorization/azure-mgmt-authorization/azure/mgmt/authorization/v2018_05_01_preview
 ```
 
 ### Tag: package-2018-01-01-preview-only and python

--- a/specification/authorization/resource-manager/readme.python.md
+++ b/specification/authorization/resource-manager/readme.python.md
@@ -24,10 +24,10 @@ batch:
   - tag: package-2020-04-01-preview-only
   - tag: package-2018-09-01-preview-only
   - tag: package-2018-07-01-preview-only
+  - tag: package-2018-05-01-preview
   - tag: package-2018-01-01-preview-only
   - tag: package-2015-07-01
   - tag: package-2015-06-01-preview
-  - tag: package-2018-05-01-preview-only
 ```
 
 ### Tag: package-2020-04-01-preview-only and python
@@ -60,11 +60,11 @@ python:
   output-folder: $(python-sdks-folder)/authorization/azure-mgmt-authorization/azure/mgmt/authorization/v2018_07_01_preview
 ```
 
-### Tag: package-2018-05-01-preview-only and python
+### Tag: package-2018-05-01-preview and python
 
-These settings apply only when `--tag=package-2018-05-01-preview-only --python` is specified on the command line.
+These settings apply only when `--tag=package-2018-05-01-preview --python` is specified on the command line.
 
-``` yaml $(tag) == 'package-2018-05-01-preview-only' && $(python)
+``` yaml $(tag) == 'package-2018-05-01-preview' && $(python)
 python:
   namespace: azure.mgmt.authorization.v2018_05_01_preview
   output-folder: $(python-sdks-folder)/authorization/azure-mgmt-authorization/azure/mgmt/authorization/v2018_05_01_preview

--- a/specification/authorization/resource-manager/readme.ruby.md
+++ b/specification/authorization/resource-manager/readme.ruby.md
@@ -16,6 +16,7 @@ batch:
   - tag: package-2015-06-01-preview
   - tag: package-2017-10-01-preview-only
   - tag: package-2018-01-01-preview-only
+  - tag: package-2018-05-01-preview-only
 ```
 
 ### Tag: package-2015-07-01 and ruby
@@ -55,5 +56,16 @@ Please also specify `--ruby-sdks-folder=<path to the root directory of your azur
 
 ``` yaml $(tag) == 'package-2018-01-01-preview-only' && $(ruby)
 namespace: "Azure::Authorization::Mgmt::V2018_01_01_preview"
+output-folder: $(ruby-sdks-folder)/management/azure_mgmt_authorization/lib
+```
+
+
+### Tag: package-2018-05-01-preview-only and ruby
+
+These settings apply only when `--tag=package-2018-05-01-preview-only --ruby` is specified on the command line.
+Please also specify `--ruby-sdks-folder=<path to the root directory of your azure-sdk-for-ruby clone>`.
+
+``` yaml $(tag) == 'package-2018-05-01-preview-only' && $(ruby)
+namespace: "Azure::Authorization::Mgmt::V2018_05_01_preview"
 output-folder: $(ruby-sdks-folder)/management/azure_mgmt_authorization/lib
 ```


### PR DESCRIPTION
### Overview
**Note :** There is an existing PR already for the first commit of the changes here: https://github.com/Azure/azure-rest-api-specs/pull/10010. It's already been approved and it's waiting on a deployment. The changes in this PR are an addendum to the existing PR. For the purposes of this PR, please only review the second commit titled "Access Reviews Schema addendum | Expose reviewer and statistics APIs"

The following is an overview of the end to end flow for access reviews scenario.
![image](https://user-images.githubusercontent.com/2281992/90069504-3da39000-dca7-11ea-9273-b21261c0860d.png)

### Changes

So far, we've exposed admin APIs which allow administrators to create review definitions and manage them. Now, we're exposing APIs that a reviewer can call to get all of the access review instances assigned to them. This is exposed as an unauthorized tenant-level API. This tenant-level API lists out all the access review instances assigned to the calling user. The results returned are scoped down to the records where the calling user is an approver. Additionally, the reviewer can drill-down into the decisions for an instance and then record a decision by updating the access review decision record.

There are some additional changes to allow reviewers that are specified dynamically(such as managers) and some statistics APIs are exposed.

### Routes

The existing set of routes are as follows:
**Management APIs**
/subscriptions/{subscriptionId}/Microsoft.Authorization/accessReviewScheduleDefinitions
/subscriptions/{subscriptionId}/Microsoft.Authorization/accessReviewScheduleDefinitions/{id}/instances
/subscriptions/{subscriptionId}/Microsoft.Authorization/accessReviewScheduleDefinitions/{id}/instances/{id}/decisions

The new set of APIs exposed are:

**Reviewer APIs**(Tenant scope and Unauthorized)
/Microsoft.Authorization/accessReviewScheduleDefinitions?$expand=instances&$filter=assignedToMeForReview() and (instances/any(instance: instance/status eq ‘InProgress’)
/Microsoft.Authorization/accessReviewScheduleDefinitions/{id}/instances?$filter=assignedToMeForReview() and status eq ‘InProgress’
/Microsoft.Authorization/accessReviewScheduleDefinitions/{id}/instances/{id}/decisions?$filter=assignedToMeForReview()
/Microsoft.Authorization/accessReviewInstancesAssignedForMyApproval/{id}/decisionStatistics/assignedToMeForReview
/Microsoft.Authorization/accessReviewInstancesAssignedForMyApproval/{id}/acceptRecommendations (POST)

**Management API** : 
/subscriptions/{subscriptionId}/Microsoft.Authorization/accessReviewScheduleDefinitions/{id}/instances/{id}/decisionStatistics/default

