### PR TITLE
invalid dash char in mediaservices 2019-05-01-preview

### DIFF
--- a/specification/mediaservices/resource-manager/Microsoft.Media/preview/2019-05-01-preview/streamingservice.json
+++ b/specification/mediaservices/resource-manager/Microsoft.Media/preview/2019-05-01-preview/streamingservice.json
@@ -1377,7 +1377,7 @@
       "properties": {
         "language": {
           "type": "string",
-          "description": "Specifies the language (locale) used for speech-to-text transcription – it should match the spoken language in the audio track. The value should be in BCP-47 format of 'language tag-region' (e.g: 'en-US'). The list of supported languages are 'en-US' and 'en-GB'."
+          "description": "Specifies the language (locale) used for speech-to-text transcription - it should match the spoken language in the audio track. The value should be in BCP-47 format of 'language tag-region' (e.g: 'en-US'). The list of supported languages are 'en-US' and 'en-GB'."
         },
         "inputTrackSelection": {
           "type": "array",


### PR DESCRIPTION
There is a dash character on this line:
https://github.com/Azure/azure-rest-api-specs/blob/82831834a7ce4b999d6fec363c0391da80ac2674/specification/mediaservices/resource-manager/Microsoft.Media/stable/2020-05-01/streamingservice.json#L1496

When I read the file in with rust, I get "invalid unicode code point". It also shows up invalid in VS Code:

![image](https://user-images.githubusercontent.com/80104/98457081-a5a03000-2149-11eb-9d79-9342a0997a5a.png)
