### PR TITLE
fix readme Configuration Tags for ApplicationInsights

### DIFF
--- a/specification/applicationinsights/resource-manager/readme.md
+++ b/specification/applicationinsights/resource-manager/readme.md
@@ -31,7 +31,7 @@ openapi-type: arm
 tag: package-preview-2020-10
 ```
 
-## Suppression
+### Suppression
 
 ``` yaml
 directive:


### PR DESCRIPTION
This just fixes parsing of the readme. A Tag must be directly below a Configuration, not Suppression.