### PR TITLE
fix readme Configuration Tags for HDInsight

### DIFF
--- a/specification/hdinsight/resource-manager/readme.md
+++ b/specification/hdinsight/resource-manager/readme.md
@@ -32,7 +32,7 @@ azure-arm: true
 tag: package-2018-06-preview
 ```
 
-## Suppression
+### Suppression
 ``` yaml
 directive:
   - suppress: DefinitionsPropertiesNamesCamelCase


### PR DESCRIPTION
This just fixes parsing of the readme. A Tag must be directly below a Configuration, not Suppression.