### PR TITLE
Add $(multiapi) to QnA Maker's readme.md

### DIFF
--- a/specification/cognitiveservices/data-plane/QnAMaker/readme.md
+++ b/specification/cognitiveservices/data-plane/QnAMaker/readme.md
@@ -74,7 +74,7 @@ These settings apply only when `--tag=release_5_0_preview.2` is specified on the
 input-file: preview/v5.0-preview.2/QnAMaker.json
 ```
 
-``` yaml
+``` yaml $(multiapi)
 batch:
   - tag: release_4_0
   - tag: runtime_release_4_0


### PR DESCRIPTION
Generators were processing every tag when only a single one was desired. This is the common solution to support multi-api SDKs.
