### PR TITLE
Update readme.azureresourceschema.md

### DIFF
--- a/specification/redisenterprise/resource-manager/readme.azureresourceschema.md
+++ b/specification/redisenterprise/resource-manager/readme.azureresourceschema.md
@@ -8,7 +8,6 @@ These settings apply only when `--azureresourceschema` is specified on the comma
 batch:
   - tag: schema-cache-2021-03-01
   - tag: schema-cache-2021-02-01-preview
-  - tag: schema-cache-2020-10-01-preview
 
 ```
 
@@ -36,13 +35,3 @@ input-file:
 
 ```
 
-### Tag: schema-cache-2020-10-01-preview and azureresourceschema
-
-``` yaml $(tag) == 'schema-cache-2020-10-01-preview' && $(azureresourceschema)
-output-folder: $(azureresourceschema-folder)/schemas
-
-# all the input files in this apiVersion
-input-file:
-  - Microsoft.Cache/preview/2020-10-01-preview/redisenterprise.json
-
-```


### PR DESCRIPTION
Unreference 2020-10-01-preview from readme.azureresourceschema.md because it is a deprecated private preview API version for redisEnterprise.