### PR TITLE
fix readme Configuration Tags for AlertsManagement

### DIFF
--- a/specification/alertsmanagement/resource-manager/readme.md
+++ b/specification/alertsmanagement/resource-manager/readme.md
@@ -24,7 +24,7 @@ To see additional help and options, run:
 
 These are the global settings for the AlertManagement API.
 
-## Suppression
+### Suppression
 ``` yaml
 directive:
   - suppress: R3025


### PR DESCRIPTION
This just fixes parsing of the readme.  A `Tag` must be directly below a `Configuration`, not `Suppression`.