### PR TITLE
[Storage] make queue message body optional

### DIFF
--- a/specification/storage/data-plane/Microsoft.QueueStorage/preview/2018-03-28/queue.json
+++ b/specification/storage/data-plane/Microsoft.QueueStorage/preview/2018-03-28/queue.json
@@ -1799,7 +1799,7 @@
     "QueueMessage": {
       "name": "QueueMessage",
       "in": "body",
-      "required": true,
+      "required": false,
       "schema": {
         "$ref": "#/definitions/QueueMessage"
       },


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/14243 .

The message body is optional parameter. For instance Update API accepts empty body and updates visibility timeout only in such case.

See https://docs.microsoft.com/en-us/rest/api/storageservices/update-message