### PR TITLE
add tags back in the adp readme

### DIFF
--- a/specification/adp/resource-manager/readme.md
+++ b/specification/adp/resource-manager/readme.md
@@ -31,12 +31,16 @@ openapi-subtype: rpaas
 tag: package-2021-02-01-preview
 ```
 
+### Tag: package-2020-07-01-preview
+
 ```yaml $(tag) == 'package-2020-07-01-preview'
 version: 2020-07-01-preview
 version-with-underscores: 2020_07_01_preview
 input-file:
   - Microsoft.AutonomousDevelopmentPlatform/preview/2020-07-01-preview/adp.json
 ```
+
+### Tag: package-2021-02-01-preview
 
 ```yaml $(tag) == 'package-2021-02-01-preview'
 version: 2021-02-01-preview


### PR DESCRIPTION
Code generators rely on the Configuration / Tag hierarchy in the readme file. https://github.com/Azure/azure-rest-api-specs/pull/13090 removed the tags. This puts them back. cc @aelij & @weidongxu-microsoft