### PR TITLE
Adding analytical storage configuration.

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-09-01/cosmos-db.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-09-01/cosmos-db.json
@@ -6103,6 +6103,11 @@
           "description": "Flag to indicate whether to enable storage analytics.",
           "type": "boolean"
         },
+        "analyticalStorageConfig": {
+          "description": "Analytical storage specific properties.",
+          "type": "object",
+          "$ref": "#/definitions/AnalyticalStorageConfig"
+        },
         "backupPolicy": {
           "description": "The object representing the policy for taking backups on an account.",
           "type": "object",
@@ -6198,6 +6203,11 @@
         "enableAnalyticalStorage": {
           "description": "Flag to indicate whether to enable storage analytics.",
           "type": "boolean"
+        },
+        "analyticalStorageConfig": {
+          "description": "Analytical storage specific properties.",
+          "type": "object",
+          "$ref": "#/definitions/AnalyticalStorageConfig"
         },
         "backupPolicy": {
           "description": "The object representing the policy for taking backups on an account.",
@@ -6326,6 +6336,11 @@
         "enableAnalyticalStorage": {
           "description": "Flag to indicate whether to enable storage analytics.",
           "type": "boolean"
+        },
+        "analyticalStorageConfig": {
+          "description": "Analytical storage specific properties.",
+          "type": "object",
+          "$ref": "#/definitions/AnalyticalStorageConfig"
         },
         "backupPolicy": {
           "description": "The object representing the policy for taking backups on an account.",
@@ -8284,6 +8299,28 @@
             "name": "ServerVersion"
           }
         }
+      }
+    },
+    "AnalyticalStorageConfig": {
+      "type": "object",
+      "description": "Analytical storage specific properties.",
+      "properties": {
+        "schemaType": {
+          "type": "string",
+          "$ref": "#/definitions/AnalyticalStorageSchemaType"
+        }
+      }
+    },
+    "AnalyticalStorageSchemaType": {
+      "type": "string",
+      "description": "Describes the types of schema for analytical storage.",
+      "enum": [
+        "WellDefined",
+        "FullFidelity"
+      ],
+      "x-ms-enum": {
+        "modelAsString": true,
+        "name": "AnalyticalStorageSchemaType"
       }
     },
     "BackupPolicy": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-09-01/examples/CosmosDBDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-09-01/examples/CosmosDBDatabaseAccountGet.json
@@ -79,6 +79,9 @@
           "enableFreeTier": false,
           "apiProperties": {},
           "enableAnalyticalStorage": true,
+          "analyticalStorageConfig": {
+            "schemaType": "WellDefined"
+          },
           "backupPolicy": {
             "type": "Periodic",
             "periodicModeProperties": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-09-01/examples/CosmosDBDatabaseAccountPatch.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-09-01/examples/CosmosDBDatabaseAccountPatch.json
@@ -130,6 +130,9 @@
           "enableFreeTier": false,
           "apiProperties": {},
           "enableAnalyticalStorage": true,
+          "analyticalStorageConfig": {
+            "schemaType": "WellDefined"
+          },
           "backupPolicy": {
             "type": "Periodic",
             "periodicModeProperties": {


### PR DESCRIPTION
Adding an analytical storage configuration class the currently contains a single sub-property 'schemaType'.  'schemaType' can have one of the following two enum values: "WellDefined" or "FullFidelity". 