### PR TITLE
[Communication] Adding 2021-06-21 TURN API version

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1220,6 +1220,7 @@ Netfilter
 networkruleset
 networkrulesets
 networkstatus
+networktraversal
 networkwatcher
 newpassword
 newrelapp

--- a/specification/communication/data-plane/Turn/preview/2021-06-21-preview/CommunicationTurn.json
+++ b/specification/communication/data-plane/Turn/preview/2021-06-21-preview/CommunicationTurn.json
@@ -3,56 +3,73 @@
   "info": {
     "title": "CommunicationNetworkingClient",
     "description": "Azure Communication Networking Service",
-    "version": "2021-02-22-preview1"
+    "version": "2021-06-21-preview"
   },
   "paths": {
-    "/turn/{id}/:issueCredentials": {
+    "/networktraversal/:issueRelayConfiguration": {
       "post": {
         "tags": [
           "Turn"
         ],
-        "summary": "Issue TURN credentials for an existing identity.",
-        "operationId": "CommunicationIdentity_IssueTurnCredentials",
+        "summary": "Issue a configuration for an STUN/TURN server for an existing identity.",
+        "operationId": "CommunicationNetworkTraversal_IssueRelayConfiguration",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/json"
         ],
         "parameters": [
           {
-            "in": "path",
-            "name": "id",
-            "description": "Identifier of the existing identity to issue credentials for.",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "#/parameters/ApiVersionParameter"
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommunicationRelayConfigurationRequest"
+            }
           }
         ],
         "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/CommunicationRelayConfiguration"
+            }
+          },
           "default": {
             "description": "Error",
             "schema": {
               "$ref": "../../../Common/stable/2021-03-07/common.json#/definitions/CommunicationErrorResponse"
             }
-          },
-          "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/CommunicationTurnCredentialsResponse"
-            }
           }
         },
         "x-ms-examples": {
-          "Issue Turn Credentials": {
-            "$ref": "./examples/IssueTurnCredentials.json"
+          "Issue Relay Configuration": {
+            "$ref": "./examples/IssueRelayConfiguration.json"
           }
         }
       }
     }
   },
   "definitions": {
-    "CommunicationTurnServer": {
-      "description": "An instance of a TURN server with credentials.",
+    "CommunicationRelayConfigurationRequest": {
+      "description": "Request for a CommunicationRelayConfiguration.",
+      "required": [
+        "id"
+      ],
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "An existing ACS identity.",
+          "type": "string"
+        }
+      }
+    },
+    "CommunicationIceServer": {
+      "description": "An instance of a STUN/TURN server with credentials to be used for ICE negotiation.",
       "required": [
         "credential",
         "urls",
@@ -61,7 +78,7 @@
       "type": "object",
       "properties": {
         "urls": {
-          "description": "List of TURN server URLs.",
+          "description": "List of STUN/TURN server URLs.",
           "type": "array",
           "items": {
             "type": "string"
@@ -77,11 +94,11 @@
         }
       }
     },
-    "CommunicationTurnCredentialsResponse": {
-      "description": "A TURN credentials response.",
+    "CommunicationRelayConfiguration": {
+      "description": "A relay configuration containing the STUN/TURN URLs and credentials.",
       "required": [
         "expiresOn",
-        "turnServers"
+        "iceServers"
       ],
       "type": "object",
       "properties": {
@@ -90,11 +107,11 @@
           "description": "The date for which the username and credentials are not longer valid.",
           "type": "string"
         },
-        "turnServers": {
-          "description": "An array representing the credentials and the TURN server URL.",
+        "iceServers": {
+          "description": "An array representing the credentials and the STUN/TURN server URLs for use in ICE negotiations.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CommunicationTurnServer"
+            "$ref": "#/definitions/CommunicationIceServer"
           }
         }
       }
@@ -107,7 +124,7 @@
       "description": "Version of API to invoke.",
       "required": true,
       "enum": [
-        "2021-02-22-preview1"
+        "2021-06-21-preview"
       ],
       "type": "string"
     }

--- a/specification/communication/data-plane/Turn/preview/2021-06-21-preview/examples/IssueRelayConfiguration.json
+++ b/specification/communication/data-plane/Turn/preview/2021-06-21-preview/examples/IssueRelayConfiguration.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2021-06-21-preview",
+    "content-type": "application/json",
+    "body": {
+      "id": "8:acs:2dee53b4-368b-45b4-ab52-8493fb117652_00000005-14a2-493b-8a72-5a3a0d000081"
+    },
+    "endpoint": "https://my-resource.communication.azure.com"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "expiresOn": "2020-09-10T21:39:39.3244584+00:00",
+        "iceServers": [
+          {
+            "urls": [
+              "turn:131.107.255.255:3478"
+            ],
+            "username": "AgAAJNOeygwB1uVGvuwAVMHV4PLhYDgY66Fg1dUZvQ4AAAAEhXrhc8uJFjOK8lxEsZk3KIpWxc0=",
+            "credential": "9rl8ablFWj6/aqSuPLgLykLZKqw="
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/communication/data-plane/Turn/readme.md
+++ b/specification/communication/data-plane/Turn/readme.md
@@ -40,6 +40,15 @@ title:
   Azure Communication Services
 ```
 
+### Tag: package-2021-06-21-preview
+
+These settings apply only when `--tag=package-2021-06-21-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2021-06-21-preview'
+input-file:
+  - preview/2021-06-21-preview/CommunicationTurn.json
+```
+
 ---
 
 # Code Generation


### PR DESCRIPTION
Adding a new TURN/NetworkTraversal REST API version. Changes include

- Move the identity (`{id}`) from the path to the body or query parameter. Since the convention across ACS is to have it in the body, it should be in the body.
- Rename `CommunicationTurnServer` to `CommunicationIceServer`
- Rename `CommunicationTurnCredentialsResponse` to `CommunicationRelayConfiguration`
- Rename the service name path from `/turn` to something more generic to allow future paths (e.g. `/networktraversal`). This name (networktraversal) is not final and should be discussed offline for agreement
- Rename `/:issueCredentials` to `/:issueRelayConfiguration`
- Ensure the format of expiresOn date-time is rfc 3339 (if it is the same as all other ACS date-times)
- Remove the trailing number (e.g. `1`) from the preview version (e.g. `2021-06-21-preview1` -> `2021-06-21-preview`)

### Changelog
Please ensure to add changelog with this PR by answering the following questions.
  1. What's the purpose of the update?    
      - [ ] new service onboarding 
      - [X ] new API version 
      - [ ] update existing version for new feature 
      - [ ] update existing version to fix swagger quality issue in s360
      - [ ] Other, please clarify 
  2. When you are targeting to deploy new service/feature to public regions? Please provide date, or month to public if date is not available yet.
  3. When you expect to publish swagger? Please provide date, or month to public if date is not available yet.

### Contribution checklist:
- [X] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [X] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [X] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).
