### PR TITLE
remove java code owner due to no required for java.md anymore

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -80,5 +80,4 @@
 /profile/ @shahabhijeet
 /specification/**/readme.typescript.md @qiaozha
 /specification/**/readme.go.md @ArcturusZhang
-/specification/**/readme.java.md @ChenTanyi
 /specification/**/readme.python.md @jsntcy @msyyc


### PR DESCRIPTION
Remove codeowner. Currently, track 2 automation will use default parameter rather than require a java.md. Thus, java.md no need to review in every PR I think.