### PR TITLE
fix readme Configuration Tags for trafficmanager

### DIFF
--- a/specification/trafficmanager/resource-manager/readme.md
+++ b/specification/trafficmanager/resource-manager/readme.md
@@ -28,7 +28,7 @@ openapi-type: arm
 tag: package-2018-04
 ```
 
-## Suppression
+### Suppression
 ``` yaml
 directive:
   - suppress: OperationsAPIImplementation


### PR DESCRIPTION
This just fixes parsing of the readme. A `Tag` must be directly below a `Configuration`,  `Suppression`.