### PR TITLE
fix subscription readme heirarchy

### DIFF
--- a/specification/subscription/resource-manager/readme.md
+++ b/specification/subscription/resource-manager/readme.md
@@ -19,7 +19,7 @@ To see additional help and options, run:
 
 ## Configuration
 
-## Suppression
+### Suppression
 ``` yaml
 directive:
   - suppress: R2059


### PR DESCRIPTION
Some code generators rely on the Configuration / Tag hierarchy in the readme file. This fixes that hierarchy in the `subscription` readme.