### PR TITLE
Revert "Remove api-version in recoveryservicebackup"

### DIFF
--- a/specification/recoveryservicesbackup/resource-manager/readme.go.md
+++ b/specification/recoveryservicesbackup/resource-manager/readme.go.md
@@ -16,6 +16,7 @@ batch:
   - tag: package-2020-02
   - tag: package-2019-06
   - tag: package-2019-05
+  - tag: package-2017-07
   - tag: package-2016-12
   - tag: package-2016-06
 ```
@@ -45,6 +46,15 @@ Please also specify `--go-sdk-folder=<path to the root directory of your azure-s
 
 ``` yaml $(tag)=='package-2019-05' && $(go)
 output-folder: $(go-sdk-folder)/services/recoveryservices/mgmt/2019-05-13/$(namespace)
+```
+
+### Tag: package-2017-07 and go
+
+These settings apply only when `--tag=package-2017-07 --go` is specified on the command line.
+Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
+
+``` yaml $(tag)=='package-2017-07' && $(go)
+output-folder: $(go-sdk-folder)/services/recoveryservices/mgmt/2017-07-01/$(namespace)
 ```
 
 ### Tag: package-2016-12 and go


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#11846 since the issue https://github.com/Azure/azure-rest-api-specs/issues/11848 has been fixed by #11888

Fixes #11848 