### PR TITLE
fix powerplatforrm ref & duplicates

### DIFF
--- a/specification/powerplatform/resource-manager/Microsoft.PowerPlatform/preview/2020-10-30-preview/enterprisePolicy.json
+++ b/specification/powerplatform/resource-manager/Microsoft.PowerPlatform/preview/2020-10-30-preview/enterprisePolicy.json
@@ -157,7 +157,7 @@
         },
         "parameters": [
           {
-            "$ref": "../../common/v1/definitions.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "enterprisePolicyName",

--- a/specification/powerplatform/resource-manager/Microsoft.PowerPlatform/preview/2020-10-30-preview/privateEndpointConnection.json
+++ b/specification/powerplatform/resource-manager/Microsoft.PowerPlatform/preview/2020-10-30-preview/privateEndpointConnection.json
@@ -243,48 +243,6 @@
           "application/json"
         ]
       }
-    },
-    "/providers/Microsoft.PowerPlatform/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Lists all of the available PowerPlatform REST API operations.",
-        "x-ms-examples": {
-          "Lists all of the available PowerPlatform REST API operations": {
-            "$ref": "./examples/listOperations.json"
-          }
-        },
-        "operationId": "Operations_List",
-        "parameters": [
-          {
-            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "../../common/v1/definitions.json#/definitions/OperationList"
-            }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": null
-        },
-        "produces": [
-          "application/json"
-        ],
-        "consumes": [
-          "application/json"
-        ]
-      }
     }
   },
   "definitions": {

--- a/specification/powerplatform/resource-manager/Microsoft.PowerPlatform/preview/2020-10-30-preview/privateLinkResources.json
+++ b/specification/powerplatform/resource-manager/Microsoft.PowerPlatform/preview/2020-10-30-preview/privateLinkResources.json
@@ -128,48 +128,6 @@
           "application/json"
         ]
       }
-    },
-    "/providers/Microsoft.PowerPlatform/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Lists all of the available PowerPlatform REST API operations.",
-        "x-ms-examples": {
-          "Lists all of the available PowerPlatform REST API operations": {
-            "$ref": "./examples/listOperations.json"
-          }
-        },
-        "operationId": "Operations_List",
-        "parameters": [
-          {
-            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "../../common/v1/definitions.json#/definitions/OperationList"
-            }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": null
-        },
-        "produces": [
-          "application/json"
-        ],
-        "consumes": [
-          "application/json"
-        ]
-      }
     }
   },
   "definitions": {

--- a/specification/powerplatform/resource-manager/Microsoft.PowerPlatform/preview/2020-10-30-preview/subnetResources.json
+++ b/specification/powerplatform/resource-manager/Microsoft.PowerPlatform/preview/2020-10-30-preview/subnetResources.json
@@ -181,48 +181,6 @@
           "application/json"
         ]
       }
-    },
-    "/providers/Microsoft.PowerPlatform/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "description": "Lists all of the available PowerPlatform REST API operations.",
-        "x-ms-examples": {
-          "Lists all of the available PowerPlatform REST API operations": {
-            "$ref": "./examples/listOperations.json"
-          }
-        },
-        "operationId": "Operations_List",
-        "parameters": [
-          {
-            "$ref": "../../../../../common-types/resource-management/v1/types.json#/parameters/ApiVersionParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "../../common/v1/definitions.json#/definitions/OperationList"
-            }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "../../common/v1/definitions.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": null
-        },
-        "produces": [
-          "application/json"
-        ],
-        "consumes": [
-          "application/json"
-        ]
-      }
     }
   },
   "definitions": {


### PR DESCRIPTION
This fixes the spec so that the code generator I'm using works. There are two problems with the spec:
1. ResourceGroupNameParameter uses the wrong file in one instance
2. Operations_List is defined 4 times, so this removes 3 duplicates.

Defined in #10651. cc @rapatank