### PR TITLE
Update CODEOWNERS for application insights

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 /specification/analysisservices/ @taiwu
 /specification/alertsmanagement/ @ofirmanor @olalavi @erangon @orieldar @ilaizi @shakednai1 @khaboasb @orenhor
 /specification/apimanagement/ @promoisha @solankisamir
-/specification/applicationinsights/ @alexeldeib @reyang @TimothyMothra @ramthi @rajkumar-rangaraj @markwolff @trask @hectorhdzg @lzchen
+/specification/applicationinsights/ @alexeldeib @ramthi @markwolff @trask @hectorhdzg @lzchen
 /specification/asazure/ @athipp
 /specification/authorization/ @darshanhs90 @stankovski
 /specification/automation/ @vrdmr


### PR DESCRIPTION
As requested by @reyang, removing @reyang, @TimothyMothra and @rajkumar-rangaraj from the CODEOWNERS list for applicationinsights.