### PR TITLE
Add documentation for $filter query string parameter in preview App Configuration listKeys

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/appconfiguration.json
@@ -388,6 +388,13 @@
             "description": "A skip token is used to continue retrieving items after an operation returns a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the access keys. For example, you can use \"$filter=readOnly eq true\" to retrieve only read-only access keys. Properties that support filtering include 'name' and 'readOnly'.",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {


### PR DESCRIPTION
We added support for a filtering query string parameter in our latest preview API version. From what I understand this isn't a breaking change, let me know if otherwise.

Approved in private repo: https://github.com/Azure/azure-rest-api-specs-pr/pull/2698