### PR TITLE
fix readme Configuration Tags for sql

### DIFF
--- a/specification/sql/resource-manager/readme.md
+++ b/specification/sql/resource-manager/readme.md
@@ -27,7 +27,7 @@ openapi-type: arm
 tag: package-composite-v4
 ```
 
-## Composite packages
+### Composite packages
 
 The following packages may be composed from multiple api-versions.
 


### PR DESCRIPTION
This just fixes parsing of the readme. A `Tag` must be directly below a `Configuration`,  `Composite packages`.