### PR TITLE
[storage-file-datalake]Remove the redundant property in BlobPropertiesInternal definition.

### DIFF
--- a/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2020-06-12/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2020-06-12/DataLakeStorage.json
@@ -3310,10 +3310,6 @@
           "x-ms-client-name": "LastAccessedOn",
           "type": "string",
           "format": "date-time-rfc1123"
-        },
-        "DeleteTime": {
-          "type": "string",
-          "format": "date-time-rfc1123"
         }
       }
     },


### PR DESCRIPTION
BlobPropertiesInternal’s definition in datalake Swagger spec defines two properties for deletedTime, one is named “DeletedTime” and the other is named “DeleteTime”. 

Service response only has "DeletedTime", and “DeleteTime” is redundant. 
A sample response is following;
```
<Blob>
<Name>file0162330775068904497</Name>
<DeletionId>132677813564414940</DeletionId>
<Deleted>true</Deleted>
<Properties>
<Creation-Time>Thu, 10 Jun 2021 06:49:12 GMT</Creation-Time>
<Last-Modified>Thu, 10 Jun 2021 06:49:12 GMT</Last-Modified>
<Expiry-Time>Sat, 12 Jun 2021 06:49:16 GMT</Expiry-Time>
<Etag>0x8D92BDBDB44FB54</Etag>
<Content-Length>0</Content-Length>
<Content-Type>application/octet-stream</Content-Type>
<Content-Encoding />
<Content-Language />
<Content-CRC64>AAAAAAAAAAA=</Content-CRC64>
<Content-MD5 />
<Cache-Control />
<Content-Disposition />
<BlobType>BlockBlob</BlobType>
<AccessTier>Hot</AccessTier>
<AccessTierInferred>true</AccessTierInferred>
<ServerEncrypted>true</ServerEncrypted>
<DeletedTime>Thu, 10 Jun 2021 06:49:16 GMT</DeletedTime>
<RemainingRetentionDays>1</RemainingRetentionDays>
</Properties>
<OrMetadata />
</Blob>
```

