### PR TITLE
fix servicefabric allOf and duplicate Operations_List

### DIFF
--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2020-01-01-preview/managedcluster.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2020-01-01-preview/managedcluster.json
@@ -568,22 +568,19 @@
       "allOf": [
         {
           "$ref": "#/definitions/Resource"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "properties": {
-              "x-ms-client-flatten": true,
-              "$ref": "#/definitions/ManagedClusterProperties",
-              "description": "The managed cluster resource properties"
-            },
-            "sku": {
-              "$ref": "#/definitions/Sku",
-              "description": "The sku of the managed cluster"
-            }
-          }
         }
-      ]
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ManagedClusterProperties",
+          "description": "The managed cluster resource properties"
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The sku of the managed cluster"
+        }
+      }
     },
     "ManagedClusterListResult": {
       "properties": {

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2020-01-01-preview/nodetype.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/preview/2020-01-01-preview/nodetype.json
@@ -34,47 +34,6 @@
     }
   ],
   "paths": {
-    "/providers/Microsoft.ServiceFabric/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "summary": "Lists all of the available Service Fabric resource provider API operations.",
-        "description": "Get the list of available Service Fabric resource provider API operations.",
-        "operationId": "Operations_List",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The version of the Service Fabric resource provider API",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "x-ms-examples": {
-          "List node type of the specified managed cluster": {
-            "$ref": "./examples/Operations_example.json"
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK. The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/OperationListResult"
-            }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/ErrorModel"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
     "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes": {
       "get": {
         "operationId": "NodeTypes_ListByManagedClusters",
@@ -970,44 +929,6 @@
         }
       },
       "description": "The error details."
-    },
-    "OperationListResult": {
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "List of operations supported by the Service Fabric resource provider.",
-          "items": {
-            "$ref": "#/definitions/OperationResult"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "description": "URL to get the next set of operation list results if there are any.",
-          "readOnly": true
-        }
-      },
-      "description": "Describes the result of the request to list Service Fabric resource provider operations."
-    },
-    "OperationResult": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the operation."
-        },
-        "display": {
-          "$ref": "#/definitions/AvailableOperationDisplay",
-          "description": "The object that represents the operation."
-        },
-        "origin": {
-          "type": "string",
-          "description": "Origin result"
-        },
-        "nextLink": {
-          "type": "string",
-          "description": "The URL to use for getting the next set of results."
-        }
-      },
-      "description": "Available operation list result"
     }
   },
   "parameters": {

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/stable/2020-03-01/application.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/stable/2020-03-01/application.json
@@ -34,42 +34,6 @@
     }
   ],
   "paths": {
-    "/providers/Microsoft.ServiceFabric/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "summary": "Lists all of the available Service Fabric resource provider API operations.",
-        "description": "Get the list of available Service Fabric resource provider API operations.",
-        "operationId": "Operations_List",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The version of the Service Fabric resource provider API",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK. The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/OperationListResult"
-            }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/ErrorModel"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applicationTypes/{applicationTypeName}": {
       "get": {
         "tags": [
@@ -1518,10 +1482,6 @@
       "allOf": [
         {
           "$ref": "#/definitions/PartitionSchemeDescription"
-        },
-        {
-          "type": "object",
-          "description": "NamedPartitionSchemeDescription"
         }
       ],
       "x-ms-discriminator-value": "Named",
@@ -1542,44 +1502,6 @@
           "description": "Array of size specified by the ‘count’ parameter, for the names of the partitions."
         }
       }
-    },
-    "OperationListResult": {
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "List of operations supported by the Service Fabric resource provider.",
-          "items": {
-            "$ref": "#/definitions/OperationResult"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "description": "URL to get the next set of operation list results if there are any.",
-          "readOnly": true
-        }
-      },
-      "description": "Describes the result of the request to list Service Fabric resource provider operations."
-    },
-    "OperationResult": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the operation."
-        },
-        "display": {
-          "$ref": "#/definitions/AvailableOperationDisplay",
-          "description": "The object that represents the operation."
-        },
-        "origin": {
-          "type": "string",
-          "description": "Origin result"
-        },
-        "nextLink": {
-          "type": "string",
-          "description": "The URL to use for getting the next set of results."
-        }
-      },
-      "description": "Available operation list result"
     },
     "PartitionScheme": {
       "type": "string",
@@ -2068,10 +1990,6 @@
       "allOf": [
         {
           "$ref": "#/definitions/PartitionSchemeDescription"
-        },
-        {
-          "type": "object",
-          "description": "SingletonPartitionSchemeDescription"
         }
       ],
       "x-ms-discriminator-value": "Singleton"
@@ -2218,10 +2136,6 @@
       "allOf": [
         {
           "$ref": "#/definitions/PartitionSchemeDescription"
-        },
-        {
-          "type": "object",
-          "description": "UniformInt64RangePartitionSchemeDescription"
         }
       ],
       "x-ms-discriminator-value": "UniformInt64Range",

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/stable/2020-03-01/cluster.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/stable/2020-03-01/cluster.json
@@ -461,42 +461,6 @@
           }
         }
       }
-    },
-    "/providers/Microsoft.ServiceFabric/operations": {
-      "get": {
-        "tags": [
-          "Operations"
-        ],
-        "summary": "Lists all of the available Service Fabric resource provider API operations.",
-        "description": "Get the list of available Service Fabric resource provider API operations.",
-        "operationId": "Operations_List",
-        "parameters": [
-          {
-            "name": "api-version",
-            "in": "query",
-            "description": "The version of the Service Fabric resource provider API",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK. The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/OperationListResult"
-            }
-          },
-          "default": {
-            "description": "Error response describing why the operation failed.",
-            "schema": {
-              "$ref": "#/definitions/ErrorModel"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
     }
   },
   "definitions": {
@@ -666,22 +630,17 @@
       "description": "The cluster resource\n",
       "allOf": [
         {
-          "description": "The cluster resource properties"
-        },
-        {
+          "description": "The cluster resource properties",
           "$ref": "#/definitions/Resource"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "properties": {
-              "x-ms-client-flatten": true,
-              "$ref": "#/definitions/ClusterProperties",
-              "description": "The cluster resource properties"
-            }
-          }
         }
-      ]
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ClusterProperties",
+          "description": "The cluster resource properties"
+        }
+      }
     },
     "ClusterCodeVersionsListResult": {
       "properties": {
@@ -1240,44 +1199,6 @@
         }
       },
       "description": "Describes a node type in the cluster, each node type represents sub set of nodes in the cluster."
-    },
-    "OperationListResult": {
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "List of operations supported by the Service Fabric resource provider.",
-          "items": {
-            "$ref": "#/definitions/OperationResult"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "description": "URL to get the next set of operation list results if there are any.",
-          "readOnly": true
-        }
-      },
-      "description": "Describes the result of the request to list Service Fabric resource provider operations."
-    },
-    "OperationResult": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the operation."
-        },
-        "display": {
-          "$ref": "#/definitions/AvailableOperationDisplay",
-          "description": "The object that represents the operation."
-        },
-        "origin": {
-          "type": "string",
-          "description": "Origin result"
-        },
-        "nextLink": {
-          "type": "string",
-          "description": "The URL to use for getting the next set of results."
-        }
-      },
-      "description": "Available operation list result"
     },
     "ReliabilityLevel": {
       "type": "string",


### PR DESCRIPTION
It appears to be some mistakes using `allOf` in a few places. `Operations_List` is also duplicated. This fixes both issues so that a code generator I'm using works.