### PR TITLE
Added Microsoft.AppConfiguration 2021-03-01-preview API version.

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
@@ -1042,7 +1042,7 @@
       "type": "object",
       "allOf": [
         {
-          "$ref": "#/definitions/Resource"
+          "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/TrackedResource"
         }
       ],
       "properties": {
@@ -1058,6 +1058,10 @@
         "sku": {
           "$ref": "#/definitions/Sku",
           "description": "The sku of the configuration store."
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/systemData",
+          "description": "Resource system metadata."
         }
       }
     },
@@ -1691,45 +1695,6 @@
         }
       },
       "description": "The resource management error additional info."
-    },
-    "Resource": {
-      "description": "An Azure resource.",
-      "required": [
-        "location"
-      ],
-      "properties": {
-        "id": {
-          "description": "The resource ID.",
-          "type": "string",
-          "readOnly": true
-        },
-        "name": {
-          "description": "The name of the resource.",
-          "type": "string",
-          "readOnly": true
-        },
-        "type": {
-          "description": "The type of the resource.",
-          "type": "string",
-          "readOnly": true
-        },
-        "location": {
-          "description": "The location of the resource. This cannot be changed after the resource is created.",
-          "type": "string",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
-        },
-        "tags": {
-          "description": "The tags of the resource.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "x-ms-azure-resource": true
     },
     "PrivateEndpointConnectionListResult": {
       "type": "object",

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
@@ -1,0 +1,1983 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2021-03-01-preview",
+    "title": "AppConfigurationManagementClient"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AppConfiguration/configurationStores": {
+      "get": {
+        "tags": [
+          "ConfigurationStores"
+        ],
+        "description": "Lists the configuration stores for a given subscription.",
+        "operationId": "ConfigurationStores_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "A skip token is used to continue retrieving items after an operation returns a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/ConfigurationStoreListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConfigurationStores_List": {
+            "$ref": "./examples/ConfigurationStoresList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores": {
+      "get": {
+        "tags": [
+          "ConfigurationStores"
+        ],
+        "description": "Lists the configuration stores for a given resource group.",
+        "operationId": "ConfigurationStores_ListByResourceGroup",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "A skip token is used to continue retrieving items after an operation returns a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/ConfigurationStoreListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConfigurationStores_ListByResourceGroup": {
+            "$ref": "./examples/ConfigurationStoresListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}": {
+      "get": {
+        "tags": [
+          "ConfigurationStores"
+        ],
+        "description": "Gets the properties of the specified configuration store.",
+        "operationId": "ConfigurationStores_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/ConfigurationStore"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConfigurationStores_Get": {
+            "$ref": "./examples/ConfigurationStoresGet.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ConfigurationStores"
+        ],
+        "description": "Creates a configuration store with the specified parameters.",
+        "operationId": "ConfigurationStores_Create",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "configStoreCreationParameters",
+            "in": "body",
+            "description": "The parameters for creating a configuration store.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConfigurationStore"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/ConfigurationStore"
+            }
+          },
+          "201": {
+            "description": "The request was successfully accepted; the operation will complete asynchronously. The provisioning state of the resource should indicate the current state of the resource.",
+            "schema": {
+              "$ref": "#/definitions/ConfigurationStore"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConfigurationStores_Create": {
+            "$ref": "./examples/ConfigurationStoresCreate.json"
+          },
+          "ConfigurationStores_Create_WithIdentity": {
+            "$ref": "./examples/ConfigurationStoresCreateWithIdentity.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "tags": [
+          "ConfigurationStores"
+        ],
+        "description": "Deletes a configuration store.",
+        "operationId": "ConfigurationStores_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly."
+          },
+          "202": {
+            "description": "The request was successful; the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "No Content - the specified resource was not found."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConfigurationStores_Delete": {
+            "$ref": "./examples/ConfigurationStoresDelete.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "ConfigurationStores"
+        ],
+        "description": "Updates a configuration store with the specified parameters.",
+        "operationId": "ConfigurationStores_Update",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "configStoreUpdateParameters",
+            "in": "body",
+            "description": "The parameters for updating a configuration store.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConfigurationStoreUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/ConfigurationStore"
+            }
+          },
+          "201": {
+            "description": "The request was successfully accepted; the operation will complete asynchronously. The provisioning state of the resource should indicate the current state of the resource.",
+            "schema": {
+              "$ref": "#/definitions/ConfigurationStore"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConfigurationStores_Update": {
+            "$ref": "./examples/ConfigurationStoresUpdate.json"
+          },
+          "ConfigurationStores_Update_WithIdentity": {
+            "$ref": "./examples/ConfigurationStoresUpdateWithIdentity.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AppConfiguration/checkNameAvailability": {
+      "post": {
+        "tags": [
+          "Operations"
+        ],
+        "description": "Checks whether the configuration store name is available for use.",
+        "operationId": "Operations_CheckNameAvailability",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "checkNameAvailabilityParameters",
+            "in": "body",
+            "description": "The object containing information for the availability request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/NameAvailabilityStatus"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConfigurationStores_CheckNameAvailable": {
+            "$ref": "./examples/CheckNameAvailable.json"
+          },
+          "ConfigurationStores_CheckNameNotAvailable": {
+            "$ref": "./examples/CheckNameNotAvailable.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/listKeys": {
+      "post": {
+        "tags": [
+          "ConfigurationStores"
+        ],
+        "description": "Lists the access key for the specified configuration store.",
+        "operationId": "ConfigurationStores_ListKeys",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "A skip token is used to continue retrieving items after an operation returns a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/ApiKeyListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConfigurationStores_ListKeys": {
+            "$ref": "./examples/ConfigurationStoresListKeys.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/regenerateKey": {
+      "post": {
+        "tags": [
+          "ConfigurationStores"
+        ],
+        "description": "Regenerates an access key for the specified configuration store.",
+        "operationId": "ConfigurationStores_RegenerateKey",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "regenerateKeyParameters",
+            "in": "body",
+            "description": "The parameters for regenerating an access key.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/ApiKey"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConfigurationStores_RegenerateKey": {
+            "$ref": "./examples/ConfigurationStoresRegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.AppConfiguration/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists the operations available from this provider.",
+        "operationId": "Operations_List",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "A skip token is used to continue retrieving items after an operation returns a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/OperationDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {},
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/privateEndpointConnections": {
+      "get": {
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "operationId": "PrivateEndpointConnections_ListByConfigurationStore",
+        "description": "Lists all private endpoint connections for a configuration store.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnection_List": {
+            "$ref": "./examples/ConfigurationStoresListPrivateEndpointConnections.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "operationId": "PrivateEndpointConnections_Get",
+        "description": "Gets the specified private endpoint connection associated with the configuration store.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "Private endpoint connection name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnection_GetConnection": {
+            "$ref": "./examples/ConfigurationStoresGetPrivateEndpointConnection.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+        "description": "Update the state of the specified private endpoint connection associated with the configuration store.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "Private endpoint connection name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnection",
+            "in": "body",
+            "description": "The private endpoint connection properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "The request was successfully accepted; the operation will complete asynchronously. The provisioning state of the resource should indicate the current state of the resource.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnection_CreateOrUpdate": {
+            "$ref": "./examples/ConfigurationStoresCreatePrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes a private endpoint connection.",
+        "operationId": "PrivateEndpointConnections_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "Private endpoint connection name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly."
+          },
+          "202": {
+            "description": "The request was successful; the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "No Content - the specified resource was not found."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_Delete": {
+            "$ref": "./examples/ConfigurationStoresDeletePrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/privateLinkResources": {
+      "get": {
+        "tags": [
+          "PrivateLinkResources"
+        ],
+        "operationId": "PrivateLinkResources_ListByConfigurationStore",
+        "description": "Gets the private link resources that need to be created for a configuration store.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourceListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateLinkResources_ListGroupIds": {
+            "$ref": "./examples/PrivateLinkResourcesListByConfigurationStore.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/privateLinkResources/{groupName}": {
+      "get": {
+        "tags": [
+          "PrivateLinkResources"
+        ],
+        "operationId": "PrivateLinkResources_Get",
+        "description": "Gets a private link resource that need to be created for a configuration store.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "groupName",
+            "in": "path",
+            "description": "The name of the private link resource group.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateLinkResources_Get": {
+            "$ref": "./examples/PrivateLinkResourceGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/keyValues": {
+      "get": {
+        "tags": [
+          "KeyValues"
+        ],
+        "description": "Lists the key-values for a given configuration store.",
+        "operationId": "KeyValues_ListByConfigurationStore",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "A skip token is used to continue retrieving items after an operation returns a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/KeyValueListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "KeyValues_ListByConfigurationStore": {
+            "$ref": "./examples/ConfigurationStoresListKeyValues.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/keyValues/{keyValueName}": {
+      "get": {
+        "tags": [
+          "KeyValues"
+        ],
+        "description": "Gets the properties of the specified key-value.",
+        "operationId": "KeyValues_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "keyValueName",
+            "in": "path",
+            "description": "Identifier of key and label combination. Key and label are joined by $ character. Label is optional.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/KeyValue"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "KeyValues_Get": {
+            "$ref": "./examples/ConfigurationStoresGetKeyValue.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "KeyValues"
+        ],
+        "description": "Creates a key-value.",
+        "operationId": "KeyValues_CreateOrUpdate",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "keyValueName",
+            "in": "path",
+            "description": "Identifier of key and label combination. Key and label are joined by $ character. Label is optional.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "keyValueParameters",
+            "in": "body",
+            "description": "The parameters for creating a key-value.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/KeyValue"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly.",
+            "schema": {
+              "$ref": "#/definitions/KeyValue"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "KeyValues_CreateOrUpdate": {
+            "$ref": "./examples/ConfigurationStoresCreateKeyValue.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "KeyValues"
+        ],
+        "description": "Deletes a key-value.",
+        "operationId": "KeyValues_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ConfigStoreNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "keyValueName",
+            "in": "path",
+            "description": "Identifier of key and label combination. Key and label are joined by $ character. Label is optional.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful; the request was well-formed and received properly."
+          },
+          "202": {
+            "description": "The request was successful; the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "No Content - the specified resource was not found."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "KeyValues_Delete": {
+            "$ref": "./examples/ConfigurationStoresDeleteKeyValue.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "ConfigurationStoreListResult": {
+      "description": "The result of a request to list configuration stores.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The collection value.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConfigurationStore"
+          }
+        },
+        "nextLink": {
+          "description": "The URI that can be used to request the next set of paged results.",
+          "type": "string"
+        }
+      }
+    },
+    "ConfigurationStore": {
+      "description": "The configuration store along with all resource properties. The Configuration Store will have all information to begin utilizing it.",
+      "required": [
+        "location",
+        "sku"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "identity": {
+          "$ref": "#/definitions/ResourceIdentity",
+          "description": "The managed identity information, if configured."
+        },
+        "properties": {
+          "$ref": "#/definitions/ConfigurationStoreProperties",
+          "description": "The properties of a configuration store.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The sku of the configuration store."
+        }
+      }
+    },
+    "ConfigurationStoreProperties": {
+      "description": "The properties of a configuration store.",
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "description": "The provisioning state of the configuration store.",
+          "enum": [
+            "Creating",
+            "Updating",
+            "Deleting",
+            "Succeeded",
+            "Failed",
+            "Canceled"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "ProvisioningState",
+            "modelAsString": true
+          }
+        },
+        "creationDate": {
+          "format": "date-time",
+          "description": "The creation date of configuration store.",
+          "type": "string",
+          "readOnly": true
+        },
+        "endpoint": {
+          "description": "The DNS endpoint where the configuration store API will be available.",
+          "type": "string",
+          "readOnly": true
+        },
+        "encryption": {
+          "$ref": "#/definitions/EncryptionProperties",
+          "description": "The encryption settings of the configuration store."
+        },
+        "privateEndpointConnections": {
+          "description": "The list of private endpoint connections that are set up for this resource.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnectionReference"
+          }
+        },
+        "publicNetworkAccess": {
+          "description": "Control permission for data plane traffic coming from public networks while private endpoint is enabled.",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "PublicNetworkAccess",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "EncryptionProperties": {
+      "type": "object",
+      "description": "The encryption settings for a configuration store.",
+      "properties": {
+        "keyVaultProperties": {
+          "$ref": "#/definitions/KeyVaultProperties",
+          "description": "Key vault properties."
+        }
+      }
+    },
+    "PrivateEndpointConnectionReference": {
+      "type": "object",
+      "description": "A reference to a related private endpoint connection.",
+      "properties": {
+        "id": {
+          "description": "The resource ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "The name of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "The type of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "The properties of a private endpoint connection.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "KeyVaultProperties": {
+      "type": "object",
+      "description": "Settings concerning key vault encryption for a configuration store.",
+      "properties": {
+        "keyIdentifier": {
+          "description": "The URI of the key vault key used to encrypt data.",
+          "type": "string"
+        },
+        "identityClientId": {
+          "description": "The client id of the identity which will be used to access key vault.",
+          "type": "string"
+        }
+      }
+    },
+    "ConfigurationStoreUpdateParameters": {
+      "description": "The parameters for updating a configuration store.",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConfigurationStorePropertiesUpdateParameters",
+          "description": "The properties for updating a configuration store.",
+          "x-ms-client-flatten": true
+        },
+        "identity": {
+          "$ref": "#/definitions/ResourceIdentity",
+          "description": "The managed identity information for the configuration store."
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The SKU of the configuration store."
+        },
+        "tags": {
+          "description": "The ARM resource tags.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ConfigurationStorePropertiesUpdateParameters": {
+      "description": "The properties for updating a configuration store.",
+      "type": "object",
+      "properties": {
+        "encryption": {
+          "$ref": "#/definitions/EncryptionProperties",
+          "description": "The encryption settings of the configuration store."
+        }
+      }
+    },
+    "CheckNameAvailabilityParameters": {
+      "description": "Parameters used for checking whether a resource name is available.",
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name to check for availability.",
+          "type": "string"
+        },
+        "type": {
+          "description": "The resource type to check for name availability.",
+          "enum": [
+            "Microsoft.AppConfiguration/configurationStores"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ConfigurationResourceType",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "NameAvailabilityStatus": {
+      "description": "The result of a request to check the availability of a resource name.",
+      "type": "object",
+      "properties": {
+        "nameAvailable": {
+          "description": "The value indicating whether the resource name is available.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "message": {
+          "description": "If any, the error message that provides more detail for the reason that the name is not available.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reason": {
+          "description": "If any, the reason that the name is not available.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ApiKeyListResult": {
+      "description": "The result of a request to list API keys.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The collection value.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApiKey"
+          }
+        },
+        "nextLink": {
+          "description": "The URI that can be used to request the next set of paged results.",
+          "type": "string"
+        }
+      }
+    },
+    "ApiKey": {
+      "description": "An API key used for authenticating with a configuration store endpoint.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The key ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "A name for the key describing its usage.",
+          "type": "string",
+          "readOnly": true
+        },
+        "value": {
+          "description": "The value of the key that is used for authentication purposes.",
+          "type": "string",
+          "readOnly": true
+        },
+        "connectionString": {
+          "description": "A connection string that can be used by supporting clients for authentication.",
+          "type": "string",
+          "readOnly": true
+        },
+        "lastModified": {
+          "format": "date-time",
+          "description": "The last time any of the key's properties were modified.",
+          "type": "string",
+          "readOnly": true
+        },
+        "readOnly": {
+          "description": "Whether this key can only be used for read operations.",
+          "type": "boolean",
+          "readOnly": true
+        }
+      }
+    },
+    "RegenerateKeyParameters": {
+      "description": "The parameters used to regenerate an API key.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The id of the key to regenerate.",
+          "type": "string"
+        }
+      }
+    },
+    "KeyValueListResult": {
+      "description": "The result of a request to list key-values.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The collection value.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyValue"
+          }
+        },
+        "nextLink": {
+          "description": "The URI that can be used to request the next set of paged results.",
+          "type": "string"
+        }
+      }
+    },
+    "KeyValue": {
+      "description": "The key-value resource along with all resource properties.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The resource ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "The name of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "The type of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/KeyValueProperties",
+          "description": "All key-value properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "KeyValueProperties": {
+      "description": "All key-value properties.",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "The primary identifier of a key-value.\r\nThe key is used in unison with the label to uniquely identify a key-value.",
+          "type": "string",
+          "readOnly": true
+        },
+        "label": {
+          "description": "A value used to group key-values.\r\nThe label is used in unison with the key to uniquely identify a key-value.",
+          "type": "string",
+          "readOnly": true
+        },
+        "value": {
+          "description": "The value of the key-value.",
+          "type": "string"
+        },
+        "contentType": {
+          "description": "The content type of the key-value's value.\r\nProviding a proper content-type can enable transformations of values when they are retrieved by applications.",
+          "type": "string"
+        },
+        "eTag": {
+          "description": "An ETag indicating the state of a key-value within a configuration store.",
+          "type": "string",
+          "readOnly": true
+        },
+        "lastModified": {
+          "format": "date-time",
+          "description": "The last time a modifying operation was performed on the given key-value.",
+          "type": "string",
+          "readOnly": true
+        },
+        "locked": {
+          "description": "A value indicating whether the key-value is locked.\r\nA locked key-value may not be modified until it is unlocked.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "tags": {
+          "description": "A dictionary of tags that can help identify what a key-value may be applicable for.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "OperationDefinitionListResult": {
+      "description": "The result of a request to list configuration store operations.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The collection value.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OperationDefinition"
+          }
+        },
+        "nextLink": {
+          "description": "The URI that can be used to request the next set of paged results.",
+          "type": "string"
+        }
+      }
+    },
+    "OperationDefinition": {
+      "description": "The definition of a configuration store operation.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Operation name: {provider}/{resource}/{operation}.",
+          "type": "string"
+        },
+        "isDataAction": {
+          "description": "Indicates whether the operation is a data action",
+          "type": "boolean"
+        },
+        "display": {
+          "$ref": "#/definitions/OperationDefinitionDisplay",
+          "description": "The display information for the configuration store operation."
+        },
+        "origin": {
+          "description": "Origin of the operation",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/OperationProperties",
+          "description": "Properties of the operation"
+        }
+      }
+    },
+    "OperationDefinitionDisplay": {
+      "description": "The display information for a configuration store operation.",
+      "type": "object",
+      "properties": {
+        "provider": {
+          "description": "The resource provider name: Microsoft App Configuration.\"",
+          "type": "string",
+          "readOnly": true
+        },
+        "resource": {
+          "description": "The resource on which the operation is performed.",
+          "type": "string"
+        },
+        "operation": {
+          "description": "The operation that users can perform.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The description for the operation.",
+          "type": "string"
+        }
+      }
+    },
+    "OperationProperties": {
+      "description": "Extra Operation properties",
+      "type": "object",
+      "properties": {
+        "serviceSpecification": {
+          "$ref": "#/definitions/ServiceSpecification",
+          "description": "Service specifications of the operation"
+        }
+      }
+    },
+    "ServiceSpecification": {
+      "description": "Service specification payload",
+      "type": "object",
+      "properties": {
+        "logSpecifications": {
+          "description": "Specifications of the Log for Azure Monitoring",
+          "uniqueItems": false,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LogSpecification"
+          }
+        },
+        "metricSpecifications": {
+          "description": "Specifications of the Metrics for Azure Monitoring",
+          "uniqueItems": false,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MetricSpecification"
+          }
+        }
+      }
+    },
+    "LogSpecification": {
+      "description": "Specifications of the Log for Azure Monitoring",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the log",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Localized friendly display name of the log",
+          "type": "string"
+        },
+        "blobDuration": {
+          "description": "Blob duration of the log",
+          "type": "string"
+        }
+      }
+    },
+    "MetricSpecification": {
+      "description": "Specifications of the Metrics for Azure Monitoring",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the metric",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Localized friendly display name of the metric",
+          "type": "string"
+        },
+        "displayDescription": {
+          "description": "Localized friendly description of the metric",
+          "type": "string"
+        },
+        "unit": {
+          "description": "Unit that makes sense for the metric",
+          "type": "string"
+        },
+        "aggregationType": {
+          "description": "Only provide one value for this field. Valid values: Average, Minimum, Maximum, Total, Count.",
+          "type": "string"
+        },
+        "internalMetricName": {
+          "description": "Internal metric name.",
+          "type": "string"
+        },
+        "dimensions": {
+          "description": "Dimensions of the metric",
+          "uniqueItems": false,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MetricDimension"
+          }
+        }
+      }
+    },
+    "MetricDimension": {
+      "description": "Specifications of the Dimension of metrics",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the dimension",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Localized friendly display name of the dimension",
+          "type": "string"
+        },
+        "internalName": {
+          "description": "Internal name of the dimension.",
+          "type": "string"
+        }
+      }
+    },
+    "ResourceIdentity": {
+      "type": "object",
+      "description": "An identity that can be associated with a resource.",
+      "properties": {
+        "type": {
+          "description": "The type of managed identity used. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user-assigned identities. The type 'None' will remove any identities.",
+          "enum": [
+            "None",
+            "SystemAssigned",
+            "UserAssigned",
+            "SystemAssigned, UserAssigned"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "IdentityType",
+            "modelAsString": true
+          }
+        },
+        "userAssignedIdentities": {
+          "description": "The list of user-assigned identities associated with the resource. The user-assigned identity dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserIdentity"
+          }
+        },
+        "principalId": {
+          "description": "The principal id of the identity. This property will only be provided for a system-assigned identity.",
+          "type": "string",
+          "readOnly": true
+        },
+        "tenantId": {
+          "description": "The tenant id associated with the resource's identity. This property will only be provided for a system-assigned identity.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "UserIdentity": {
+      "type": "object",
+      "description": "A resource identity that is managed by the user of the service.",
+      "properties": {
+        "principalId": {
+          "description": "The principal ID of the user-assigned identity.",
+          "type": "string",
+          "readOnly": true
+        },
+        "clientId": {
+          "description": "The client ID of the user-assigned identity.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "Sku": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "The SKU name of the configuration store.",
+          "type": "string"
+        }
+      },
+      "description": "Describes a configuration store SKU."
+    },
+    "ErrorDetails": {
+      "description": "The details of the error.",
+      "properties": {
+        "code": {
+          "description": "Error code.",
+          "type": "string",
+          "readOnly": true
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "type": "string",
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorAdditionalInfo"
+          },
+          "description": "The error additional info."
+        }
+      }
+    },
+    "ErrorResponse": {
+      "description": "Error response indicates that the service is not able to process the incoming request. The reason is provided in the error message.",
+      "type": "object",
+      "properties": {
+        "error": {
+          "description": "The details of the error.",
+          "$ref": "#/definitions/ErrorDetails"
+        }
+      }
+    },
+    "ErrorAdditionalInfo": {
+      "properties": {
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The additional info type."
+        },
+        "info": {
+          "readOnly": true,
+          "type": "object",
+          "description": "The additional info."
+        }
+      },
+      "description": "The resource management error additional info."
+    },
+    "Resource": {
+      "description": "An Azure resource.",
+      "required": [
+        "location"
+      ],
+      "properties": {
+        "id": {
+          "description": "The resource ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "The name of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "The type of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "location": {
+          "description": "The location of the resource. This cannot be changed after the resource is created.",
+          "type": "string",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "description": "The tags of the resource.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "A list of private endpoint connections",
+      "properties": {
+        "value": {
+          "description": "The collection value.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "description": "The URI that can be used to request the next set of paged results.",
+          "type": "string"
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "description": "A private endpoint connection",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The resource ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "The name of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "The type of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "The properties of a private endpoint.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of a private endpoint connection.",
+      "properties": {
+        "provisioningState": {
+          "enum": [
+            "Creating",
+            "Updating",
+            "Deleting",
+            "Succeeded",
+            "Failed",
+            "Canceled"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "description": "The provisioning status of the private endpoint connection.",
+          "x-ms-enum": {
+            "name": "ProvisioningState",
+            "modelAsString": true
+          }
+        },
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The resource of private endpoint."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of information about the state of the connection between service consumer and provider."
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ]
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "Private endpoint which a connection belongs to.",
+      "properties": {
+        "id": {
+          "description": "The resource Id for private endpoint",
+          "type": "string"
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "description": "The state of a private link service connection.",
+      "type": "object",
+      "properties": {
+        "status": {
+          "enum": [
+            "Pending",
+            "Approved",
+            "Rejected",
+            "Disconnected"
+          ],
+          "type": "string",
+          "description": "The private link service connection status.",
+          "x-ms-enum": {
+            "name": "ConnectionStatus",
+            "modelAsString": true
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "The private link service connection description."
+        },
+        "actionsRequired": {
+          "enum": [
+            "None",
+            "Recreate"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "description": "Any action that is required beyond basic workflow (approve/ reject/ disconnect)",
+          "x-ms-enum": {
+            "name": "ActionsRequired",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "PrivateLinkResourceListResult": {
+      "type": "object",
+      "description": "A list of private link resources.",
+      "properties": {
+        "value": {
+          "description": "The collection value.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "description": "The URI that can be used to request the next set of paged results.",
+          "type": "string"
+        }
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "A resource that supports private link capabilities.",
+      "properties": {
+        "id": {
+          "description": "The resource ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "The name of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "The type of the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "Private link resource properties.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "description": "The private link resource group id.",
+          "type": "string",
+          "readOnly": true
+        },
+        "requiredMembers": {
+          "description": "The private link resource required member names.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true,
+          "description": "The list of required DNS zone names of the private link resource."
+        }
+      },
+      "description": "Properties of a private link resource."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "The Microsoft Azure subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "ResourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group to which the container registry belongs.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "ConfigStoreNameParameter": {
+      "name": "configStoreName",
+      "in": "path",
+      "description": "The name of the configuration store.",
+      "required": true,
+      "type": "string",
+      "maxLength": 50,
+      "minLength": 5,
+      "pattern": "^[a-zA-Z0-9_-]*$",
+      "x-ms-parameter-location": "method"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The client API version.",
+      "required": true,
+      "type": "string"
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      },
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow"
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ]
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
@@ -204,8 +204,11 @@
           "ConfigurationStores_Create": {
             "$ref": "./examples/ConfigurationStoresCreate.json"
           },
-          "ConfigurationStores_Create_WithIdentity": {
+          "ConfigurationStores_Create_With_Identity": {
             "$ref": "./examples/ConfigurationStoresCreateWithIdentity.json"
+          },
+          "ConfigurationStores_Create_With_Local_Auth_Disabled": {
+            "$ref": "./examples/ConfigurationStoresCreateWithLocalAuthDisabled.json"
           }
         },
         "x-ms-long-running-operation": true
@@ -307,8 +310,11 @@
           "ConfigurationStores_Update": {
             "$ref": "./examples/ConfigurationStoresUpdate.json"
           },
-          "ConfigurationStores_Update_WithIdentity": {
+          "ConfigurationStores_Update_With_Identity": {
             "$ref": "./examples/ConfigurationStoresUpdateWithIdentity.json"
+          },
+          "ConfigurationStores_Update_Disable_Local_Auth": {
+            "$ref": "./examples/ConfigurationStoresUpdateDisableLocalAuth.json"
           }
         },
         "x-ms-long-running-operation": true

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
@@ -1120,6 +1120,10 @@
             "name": "PublicNetworkAccess",
             "modelAsString": true
           }
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "Disables all authentication methods other than AAD authentication."
         }
       }
     },
@@ -1206,6 +1210,10 @@
         "encryption": {
           "$ref": "#/definitions/EncryptionProperties",
           "description": "The encryption settings of the configuration store."
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "Disables all authentication methods other than AAD authentication."
         }
       }
     },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/CheckNameAvailable.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/CheckNameAvailable.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "api-version": "2021-03-01-preview",
+    "checkNameAvailabilityParameters": {
+      "name": "contoso",
+      "type": "Microsoft.AppConfiguration/configurationStores"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nameAvailable": true,
+        "message": "The specified name is available.",
+        "reason": null
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/CheckNameNotAvailable.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/CheckNameNotAvailable.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "api-version": "2021-03-01-preview",
+    "checkNameAvailabilityParameters": {
+      "name": "contoso",
+      "type": "Microsoft.AppConfiguration/configurationStores"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nameAvailable": false,
+        "reason": "AlreadyExists",
+        "message": "The specified name is already in use."
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreate.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreate.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview",
+    "configStoreCreationParameters": {
+      "location": "westus",
+      "sku": {
+        "name": "Standard"
+      },
+      "tags": {
+        "myTag": "myTagValue"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "creationDate": "2018-04-24T16:30:55+00:00",
+          "endpoint": "https://contoso.azconfig.io",
+          "encryption": {
+            "keyVaultProperties": {
+              "keyIdentifier": null,
+              "identityClientId": null
+            }
+          },
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
+        },
+        "sku": {
+          "name": "Standard"
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+        "name": "contoso",
+        "location": "westus",
+        "tags": {
+          "myTag": "myTagValue"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores",
+        "properties": {
+          "provisioningState": "Creating",
+          "creationDate": "2018-04-24T16:30:55+00:00",
+          "endpoint": "https://contoso.azconfig.io",
+          "encryption": {
+            "keyVaultProperties": {
+              "keyIdentifier": null,
+              "identityClientId": null
+            }
+          },
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
+        },
+        "sku": {
+          "name": "Standard"
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+        "name": "contoso",
+        "location": "westus",
+        "tags": {
+          "myTag": "myTagValue"
+        }
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreate.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreate.json
@@ -28,6 +28,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
@@ -55,6 +56,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateKeyValue.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateKeyValue.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview",
+    "keyValueName": "myKey$myLabel",
+    "keyValueParameters": {
+      "properties": {
+        "value": "myValue",
+        "tags": {
+          "tag1": "tagValue1",
+          "tag2": "tagValue2"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+        "properties": {
+          "key": "myKey",
+          "label": "myLabel",
+          "value": "myValue",
+          "contentType": "",
+          "eTag": "IhDxoa8VkXxPsYsemBlxvV0d5fp",
+          "lastModified": "2020-06-23T06:42:24+00:00",
+          "locked": false,
+          "tags": {
+            "tag1": "tagValue1",
+            "tag2": "tagValue2"
+          }
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/keyValues/myKey$myLabel",
+        "name": "myKey$myLabel"
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreatePrivateEndpointConnection.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreatePrivateEndpointConnection.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "privateEndpointConnectionName": "myConnection",
+    "api-version": "2021-03-01-preview",
+    "privateEndpointConnection": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "status": "Approved",
+          "description": "Auto-Approved"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/privateEndpointConnections/myConnection",
+        "name": "myConnection",
+        "type": "Microsoft.AppConfiguration/configurationStores/privateEndpointConnections",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateEndpoint": {
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/peexample01"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved",
+            "description": "Auto-Approved",
+            "actionsRequired": "None"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/privateEndpointConnections/myConnection",
+        "name": "myConnection",
+        "type": "Microsoft.AppConfiguration/configurationStores/privateEndpointConnections",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateEndpoint": {
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/peexample01"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved",
+            "description": "Auto-Approved",
+            "actionsRequired": "None"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithIdentity.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithIdentity.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview",
+    "configStoreCreationParameters": {
+      "location": "westus",
+      "sku": {
+        "name": "Standard"
+      },
+      "tags": {
+        "myTag": "myTagValue"
+      },
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourcegroups/myResourceGroup1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity2": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "creationDate": "2018-04-24T16:30:55+00:00",
+          "endpoint": "https://contoso.azconfig.io",
+          "encryption": {
+            "keyVaultProperties": {
+              "keyIdentifier": null,
+              "identityClientId": null
+            }
+          },
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
+        },
+        "sku": {
+          "name": "Standard"
+        },
+        "identity": {
+          "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+          "tenantId": "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourcegroups/myResourceGroup1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity2": {
+              "clientId": "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC",
+              "principalId": "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD"
+            }
+          }
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+        "name": "contoso",
+        "location": "westus",
+        "tags": {
+          "myTag": "myTagValue"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores",
+        "properties": {
+          "provisioningState": "Creating",
+          "creationDate": "2018-04-24T16:30:55+00:00",
+          "endpoint": "https://contoso.azconfig.io",
+          "encryption": {
+            "keyVaultProperties": {
+              "keyIdentifier": null,
+              "identityClientId": null
+            }
+          },
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
+        },
+        "sku": {
+          "name": "Standard"
+        },
+        "identity": {
+          "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+          "tenantId": "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourcegroups/myResourceGroup1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity2": {
+              "clientId": "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC",
+              "principalId": "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD"
+            }
+          }
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+        "name": "contoso",
+        "location": "westus",
+        "tags": {
+          "myTag": "myTagValue"
+        }
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithIdentity.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithIdentity.json
@@ -35,8 +35,15 @@
             }
           },
           "disableLocalAuth": false,
-          "privateEndpointConnections": [],
-          "publicNetworkAccess": "Disabled"
+          "privateEndpointConnections": []
+        },
+        "systemData": {
+          "createdBy": "foo@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2018-04-24T16:30:55+00:00",
+          "lastModifiedBy": "foo@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2018-04-24T16:30:55+00:00"
         },
         "sku": {
           "name": "Standard"
@@ -73,8 +80,16 @@
               "identityClientId": null
             }
           },
-          "privateEndpointConnections": [],
-          "publicNetworkAccess": "Disabled"
+          "disableLocalAuth": false,
+          "privateEndpointConnections": []
+        },
+        "systemData": {
+          "createdBy": "foo@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2018-04-24T16:30:55+00:00",
+          "lastModifiedBy": "foo@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2018-04-24T16:30:55+00:00"
         },
         "sku": {
           "name": "Standard"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithIdentity.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithIdentity.json
@@ -34,6 +34,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithLocalAuthDisabled.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithLocalAuthDisabled.json
@@ -9,8 +9,8 @@
       "sku": {
         "name": "Standard"
       },
-      "tags": {
-        "myTag": "myTagValue"
+      "properties": {
+        "disableLocalAuth": true 
       }
     }
   },
@@ -28,7 +28,7 @@
               "identityClientId": null
             }
           },
-          "disableLocalAuth": false,
+          "disableLocalAuth": true,
           "privateEndpointConnections": []
         },
         "systemData": {
@@ -45,9 +45,7 @@
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",
         "location": "westus",
-        "tags": {
-          "myTag": "myTagValue"
-        }
+        "tags": { }
       }
     },
     "201": {
@@ -63,7 +61,7 @@
               "identityClientId": null
             }
           },
-          "disableLocalAuth": false,
+          "disableLocalAuth": true,
           "privateEndpointConnections": []
         },
         "systemData": {
@@ -80,9 +78,7 @@
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",
         "location": "westus",
-        "tags": {
-          "myTag": "myTagValue"
-        }
+        "tags": { }
       }
     }
   }

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithLocalAuthDisabled.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresCreateWithLocalAuthDisabled.json
@@ -10,7 +10,7 @@
         "name": "Standard"
       },
       "properties": {
-        "disableLocalAuth": true 
+        "disableLocalAuth": true
       }
     }
   },
@@ -45,7 +45,7 @@
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",
         "location": "westus",
-        "tags": { }
+        "tags": {}
       }
     },
     "201": {
@@ -78,7 +78,7 @@
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",
         "location": "westus",
-        "tags": { }
+        "tags": {}
       }
     }
   }

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresDelete.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresDelete.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {},
+    "202": {},
+    "204": {}
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresDeleteKeyValue.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresDeleteKeyValue.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview",
+    "keyValueName": "myKey$myLabel"
+  },
+  "responses": {
+    "200": {},
+    "202": {},
+    "204": {}
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresDeletePrivateEndpointConnection.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresDeletePrivateEndpointConnection.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "privateEndpointConnectionName": "myConnection",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {},
+    "202": {},
+    "204": {}
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGet.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGet.json
@@ -19,6 +19,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGet.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGet.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "creationDate": "2018-04-24T16:30:55+00:00",
+          "endpoint": "https://contoso.azconfig.io",
+          "encryption": {
+            "keyVaultProperties": {
+              "keyIdentifier": null,
+              "identityClientId": null
+            }
+          },
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
+        },
+        "sku": {
+          "name": "Standard"
+        },
+        "identity": {
+          "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+          "tenantId": "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+          "type": "SystemAssigned"
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+        "name": "contoso",
+        "location": "westus",
+        "tags": {}
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGet.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGet.json
@@ -23,6 +23,14 @@
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
+        "systemData": {
+          "createdBy": "foo@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2018-04-24T16:30:55+00:00",
+          "lastModifiedBy": "foo@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2018-04-24T16:30:55+00:00"
+        },
         "sku": {
           "name": "Standard"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGetKeyValue.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGetKeyValue.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview",
+    "keyValueName": "myKey$myLabel"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+        "properties": {
+          "key": "myKey",
+          "label": "myLabel",
+          "value": "myValue",
+          "contentType": "",
+          "eTag": "IhDxoa8VkXxPsYsemBlxvV0d5fp",
+          "lastModified": "2020-06-23T06:42:24+00:00",
+          "locked": false,
+          "tags": {
+            "tag1": "tagValue1",
+            "tag2": "tagValue2"
+          }
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/keyValues/myKey$myLabel",
+        "name": "myKey$myLabel"
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGetPrivateEndpointConnection.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresGetPrivateEndpointConnection.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "privateEndpointConnectionName": "myConnection",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/privateEndpointConnections/myConnection",
+        "name": "myConnection",
+        "type": "Microsoft.AppConfiguration/configurationStores/privateEndpointConnections",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateEndpoint": {
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/peexample01"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved",
+            "description": "Auto-Approved",
+            "actionsRequired": "None"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresList.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresList.json
@@ -23,6 +23,14 @@
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },
+            "systemData": {
+              "createdBy": "foo@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2018-04-24T16:30:55+00:00",
+              "lastModifiedBy": "foo@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2018-04-24T16:30:55+00:00"
+            },
             "sku": {
               "name": "Standard"
             },
@@ -51,6 +59,14 @@
               "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
+            },
+            "systemData": {
+              "createdBy": "foo@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2018-04-24T16:30:55+00:00",
+              "lastModifiedBy": "foo@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2018-04-24T16:30:55+00:00"
             },
             "sku": {
               "name": "Standard"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresList.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresList.json
@@ -19,6 +19,7 @@
                   "identityClientId": null
                 }
               },
+              "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },
@@ -47,6 +48,7 @@
                   "identityClientId": null
                 }
               },
+              "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresList.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresList.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.AppConfiguration/configurationStores",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "creationDate": "2018-04-24T16:30:55+00:00",
+              "endpoint": "https://contoso.azconfig.io",
+              "encryption": {
+                "keyVaultProperties": {
+                  "keyIdentifier": null,
+                  "identityClientId": null
+                }
+              },
+              "privateEndpointConnections": [],
+              "publicNetworkAccess": "Disabled"
+            },
+            "sku": {
+              "name": "Standard"
+            },
+            "identity": {
+              "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+              "tenantId": "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+              "type": "SystemAssigned"
+            },
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+            "name": "contoso",
+            "location": "westus",
+            "tags": {}
+          },
+          {
+            "type": "Microsoft.AppConfiguration/configurationStores",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "creationDate": "2018-04-24T23:06:59+00:00",
+              "endpoint": "https://contoso2.azconfig.io",
+              "encryption": {
+                "keyVaultProperties": {
+                  "keyIdentifier": null,
+                  "identityClientId": null
+                }
+              },
+              "privateEndpointConnections": [],
+              "publicNetworkAccess": "Disabled"
+            },
+            "sku": {
+              "name": "Standard"
+            },
+            "identity": {
+              "principalId": "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC",
+              "tenantId": "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+              "type": "SystemAssigned"
+            },
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso2",
+            "name": "contoso2",
+            "location": "westus",
+            "tags": {}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListByResourceGroup.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListByResourceGroup.json
@@ -20,6 +20,7 @@
                   "identityClientId": null
                 }
               },
+              "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },
@@ -43,6 +44,7 @@
                   "identityClientId": null
                 }
               },
+              "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListByResourceGroup.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListByResourceGroup.json
@@ -24,6 +24,14 @@
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
             },
+            "systemData": {
+              "createdBy": "foo@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2018-04-24T16:30:55+00:00",
+              "lastModifiedBy": "foo@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2018-04-24T16:30:55+00:00"
+            },
             "sku": {
               "name": "Standard"
             },
@@ -47,6 +55,14 @@
               "disableLocalAuth": false,
               "privateEndpointConnections": [],
               "publicNetworkAccess": "Disabled"
+            },
+            "systemData": {
+              "createdBy": "foo@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2018-04-24T16:30:55+00:00",
+              "lastModifiedBy": "foo@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2018-04-24T16:30:55+00:00"
             },
             "sku": {
               "name": "Standard"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListByResourceGroup.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListByResourceGroup.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.AppConfiguration/configurationStores",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "creationDate": "2018-04-24T16:30:55+00:00",
+              "endpoint": "https://contoso.azconfig.io",
+              "encryption": {
+                "keyVaultProperties": {
+                  "keyIdentifier": null,
+                  "identityClientId": null
+                }
+              },
+              "privateEndpointConnections": [],
+              "publicNetworkAccess": "Disabled"
+            },
+            "sku": {
+              "name": "Standard"
+            },
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+            "name": "contoso",
+            "location": "westus",
+            "tags": {}
+          },
+          {
+            "type": "Microsoft.AppConfiguration/configurationStores",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "creationDate": "2018-04-24T23:06:59+00:00",
+              "endpoint": "https://contoso2.azconfig.io",
+              "encryption": {
+                "keyVaultProperties": {
+                  "keyIdentifier": null,
+                  "identityClientId": null
+                }
+              },
+              "privateEndpointConnections": [],
+              "publicNetworkAccess": "Disabled"
+            },
+            "sku": {
+              "name": "Standard"
+            },
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso2",
+            "name": "contoso2",
+            "location": "westus",
+            "tags": {}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListKeyValues.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListKeyValues.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+            "properties": {
+              "key": "myKey",
+              "label": "myLabel",
+              "value": "myValue",
+              "contentType": "",
+              "eTag": "IhDxoa8VkXxPsYsemBlxvV0d5fp",
+              "lastModified": "2020-06-23T06:42:24+00:00",
+              "locked": false,
+              "tags": {
+                "tag1": "tagValue1",
+                "tag2": "tagValue2"
+              }
+            },
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/keyValues/myKey$myLabel",
+            "name": "myKey$myLabel"
+          },
+          {
+            "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+            "properties": {
+              "key": "myKey2",
+              "label": "myLabel2",
+              "value": "myValue",
+              "contentType": "",
+              "eTag": "IfDxoa8VkXxPsYsemBlxvV0d5fp",
+              "lastModified": "2020-06-23T06:42:24+00:00",
+              "locked": false,
+              "tags": {
+                "tag1": "tagValue1",
+                "tag2": "tagValue2"
+              }
+            },
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/keyValues/myKey2$myLabel2",
+            "name": "myKey2$myLabel2"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListKeys.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListKeys.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "439AD01B4BE67DB1",
+            "name": "Primary",
+            "value": "000000000000000000000000000000000000000000000000000000",
+            "connectionString": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "lastModified": "2018-04-24T16:30:54+00:00",
+            "readOnly": false
+          },
+          {
+            "id": "CB45E100456857B9",
+            "name": "Secondary",
+            "value": "000000000000000000000000000000000000000000000000000000",
+            "connectionString": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "lastModified": "2018-04-24T16:30:54+00:00",
+            "readOnly": false
+          },
+          {
+            "id": "B3AC55B7E71431A9",
+            "name": "Primary Read Only",
+            "value": "000000000000000000000000000000000000000000000000000000",
+            "connectionString": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "lastModified": "2018-04-24T16:30:54+00:00",
+            "readOnly": true
+          },
+          {
+            "id": "E2AF6A9A89DCC177",
+            "name": "Secondary Read Only",
+            "value": "000000000000000000000000000000000000000000000000000000",
+            "connectionString": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "lastModified": "2018-04-24T16:30:54+00:00",
+            "readOnly": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListPrivateEndpointConnections.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresListPrivateEndpointConnections.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/privateEndpointConnections/myConnection",
+            "name": "myConnection",
+            "type": "Microsoft.AppConfiguration/configurationStores/privateEndpointConnections",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "privateEndpoint": {
+                "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/peexample01"
+              },
+              "privateLinkServiceConnectionState": {
+                "status": "Approved",
+                "description": "Auto-Approved",
+                "actionsRequired": "None"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresRegenerateKey.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresRegenerateKey.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview",
+    "regenerateKeyParameters": {
+      "id": "439AD01B4BE67DB1"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "439AD01B4BE67DB1",
+        "name": "Primary",
+        "value": "000000000000000000000000000000000000000000000000000000",
+        "connectionString": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "lastModified": "2018-04-26T22:59:24.2370906+00:00",
+        "readOnly": false
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdate.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdate.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview",
+    "configStoreUpdateParameters": {
+      "tags": {
+        "Category": "Marketing"
+      },
+      "sku": {
+        "name": "Standard"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "creationDate": "2018-04-24T16:30:55+00:00",
+          "endpoint": "https://contoso.azconfig.io",
+          "encryption": {
+            "keyVaultProperties": {
+              "keyIdentifier": null,
+              "identityClientId": null
+            }
+          },
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
+        },
+        "sku": {
+          "name": "Standard"
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+        "name": "contoso",
+        "location": "westus",
+        "tags": {
+          "Category": "Marketing"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores",
+        "properties": {
+          "provisioningState": "Updating",
+          "creationDate": "2018-04-24T16:30:55+00:00",
+          "endpoint": "https://contoso.azconfig.io",
+          "encryption": {
+            "keyVaultProperties": {
+              "keyIdentifier": null,
+              "identityClientId": null
+            }
+          },
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
+        },
+        "sku": {
+          "name": "Standard"
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+        "name": "contoso",
+        "location": "westus",
+        "tags": {
+          "Category": "Marketing"
+        }
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdate.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdate.json
@@ -27,6 +27,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
@@ -54,6 +55,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdate.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdate.json
@@ -31,6 +31,14 @@
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
+        "systemData": {
+          "createdBy": "foo@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2018-04-24T16:30:55+00:00",
+          "lastModifiedBy": "foo@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2018-04-24T16:30:55+00:00"
+        },
         "sku": {
           "name": "Standard"
         },
@@ -58,6 +66,14 @@
           "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
+        },
+        "systemData": {
+          "createdBy": "foo@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2018-04-24T16:30:55+00:00",
+          "lastModifiedBy": "foo@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2018-04-24T16:30:55+00:00"
         },
         "sku": {
           "name": "Standard"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateDisableLocalAuth.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateDisableLocalAuth.json
@@ -9,7 +9,7 @@
         "name": "Standard"
       },
       "properties": {
-        "disableLocalAuth": true 
+        "disableLocalAuth": true
       }
     }
   },
@@ -45,7 +45,7 @@
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",
         "location": "westus",
-        "tags": { }
+        "tags": {}
       }
     },
     "201": {
@@ -79,7 +79,7 @@
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",
         "location": "westus",
-        "tags": { }
+        "tags": {}
       }
     }
   }

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateDisableLocalAuth.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateDisableLocalAuth.json
@@ -4,13 +4,12 @@
     "resourceGroupName": "myResourceGroup",
     "configStoreName": "contoso",
     "api-version": "2021-03-01-preview",
-    "configStoreCreationParameters": {
-      "location": "westus",
+    "configStoreUpdateParameters": {
       "sku": {
         "name": "Standard"
       },
-      "tags": {
-        "myTag": "myTagValue"
+      "properties": {
+        "disableLocalAuth": true 
       }
     }
   },
@@ -28,8 +27,9 @@
               "identityClientId": null
             }
           },
-          "disableLocalAuth": false,
-          "privateEndpointConnections": []
+          "disableLocalAuth": true,
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
         },
         "systemData": {
           "createdBy": "foo@contoso.com",
@@ -45,16 +45,14 @@
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",
         "location": "westus",
-        "tags": {
-          "myTag": "myTagValue"
-        }
+        "tags": { }
       }
     },
     "201": {
       "body": {
         "type": "Microsoft.AppConfiguration/configurationStores",
         "properties": {
-          "provisioningState": "Creating",
+          "provisioningState": "Updating",
           "creationDate": "2018-04-24T16:30:55+00:00",
           "endpoint": "https://contoso.azconfig.io",
           "encryption": {
@@ -63,8 +61,9 @@
               "identityClientId": null
             }
           },
-          "disableLocalAuth": false,
-          "privateEndpointConnections": []
+          "disableLocalAuth": true,
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
         },
         "systemData": {
           "createdBy": "foo@contoso.com",
@@ -80,9 +79,7 @@
         "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
         "name": "contoso",
         "location": "westus",
-        "tags": {
-          "myTag": "myTagValue"
-        }
+        "tags": { }
       }
     }
   }

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateWithIdentity.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateWithIdentity.json
@@ -33,6 +33,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
@@ -71,6 +72,7 @@
               "identityClientId": null
             }
           },
+          "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateWithIdentity.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateWithIdentity.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview",
+    "configStoreUpdateParameters": {
+      "tags": {
+        "Category": "Marketing"
+      },
+      "sku": {
+        "name": "Standard"
+      },
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourcegroups/myResourceGroup1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity2": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "creationDate": "2018-04-24T16:30:55+00:00",
+          "endpoint": "https://contoso.azconfig.io",
+          "encryption": {
+            "keyVaultProperties": {
+              "keyIdentifier": null,
+              "identityClientId": null
+            }
+          },
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
+        },
+        "sku": {
+          "name": "Standard"
+        },
+        "identity": {
+          "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+          "tenantId": "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourcegroups/myResourceGroup1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity2": {
+              "clientId": "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC",
+              "principalId": "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD"
+            }
+          }
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+        "name": "contoso",
+        "location": "westus",
+        "tags": {
+          "Category": "Marketing"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.AppConfiguration/configurationStores",
+        "properties": {
+          "provisioningState": "Updating",
+          "creationDate": "2018-04-24T16:30:55+00:00",
+          "endpoint": "https://contoso.azconfig.io",
+          "encryption": {
+            "keyVaultProperties": {
+              "keyIdentifier": null,
+              "identityClientId": null
+            }
+          },
+          "privateEndpointConnections": [],
+          "publicNetworkAccess": "Disabled"
+        },
+        "sku": {
+          "name": "Standard"
+        },
+        "identity": {
+          "principalId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+          "tenantId": "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourcegroups/myResourceGroup1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity2": {
+              "clientId": "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC",
+              "principalId": "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD"
+            }
+          }
+        },
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso",
+        "name": "contoso",
+        "location": "westus",
+        "tags": {
+          "Category": "Marketing"
+        }
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateWithIdentity.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/ConfigurationStoresUpdateWithIdentity.json
@@ -37,6 +37,14 @@
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
         },
+        "systemData": {
+          "createdBy": "foo@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2018-04-24T16:30:55+00:00",
+          "lastModifiedBy": "foo@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2018-04-24T16:30:55+00:00"
+        },
         "sku": {
           "name": "Standard"
         },
@@ -75,6 +83,14 @@
           "disableLocalAuth": false,
           "privateEndpointConnections": [],
           "publicNetworkAccess": "Disabled"
+        },
+        "systemData": {
+          "createdBy": "foo@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2018-04-24T16:30:55+00:00",
+          "lastModifiedBy": "foo@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2018-04-24T16:30:55+00:00"
         },
         "sku": {
           "name": "Standard"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/PrivateLinkResourceGet.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/PrivateLinkResourceGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview",
+    "groupName": "configurationStores"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/privateLinkResources/configurationStores",
+        "name": "configurationStores",
+        "type": "Microsoft.AppConfiguraiton/configurationStores/privateLinkResources",
+        "properties": {
+          "groupId": "configurationStores",
+          "requiredMembers": [
+            "configurationStores"
+          ],
+          "requiredZoneNames": [
+            "privatelink.azconfig.io"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/PrivateLinkResourcesListByConfigurationStore.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/examples/PrivateLinkResourcesListByConfigurationStore.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "subscriptionId": "c80fb759-c965-4c6a-9110-9b2b2d038882",
+    "resourceGroupName": "myResourceGroup",
+    "configStoreName": "contoso",
+    "api-version": "2021-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/c80fb759-c965-4c6a-9110-9b2b2d038882/resourceGroups/myResourceGroup/providers/Microsoft.AppConfiguration/configurationStores/contoso/privateLinkResources/configurationStores",
+            "name": "configurationStores",
+            "type": "Microsoft.AppConfiguraiton/configurationStores/privateLinkResources",
+            "properties": {
+              "groupId": "configurationStores",
+              "requiredMembers": [
+                "configurationStores"
+              ],
+              "requiredZoneNames": [
+                "privatelink.azconfig.io"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/appconfiguration/resource-manager/readme.md
+++ b/specification/appconfiguration/resource-manager/readme.md
@@ -149,6 +149,18 @@ directive:
     from: appconfiguration.json
     where: $.definitions.KeyValueProperties.properties.locked
     reason: This is data plane level information proxied through the RP and cannot be changed.
+  - suppress: EnumInsteadOfBoolean
+    from: appconfiguration.json
+    where: $.definitions.ConfigurationStoreProperties.properties.disableLocalAuth
+    reason: This is a standardized ARM API.
+  - suppress: EnumInsteadOfBoolean
+    from: appconfiguration.json
+    where: $.definitions.ConfigurationStorePropertiesUpdateParameters.properties.disableLocalAuth
+    reason: This is a standardized ARM API.
+  - suppress: EnumInsteadOfBoolean
+    from: appconfiguration.json
+    where: $.definitions.OperationDefinition.properties.isDataAction
+    reason: This is a standardized ARM API.
 ```
 
 ## AzureResourceSchema

--- a/specification/appconfiguration/resource-manager/readme.md
+++ b/specification/appconfiguration/resource-manager/readme.md
@@ -26,7 +26,16 @@ These are the global settings for the AppConfiguration API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2020-07-01-preview
+tag: package-2021-03-01-preview
+```
+
+### Tag: package-2021-03-01-preview
+
+These settings apply only when `--tag=2021-03-01-preview` is specified on the command line.
+
+``` yaml $(tag) == 'package-2021-03-01-preview'
+input-file:
+- Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
 ```
 
 ### Tag: package-2020-07-01-preview


### PR DESCRIPTION
This PR introduces a new preview API version, 2021-03-01-preview. This API version is the same as our latest existing preview API version, 2020-07-01-preview except the two following additions:

* Added `disableLocalAuth` property
The disableLocalAuth property will be required for all Azure Resources that support AAD Authentication and local authentication schemes. When disableLocalAuth is set to true only AAD authentication can be used to access the respective configurationStore.

* Added the `systemData` property to the `ConfigurationStore` resource.


The first commit in this PR contains the copied files from 2020-07-01-preview. The following two commits introduce the changes mentioned above.

This PR replaces the following two PRs that were blocked due to breaking changes:
* #13407
* #13320 