### PR TITLE
[mgmt keyvault] Add default value for SKU family value

### DIFF
--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2018-02-14-preview/keyvault.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2018-02-14-preview/keyvault.json
@@ -677,6 +677,7 @@
           "enum": [
             "A"
           ],
+          "x-ms-client-default": "A",
           "x-ms-enum": {
             "name": "SkuFamily",
             "modelAsString": true

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2020-04-01-preview/keyvault.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2020-04-01-preview/keyvault.json
@@ -923,6 +923,7 @@
           "enum": [
             "A"
           ],
+          "x-ms-client-default": "A",
           "x-ms-enum": {
             "name": "SkuFamily",
             "modelAsString": true

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2020-04-01-preview/managedHsm.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2020-04-01-preview/managedHsm.json
@@ -353,6 +353,7 @@
           "enum": [
             "B"
           ],
+          "x-ms-client-default": "B",
           "x-ms-enum": {
             "name": "ManagedHsmSkuFamily",
             "modelAsString": true

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2015-06-01/keyvault.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2015-06-01/keyvault.json
@@ -250,6 +250,7 @@
           "enum": [
             "A"
           ],
+          "x-ms-client-default": "A",
           "x-ms-enum": {
             "name": "SkuFamily",
             "modelAsString": true

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2016-10-01/keyvault.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2016-10-01/keyvault.json
@@ -676,6 +676,7 @@
           "enum": [
             "A"
           ],
+          "x-ms-client-default": "A",
           "x-ms-enum": {
             "name": "SkuFamily",
             "modelAsString": true

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2018-02-14/keyvault.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2018-02-14/keyvault.json
@@ -924,6 +924,7 @@
           "enum": [
             "A"
           ],
+          "x-ms-client-default": "A",
           "x-ms-enum": {
             "name": "SkuFamily",
             "modelAsString": true

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2019-09-01/keyvault.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2019-09-01/keyvault.json
@@ -924,6 +924,7 @@
           "enum": [
             "A"
           ],
+          "x-ms-client-default": "A",
           "x-ms-enum": {
             "name": "SkuFamily",
             "modelAsString": true


### PR DESCRIPTION
With the new autorest code generators, in the case of an extensible enum with one value, we are no longer defaulting the value to that one value since this can precipitate breaking changes later on. For keyvault, we got an [issue](https://github.com/Azure/azure-sdk-for-python/issues/14656) filed that, while before when instantiating a SKU, they didn't have to specify a value of `family`, they now do. To remedy this, I'm making a PR that adds a default value for `family`, so if users don't pass in a value, we will pass in the default value.

My question to the service team: is this fix correct with service behavior? Or do you actually want the value for `family` to be a constant. Thanks! @heaths @randallilama @jlichwa