### PR TITLE
fix readme Configuration Tags for eventhub

### DIFF
--- a/specification/eventhub/resource-manager/readme.md
+++ b/specification/eventhub/resource-manager/readme.md
@@ -29,7 +29,7 @@ openapi-type: arm
 tag: package-2018-01-preview
 ```
 
-## Suppression
+### Suppression
 
 ``` yaml
 directive:


### PR DESCRIPTION
This just fixes parsing of the readme. A Tag must be directly below a Configuration, not Suppression.