### PR TITLE
Amend error response to indicate that we return additional error info.

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/appconfiguration.json
@@ -1656,6 +1656,14 @@
           "description": "Error message indicating why the operation failed.",
           "type": "string",
           "readOnly": true
+        },
+        "additionalInfo": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorAdditionalInfo"
+          },
+          "description": "The error additional info."
         }
       }
     },
@@ -1668,6 +1676,21 @@
           "$ref": "#/definitions/ErrorDetails"
         }
       }
+    },
+    "ErrorAdditionalInfo": {
+      "properties": {
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The additional info type."
+        },
+        "info": {
+          "readOnly": true,
+          "type": "object",
+          "description": "The additional info."
+        }
+      },
+      "description": "The resource management error additional info."
     },
     "Resource": {
       "description": "An Azure resource.",


### PR DESCRIPTION
Staring in this preview version, we now return `additionalInfo` in our error objects. We need to add this here to fix Swagger correctness errors filed against our service. 