### PR TITLE
Change ResourceLocation property to Location [Do Not Merge]

### DIFF
--- a/specification/cognitiveservices/data-plane/Face/stable/v1.0/Face.json
+++ b/specification/cognitiveservices/data-plane/Face/stable/v1.0/Face.json
@@ -4065,7 +4065,7 @@
           "format": "date-time",
           "description": "A combined UTC date and time string that describes the last time the operation (take or apply a snapshot) is actively migrating data. The lastActionTime will keep increasing until the operation finishes. E.g. 2018-12-25T11:51:27.8705696Z."
         },
-        "resourceLocation": {
+        "location": {
           "type": "string",
           "description": "When the operation succeeds successfully, for snapshot taking operation the snapshot id will be included in this field, and for snapshot applying operation, the path to get the target object will be returned in this field."
         },

--- a/specification/cognitiveservices/data-plane/Face/stable/v1.0/examples/GetSnapshotOperationStatus.json
+++ b/specification/cognitiveservices/data-plane/Face/stable/v1.0/examples/GetSnapshotOperationStatus.json
@@ -11,7 +11,7 @@
         "status": "succeeded",
         "createdTime": "2018-12-25T11:41:02.2331413Z",
         "lastActionTime": "2018-12-25T11:51:27.8705696Z",
-        "resourceLocation": "/snapshots/e58b3f08-1e8b-4165-81df-aa9858f233dc",
+        "location": "/snapshots/e58b3f08-1e8b-4165-81df-aa9858f233dc",
         "message": null
       }
     }


### PR DESCRIPTION
This PR is related to two issues (Both issues are same but raised in two language SDKs):

1. https://github.com/Azure/azure-sdk-for-js/issues/11224 
2. https://github.com/Azure/azure-sdk-for-net/issues/15120 

The issue is, in the Cognitive Services Face API, the service returns the property `location` in the response (This has been confirmed by the HTTP Logs). But, in the swagger response it was mentioned as `resourceLocation`, which is a mistake. So, this PR fixes it. 