### PR TITLE
[Anomaly Detector] Fix casing for changepoint URL path

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -275,6 +275,7 @@ certificatesdelete
 Certificatethumbprint
 certverify
 chainer
+changepoint
 changestate
 CHECKACCESS
 checkmark

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/preview/v1.0/AnomalyDetector.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/preview/v1.0/AnomalyDetector.json
@@ -113,7 +113,7 @@
         }
       }
     },
-    "/timeseries/changePoint/detect": {
+    "/timeseries/changepoint/detect": {
       "post": {
         "summary": "Detect change point for the entire series",
         "description": "Evaluate change point score of every series point",


### PR DESCRIPTION
`ChangePointDetect` operation is giving 404 exception. Changing URL path in all lower-case (../changePoint/… ->  ../changepoint/…)  fixes the issue.

Reference doc: https://westus2.dev.cognitive.microsoft.com/docs/services/AnomalyDetector/operations/post-timeseries-changepoint-detect