### PR TITLE
fix readme Configuration Tags for machinelearningservices data-plane

### DIFF
--- a/specification/machinelearningservices/data-plane/readme.md
+++ b/specification/machinelearningservices/data-plane/readme.md
@@ -31,7 +31,7 @@ use-internal-constructors: true
 add-credentials: true
 ```
 
-## Suppression
+### Suppression
 
 ``` yaml
 directive:


### PR DESCRIPTION
This just fixes parsing of the readme. A Tag must be directly below a Configuration, not Suppression.