### PR TITLE
[Hub Generated] Updating definition of subscriptionId parameter for resources APIs in stable/2021-04-01

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2021-04-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2021-04-01/resources.json
@@ -2848,14 +2848,14 @@
         ],
         "operationId": "Resources_MoveResources",
         "summary": "Moves resources from one resource group to another resource group.",
-        "description": "The resources to move must be in the same source resource group. The target resource group may be in a different subscription. When moving resources, both the source group and the target group are locked for the duration of the operation. Write and delete operations are blocked on the groups until the move completes. ",
+        "description": "The resources to be moved must be in the same source resource group in the source subscription being used. The target resource group may be in a different subscription. When moving resources, both the source group and the target group are locked for the duration of the operation. Write and delete operations are blocked on the groups until the move completes. ",
         "parameters": [
           {
             "name": "sourceResourceGroupName",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the resource group containing the resources to move.",
+            "description": "The name of the resource group from the source subscription containing the resources to be moved.",
             "pattern": "^[-\\w\\._\\(\\)]+$",
             "minLength": 1,
             "maxLength": 90
@@ -2900,14 +2900,14 @@
         ],
         "operationId": "Resources_ValidateMoveResources",
         "summary": "Validates whether resources can be moved from one resource group to another resource group.",
-        "description": "This operation checks whether the specified resources can be moved to the target. The resources to move must be in the same source resource group. The target resource group may be in a different subscription. If validation succeeds, it returns HTTP response code 204 (no content). If validation fails, it returns HTTP response code 409 (Conflict) with an error message. Retrieve the URL in the Location header value to check the result of the long-running operation.",
+        "description": "This operation checks whether the specified resources can be moved to the target. The resources to be moved must be in the same source resource group in the source subscription being used. The target resource group may be in a different subscription. If validation succeeds, it returns HTTP response code 204 (no content). If validation fails, it returns HTTP response code 409 (Conflict) with an error message. Retrieve the URL in the Location header value to check the result of the long-running operation.",
         "parameters": [
           {
             "name": "sourceResourceGroupName",
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the resource group containing the resources to validate for move.",
+            "description": "The name of the resource group from the source subscription containing the resources to be validated for move.",
             "pattern": "^[-\\w\\._\\(\\)]+$",
             "minLength": 1,
             "maxLength": 90

--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2021-04-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2021-04-01/resources.json
@@ -2841,7 +2841,7 @@
         "x-ms-odata": "#/definitions/ResourceGroupFilter"
       }
     },
-    "/subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroupName}/moveResources": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}/moveResources": {
       "post": {
         "tags": [
           "Resources"
@@ -2873,7 +2873,7 @@
             "$ref": "#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "#/parameters/SourceSubscriptionIdParameter"
+            "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -2893,7 +2893,7 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroupName}/validateMoveResources": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}/validateMoveResources": {
       "post": {
         "tags": [
           "Resources"
@@ -2925,7 +2925,7 @@
             "$ref": "#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "#/parameters/SourceSubscriptionIdParameter"
+            "$ref": "#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -6598,13 +6598,6 @@
       "minLength": 1,
       "maxLength": 90
     },
-    "SourceSubscriptionIdParameter": {
-        "name": "sourceSubscriptionId",
-        "in": "path",
-        "required": true,
-        "type": "string",
-        "description": "The ID of the source subscription."
-      },
     "SubscriptionIdParameter": {
       "name": "subscriptionId",
       "in": "path",

--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2021-04-01/resources.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2021-04-01/resources.json
@@ -2841,7 +2841,7 @@
         "x-ms-odata": "#/definitions/ResourceGroupFilter"
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}/moveResources": {
+    "/subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroupName}/moveResources": {
       "post": {
         "tags": [
           "Resources"
@@ -2873,7 +2873,7 @@
             "$ref": "#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
+            "$ref": "#/parameters/SourceSubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -2893,7 +2893,7 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}/validateMoveResources": {
+    "/subscriptions/{sourceSubscriptionId}/resourceGroups/{sourceResourceGroupName}/validateMoveResources": {
       "post": {
         "tags": [
           "Resources"
@@ -2925,7 +2925,7 @@
             "$ref": "#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "#/parameters/SubscriptionIdParameter"
+            "$ref": "#/parameters/SourceSubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -6598,12 +6598,19 @@
       "minLength": 1,
       "maxLength": 90
     },
+    "SourceSubscriptionIdParameter": {
+        "name": "sourceSubscriptionId",
+        "in": "path",
+        "required": true,
+        "type": "string",
+        "description": "The ID of the source subscription."
+      },
     "SubscriptionIdParameter": {
       "name": "subscriptionId",
       "in": "path",
       "required": true,
       "type": "string",
-      "description": "The ID of the target subscription."
+      "description": "The Microsoft Azure subscription ID."
     },
     "DeploymentNameParameter": {
       "name": "deploymentName",


### PR DESCRIPTION
This is a PR generated at [OpenAPI Hub](https://aka.ms/openapihub). You can view your [work branch via this link](https://portal.azure-devex-tools.com/branch/ifeoluwaokunoren/azure-rest-api-specs/ifokunor-resources-Microsoft.Resources-2021-04-01...master/).
This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

Issue Link: https://github.com/Azure/azure-rest-api-specs/issues/7204

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [x] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
