### PR TITLE
Added RunAsSystem optional boolean to PowershellCustomizer definition in imagebuilder 2020-02-14 API specification

### DIFF
--- a/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/stable/2020-02-14/examples/CreateImageTemplateWindows.json
+++ b/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/stable/2020-02-14/examples/CreateImageTemplateWindows.json
@@ -33,8 +33,50 @@
           },
           {
             "type": "PowerShell",
+            "name": "PowerShell (inline) Customizer Elevated user Example",
+            "inline": [
+              "Powershell command-1",
+              "Powershell command-2",
+              "Powershell command-3"
+            ],
+            "runElevated": true
+          },
+          {
+            "type": "PowerShell",
+            "name": "PowerShell (inline) Customizer Elevated Local System user Example",
+            "inline": [
+              "Powershell command-1",
+              "Powershell command-2",
+              "Powershell command-3"
+            ],
+            "runElevated": true,
+            "runAsSystem": true
+          },
+          {
+            "type": "PowerShell",
             "name": "PowerShell (script) Customizer Example",
             "scriptUri": "https://example.com/path/to/script.ps1",
+            "validExitCodes": [
+              0,
+              1
+            ]
+          },
+          {
+            "type": "PowerShell",
+            "name": "PowerShell (script) Customizer Elevated Local System user Example",
+            "scriptUri": "https://example.com/path/to/script.ps1",
+            "runElevated": true,
+            "validExitCodes": [
+              0,
+              1
+            ]
+          },
+          {
+            "type": "PowerShell",
+            "name": "PowerShell (script) Customizer Elevated Local System user Example",
+            "scriptUri": "https://example.com/path/to/script.ps1",
+            "runElevated": true,
+            "runAsSystem": true,
             "validExitCodes": [
               0,
               1
@@ -101,9 +143,86 @@
           },
           "customize": [
             {
-              "type": "Shell",
-              "name": "Shell Customizer Example",
-              "scriptUri": "https://example.com/path/to/script.sh"
+              "type": "PowerShell",
+              "name": "PowerShell (inline) Customizer Example",
+              "inline": [
+                "Powershell command-1",
+                "Powershell command-2",
+                "Powershell command-3"
+              ],
+              "runElevated": false,
+              "runAsSystem": false
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (inline) Customizer Elevated user Example",
+              "inline": [
+                "Powershell command-1",
+                "Powershell command-2",
+                "Powershell command-3"
+              ],
+              "runElevated": true,
+              "runAsSystem": false
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (inline) Customizer Elevated Local System user Example",
+              "inline": [
+                "Powershell command-1",
+                "Powershell command-2",
+                "Powershell command-3"
+              ],
+              "runElevated": true,
+              "runAsSystem": true
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (script) Customizer Example",
+              "scriptUri": "https://example.com/path/to/script.ps1",
+              "validExitCodes": [
+                0,
+                1
+              ],
+              "runElevated": false,
+              "runAsSystem": false
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (script) Customizer Elevated Local System user Example",
+              "scriptUri": "https://example.com/path/to/script.ps1",
+              "runElevated": true,
+              "runAsSystem": false,
+              "validExitCodes": [
+                0,
+                1
+              ]
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (script) Customizer Elevated Local System user Example",
+              "scriptUri": "https://example.com/path/to/script.ps1",
+              "runElevated": true,
+              "runAsSystem": true,
+              "validExitCodes": [
+                0,
+                1
+              ]
+            },
+            {
+              "type": "WindowsRestart",
+              "name": "Restart Customizer Example",
+              "restartCommand": "shutdown /f /r /t 0 /c \"packer restart\"",
+              "restartCheckCommand": "powershell -command \"& {Write-Output 'restarted.'}\"",
+              "restartTimeout": "10m"
+            },
+            {
+              "type": "WindowsUpdate",
+              "name": "Windows Update Customizer Example",
+              "searchCriteria": "BrowseOnly=0 and IsInstalled=0",
+              "filters": [
+                "$_.BrowseOnly"
+              ],
+              "updateLimit": 100
             }
           ],
           "distribute": [
@@ -149,9 +268,86 @@
           },
           "customize": [
             {
-              "type": "Shell",
-              "name": "Shell Customizer Example",
-              "scriptUri": "https://example.com/path/to/script.sh"
+              "type": "PowerShell",
+              "name": "PowerShell (inline) Customizer Example",
+              "inline": [
+                "Powershell command-1",
+                "Powershell command-2",
+                "Powershell command-3"
+              ],
+              "runElevated": false,
+              "runAsSystem": false
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (inline) Customizer Elevated user Example",
+              "inline": [
+                "Powershell command-1",
+                "Powershell command-2",
+                "Powershell command-3"
+              ],
+              "runElevated": true,
+              "runAsSystem": false
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (inline) Customizer Elevated Local System user Example",
+              "inline": [
+                "Powershell command-1",
+                "Powershell command-2",
+                "Powershell command-3"
+              ],
+              "runElevated": true,
+              "runAsSystem": true
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (script) Customizer Example",
+              "scriptUri": "https://example.com/path/to/script.ps1",
+              "validExitCodes": [
+                0,
+                1
+              ],
+              "runElevated": false,
+              "runAsSystem": false
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (script) Customizer Elevated Local System user Example",
+              "scriptUri": "https://example.com/path/to/script.ps1",
+              "runElevated": true,
+              "runAsSystem": false,
+              "validExitCodes": [
+                0,
+                1
+              ]
+            },
+            {
+              "type": "PowerShell",
+              "name": "PowerShell (script) Customizer Elevated Local System user Example",
+              "scriptUri": "https://example.com/path/to/script.ps1",
+              "runElevated": true,
+              "runAsSystem": true,
+              "validExitCodes": [
+                0,
+                1
+              ]
+            },
+            {
+              "type": "WindowsRestart",
+              "name": "Restart Customizer Example",
+              "restartCommand": "shutdown /f /r /t 0 /c \"packer restart\"",
+              "restartCheckCommand": "powershell -command \"& {Write-Output 'restarted.'}\"",
+              "restartTimeout": "10m"
+            },
+            {
+              "type": "WindowsUpdate",
+              "name": "Windows Update Customizer Example",
+              "searchCriteria": "BrowseOnly=0 and IsInstalled=0",
+              "filters": [
+                "$_.BrowseOnly"
+              ],
+              "updateLimit": 100
             }
           ],
           "distribute": [

--- a/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/stable/2020-02-14/imagebuilder.json
+++ b/specification/imagebuilder/resource-manager/Microsoft.VirtualMachineImages/stable/2020-02-14/imagebuilder.json
@@ -763,6 +763,10 @@
           "type": "boolean",
           "description": "If specified, the PowerShell script will be run with elevated privileges"
         },
+        "runAsSystem": {
+          "type": "boolean",
+          "description": "If specified, the PowerShell script will be run with elevated privileges using the Local System user. Can only be true when the runElevated field above is set to true."
+        },
         "validExitCodes": {
           "type": "array",
           "description": "Valid exit codes for the PowerShell script. [Default: 0]",


### PR DESCRIPTION
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Contribution checklist:
- [X] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of “no breaking changes
- [X] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [X] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Ensure to check this box if one of the following scenarios meet updates in the PR, so that label “WaitForARMFeedback” will be added automatically to involve ARM API Review. Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs, all “removals” and “adding a new property” no more require ARM API review.
  - Adding new API(s) 
  - Adding a new API version
  -Adding a new service

- [ ] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM oncall for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them. 

### Breaking Change Review Checklist 
If there are following updates in the PR, ensure to request an approval from API Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 

- [ ] Removing API(s) in stable version
- [ ] Removing properties in stable version
- [ ] Removing API version(s) in stable version
- [X] Updating API in stable version with Breaking Change Validation errors
- [ ] Updating API(s) in preview over 1 year

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).

### API Change Reasoning
Our service runs packer in order to create images from image templates that the customer submits. If a customer submits an image template requesting an image of Windows 10 Desktop that will run elevated powershell commands during image creation, packer fails to create an image. This is due to the fact that the Windows 10 Out of Box Experience Privacy agreement page blocks any user from performing elevated actions until the page is dismissed, namely the admin 'packer' user that packer uses to execute its elevated powershell commands. However, if the Local System user is instead used to execute the powershell commands, packer successfully creates the image to specification. This is due to the fact that the Local System user is ignored by the Windows 10 security subsystem, and therefore does not have to validate with the Windows 10 OOBE. This API change adds in the ability for the customer to specify a boolean named 'runAsSystem', which if set to true along with the currently existing field 'runElevated', will cause packer to use the Local System user instead of the default 'packer' user for elevated powershell commands. 
This fix is important to roll out ASAP as customers have run into this issue, and will impact the deployment of Windows Virtual Desktop as they are using image builder to create Windows 10 desktops. 

### Breaking Change Explanation
In this PR, the Azure Image Builder RP has added the optional boolean field 'runAsSystem' to the response, which is a breaking change. However, this change is not breaking for our service. This is due to the fact that our service does not support the GET-PUT semantics that would be broken by this change. Our service does not allow updating of already existing image templates; once an image template is PUT once, it can not be changed again. The only way to make changes to a template is to submit a completely new template to the service. Due to this, the addition of this boolean will not cause existing customer image templates to fail to be created / fail to create images from the templates. I have tested this by successfully creating images from image templates containing PowerShell customizers (elevated or otherwise) submitted BEFORE any API changes were tested.  Additionally, **the Azure Image Builder RP service is still in preview** and is not set to release until late November / December. 
Therefore, even though this change is defined as 'Breaking', it is not 'Breaking' for our service. Please let me know if you would like additional clarification on this matter. 