### PR TITLE
fix readme Configuration Tags for mixedreality data-plane

### DIFF
--- a/specification/mixedreality/data-plane/readme.md
+++ b/specification/mixedreality/data-plane/readme.md
@@ -20,7 +20,7 @@ For other options on installation see [Installing AutoRest](https://aka.ms/autor
 
 ## Configuration
 
-## Suppression
+### Suppression
 
 ``` yaml
 directive:


### PR DESCRIPTION
This just fixes parsing of the readme. A `Tag` must be directly below a `Configuration`,  `Suppression`.