### PR TITLE
Fix Blob Quick Query XML elements to align with service and documentation.

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-12-12/blob.json
@@ -10030,47 +10030,40 @@
       "xml": {
         "name": "DelimitedTextConfiguration"
       },
-      "description": "delimited text configuration",
+      "description": "Groups the settings used for interpreting the blob data if the blob is delimited text formatted.",
       "type": "object",
-      "required": [
-        "ColumnSeparator",
-        "FieldQuote",
-        "RecordSeparator",
-        "EscapeChar",
-        "HeadersPresent"
-      ],
       "properties": {
         "ColumnSeparator": {
           "type": "string",
-          "description": "column separator",
+          "description": "The string used to separate columns.",
           "xml": {
             "name": "ColumnSeparator"
           }
         },
         "FieldQuote": {
           "type": "string",
-          "description": "field quote",
+          "description": "The string used to quote a specific field.",
           "xml": {
             "name": "FieldQuote"
           }
         },
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
         },
         "EscapeChar": {
           "type": "string",
-          "description": "escape char",
+          "description": "The string used as an escape character.",
           "xml": {
             "name": "EscapeChar"
           }
         },
         "HeadersPresent": {
           "type": "boolean",
-          "description": "has headers",
+          "description": "Represents whether the data has headers.",
           "xml": {
             "name": "HasHeaders"
           }
@@ -10083,13 +10076,10 @@
       },
       "description": "json text configuration",
       "type": "object",
-      "required": [
-        "RecordSeparator"
-      ],
       "properties": {
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
@@ -10542,7 +10532,7 @@
       }
     },
     "QueryRequest": {
-      "description": "the quick query body",
+      "description": "Groups the set of query request settings.",
       "type": "object",
       "required": [
         "QueryType",
@@ -10551,7 +10541,7 @@
       "properties": {
         "QueryType": {
           "type": "string",
-          "description": "the query type",
+          "description": "Required. The type of the provided query expression.",
           "xml": {
             "name": "QueryType"
           },
@@ -10561,7 +10551,7 @@
         },
         "Expression": {
           "type": "string",
-          "description": "a query statement",
+          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB.",
           "xml": {
             "name": "Expression"
           }

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-02-10/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-02-10/blob.json
@@ -10053,47 +10053,40 @@
       "xml": {
         "name": "DelimitedTextConfiguration"
       },
-      "description": "delimited text configuration",
+      "description": "Groups the settings used for interpreting the blob data if the blob is delimited text formatted.",
       "type": "object",
-      "required": [
-        "ColumnSeparator",
-        "FieldQuote",
-        "RecordSeparator",
-        "EscapeChar",
-        "HeadersPresent"
-      ],
       "properties": {
         "ColumnSeparator": {
           "type": "string",
-          "description": "column separator",
+          "description": "The string used to separate columns.",
           "xml": {
             "name": "ColumnSeparator"
           }
         },
         "FieldQuote": {
           "type": "string",
-          "description": "field quote",
+          "description": "The string used to quote a specific field.",
           "xml": {
             "name": "FieldQuote"
           }
         },
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
         },
         "EscapeChar": {
           "type": "string",
-          "description": "escape char",
+          "description": "The string used as an escape character.",
           "xml": {
             "name": "EscapeChar"
           }
         },
         "HeadersPresent": {
           "type": "boolean",
-          "description": "has headers",
+          "description": "Represents whether the data has headers.",
           "xml": {
             "name": "HasHeaders"
           }
@@ -10106,13 +10099,10 @@
       },
       "description": "json text configuration",
       "type": "object",
-      "required": [
-        "RecordSeparator"
-      ],
       "properties": {
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
@@ -10123,7 +10113,7 @@
       "xml": {
         "name": "ArrowConfiguration"
       },
-      "description": "arrow configuration",
+      "description": "Groups the settings used for formatting the response if the response should be Arrow formatted.",
       "type": "object",
       "required": [
         "Schema"
@@ -10145,7 +10135,7 @@
       "xml": {
         "name": "Field"
       },
-      "description": "field of an arrow schema",
+      "description": "Groups settings regarding specific field of an arrow schema",
       "type": "object",
       "required": [
         "Type"
@@ -10611,7 +10601,7 @@
       }
     },
     "QueryRequest": {
-      "description": "the quick query body",
+      "description": "Groups the set of query request settings.",
       "type": "object",
       "required": [
         "QueryType",
@@ -10620,7 +10610,7 @@
       "properties": {
         "QueryType": {
           "type": "string",
-          "description": "the query type",
+          "description": "Required. The type of the provided query expression.",
           "xml": {
             "name": "QueryType"
           },
@@ -10630,7 +10620,7 @@
         },
         "Expression": {
           "type": "string",
-          "description": "a query statement",
+          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB.",
           "xml": {
             "name": "Expression"
           }

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-04-08/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-04-08/blob.json
@@ -10435,47 +10435,40 @@
       "xml": {
         "name": "DelimitedTextConfiguration"
       },
-      "description": "delimited text configuration",
+      "description": "Groups the settings used for interpreting the blob data if the blob is delimited text formatted.",
       "type": "object",
-      "required": [
-        "ColumnSeparator",
-        "FieldQuote",
-        "RecordSeparator",
-        "EscapeChar",
-        "HeadersPresent"
-      ],
       "properties": {
         "ColumnSeparator": {
           "type": "string",
-          "description": "column separator",
+          "description": "The string used to separate columns.",
           "xml": {
             "name": "ColumnSeparator"
           }
         },
         "FieldQuote": {
           "type": "string",
-          "description": "field quote",
+          "description": "The string used to quote a specific field.",
           "xml": {
             "name": "FieldQuote"
           }
         },
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
         },
         "EscapeChar": {
           "type": "string",
-          "description": "escape char",
+          "description": "The string used as an escape character.",
           "xml": {
             "name": "EscapeChar"
           }
         },
         "HeadersPresent": {
           "type": "boolean",
-          "description": "has headers",
+          "description": "Represents whether the data has headers.",
           "xml": {
             "name": "HasHeaders"
           }
@@ -10488,13 +10481,10 @@
       },
       "description": "json text configuration",
       "type": "object",
-      "required": [
-        "RecordSeparator"
-      ],
       "properties": {
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
@@ -10505,7 +10495,7 @@
       "xml": {
         "name": "ArrowConfiguration"
       },
-      "description": "arrow configuration",
+      "description": "Groups the settings used for formatting the response if the response should be Arrow formatted.",
       "type": "object",
       "required": [
         "Schema"
@@ -10527,7 +10517,7 @@
       "xml": {
         "name": "Field"
       },
-      "description": "field of an arrow schema",
+      "description": "Groups settings regarding specific field of an arrow schema",
       "type": "object",
       "required": [
         "Type"
@@ -10993,7 +10983,7 @@
       }
     },
     "QueryRequest": {
-      "description": "the quick query body",
+      "description": "Groups the set of query request settings.",
       "type": "object",
       "required": [
         "QueryType",
@@ -11002,7 +10992,7 @@
       "properties": {
         "QueryType": {
           "type": "string",
-          "description": "the query type",
+          "description": "Required. The type of the provided query expression.",
           "xml": {
             "name": "QueryType"
           },
@@ -11012,7 +11002,7 @@
         },
         "Expression": {
           "type": "string",
-          "description": "a query statement",
+          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB.",
           "xml": {
             "name": "Expression"
           }

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-06-12/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-06-12/blob.json
@@ -10820,47 +10820,40 @@
       "xml": {
         "name": "DelimitedTextConfiguration"
       },
-      "description": "delimited text configuration",
+      "description": "Groups the settings used for interpreting the blob data if the blob is delimited text formatted.",
       "type": "object",
-      "required": [
-        "ColumnSeparator",
-        "FieldQuote",
-        "RecordSeparator",
-        "EscapeChar",
-        "HeadersPresent"
-      ],
       "properties": {
         "ColumnSeparator": {
           "type": "string",
-          "description": "column separator",
+          "description": "The string used to separate columns.",
           "xml": {
             "name": "ColumnSeparator"
           }
         },
         "FieldQuote": {
           "type": "string",
-          "description": "field quote",
+          "description": "The string used to quote a specific field.",
           "xml": {
             "name": "FieldQuote"
           }
         },
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
         },
         "EscapeChar": {
           "type": "string",
-          "description": "escape char",
+          "description": "The string used as an escape character.",
           "xml": {
             "name": "EscapeChar"
           }
         },
         "HeadersPresent": {
           "type": "boolean",
-          "description": "has headers",
+          "description": "Represents whether the data has headers.",
           "xml": {
             "name": "HasHeaders"
           }
@@ -10873,13 +10866,10 @@
       },
       "description": "json text configuration",
       "type": "object",
-      "required": [
-        "RecordSeparator"
-      ],
       "properties": {
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
@@ -10890,7 +10880,7 @@
       "xml": {
         "name": "ArrowConfiguration"
       },
-      "description": "arrow configuration",
+      "description": "Groups the settings used for formatting the response if the response should be Arrow formatted.",
       "type": "object",
       "required": [
         "Schema"
@@ -10912,7 +10902,7 @@
       "xml": {
         "name": "Field"
       },
-      "description": "field of an arrow schema",
+      "description": "Groups settings regarding specific field of an arrow schema",
       "type": "object",
       "required": [
         "Type"
@@ -11378,7 +11368,7 @@
       }
     },
     "QueryRequest": {
-      "description": "the quick query body",
+      "description": "Groups the set of query request settings.",
       "type": "object",
       "required": [
         "QueryType",
@@ -11387,7 +11377,7 @@
       "properties": {
         "QueryType": {
           "type": "string",
-          "description": "the query type",
+          "description": "Required. The type of the provided query expression.",
           "xml": {
             "name": "QueryType"
           },
@@ -11397,7 +11387,7 @@
         },
         "Expression": {
           "type": "string",
-          "description": "a query statement",
+          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB.",
           "xml": {
             "name": "Expression"
           }

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-08-04/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-08-04/blob.json
@@ -10820,47 +10820,40 @@
       "xml": {
         "name": "DelimitedTextConfiguration"
       },
-      "description": "delimited text configuration",
+      "description": "Groups the settings used for interpreting the blob data if the blob is delimited text formatted.",
       "type": "object",
-      "required": [
-        "ColumnSeparator",
-        "FieldQuote",
-        "RecordSeparator",
-        "EscapeChar",
-        "HeadersPresent"
-      ],
       "properties": {
         "ColumnSeparator": {
           "type": "string",
-          "description": "column separator",
+          "description": "The string used to separate columns.",
           "xml": {
             "name": "ColumnSeparator"
           }
         },
         "FieldQuote": {
           "type": "string",
-          "description": "field quote",
+          "description": "The string used to quote a specific field.",
           "xml": {
             "name": "FieldQuote"
           }
         },
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
         },
         "EscapeChar": {
           "type": "string",
-          "description": "escape char",
+          "description": "The string used as an escape character.",
           "xml": {
             "name": "EscapeChar"
           }
         },
         "HeadersPresent": {
           "type": "boolean",
-          "description": "has headers",
+          "description": "Represents whether the data has headers.",
           "xml": {
             "name": "HasHeaders"
           }
@@ -10873,13 +10866,10 @@
       },
       "description": "json text configuration",
       "type": "object",
-      "required": [
-        "RecordSeparator"
-      ],
       "properties": {
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
@@ -10890,7 +10880,7 @@
       "xml": {
         "name": "ArrowConfiguration"
       },
-      "description": "arrow configuration",
+      "description": "Groups the settings used for formatting the response if the response should be Arrow formatted.",
       "type": "object",
       "required": [
         "Schema"
@@ -10919,7 +10909,7 @@
       "xml": {
         "name": "Field"
       },
-      "description": "field of an arrow schema",
+      "description": "Groups settings regarding specific field of an arrow schema",
       "type": "object",
       "required": [
         "Type"
@@ -11385,7 +11375,7 @@
       }
     },
     "QueryRequest": {
-      "description": "the quick query body",
+      "description": "Groups the set of query request settings.",
       "type": "object",
       "required": [
         "QueryType",
@@ -11394,7 +11384,7 @@
       "properties": {
         "QueryType": {
           "type": "string",
-          "description": "the query type",
+          "description": "Required. The type of the provided query expression.",
           "xml": {
             "name": "QueryType"
           },
@@ -11404,7 +11394,7 @@
         },
         "Expression": {
           "type": "string",
-          "description": "a query statement",
+          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB.",
           "xml": {
             "name": "Expression"
           }

--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-10-02/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-10-02/blob.json
@@ -10838,47 +10838,40 @@
       "xml": {
         "name": "DelimitedTextConfiguration"
       },
-      "description": "delimited text configuration",
+      "description": "Groups the settings used for interpreting the blob data if the blob is delimited text formatted.",
       "type": "object",
-      "required": [
-        "ColumnSeparator",
-        "FieldQuote",
-        "RecordSeparator",
-        "EscapeChar",
-        "HeadersPresent"
-      ],
       "properties": {
         "ColumnSeparator": {
           "type": "string",
-          "description": "column separator",
+          "description": "The string used to separate columns.",
           "xml": {
             "name": "ColumnSeparator"
           }
         },
         "FieldQuote": {
           "type": "string",
-          "description": "field quote",
+          "description": "The string used to quote a specific field.",
           "xml": {
             "name": "FieldQuote"
           }
         },
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
         },
         "EscapeChar": {
           "type": "string",
-          "description": "escape char",
+          "description": "The string used as an escape character.",
           "xml": {
             "name": "EscapeChar"
           }
         },
         "HeadersPresent": {
           "type": "boolean",
-          "description": "has headers",
+          "description": "Represents whether the data has headers.",
           "xml": {
             "name": "HasHeaders"
           }
@@ -10891,13 +10884,10 @@
       },
       "description": "json text configuration",
       "type": "object",
-      "required": [
-        "RecordSeparator"
-      ],
       "properties": {
         "RecordSeparator": {
           "type": "string",
-          "description": "record separator",
+          "description": "The string used to separate records.",
           "xml": {
             "name": "RecordSeparator"
           }
@@ -10908,7 +10898,7 @@
       "xml": {
         "name": "ArrowConfiguration"
       },
-      "description": "arrow configuration",
+      "description": "Groups the settings used for formatting the response if the response should be Arrow formatted.",
       "type": "object",
       "required": [
         "Schema"
@@ -10937,7 +10927,7 @@
       "xml": {
         "name": "Field"
       },
-      "description": "field of an arrow schema",
+      "description": "Groups settings regarding specific field of an arrow schema",
       "type": "object",
       "required": [
         "Type"
@@ -11403,7 +11393,7 @@
       }
     },
     "QueryRequest": {
-      "description": "the quick query body",
+      "description": "Groups the set of query request settings.",
       "type": "object",
       "required": [
         "QueryType",
@@ -11412,7 +11402,7 @@
       "properties": {
         "QueryType": {
           "type": "string",
-          "description": "the query type",
+          "description": "Required. The type of the provided query expression.",
           "xml": {
             "name": "QueryType"
           },
@@ -11422,7 +11412,7 @@
         },
         "Expression": {
           "type": "string",
-          "description": "a query statement",
+          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB.",
           "xml": {
             "name": "Expression"
           }


### PR DESCRIPTION
Align with service and documentation where Blob Quick Query XML elements are optional instead of required.
This PR would help address this issue https://github.com/Azure/azure-sdk-for-net/issues/21401

See https://docs.microsoft.com/en-us/rest/api/storageservices/query-blob-contents#request-body
Already confirmed with service that the documentation is an accurate representation of what the service requires and marks as optional.
 
After this merges, we need to regenerate across platforms
- Confirmed Java and Python will not require any changes aside from regeneration
- .NET will need some code changes along with regeneration
- Pending other platforms input.

<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Changelog
Please ensure to add changelog with this PR by answering the following questions.
  1. What's the purpose of the update?    
      - [ ] new service onboarding 
      - [ ] new API version 
      - [x] update existing version for new feature 
      - [ ] update existing version to fix swagger quality issue in s360
      - [ ] Other, please clarify 
  2. When you are targeting to deploy new service/feature to public regions? Please provide date, or month to public if date is not available yet.
  3. When you expect to publish swagger? Please provide date, or month to public if date is not available yet.
  4. If it's an update to existing version,  please select SDKs of specific language and CLIs that require refresh after swagger is published.
      - [x] SDK of .NET (need service team to ensure code readiness)
      - [x] SDK of Python
      - [x] SDK of Java
      - [x] SDK of Js
      - [x] SDK of Go
      - [ ] PowerShell
      - [ ] CLI
      - [ ] Terraform
      - [ ] No, no need to refresh for updates in this PR

### Contribution checklist:
- [ ] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [ ] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [ ] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Ensure to check this box if one of the following scenarios meet updates in the PR, so that label “WaitForARMFeedback” will be added automatically to involve ARM API Review. Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs, all “removals” and “adding a new property” no more require ARM API review.
  - Adding new API(s)
  - Adding a new API version
  -  [ ] Ensure to copy the existing version into new directory structure for first commit (including refactoring) and then push new changes including version updates in separate commits. This is required to review the changes efficiently.
  - Adding a new service

- [ ] Please ensure you've reviewed following [guidelines](https://aka.ms/rpguidelines) including [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md). Estimated time (4 hours). This is required before you can request review from ARM API Review board.

- [ ] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM oncall for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them. 

### Breaking Change Review Checklist 
If there are following updates in the PR, ensure to request an approval from Breaking Change Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 

- [ ] Removing API(s) in stable version
- [ ] Removing properties in stable version
- [ ] Removing API version(s) in stable version
- [ ] Updating API in stable or public preview version with Breaking Change Validation errors
- [ ] Updating API(s) in public preview over 1 year (refer to [Retirement of Previews](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37683/Retirement-of-Previews))

**Action**: to initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate). Addition details on the process and office hours are on the [Breaking change Wiki](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37684/Breaking-Changes).

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).
