### PR TITLE
Fix CI for EG data-plane

### DIFF
--- a/specification/eventgrid/data-plane/readme.md
+++ b/specification/eventgrid/data-plane/readme.md
@@ -19,7 +19,7 @@ In order to automate the mapping of event definition with event type, please fol
 - The description of the new event should include the event type. This is the `eventType` name in an `EventGridEvent` or `type` name in `CloudEvent`. For e.g. `"Schema of the Data property of an EventGridEvent for a Microsoft.Communication.ChatMessageReceived event.` Here `Microsoft.Communication.ChatMessageReceived` is the event name.
 
 A sample valid event definition is shown below:
-```json
+```json $(autorest-ignore-this-block-please)
 "AcsChatMessageReceivedEventData": {
   "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Communication.ChatMessageReceived event.",
   "allOf": [

--- a/specification/eventgrid/data-plane/readme.md
+++ b/specification/eventgrid/data-plane/readme.md
@@ -19,7 +19,8 @@ In order to automate the mapping of event definition with event type, please fol
 - The description of the new event should include the event type. This is the `eventType` name in an `EventGridEvent` or `type` name in `CloudEvent`. For e.g. `"Schema of the Data property of an EventGridEvent for a Microsoft.Communication.ChatMessageReceived event.` Here `Microsoft.Communication.ChatMessageReceived` is the event name.
 
 A sample valid event definition is shown below:
-```json $(autorest-ignore-this-block-please)
+~~~ markdown
+```json
 "AcsChatMessageReceivedEventData": {
   "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Communication.ChatMessageReceived event.",
   "allOf": [
@@ -35,6 +36,7 @@ A sample valid event definition is shown below:
   }
 }
 ```
+~~~
 
 ---
 ## Getting Started


### PR DESCRIPTION
We put a JSON snippet into the main readme for guidance to service team, but autorest is trying to be too smart and read it. I'm trying to bypass the process by making this block ignored with a fake filter.