### PR TITLE
Fix Digital Twins public preview swagger to match service behavior

### DIFF
--- a/specification/digitaltwins/data-plane/Microsoft.DigitalTwins/preview/2020-05-31-preview/digitaltwins.json
+++ b/specification/digitaltwins/data-plane/Microsoft.DigitalTwins/preview/2020-05-31-preview/digitaltwins.json
@@ -48,7 +48,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "201": {
             "description": "Success",
             "schema": {
               "$ref": "#/definitions/NonPagedModelDataCollection"

--- a/specification/digitaltwins/data-plane/Microsoft.DigitalTwins/preview/2020-05-31-preview/examples/ModelAdd.json
+++ b/specification/digitaltwins/data-plane/Microsoft.DigitalTwins/preview/2020-05-31-preview/examples/ModelAdd.json
@@ -31,7 +31,7 @@
     "api-version": "2020-05-31-preview"
   },
   "responses": {
-    "200": {
+    "201": {
       "body": [
         {
           "id": "dtmi:com:example:Sample;1",


### PR DESCRIPTION
Swagger claimed to return 200 when creating models, but the service returns 201