### PR TITLE
[azureadb2c] delete unnecessary track1 configuration for python

### DIFF
--- a/specification/cpim/resource-manager/readme.python.md
+++ b/specification/cpim/resource-manager/readme.python.md
@@ -1,19 +1,5 @@
 ## Python
 
-These settings apply only when `--python` is specified on the command line.
-
-```yaml !$(track2)
-python:
-  azure-arm: true
-  license-header: MICROSOFT_MIT_NO_VERSION
-  payload-flattening-threshold: 2
-  package-name: azure-mgmt-azureadb2c
-  clear-output-folder: true
-  no-namespace-folders: true
-  python-base-folder: azureadb2c/azure-mgmt-azureadb2c/azure/mgmt/azureadb2c
-  python-base-namespace: azure.mgmt.azureadb2c
-```
-
 These settings apply only when `--track2` is specified on the command line.
 
 ```yaml $(track2)
@@ -22,18 +8,11 @@ license-header: MICROSOFT_MIT_NO_VERSION
 package-name: azure-mgmt-azureadb2c
 package-version: 1.0.0b2
 no-namespace-folders: true
-python-base-folder: azureadb2c/azure-mgmt-azureadb2c/azure/mgmt/azureadb2c
 ```
 
 ### Python multi-api
 
 Generate all API versions currently shipped for this package
-
-```yaml $(multiapi) && !$(track2)
-batch:
-  - tag: package-2020-05-01-preview
-  - tag: package-2019-01-01-preview
-```
 
 ```yaml $(multiapi) && $(track2)
 clear-output-folder: true
@@ -56,9 +35,6 @@ These settings apply only when `--tag=package-2020-05-01-preview --python` is sp
 ```yaml $(tag) =='package-2020-05-01-preview'
 namespace: $(python-base-namespace).v2020_05_01_preview
 output-folder: $(python-sdks-folder)/$(python-base-folder)/v2020_05_01_preview
-python:
-  namespace: $(python-base-namespace).v2020_05_01_preview
-  output-folder: $(python-sdks-folder)/$(python-base-folder)/v2020_05_01_preview
 ```
 
 ### Tag: package-2019-01-01-preview and python
@@ -68,7 +44,4 @@ These settings apply only when `--tag=package-2019-01-01-preview --python` is sp
 ```yaml $(tag) =='package-2019-01-01-preview'
 namespace: $(python-base-namespace).v2019_01_01_preview
 output-folder: $(python-sdks-folder)/$(python-base-folder)/v2019_01_01_preview
-python:
-  namespace: $(python-base-namespace).v2019_01_01_preview
-  output-folder: $(python-sdks-folder)/$(python-base-folder)/v2019_01_01_preview
 ```

--- a/specification/cpim/resource-manager/readme.python.md
+++ b/specification/cpim/resource-manager/readme.python.md
@@ -8,6 +8,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 package-name: azure-mgmt-azureadb2c
 package-version: 1.0.0b2
 no-namespace-folders: true
+python-base-folder: azureadb2c/azure-mgmt-azureadb2c/azure/mgmt/azureadb2c
 ```
 
 ### Python multi-api


### PR DESCRIPTION
azureacb2c does not publish any track1 package. So there is no need to keep the track1 configuration