### PR TITLE
Updating AzureCommunicationServices Chat Events Schema for MRI->CommunicationIdentifier transition

### DIFF
--- a/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
+++ b/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
@@ -7,11 +7,11 @@
   },
   "paths": {},
   "definitions": {
-    "ACSChatMessageReceivedEventData": {
+    "AcsChatMessageReceivedEventData": {
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatMessageReceived event.",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatMessageEventBaseProperties"
+          "$ref": "#/definitions/AcsChatMessageEventBaseProperties"
         }
       ],
       "properties": {
@@ -21,11 +21,11 @@
         }
       }
     },
-    "ACSChatMessageEditedEventData": {
+    "AcsChatMessageEditedEventData": {
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatMessageEdited event.",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatMessageEventBaseProperties"
+          "$ref": "#/definitions/AcsChatMessageEventBaseProperties"
         }
       ],
       "properties": {
@@ -40,11 +40,11 @@
         }
       }
     },
-    "ACSChatMessageDeletedEventData": {
+    "AcsChatMessageDeletedEventData": {
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatMessageDeleted event.",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatMessageEventBaseProperties"
+          "$ref": "#/definitions/AcsChatMessageEventBaseProperties"
         }
       ],
       "properties": {
@@ -55,11 +55,11 @@
         }
       }
     },
-    "ACSChatThreadCreatedWithUserEventData": {
+    "AcsChatThreadCreatedWithUserEventData": {
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatThreadCreatedWithUser event.",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatThreadEventBaseProperties"
+          "$ref": "#/definitions/AcsChatThreadEventBaseProperties"
         }
       ],
       "properties": {
@@ -78,16 +78,16 @@
           "description": "The list of properties of participants who are part of the thread",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ACSChatThreadParticipantProperties"
+            "$ref": "#/definitions/AcsChatThreadParticipantProperties"
           }
         }
       }
     },
-    "ACSChatThreadWithUserDeletedEventData": {
+    "AcsChatThreadWithUserDeletedEventData": {
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatThreadWithUserDeleted event.",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatThreadEventBaseProperties"
+          "$ref": "#/definitions/AcsChatThreadEventBaseProperties"
         }
       ],
       "properties": {
@@ -102,11 +102,11 @@
         }
       }
     },
-    "ACSChatThreadPropertiesUpdatedPerUserEventData": {
+    "AcsChatThreadPropertiesUpdatedPerUserEventData": {
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatThreadPropertiesUpdatedPerUser event.",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatThreadEventBaseProperties"
+          "$ref": "#/definitions/AcsChatThreadEventBaseProperties"
         }
       ],
       "properties": {
@@ -128,11 +128,11 @@
         }
       }
     },
-    "ACSChatParticipantAddedToThreadWithUserEventData": {
+    "AcsChatParticipantAddedToThreadWithUserEventData": {
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatParticipantAddedToThreadWithUser event.",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatThreadEventBaseProperties"
+          "$ref": "#/definitions/AcsChatThreadEventBaseProperties"
         }
       ],
       "properties": {
@@ -147,15 +147,15 @@
         },
         "participantAdded": {
           "description": "The details of the user who was added",
-          "$ref": "#/definitions/ACSChatThreadParticipantProperties"
+          "$ref": "#/definitions/AcsChatThreadParticipantProperties"
         }
       }
     },
-    "ACSChatParticipantRemovedFromThreadWithUserEventData": {
+    "AcsChatParticipantRemovedFromThreadWithUserEventData": {
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatParticipantRemovedFromThreadWithUser event.",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatThreadEventBaseProperties"
+          "$ref": "#/definitions/AcsChatThreadEventBaseProperties"
         }
       ],
       "properties": {
@@ -170,7 +170,7 @@
         },
         "participantRemoved": {
           "description": "The details of the user who was removed",
-          "$ref": "#/definitions/ACSChatThreadParticipantProperties"
+          "$ref": "#/definitions/AcsChatThreadParticipantProperties"
         }
       }
     },
@@ -223,11 +223,11 @@
         }
       }
     },
-    "ACSChatThreadEventBaseProperties": {
+    "AcsChatThreadEventBaseProperties": {
       "description": "Schema of common properties of all chat thread events",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatEventBaseProperties"
+          "$ref": "#/definitions/AcsChatEventBaseProperties"
         }
       ],
       "properties": {
@@ -243,11 +243,11 @@
         }
       }
     },
-    "ACSChatMessageEventBaseProperties": {
+    "AcsChatMessageEventBaseProperties": {
       "description": "Schema of common properties of all chat message events",
       "allOf": [
         {
-          "$ref": "#/definitions/ACSChatEventBaseProperties"
+          "$ref": "#/definitions/AcsChatEventBaseProperties"
         }
       ],
       "properties": {
@@ -279,7 +279,7 @@
         }
       }
     },
-    "ACSChatEventBaseProperties": {
+    "AcsChatEventBaseProperties": {
       "description": "Schema of common properties of all chat events",
       "type": "object",
       "properties": {
@@ -297,7 +297,7 @@
         }
       }
     },
-    "ACSChatThreadParticipantProperties": {
+    "AcsChatThreadParticipantProperties": {
       "description": "Schema of the chat thread participant",
       "type": "object",
       "properties": {

--- a/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
+++ b/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
@@ -63,10 +63,6 @@
         }
       ],
       "properties": {
-        "createdBy": {
-          "description": "The MRI of the creator of the thread",
-          "type": "string"
-        },
         "createdByCommunicationIdentifier": {
           "description": "The communication identifier of the user who created the thread",
           "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
@@ -76,13 +72,6 @@
           "type": "object",
           "additionalProperties": {
             "type": "object"
-          }
-        },
-        "members": {
-          "description": "The list of properties of users who are part of the thread",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ACSChatThreadMemberProperties"
           }
         },
         "participants": {
@@ -102,10 +91,6 @@
         }
       ],
       "properties": {
-        "deletedBy": {
-          "description": "The MRI of the user who deleted the thread",
-          "type": "string"
-        },
         "deletedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who deleted the thread",
           "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
@@ -125,10 +110,6 @@
         }
       ],
       "properties": {
-        "editedBy": {
-          "description": "The MRI of the user who updated the thread properties",
-          "type": "string"
-        },
         "editedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who updated the thread properties",
           "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
@@ -144,52 +125,6 @@
           "additionalProperties": {
             "type": "object"
           }
-        }
-      }
-    },
-    "ACSChatMemberAddedToThreadWithUserEventData": {
-      "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatMemberAddedToThreadWithUser event.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/ACSChatThreadEventBaseProperties"
-        }
-      ],
-      "properties": {
-        "time": {
-          "description": "The time at which the user was added to the thread",
-          "format": "date-time",
-          "type": "string"
-        },
-        "addedBy": {
-          "description": "The MRI of the user who added the user",
-          "type": "string"
-        },
-        "memberAdded": {
-          "description": "The details of the user who was added",
-          "$ref": "#/definitions/ACSChatThreadMemberProperties"
-        }
-      }
-    },
-    "ACSChatMemberRemovedFromThreadWithUserEventData": {
-      "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatMemberRemovedFromThreadWithUser event.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/ACSChatThreadEventBaseProperties"
-        }
-      ],
-      "properties": {
-        "time": {
-          "description": "The time at which the user was removed to the thread",
-          "format": "date-time",
-          "type": "string"
-        },
-        "removedBy": {
-          "description": "The MRI of the user who removed the user",
-          "type": "string"
-        },
-        "memberRemoved": {
-          "description": "The details of the user who was removed",
-          "$ref": "#/definitions/ACSChatThreadMemberProperties"
         }
       }
     },
@@ -320,10 +255,6 @@
           "description": "The chat message id",
           "type": "string"
         },
-        "senderId": {
-          "description": "The MRI of the sender",
-          "type": "string"
-        },
         "senderCommunicationIdentifier": {
           "description": "The communication identifier of the sender",
           "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
@@ -352,10 +283,6 @@
       "description": "Schema of common properties of all chat events",
       "type": "object",
       "properties": {
-        "recipientId": {
-          "description": "The MRI of the target user",
-          "type": "string"
-        },
         "recipientCommunicationIdentifier": {
           "description": "The communication identifier of the target user",
           "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
@@ -366,20 +293,6 @@
         },
         "threadId": {
           "description": "The chat thread id",
-          "type": "string"
-        }
-      }
-    },
-    "ACSChatThreadMemberProperties": {
-      "description": "Schema of the chat thread member",
-      "type": "object",
-      "properties": {
-        "displayName": {
-          "description": "The name of the user",
-          "type": "string"
-        },
-        "memberId": {
-          "description": "The MRI of the user",
           "type": "string"
         }
       }

--- a/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
+++ b/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
@@ -298,7 +298,7 @@
       }
     },
     "ACSChatThreadParticipantProperties": {
-      "description": "Schema of the chat thread member",
+      "description": "Schema of the chat thread participant",
       "type": "object",
       "properties": {
         "displayName": {

--- a/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
+++ b/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
@@ -65,7 +65,7 @@
       "properties": {
         "createdByCommunicationIdentifier": {
           "description": "The communication identifier of the user who created the thread",
-          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+          "$ref": "#/definitions/CommunicationIdentifier"
         },
         "properties": {
           "description": "The thread properties",
@@ -93,7 +93,7 @@
       "properties": {
         "deletedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who deleted the thread",
-          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+          "$ref": "#/definitions/CommunicationIdentifier"
         },
         "deleteTime": {
           "description": "The deletion time of the thread",
@@ -112,7 +112,7 @@
       "properties": {
         "editedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who updated the thread properties",
-          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+          "$ref": "#/definitions/CommunicationIdentifier"
         },
         "editTime": {
           "description": "The time at which the properties of the thread were updated",
@@ -143,7 +143,7 @@
         },
         "addedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who added the user",
-          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+          "$ref": "#/definitions/CommunicationIdentifier"
         },
         "participantAdded": {
           "description": "The details of the user who was added",
@@ -166,7 +166,7 @@
         },
         "removedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who removed the user",
-          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+          "$ref": "#/definitions/CommunicationIdentifier"
         },
         "participantRemoved": {
           "description": "The details of the user who was removed",
@@ -257,7 +257,7 @@
         },
         "senderCommunicationIdentifier": {
           "description": "The communication identifier of the sender",
-          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+          "$ref": "#/definitions/CommunicationIdentifier"
         },
         "senderDisplayName": {
           "description": "The display name of the sender",
@@ -285,7 +285,7 @@
       "properties": {
         "recipientCommunicationIdentifier": {
           "description": "The communication identifier of the target user",
-          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+          "$ref": "#/definitions/CommunicationIdentifier"
         },
         "transactionId": {
           "description": "The transaction id will be used as co-relation vector",
@@ -307,7 +307,7 @@
         },
         "participantCommunicationIdentifier": {
           "description": "The communication identifier of the user",
-          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+          "$ref": "#/definitions/CommunicationIdentifier"
         }
       }
     },
@@ -347,6 +347,14 @@
           "type": "integer"
         }
       }
+    },
+    "CommunicationIdentifier": {
+      "description": "Schema of the CommunicationIdentifier object used to identify an ACS user",
+      "allOf": [
+        {
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+        }
+      ]
     }
   }
 }

--- a/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
+++ b/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
@@ -65,7 +65,7 @@
       "properties": {
         "createdByCommunicationIdentifier": {
           "description": "The communication identifier of the user who created the thread",
-          "$ref": "#/definitions/CommunicationIdentifier"
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         },
         "properties": {
           "description": "The thread properties",
@@ -93,7 +93,7 @@
       "properties": {
         "deletedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who deleted the thread",
-          "$ref": "#/definitions/CommunicationIdentifier"
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         },
         "deleteTime": {
           "description": "The deletion time of the thread",
@@ -112,7 +112,7 @@
       "properties": {
         "editedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who updated the thread properties",
-          "$ref": "#/definitions/CommunicationIdentifier"
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         },
         "editTime": {
           "description": "The time at which the properties of the thread were updated",
@@ -143,7 +143,7 @@
         },
         "addedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who added the user",
-          "$ref": "#/definitions/CommunicationIdentifier"
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         },
         "participantAdded": {
           "description": "The details of the user who was added",
@@ -166,7 +166,7 @@
         },
         "removedByCommunicationIdentifier": {
           "description": "The communication identifier of the user who removed the user",
-          "$ref": "#/definitions/CommunicationIdentifier"
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         },
         "participantRemoved": {
           "description": "The details of the user who was removed",
@@ -257,7 +257,7 @@
         },
         "senderCommunicationIdentifier": {
           "description": "The communication identifier of the sender",
-          "$ref": "#/definitions/CommunicationIdentifier"
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         },
         "senderDisplayName": {
           "description": "The display name of the sender",
@@ -285,7 +285,7 @@
       "properties": {
         "recipientCommunicationIdentifier": {
           "description": "The communication identifier of the target user",
-          "$ref": "#/definitions/CommunicationIdentifier"
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         },
         "transactionId": {
           "description": "The transaction id will be used as co-relation vector",
@@ -307,7 +307,7 @@
         },
         "participantCommunicationIdentifier": {
           "description": "The communication identifier of the user",
-          "$ref": "#/definitions/CommunicationIdentifier"
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         }
       }
     },
@@ -347,14 +347,6 @@
           "type": "integer"
         }
       }
-    },
-    "CommunicationIdentifier": {
-      "description": "Schema of the CommunicationIdentifier object used to identify an ACS user",
-      "allOf": [
-        {
-          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
-        }
-      ]
     }
   }
 }

--- a/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
+++ b/specification/eventgrid/data-plane/Microsoft.Communication/stable/2018-01-01/AzureCommunicationServices.json
@@ -67,6 +67,10 @@
           "description": "The MRI of the creator of the thread",
           "type": "string"
         },
+        "createdByCommunicationIdentifier": {
+          "description": "The communication identifier of the user who created the thread",
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+        },
         "properties": {
           "description": "The thread properties",
           "type": "object",
@@ -79,6 +83,13 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/ACSChatThreadMemberProperties"
+          }
+        },
+        "participants": {
+          "description": "The list of properties of participants who are part of the thread",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ACSChatThreadParticipantProperties"
           }
         }
       }
@@ -94,6 +105,10 @@
         "deletedBy": {
           "description": "The MRI of the user who deleted the thread",
           "type": "string"
+        },
+        "deletedByCommunicationIdentifier": {
+          "description": "The communication identifier of the user who deleted the thread",
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         },
         "deleteTime": {
           "description": "The deletion time of the thread",
@@ -113,6 +128,10 @@
         "editedBy": {
           "description": "The MRI of the user who updated the thread properties",
           "type": "string"
+        },
+        "editedByCommunicationIdentifier": {
+          "description": "The communication identifier of the user who updated the thread properties",
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         },
         "editTime": {
           "description": "The time at which the properties of the thread were updated",
@@ -171,6 +190,52 @@
         "memberRemoved": {
           "description": "The details of the user who was removed",
           "$ref": "#/definitions/ACSChatThreadMemberProperties"
+        }
+      }
+    },
+    "ACSChatParticipantAddedToThreadWithUserEventData": {
+      "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatParticipantAddedToThreadWithUser event.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ACSChatThreadEventBaseProperties"
+        }
+      ],
+      "properties": {
+        "time": {
+          "description": "The time at which the user was added to the thread",
+          "format": "date-time",
+          "type": "string"
+        },
+        "addedByCommunicationIdentifier": {
+          "description": "The communication identifier of the user who added the user",
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+        },
+        "participantAdded": {
+          "description": "The details of the user who was added",
+          "$ref": "#/definitions/ACSChatThreadParticipantProperties"
+        }
+      }
+    },
+    "ACSChatParticipantRemovedFromThreadWithUserEventData": {
+      "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Communication.ChatParticipantRemovedFromThreadWithUser event.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ACSChatThreadEventBaseProperties"
+        }
+      ],
+      "properties": {
+        "time": {
+          "description": "The time at which the user was removed to the thread",
+          "format": "date-time",
+          "type": "string"
+        },
+        "removedByCommunicationIdentifier": {
+          "description": "The communication identifier of the user who removed the user",
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+        },
+        "participantRemoved": {
+          "description": "The details of the user who was removed",
+          "$ref": "#/definitions/ACSChatThreadParticipantProperties"
         }
       }
     },
@@ -259,6 +324,10 @@
           "description": "The MRI of the sender",
           "type": "string"
         },
+        "senderCommunicationIdentifier": {
+          "description": "The communication identifier of the sender",
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+        },
         "senderDisplayName": {
           "description": "The display name of the sender",
           "type": "string"
@@ -287,6 +356,10 @@
           "description": "The MRI of the target user",
           "type": "string"
         },
+        "recipientCommunicationIdentifier": {
+          "description": "The communication identifier of the target user",
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
+        },
         "transactionId": {
           "description": "The transaction id will be used as co-relation vector",
           "type": "string"
@@ -308,6 +381,20 @@
         "memberId": {
           "description": "The MRI of the user",
           "type": "string"
+        }
+      }
+    },
+    "ACSChatThreadParticipantProperties": {
+      "description": "Schema of the chat thread member",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "description": "The name of the user",
+          "type": "string"
+        },
+        "participantCommunicationIdentifier": {
+          "description": "The communication identifier of the user",
+          "$ref": "../../../../../communication/data-plane/Microsoft.CommunicationServicesCommon/stable/2021-03-07/common.json#/definitions/CommunicationIdentifierModel"
         }
       }
     },


### PR DESCRIPTION
The events will be published with both the old/new properties, so the previously released SDKs will continue to work. We are removing the older properties explicitly to ensure that newer SDKs don't continue to expose the older properties.

### Changelog
Please ensure to add changelog with this PR by answering the following questions.
  1. What's the purpose of the update?    
      - [ ] new service onboarding 
      - [ ] new API version 
      - [X ] update existing version for new feature 
      - [ ] update existing version to fix swagger quality issue in s360
      - [ ] Other, please clarify 
  2. When you are targeting to deploy new service/feature to public regions? Please provide date, or month to public if date is not available yet.
  3. When you expect to publish swagger? Please provide date, or month to public if date is not available yet.
  4. If it's an update to existing version,  please select SDKs of specific language and CLIs that require refresh after swagger is published.
      - [X] SDK of .NET (need service team to ensure code readiness)
      - [X] SDK of Python
      - [X] SDK of Java
      - [X] SDK of Js
      - [X] SDK of Go
      - [X] PowerShell
      - [ ] CLI
      - [ ] Terraform
      - [ ] No, no need to refresh for updates in this PR

### Contribution checklist:
- [X] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [X] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [X] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Ensure to check this box if one of the following scenarios meet updates in the PR, so that label “WaitForARMFeedback” will be added automatically to involve ARM API Review. Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs, all “removals” and “adding a new property” no more require ARM API review.
  - Adding new API(s)
  - Adding a new API version
  - Adding a new service

- [ ] Please ensure you've reviewed following [guidelines](https://aka.ms/rpguidelines) including [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md). Estimated time (4 hours). This is required before you can request review from ARM API Review board.

- [ ] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM oncall for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them. 

### Breaking Change Review Checklist 
If there are following updates in the PR, ensure to request an approval from Breaking Change Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 

- [ ] Removing API(s) in stable version
- [X] Removing properties in stable version
- [ ] Removing API version(s) in stable version
- [ ] Updating API in stable or public preview version with Breaking Change Validation errors
- [ ] Updating API(s) in public preview over 1 year (refer to [Retirement of Previews](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37683/Retirement-of-Previews))

**Action**: to initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate). Addition details on the process and office hours are on the [Breaking change Wiki](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37684/Breaking-Changes).

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).
