### PR TITLE
[text analytics] add client default for string-index-type

### DIFF
--- a/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.4/TextAnalytics.json
+++ b/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.4/TextAnalytics.json
@@ -2567,6 +2567,7 @@
         "UnicodeCodePoint",
         "Utf16CodeUnit"
       ],
+      "x-ms-client-default": "TextElements_v8",
       "x-ms-enum": {
         "name": "StringIndexType",
         "modelAsString": true,


### PR DESCRIPTION
For reasons i'm not 100% sure of, @maririos 's PR to de-duplicate string index type has removed the default behavior for the `string-index-type` param. I think the code was just working last time, and this swagger looks better, where we explicitly set the default value of the param.