### PR TITLE
ADT: refix .NET output path

### DIFF
--- a/specification/digitaltwins/resource-manager/readme.csharp.md
+++ b/specification/digitaltwins/resource-manager/readme.csharp.md
@@ -11,5 +11,5 @@ csharp:
   clear-output-folder: true
   client-side-validation: false
   namespace: Microsoft.Azure.Management.DigitalTwins
-  output-folder: $(csharp-sdks-folder)/digitaltwins/Microsoft.Azure.Management.DigitalTwins/
+  output-folder: $(csharp-sdks-folder)/digitaltwins/Microsoft.Azure.Management.DigitalTwins/src/Generated/
 ```


### PR DESCRIPTION
I had the wrong path in my [last PR](https://github.com/Azure/azure-rest-api-specs/pull/12148). After testing (I learned how to test from my fork branch), I realized it should be the new value.