### PR TITLE
GetBlockList returns long block sizes

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -9885,7 +9885,8 @@
         },
         "Size": {
           "description": "The block size in bytes.",
-          "type": "integer"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-02-10/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-02-10/blob.json
@@ -9908,7 +9908,8 @@
         },
         "Size": {
           "description": "The block size in bytes.",
-          "type": "integer"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-04-08/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-04-08/blob.json
@@ -10290,7 +10290,8 @@
         },
         "Size": {
           "description": "The block size in bytes.",
-          "type": "integer"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-06-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-06-12/blob.json
@@ -10290,7 +10290,8 @@
         },
         "Size": {
           "description": "The block size in bytes.",
-          "type": "integer"
+          "type": "integer",
+          "format": "int64"
         }
       }
     },


### PR DESCRIPTION
Fixes a service-returned long that was marked as an int.