### PR TITLE
fix readme Configuration Tags for Authorization

### DIFF
--- a/specification/authorization/resource-manager/readme.md
+++ b/specification/authorization/resource-manager/readme.md
@@ -29,7 +29,7 @@ openapi-type: arm
 tag: package-2020-04-01-preview-only
 ```
 
-## Suppression
+### Suppression
 
 ``` yaml
 directive:


### PR DESCRIPTION
This just fixes parsing of the readme. A Tag must be directly below a Configuration, not Suppression.