### PR TITLE
Added `disableLocalAuth` property to Microsoft.AppConfiguration/configurationStores

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/appconfiguration.json
@@ -1116,6 +1116,10 @@
             "name": "PublicNetworkAccess",
             "modelAsString": true
           }
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "Disables all authentication methods other than AAD authentication."
         }
       }
     },
@@ -1202,6 +1206,10 @@
         "encryption": {
           "$ref": "#/definitions/EncryptionProperties",
           "description": "The encryption settings of the configuration store."
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "Disables all authentication methods other than AAD authentication."
         }
       }
     },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresCreate.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresCreate.json
@@ -28,6 +28,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
@@ -55,6 +56,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresCreateWithIdentity.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresCreateWithIdentity.json
@@ -34,6 +34,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
@@ -72,6 +73,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresGet.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresGet.json
@@ -19,6 +19,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresList.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresList.json
@@ -19,6 +19,7 @@
                   "identityClientId": null
                 }
               },
+              "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },
@@ -47,6 +48,7 @@
                   "identityClientId": null
                 }
               },
+              "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresListByResourceGroup.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresListByResourceGroup.json
@@ -20,6 +20,7 @@
                   "identityClientId": null
                 }
               },
+              "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },
@@ -43,6 +44,7 @@
                   "identityClientId": null
                 }
               },
+              "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresUpdate.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresUpdate.json
@@ -27,6 +27,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
@@ -54,6 +55,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresUpdateWithIdentity.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2020-07-01-preview/examples/ConfigurationStoresUpdateWithIdentity.json
@@ -33,6 +33,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
@@ -71,6 +72,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },


### PR DESCRIPTION
Added the `disableLocalAuth` property to the latest preview version of `Microsoft.AppConfiguration/configurationStores`.


The `disableLocalAuth` property will be required for all Azure Resources that support AAD Authentication and local authentication schemes. When `disableLocalAuth` is set to `true` only AAD authentication can be used to access the respective configurationStore.