### PR TITLE
Remove/move XML name mapping when ref is provided

### DIFF
--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-12-12/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-12-12/file.json
@@ -4784,7 +4784,7 @@
             "type": "object",
             "xml": {
               "name": "SMB"
-                },
+            },
             "properties": {
                 "Multichannel": {
                     "description": "Settings for SMB Multichannel.",

--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-12-12/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-12-12/file.json
@@ -4783,7 +4783,7 @@
             "description": "Settings for SMB protocol.",
             "type": "object",
             "xml": {
-              "name": "SMB"
+                "name": "SMB"
             },
             "properties": {
                 "Multichannel": {

--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-12-12/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-12-12/file.json
@@ -4610,10 +4610,7 @@
             "properties": {
                 "SmbSettings": {
                     "description": "Settings for SMB protocol.",
-                    "$ref": "#/definitions/SmbSettings",
-                    "xml": {
-                        "name": "SMB"
-                    }
+                    "$ref": "#/definitions/SmbSettings"
                 }
             }
         },
@@ -4785,6 +4782,9 @@
         "SmbSettings": {
             "description": "Settings for SMB protocol.",
             "type": "object",
+            "xml": {
+              "name": "SMB"
+                },
             "properties": {
                 "Multichannel": {
                     "description": "Settings for SMB Multichannel.",

--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-02-10/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-02-10/file.json
@@ -5337,8 +5337,8 @@
             "description": "Protocol settings",
             "type": "object",
             "xml": {
-              "name": "ProtocolSettings"
-                },
+                "name": "ProtocolSettings"
+            },
             "properties": {
                 "Smb": {
                     "description": "Settings for SMB protocol.",
@@ -5531,8 +5531,8 @@
             "description": "Settings for SMB protocol.",
             "type": "object",
             "xml": {
-              "name": "SMB"
-                },
+                "name": "SMB"
+            },
             "properties": {
                 "Multichannel": {
                     "description": "Settings for SMB Multichannel.",

--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-02-10/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-02-10/file.json
@@ -5336,13 +5336,13 @@
         "ShareProtocolSettings": {
             "description": "Protocol settings",
             "type": "object",
+            "xml": {
+              "name": "ProtocolSettings"
+                },
             "properties": {
                 "Smb": {
                     "description": "Settings for SMB protocol.",
-                    "$ref": "#/definitions/ShareSmbSettings",
-                    "xml": {
-                        "name": "SMB"
-                    }
+                    "$ref": "#/definitions/ShareSmbSettings"
                 }
             }
         },
@@ -5530,6 +5530,9 @@
         "ShareSmbSettings": {
             "description": "Settings for SMB protocol.",
             "type": "object",
+            "xml": {
+              "name": "SMB"
+                },
             "properties": {
                 "Multichannel": {
                     "description": "Settings for SMB Multichannel.",
@@ -5561,10 +5564,7 @@
                 },
                 "Protocol": {
                     "description": "Protocol settings",
-                    "$ref":"#/definitions/ShareProtocolSettings",
-                    "xml": {
-                        "name": "ProtocolSettings"
-                    }
+                    "$ref":"#/definitions/ShareProtocolSettings"
                 }
             }
         },

--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-04-08/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-04-08/file.json
@@ -5364,13 +5364,13 @@
         "ShareProtocolSettings": {
             "description": "Protocol settings",
             "type": "object",
+            "xml": {
+                "name": "ProtocolSettings"
+            },
             "properties": {
                 "Smb": {
                     "description": "Settings for SMB protocol.",
-                    "$ref": "#/definitions/ShareSmbSettings",
-                    "xml": {
-                        "name": "SMB"
-                    }
+                    "$ref": "#/definitions/ShareSmbSettings"
                 }
             }
         },
@@ -5564,6 +5564,9 @@
         "ShareSmbSettings": {
             "description": "Settings for SMB protocol.",
             "type": "object",
+            "xml": {
+                "name": "SMB"
+            },
             "properties": {
                 "Multichannel": {
                     "description": "Settings for SMB Multichannel.",
@@ -5595,10 +5598,7 @@
                 },
                 "Protocol": {
                     "description": "Protocol settings",
-                    "$ref":"#/definitions/ShareProtocolSettings",
-                    "xml": {
-                        "name": "ProtocolSettings"
-                    }
+                    "$ref":"#/definitions/ShareProtocolSettings"
                 }
             }
         },


### PR DESCRIPTION
Currently the modeler ignores an xml map if its provided alongside a ref. This worked in previous modeler versions but no longer does. Instead we need to move this mapping under the corresponding type reference.
https://github.com/Azure/autorest/issues/3756