### PR TITLE
Remove gallery preview version 2020-09-30 from stable release

### DIFF
--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -233,6 +233,30 @@ input-file:
 - Microsoft.Compute/preview/2020-10-01-preview/cloudService.json
 ```
 
+### Tag: package-2020-09-30
+These settings apply only when `--tag=package-2020-09-30` is specified on the command line.
+
+``` yaml $(tag) == 'package-2020-09-30'
+input-file:
+- Microsoft.Compute/stable/2020-06-01/compute.json
+- Microsoft.Compute/stable/2020-06-01/runCommands.json
+- Microsoft.Compute/stable/2019-04-01/skus.json
+- Microsoft.Compute/stable/2020-06-30/disk.json
+- Microsoft.Compute/preview/2020-09-30/gallery.json
+- Microsoft.Compute/preview/2020-09-30/sharedGallery.json
+- Microsoft.ContainerService/stable/2017-01-31/containerService.json
+```
+
+### Tag: package-2020-09-30-only
+
+These settings apply only when `--tag=package-2020-09-30-only` is specified on the command line.
+
+``` yaml $(tag) == 'package-2020-09-30-only'
+input-file:
+- Microsoft.Compute/preview/2020-09-30/gallery.json
+- Microsoft.Compute/preview/2020-09-30/sharedGallery.json
+```
+
 ### Tag: package-2020-06-30
 
 These settings apply only when `--tag=package-2020-06-30` is specified on the command line.

--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -219,8 +219,7 @@ input-file:
 - Microsoft.Compute/stable/2020-06-01/runCommands.json
 - Microsoft.Compute/stable/2019-04-01/skus.json
 - Microsoft.Compute/stable/2020-06-30/disk.json
-- Microsoft.Compute/preview/2020-09-30/gallery.json
-- Microsoft.Compute/preview/2020-09-30/sharedGallery.json
+- Microsoft.Compute/stable/2019-12-01/gallery.json
 - Microsoft.ContainerService/stable/2017-01-31/containerService.json
 - Microsoft.Compute/preview/2020-10-01-preview/cloudService.json
 ```
@@ -244,19 +243,8 @@ input-file:
 - Microsoft.Compute/stable/2020-06-01/runCommands.json
 - Microsoft.Compute/stable/2019-04-01/skus.json
 - Microsoft.Compute/stable/2020-06-30/disk.json
-- Microsoft.Compute/preview/2020-09-30/gallery.json
-- Microsoft.Compute/preview/2020-09-30/sharedGallery.json
+- Microsoft.Compute/stable/2019-12-01/gallery.json
 - Microsoft.ContainerService/stable/2017-01-31/containerService.json
-```
-
-### Tag: package-2020-09-30-only
-
-These settings apply only when `--tag=package-2020-09-30-only` is specified on the command line.
-
-``` yaml $(tag) == 'package-2020-09-30-only'
-input-file:
-- Microsoft.Compute/preview/2020-09-30/gallery.json
-- Microsoft.Compute/preview/2020-09-30/sharedGallery.json
 ```
 
 ### Tag: package-2020-06-30

--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -233,20 +233,6 @@ input-file:
 - Microsoft.Compute/preview/2020-10-01-preview/cloudService.json
 ```
 
-### Tag: package-2020-09-30
-
-These settings apply only when `--tag=package-2020-09-30` is specified on the command line.
-
-``` yaml $(tag) == 'package-2020-09-30'
-input-file:
-- Microsoft.Compute/stable/2020-06-01/compute.json
-- Microsoft.Compute/stable/2020-06-01/runCommands.json
-- Microsoft.Compute/stable/2019-04-01/skus.json
-- Microsoft.Compute/stable/2020-06-30/disk.json
-- Microsoft.Compute/stable/2019-12-01/gallery.json
-- Microsoft.ContainerService/stable/2017-01-31/containerService.json
-```
-
 ### Tag: package-2020-06-30
 
 These settings apply only when `--tag=package-2020-06-30` is specified on the command line.


### PR DESCRIPTION
**Do not merge without approval from 'akning-ms'.** 

Work for https://msazure.visualstudio.com/One/_workitems/edit/9019024

Breaking change exception request to ensure visibility: https://msazure.visualstudio.com/One/_workitems/edit/9021526

The 2020-09-30 Gallery preview version introduced breaking changes into the SDKs because the Compute SDKs are generated on everything in the Compute > Stable folder in the Rest API repo. 
This PR is to remove the version, but also act as a discussion point for preventing this from happening again. I see that the CloudService 2020-10-01 version is also in the Preview folder but is included in the Stable release. This can be a problem for our consumers such as Terraform which has issues with including previews in the stable release. 

Other SDKs may have released with the changes from this Gallery version. We know that .Net SDK has not as its most recent release was based on 2020-06-30. 

<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Changelog
Please ensure to add changelog with this PR by answering the following questions.
  1. What's the purpose of the update?    
      - [ ] new service onboarding 
      - [ ] new API version 
      - [ ] update existing version for new feature 
      - [x] update existing version to fix swagger quality issue in s360
      - [x] Other, please clarify 
  2. When you are targeting to deploy new service/feature to public regions? Please provide date, or month to public if date is not available yet.
  3. When you expect to publish swagger? Please provide date, or month to public if date is not available yet.
  4. If it's an update to existing version,  please select SDKs of specific language and CLIs that require refresh after swagger is published.
      - [x] SDK of .NET (need service team to ensure code readiness)
      - [ ] SDK of Python
      - [ ] SDK of Java
      - [ ] SDK of Js
      - [x] SDK of Go
      - [ ] PowerShell
      - [ ] CLI
      - [x] Terraform
      - [ ] No, no need to refresh for updates in this PR

### Contribution checklist:
- [ ] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of “no breaking changes
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Ensure to check this box if one of the following scenarios meet updates in the PR, so that label “WaitForARMFeedback” will be added automatically to involve ARM API Review. Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs, all “removals” and “adding a new property” no more require ARM API review.
  - Adding new API(s)
  - Adding a new API version
  - Adding a new service

- [ ] Please ensure you've reviewed following [guidelines](https://aka.ms/rpguidelines) including [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md). Estimated time (4 hours). This is required before you can request review from ARM API Review board.

- [ ] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM oncall for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them. 

### Breaking Change Review Checklist 
If there are following updates in the PR, ensure to request an approval from API Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 

- [x] Removing API(s) in stable version
- [ ] Removing properties in stable version
- [x] Removing API version(s) in stable version
- [ ] Updating API in stable version with Breaking Change Validation errors
- [ ] Updating API(s) in preview over 1 year

**Action**: to initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate). Addition details on the process and office hours are on the [Breaking change Wiki](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37684/Breaking-Changes).

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).
