### PR TITLE
reuse ControllerDetails definition in dnc 2020-08-08-preview

### DIFF
--- a/specification/dnc/resource-manager/Microsoft.DelegatedNetwork/preview/2020-08-08-preview/delegatedSubnets.json
+++ b/specification/dnc/resource-manager/Microsoft.DelegatedNetwork/preview/2020-08-08-preview/delegatedSubnets.json
@@ -418,30 +418,20 @@
         },
         "subnetDetails": {
           "description": "orchestrator details",
-          "$ref": "#/definitions/subnetDetails"
+          "$ref": "#/definitions/SubnetDetails"
         },
         "controllerDetails": {
           "description": "controller details",
-          "$ref": "#/definitions/controllerDetails"
+          "$ref": "./orchestrators.json#/definitions/ControllerDetails"
         }
       }
     },
-    "subnetDetails": {
+    "SubnetDetails": {
       "description": "Properties of orchestrator",
       "type": "object",
       "properties": {
         "id": {
           "description": "subnet arm resource id",
-          "type": "string"
-        }
-      }
-    },
-    "controllerDetails": {
-      "description": "controller details",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "controller arm resource id",
           "type": "string"
         }
       }


### PR DESCRIPTION
A code generator I'm using generates duplicate `ControllerDetails` types for dnc 2020-08-08-preview. It is defining the type in two different input files instead of just using references. It should also reference common types for the common parameters instead of duplicating them. This pull request, just reuses a `ControllerDetails` definition, which fixes it for the code generator I'm using.

input-file:
- Microsoft.DelegatedNetwork/preview/2020-08-08-preview/controller.json
- Microsoft.DelegatedNetwork/preview/2020-08-08-preview/orchestrators.json
- Microsoft.DelegatedNetwork/preview/2020-08-08-preview/delegatedSubnets.json
- Microsoft.DelegatedNetwork/preview/2020-08-08-preview/operations.json

![image](https://user-images.githubusercontent.com/80104/98468796-b3819f80-21a1-11eb-89e0-2d2b5db825c4.png)
