### PR TITLE
fix MissingTypeObject/R4037/SDKViolation for ErrorResponse & ErrorAdditionalInfo

### DIFF
--- a/specification/common-types/resource-management/v1/types.json
+++ b/specification/common-types/resource-management/v1/types.json
@@ -277,6 +277,7 @@
     "ErrorResponse": {
       "title": "Error Response",
       "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.)",
+      "type": "object",
       "properties": {
         "code": {
           "readOnly": true,
@@ -312,6 +313,7 @@
       }
     },
     "ErrorAdditionalInfo": {
+      "type": "object",
       "properties": {
         "type": {
           "readOnly": true,


### PR DESCRIPTION
This adds the explicit `"type": "object"` to two common objects to avoid the MissingTypeObject/R4037/SDKViolation error.