### PR TITLE
Reduce code owner scope for Monitor.Exporters team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,8 @@
 /specification/analysisservices/ @taiwu
 /specification/alertsmanagement/ @ofirmanor @olalavi @erangon @orieldar @ilaizi @shakednai1 @khaboasb @orenhor
 /specification/apimanagement/ @promoisha @solankisamir
-/specification/applicationinsights/ @alexeldeib @ramthi @markwolff @trask @hectorhdzg @lzchen
+/specification/applicationinsights/ @alexeldeib
+/specification/applicationinsights/data-plane/Monitor.Exporters/ @ramthi @trask @hectorhdzg @lzchen
 /specification/asazure/ @athipp
 /specification/authorization/ @darshanhs90 @stankovski
 /specification/automation/ @vrdmr


### PR DESCRIPTION
Reduce code owner scope for @ramthi @trask @hectorhdzg @lzchen from all of

`/specification/applicationinsights/`

to just

`/specification/applicationinsights/data-plane/Monitor.Exporters/`

Also, removes @markwolff who is not in @microsoft anymore.