### PR TITLE
fix readme Configuration Tags for security

### DIFF
--- a/specification/security/resource-manager/readme.md
+++ b/specification/security/resource-manager/readme.md
@@ -20,7 +20,7 @@ To see additional help and options, run:
 
 ## Configuration
 
-## Suppression
+### Suppression
 
 ``` yaml
 directive:

--- a/specification/security/resource-manager/readme.md
+++ b/specification/security/resource-manager/readme.md
@@ -73,7 +73,7 @@ openapi-type: arm
 tag: package-composite-v3
 ```
 
-## Composite packages
+### Composite packages
 
 The following packages may be composed from multiple api-versions.
 


### PR DESCRIPTION
This just fixes parsing of the readme. A Tag must be directly below a Configuration, not Suppression.