### PR TITLE
[EventGrid] Add "FarmBeats" prefix to two enums

### DIFF
--- a/specification/eventgrid/data-plane/Microsoft.AgFoodPlatform/stable/2018-01-01/AzureFarmBeats.json
+++ b/specification/eventgrid/data-plane/Microsoft.AgFoodPlatform/stable/2018-01-01/AzureFarmBeats.json
@@ -7,7 +7,7 @@
   },
   "paths": {},
   "definitions": {
-    "ResourceActionType": {
+    "FarmBeatsResourceActionType": {
       "description": "Action occurred on a resource.",
       "enum": [
         "Created",
@@ -16,7 +16,7 @@
       ],
       "type": "string",
       "x-ms-enum": {
-        "name": "ResourceActionType",
+        "name": "FarmBeatsResourceActionType",
         "modelAsString": true
       }
     },
@@ -41,7 +41,7 @@
           "type": "boolean"
         },
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "status": {
           "description": "Status of the resource.",
@@ -87,7 +87,7 @@
       "type": "object",
       "properties": {
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "status": {
           "description": "Status of the resource.",
@@ -137,7 +137,7 @@
           "type": "string"
         },
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "status": {
           "description": "Status of the resource.",
@@ -187,7 +187,7 @@
           "type": "string"
         },
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "status": {
           "description": "Status of the resource.",
@@ -233,7 +233,7 @@
       "type": "object",
       "properties": {
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "status": {
           "description": "Status of the resource.",
@@ -287,7 +287,7 @@
           "type": "string"
         },
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "status": {
           "description": "Status of the resource.",
@@ -349,7 +349,7 @@
           "type": "string"
         },
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "status": {
           "description": "Status of the resource.",
@@ -395,7 +395,7 @@
       "type": "object",
       "properties": {
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "status": {
           "description": "Status of the resource.",
@@ -441,7 +441,7 @@
       "type": "object",
       "properties": {
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "farmerId": {
           "description": "Id of the farmer it belongs to.",
@@ -495,7 +495,7 @@
       "type": "object",
       "properties": {
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "farmerId": {
           "description": "Id of the farmer it belongs to.",
@@ -549,7 +549,7 @@
       "type": "object",
       "properties": {
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "farmerId": {
           "description": "Id of the farmer it belongs to.",
@@ -603,7 +603,7 @@
       "type": "object",
       "properties": {
         "actionType": {
-          "$ref": "#/definitions/ResourceActionType"
+          "$ref": "#/definitions/FarmBeatsResourceActionType"
         },
         "farmerId": {
           "description": "Id of the farmer it belongs to.",
@@ -652,7 +652,7 @@
         }
       }
     },
-    "JobStatus": {
+    "FarmBeatsJobStatus": {
       "description": "Various states a job can be in.",
       "enum": [
         "Waiting",
@@ -663,7 +663,7 @@
       ],
       "type": "string",
       "x-ms-enum": {
-        "name": "JobStatus",
+        "name": "FarmBeatsJobStatus",
         "modelAsString": true
       }
     },
@@ -680,7 +680,7 @@
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/JobStatus"
+          "$ref": "#/definitions/FarmBeatsJobStatus"
         },
         "lastActionDateTime": {
           "format": "date-time",
@@ -730,7 +730,7 @@
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/JobStatus"
+          "$ref": "#/definitions/FarmBeatsJobStatus"
         },
         "lastActionDateTime": {
           "format": "date-time",
@@ -780,7 +780,7 @@
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/JobStatus"
+          "$ref": "#/definitions/FarmBeatsJobStatus"
         },
         "lastActionDateTime": {
           "format": "date-time",


### PR DESCRIPTION
The `JobStatus` and `ResourceActionType` has very general names and
did not indicate they were specific to FarmBeats. Add a prefix to the
names so the generated types in the SDKs have more specific names.
