### PR TITLE
[deviceupdate] make changes to readme in time for first release

### DIFF
--- a/specification/deviceupdate/data-plane/readme.python.md
+++ b/specification/deviceupdate/data-plane/readme.python.md
@@ -4,14 +4,21 @@ These settings apply only when `--python` is specified on the command line.
 Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
 
 ```yaml
-  azure-arm: false
-  license-header: MICROSOFT_MIT_SMALL_NO_CODEGEN
-  namespace: azure.deviceupdate
-  package-name: azure-deviceupdate
-  package-version: 2020-09-01-preview
+  python-mode: create
+  license-header: MICROSOFT_MIT_NO_VERSION
+  namespace: azure.iot.deviceupdate
+  package-name: azure-iot-deviceupdate
+  package-version: 1.0.0b1
   clear-output-folder: true
-  add-credentials: true 
+  add-credentials: true
   credential-scopes: 6ee392c4-d339-4083-b04d-6b7947c6cf78/.default
-  no-namespace-folders: true
-  output-folder: $(python-sdks-folder)/sdk/deviceupdate/azure-deviceupdate/azure/deviceupdate
+```
+
+```yaml $(python-mode) == 'create'
+output-folder: $(python-sdks-folder)/sdk/deviceupdate/azure-iot-deviceupdate
+```
+
+```yaml $(python-mode) == 'update'
+no-namespace-folders: true
+output-folder: $(python-sdks-folder)/sdk/deviceupdate/azure-iot-deviceupdate/azure/iot/deviceupdate
 ```

--- a/specification/deviceupdate/data-plane/readme.python.md
+++ b/specification/deviceupdate/data-plane/readme.python.md
@@ -15,10 +15,10 @@ Please also specify `--python-sdks-folder=<path to the root directory of your az
 ```
 
 ```yaml $(python-mode) == 'create'
-output-folder: $(python-sdks-folder)/sdk/deviceupdate/azure-iot-deviceupdate
+output-folder: $(python-sdks-folder)/deviceupdate/azure-iot-deviceupdate
 ```
 
 ```yaml $(python-mode) == 'update'
 no-namespace-folders: true
-output-folder: $(python-sdks-folder)/sdk/deviceupdate/azure-iot-deviceupdate/azure/iot/deviceupdate
+output-folder: $(python-sdks-folder)/deviceupdate/azure-iot-deviceupdate/azure/iot/deviceupdate
 ```


### PR DESCRIPTION
@dpokluda made these changes based off of looking at your [generated code](https://github.com/Azure/azure-sdk-for-python/pull/17005). For this first release, I would generate the file with command line. This command will get you the updated folder structure and all of the needed namespace packages, so you should generate with this command first.

```
autorest {path to readme.md} --python --python-sdks-folder={local path to azure-sdk-for-python}/sdk
```

For subsequent releases, when you don't want to regenerate all of the namespace folders, I would add `--python-mode=update` to the comamnd line, making it

```
autorest {path to readme.md} --python --python-sdks-folder={local path to azure-sdk-for-python}/sdk --python-mode=update
```