### PR TITLE
Stricter validation for secret-name

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/secrets.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/secrets.json
@@ -41,7 +41,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "pattern": "^[0-9a-zA-Z-]+$",
+            "pattern": "^[0-9a-zA-Z-]{1,127}$",
             "description": "The name of the secret."
           },
           {
@@ -91,6 +91,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "pattern": "^[0-9a-zA-Z-]{1,127}$",
             "description": "The name of the secret."
           },
           {
@@ -132,6 +133,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "pattern": "^[0-9a-zA-Z-]{1,127}$",
             "description": "The name of the secret."
           },
           {
@@ -188,6 +190,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "pattern": "^[0-9a-zA-Z-]{1,127}$",
             "description": "The name of the secret."
           },
           {
@@ -283,6 +286,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "pattern": "^[0-9a-zA-Z-]{1,127}$",
             "description": "The name of the secret."
           },
           {
@@ -384,6 +388,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "pattern": "^[0-9a-zA-Z-]{1,127}$",
             "description": "The name of the secret."
           },
           {
@@ -423,6 +428,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "pattern": "^[0-9a-zA-Z-]{1,127}$",
             "description": "The name of the secret."
           },
           {
@@ -461,6 +467,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "pattern": "^[0-9a-zA-Z-]{1,127}$",
             "description": "The name of the deleted secret."
           },
           {
@@ -502,6 +509,7 @@
             "in": "path",
             "required": true,
             "type": "string",
+            "pattern": "^[0-9a-zA-Z-]{1,127}$",
             "description": "The name of the secret."
           },
           {


### PR DESCRIPTION
While working on Azure SDK for Go, I was getting cryptic `400 status code` response from API server without a helpful message about why it was failing, ultimately I tracked it to invalid `secret-name`. 

* It would be nice to have stricter validation in swagger for the object `secret-name`. Is this something that's acceptable? 
* I also added `secret-name` validation on all paths, not just one which I feel is super helpful. 

