### PR TITLE
fix readme Configuration Tags for PolicyInsights

### DIFF
--- a/specification/policyinsights/resource-manager/readme.md
+++ b/specification/policyinsights/resource-manager/readme.md
@@ -40,7 +40,7 @@ model-validator: true
 message-format: json
 ```
 
-## Suppression
+### Suppression
 ``` yaml
 directive:
   - suppress: EnumInsteadOfBoolean


### PR DESCRIPTION
This just fixes parsing of the readme. A Tag must be directly below a Configuration, not Suppression.