### PR TITLE
add timeseriesinsights track2 config

### DIFF
--- a/specification/timeseriesinsights/resource-manager/Microsoft.TimeSeriesInsights/stable/2020-05-15/timeseriesinsights.json
+++ b/specification/timeseriesinsights/resource-manager/Microsoft.TimeSeriesInsights/stable/2020-05-15/timeseriesinsights.json
@@ -1618,9 +1618,6 @@
         },
         {
           "$ref": "#/definitions/EnvironmentResourceProperties"
-        },
-        {
-          "$ref": "#/definitions/ResourceProperties"
         }
       ],
       "required": [
@@ -1654,9 +1651,6 @@
       "allOf": [
         {
           "$ref": "#/definitions/EnvironmentResourceProperties"
-        },
-        {
-          "$ref": "#/definitions/ResourceProperties"
         }
       ],
       "description": "Properties of the Gen2 environment."

--- a/specification/timeseriesinsights/resource-manager/readme.md
+++ b/specification/timeseriesinsights/resource-manager/readme.md
@@ -106,6 +106,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python
+  - repo: azure-sdk-for-python-track2
   - repo: azure-resource-manager-schemas
     after_scripts:
       - node sdkauto_afterscript.js timeseriesinsights/resource-manager

--- a/specification/timeseriesinsights/resource-manager/readme.python.md
+++ b/specification/timeseriesinsights/resource-manager/readme.python.md
@@ -4,7 +4,7 @@ These settings apply only when `--python` is specified on the command line.
 Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
 Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
 
-``` yaml $(python)
+``` yaml $(python) && !$(track2)
 python-mode: create
 python:
   azure-arm: true
@@ -15,14 +15,32 @@ python:
   package-version: 0.1.0
   clear-output-folder: true
 ```
-``` yaml $(python) && $(python-mode) == 'update'
+``` yaml $(python) && $(track2)
+python-mode: create
+azure-arm: true
+license-header: MICROSOFT_MIT_NO_VERSION
+payload-flattening-threshold: 2
+namespace: azure.mgmt.timeseriesinsights
+package-name: azure-mgmt-timeseriesinsights
+package-version: 0.1.0
+clear-output-folder: true
+```
+``` yaml $(python) && $(python-mode) == 'update' && !$(track2)
 python:
   no-namespace-folders: true
   output-folder: $(python-sdks-folder)/timeseriesinsights/azure-mgmt-timeseriesinsights/azure/mgmt/timeseriesinsights
 ```
-``` yaml $(python) && $(python-mode) == 'create'
+``` yaml $(python) && $(python-mode) == 'create' && !$(track2)
 python:
   basic-setup-py: true
   output-folder: $(python-sdks-folder)/timeseriesinsights/azure-mgmt-timeseriesinsights
+```
+``` yaml $(python) && $(python-mode) == 'update' && $(track2)
+no-namespace-folders: true
+output-folder: $(python-sdks-folder)/timeseriesinsights/azure-mgmt-timeseriesinsights/azure/mgmt/timeseriesinsights
+```
+``` yaml $(python) && $(python-mode) == 'create' && $(track2)
+basic-setup-py: true
+output-folder: $(python-sdks-folder)/timeseriesinsights/azure-mgmt-timeseriesinsights
 ```
 	


### PR DESCRIPTION
Fix track2 generating error:
```
ERROR (PreCheck/DuplicateInheritance): Schema 'Gen1EnvironmentResourceProperties' inherits 'EnvironmentResourceProperties' via an allOf that is already coming from parent 'ResourceProperties'
ERROR (PreCheck/DuplicateInheritance): Schema 'Gen2EnvironmentResourceProperties' inherits 'EnvironmentResourceProperties' via an allOf that is already coming from parent 'ResourceProperties'
FATAL: Error: 2 errors occured -- cannot continue.
  Error: Plugin prechecker reported failure.
```