### PR TITLE
Add optional param - private DNS zone to server API

### DIFF
--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerCreate.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerCreate.json
@@ -18,6 +18,9 @@
         "delegatedSubnetArguments": {
           "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
         },
+        "privateDnsZoneArguments": {
+          "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
+        },
         "storageProfile": {
           "storageMB": 524288,
           "backupRetentionDays": 7
@@ -47,6 +50,9 @@
           "haEnabled": "Enabled",
           "delegatedSubnetArguments": {
             "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
+          },
+          "privateDnsZoneArguments": {
+            "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
           },
           "storageProfile": {
             "storageMB": 524288,
@@ -87,6 +93,9 @@
           "haEnabled": "Enabled",
           "delegatedSubnetArguments": {
             "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
+          },
+          "privateDnsZoneArguments": {
+            "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
           },
           "storageProfile": {
             "storageMB": 524288,

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerCreatePointInTimeRestore.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerCreatePointInTimeRestore.json
@@ -32,6 +32,7 @@
           "publicNetworkAccess": "Enabled",
           "haEnabled": "Disabled",
           "delegatedSubnetArguments": {},
+          "privateDnsZoneArguments": {},
           "storageProfile": {
             "storageMB": 524288,
             "backupRetentionDays": 7
@@ -63,6 +64,7 @@
           "publicNetworkAccess": "Enabled",
           "haEnabled": "Disabled",
           "delegatedSubnetArguments": {},
+          "privateDnsZoneArguments": {},
           "storageProfile": {
             "storageMB": 524288,
             "backupRetentionDays": 7

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerGetWithVnet.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerGetWithVnet.json
@@ -23,6 +23,9 @@
           "delegatedSubnetArguments": {
             "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
           },
+          "privateDnsZoneArguments": {
+            "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
+          },
           "storageProfile": {
             "storageMB": 524288,
             "backupRetentionDays": 7

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerUpdate.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerUpdate.json
@@ -39,6 +39,7 @@
             "backupRetentionDays": 20
           },
           "delegatedSubnetArguments": {},
+          "privateDnsZoneArguments": {},
           "haEnabled": "Disabled",
           "availabilityZone": "1"
         },

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerUpdateWithCustomerMaintenanceWindow.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/examples/ServerUpdateWithCustomerMaintenanceWindow.json
@@ -36,6 +36,7 @@
             "backupRetentionDays": 20
           },
           "delegatedSubnetArguments": {},
+          "privateDnsZoneArguments": {},
           "haEnabled": "Disabled",
           "availabilityZone": "1",
           "maintenanceWindow": {

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/postgresql.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-preview/postgresql.json
@@ -1305,6 +1305,14 @@
             }
           }
         },
+        "privateDnsZoneArguments": {
+          "properties": {
+            "privateDnsZoneArmResourceId": {
+              "type": "string",
+              "description": "private dns zone arm resource id."
+            }
+          }
+        },
         "createMode": {
           "type": "string",
           "description": "The mode to create a new PostgreSQL server.",

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerCreate.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerCreate.json
@@ -18,6 +18,9 @@
         "delegatedSubnetArguments": {
           "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
         },
+        "privateDnsZoneArguments": {
+          "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
+        },
         "storageProfile": {
           "storageMB": 524288,
           "backupRetentionDays": 7
@@ -47,6 +50,9 @@
           "haEnabled": "Enabled",
           "delegatedSubnetArguments": {
             "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
+          },
+          "privateDnsZoneArguments": {
+            "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
           },
           "storageProfile": {
             "storageMB": 524288,
@@ -87,6 +93,9 @@
           "haEnabled": "Enabled",
           "delegatedSubnetArguments": {
             "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
+          },
+          "privateDnsZoneArguments": {
+            "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
           },
           "storageProfile": {
             "storageMB": 524288,

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerCreatePointInTimeRestore.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerCreatePointInTimeRestore.json
@@ -32,6 +32,7 @@
           "publicNetworkAccess": "Enabled",
           "haEnabled": "Disabled",
           "delegatedSubnetArguments": {},
+          "privateDnsZoneArguments": {},
           "storageProfile": {
             "storageMB": 524288,
             "backupRetentionDays": 7
@@ -63,6 +64,7 @@
           "publicNetworkAccess": "Enabled",
           "haEnabled": "Disabled",
           "delegatedSubnetArguments": {},
+          "privateDnsZoneArguments": {},
           "storageProfile": {
             "storageMB": 524288,
             "backupRetentionDays": 7

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerGetWithVnet.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerGetWithVnet.json
@@ -23,6 +23,9 @@
           "delegatedSubnetArguments": {
             "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
           },
+          "privateDnsZoneArguments": {
+            "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
+          },
           "storageProfile": {
             "storageMB": 524288,
             "backupRetentionDays": 7

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerUpdate.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerUpdate.json
@@ -39,6 +39,7 @@
             "backupRetentionDays": 20
           },
           "delegatedSubnetArguments": {},
+          "privateDnsZoneArguments": {},
           "haEnabled": "Disabled",
           "availabilityZone": "1"
         },

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerUpdateWithCustomerMaintenanceWindow.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/examples/ServerUpdateWithCustomerMaintenanceWindow.json
@@ -36,6 +36,7 @@
             "backupRetentionDays": 20
           },
           "delegatedSubnetArguments": {},
+          "privateDnsZoneArguments": {},
           "haEnabled": "Disabled",
           "availabilityZone": "1",
           "maintenanceWindow": {

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/postgresql.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-02-14-privatepreview/postgresql.json
@@ -1583,6 +1583,14 @@
             }
           }
         },
+        "privateDnsZoneArguments": {
+          "properties": {
+            "privateDnsZoneArmResourceId": {
+              "type": "string",
+              "description": "private dns zone arm resource id."
+            }
+          }
+        },
         "createMode": {
           "type": "string",
           "description": "The mode to create a new PostgreSQL server.",

--- a/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/examples/ServerGroupCreate.json
+++ b/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/examples/ServerGroupCreate.json
@@ -13,6 +13,9 @@
         "delegatedSubnetArguments": {
           "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
         },
+        "privateDnsZoneArguments": {
+          "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
+        },
         "enableMx": true,
         "enableZfs": false,
         "postgresqlVersion": "12",

--- a/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/examples/ServerGroupGet.json
+++ b/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/examples/ServerGroupGet.json
@@ -39,6 +39,9 @@
           "delegatedSubnetArguments": {
             "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
           },
+          "privateDnsZoneArguments": {
+            "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
+          },
           "maintenanceWindow": {
             "dayOfWeek": 0,
             "startHour": 0,

--- a/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/examples/ServerGroupList.json
+++ b/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/examples/ServerGroupList.json
@@ -38,6 +38,9 @@
               "delegatedSubnetArguments": {
                 "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
               },
+              "privateDnsZoneArguments": {
+                "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
+              },
               "readReplicas": [
                 "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/TestGroup/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/hsctestsg2"
               ],
@@ -184,6 +187,9 @@
               "standbyAvailabilityZone": "2",
               "delegatedSubnetArguments": {
                 "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
+              },
+              "privateDnsZoneArguments": {
+                "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
               },
               "readReplicas": null,
               "sourceServerGroup": null,

--- a/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/examples/ServerGroupListByResourceGroup.json
+++ b/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/examples/ServerGroupListByResourceGroup.json
@@ -39,6 +39,9 @@
               "delegatedSubnetArguments": {
                 "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
               },
+              "privateDnsZoneArguments": {
+                "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
+              },
               "readReplicas": null,
               "sourceServerGroup": null,
               "serverRoleGroups": [
@@ -183,6 +186,9 @@
               "standbyAvailabilityZone": "2",
               "delegatedSubnetArguments": {
                 "subnetArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-subnet"
+              },
+              "privateDnsZoneArguments": {
+                "privateDnsZoneArmResourceId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/testrg/providers/Microsoft.Network/privateDnsZones/test-private-dns-zone"
               },
               "readReplicas": null,
               "sourceServerGroup": null,

--- a/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/postgresqlhsc.json
+++ b/specification/postgresqlhsc/resource-manager/Microsoft.DBforPostgreSQL/preview/2020-10-05-privatepreview/postgresqlhsc.json
@@ -1657,6 +1657,15 @@
             }
           }
         },
+        "privateDnsZoneArguments": {
+          "description": "The private dns zone arguments for a server group.",
+          "properties": {
+            "privateDnsZoneArmResourceId": {
+              "type": "string",
+              "description": "private dns zone arm resource id."
+            }
+          }
+        },
         "readReplicas": {
           "type": "array",
           "description": "The array of read replica server groups.",

--- a/specification/postgresqlhsc/resource-manager/readme.go.md
+++ b/specification/postgresqlhsc/resource-manager/readme.go.md
@@ -22,5 +22,5 @@ These settings apply only when `--tag=package-2020-10-05-privatepreview --go` is
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag) == 'package-2020-10-05-privatepreview' && $(go)
-output-folder: $(go-sdk-folder)/services/preview/$(namespace)/mgmt/2020-10-05-privatepreview/$(namespace)
+output-folder: $(go-sdk-folder)/services/preview/$(namespace)/mgmt/2020-10-05-preview/$(namespace)
 ```


### PR DESCRIPTION
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Changelog
Please ensure to add changelog with this PR by answering the following questions.
  1. What's the purpose of the update?    
      - [x] update existing version for new feature 
  2. When you are targeting to deploy new service/feature to public regions? Please provide date, or month to public if date is not available yet.
        04/07/2021
  3. When you expect to publish swagger? Please provide date, or month to public if date is not available yet.
        04/02/2021
  4. If it's an update to existing version,  please select SDKs of specific language and CLIs that require refresh after swagger is published.
      - [ ] SDK of .NET (need service team to ensure code readiness)
      - [ ] SDK of Python
      - [ ] SDK of Java
      - [ ] SDK of Js
      - [ ] SDK of Go
      - [ ] PowerShell
      - [ ] CLI
      - [ ] Terraform
      - [ ] No, no need to refresh for updates in this PR

### Contribution checklist:
- [ ] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [x] Ensure to check this box if one of the following scenarios meet updates in the PR, so that label “WaitForARMFeedback” will be added automatically to involve ARM API Review. Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs, all “removals” and “adding a new property” no more require ARM API review.
  - Adding new API(s)
  - Adding a new API version
  -  [x] Ensure to copy the existing version into new directory structure for first commit (including refactoring) and then push new changes including version updates in separate commits. This is required to review the changes efficiently.
  - Adding a new service

- [x] Please ensure you've reviewed following [guidelines](https://aka.ms/rpguidelines) including [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md). Estimated time (4 hours). This is required before you can request review from ARM API Review board.

- [x] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM oncall for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them. 

### Breaking Change Review Checklist 
If there are following updates in the PR, ensure to request an approval from Breaking Change Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 

- [ ] Removing API(s) in stable version
- [ ] Removing properties in stable version
- [ ] Removing API version(s) in stable version
- [ ] Updating API in stable or public preview version with Breaking Change Validation errors
- [ ] Updating API(s) in public preview over 1 year (refer to [Retirement of Previews](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37683/Retirement-of-Previews))

**Action**: to initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate). Addition details on the process and office hours are on the [Breaking change Wiki](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37684/Breaking-Changes).

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).
