### PR TITLE
remove assignee

### DIFF
--- a/.github/pull_request_assignment.yml
+++ b/.github/pull_request_assignment.yml
@@ -209,7 +209,6 @@
       - weidongxu-microsoft
       - ArcturusZhang
       - raych1
-      - ChenTanyi
       - akning-ms
       - leni-msft
       - qianwens


### PR DESCRIPTION
It seems to be added back by mistake after https://github.com/Azure/azure-rest-api-specs/pull/14441