### PR TITLE
Add "mail" parameter to UserUpdateParameters in graphrbac

### DIFF
--- a/specification/graphrbac/data-plane/Microsoft.GraphRbac/stable/1.6/graphrbac.json
+++ b/specification/graphrbac/data-plane/Microsoft.GraphRbac/stable/1.6/graphrbac.json
@@ -4011,6 +4011,10 @@
         "mailNickname": {
           "type": "string",
           "description": "The mail alias for the user."
+        },
+        "mail": {
+          "type": "string",
+          "description": "The primary email address of the user."
         }
       },
       "description": "Request parameters for updating an existing work or school account user."


### PR DESCRIPTION
This patch adds a single optional field "mail" to UserUpdateParameters schema. This makes it possible to update user's e-mail address using the (Go) Azure SDK. Currently this is not possible.

I have curled the graphrbac API with the extra body parameter and it works as expected. It seems that this field was omitted from the OpenAPI spec by accident rather than on purpose, since the field is available in the UserCreateParameters (so not including it in UserUpdateParameters creates a strange asymmetry where I can configure a user's e-mail address, but cannot change it later on).

The curl proving that the field is in fact respected by the UserUpdate endpoint is

    curl \
        -i \
        -X PATCH \
        -H "Authorization: Bearer <token>" \
        -H "Content-Type: application/json" \
        -d '{"mail": "foo@bar.com"}' \
        "https://graph.windows.net/<tenantID>/users/<objectID>?api-version=1.6"

Addition of the field will make it possible to support the mail property on the azuread_user resource in terraform-provider-azuread. Currently it's not possible to configure e-mail addresses for users onboarded via Terraform.

Sorry for not sticking with the original pull request checklist, it seemed to me that it applies to Microsoft employees only.
