### PR TITLE
Template Specs: Including "expand" parameter, TemplateSpecVersionInfo model for getting basic version info with template spec(s).

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/preview/2019-06-01-preview/templateSpecs.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/preview/2019-06-01-preview/templateSpecs.json
@@ -160,6 +160,9 @@
             "$ref": "#/parameters/TemplateSpecNameParameter"
           },
           {
+            "$ref": "#/parameters/TemplateSpecExpandParameter"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
@@ -236,6 +239,9 @@
             "$ref": "#/parameters/SubscriptionIdParameter"
           },
           {
+            "$ref": "#/parameters/TemplateSpecExpandParameter"
+          },
+          {
             "$ref": "#/parameters/ApiVersionParameter"
           }
         ],
@@ -276,6 +282,9 @@
           },
           {
             "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/TemplateSpecExpandParameter"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -591,6 +600,14 @@
           "type": "string",
           "maxLength": 64,
           "description": "Template Spec display name."
+        },
+        "versions": {
+          "type": "object",
+          "readOnly": true,
+          "description": "High-level information about the versions within this Template Spec. The keys are the version names. Only populated if the $expand query parameter is set to 'versions'.",
+          "additionalProperties": {
+            "$ref": "#/definitions/TemplateSpecVersionInfo"
+          }
         }
       }
     },
@@ -800,6 +817,29 @@
         }
       ]
     },
+    "TemplateSpecVersionInfo": {
+      "type": "object",
+      "description": "High-level information about a Template Spec version.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Template Spec version description."
+        },
+        "timeCreated": {
+          "type": "string",
+          "readOnly": true,
+          "format": "date-time",
+          "description": "The timestamp of when the version was created."
+        },
+        "timeModified": {
+          "type": "string",
+          "readOnly": true,
+          "format": "date-time",
+          "description": "The timestamp of when the version was last modified."
+        }
+      }
+    },
     "TemplateSpecsError": {
       "properties": {
         "error": {
@@ -850,6 +890,27 @@
       "minLength": 1,
       "maxLength": 90,
       "x-ms-parameter-location": "method"
+    },
+    "TemplateSpecExpandParameter": {
+      "name": "$expand",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "Allows for expansion of additional Template Spec details in the response. Optional.",
+      "x-ms-parameter-location": "method",
+      "enum": [
+        "versions"
+      ],
+      "x-ms-enum": {
+        "name": "TemplateSpecExpandKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "versions",
+            "description": "Includes version information with the Template Spec."
+          }
+        ]
+      }
     },
     "ApiVersionParameter": {
       "name": "api-version",


### PR DESCRIPTION
We've had a expand parameter with the possible value of "versions" in our backend for a long while, but it was not documented in the swagger as it was intended for use only through the Portal UI. Due to recent S360 flagging changes, we must now document the expand in the swagger, this PR adds the appropriate definitions to our existing swagger.

### Contribution checklist:
- [X] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of “no breaking changes
- [X] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [X] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Ensure to check this box if one of the following scenarios meet updates in the PR, so that label “WaitForARMFeedback” will be added automatically to involve ARM API Review. Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs, all “removals” and “adding a new property” no more require ARM API review.
  - Adding new API(s)
  - Adding a new API version
  - Adding a new service

- [ ] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM oncall for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them. 

### Breaking Change Review Checklist 
If there are following updates in the PR, ensure to request an approval from API Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 

- [ ] Removing API(s) in stable version
- [ ] Removing properties in stable version
- [ ] Removing API version(s) in stable version
- [ ] Updating API in stable version with Breaking Change Validation errors
- [ ] Updating API(s) in preview over 1 year

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).