### PR TITLE
remove security duplicate tag package-2020-01-preview-only

### DIFF
--- a/specification/security/resource-manager/readme.md
+++ b/specification/security/resource-manager/readme.md
@@ -358,19 +358,6 @@ override-info:
   title: SecurityCenter
 ```
 
-### Tag: package-2020-01-preview-only
-
-These settings apply only when `--tag=package-2020-01-preview-only` is specified on the command line. This tag is used for Ruby SDK.
-
-``` yaml $(tag) == 'package-package-2020-01-preview-only'
-input-file:
-- Microsoft.Security/preview/2020-01-01-preview/secureScore.json
-
-# Needed when there is more than one input file
-override-info:
-  title: SecurityCenter
-```
-
 ### Tag: package-2020-01-only
 
 These settings apply only when `--tag=package-2020-01-only` is specified on the command line. This tag is used for Ruby SDK.


### PR DESCRIPTION
There are two sections with `### Tag: package-2020-01-preview-only`. This removed the older invalid one. You can see it is invalid with the `yaml $(tag) == 'package-package-2020-01-preview-only`.