### PR TITLE
change profile to profile-content in readme.typescript.md

### DIFF
--- a/specification/authorization/resource-manager/readme.typescript.md
+++ b/specification/authorization/resource-manager/readme.typescript.md
@@ -12,7 +12,7 @@ typescript:
   payload-flattening-threshold: 1
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-authorization"
   output-folder: "$(typescript-sdks-folder)/sdk/authorization/arm-authorization"
@@ -21,9 +21,9 @@ typescript:
 
 ### Profile: profile-hybrid-2019-03-01
 
-These settings apply only when `--profile=profile-hybrid-2019-03-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2019-03-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2019-03-01'
+``` yaml $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   package-name: "@azure/arm-authorization-profile-2019-03-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/authorization/arm-authorization-profile-2019-03-01-hybrid"
@@ -34,9 +34,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-authorization-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid"
@@ -47,9 +47,9 @@ typescript:
 
 ### Profile: package-2020-10-01-preview
 
-These settings apply only when `--profile=package-2020-10-01-preview` is specified on the command line.
+These settings apply only when `--profile-content=package-2020-10-01-preview` is specified on the command line.
 
-``` yaml $(profile)=='package-2020-10-01-preview'
+``` yaml $(profile-content)=='package-2020-10-01-preview'
 typescript:
   package-name: "@azure/arm-authorization-package-2020-10-01-preview"
   output-folder: "$(typescript-sdks-folder)/sdk/authorization/arm-authorization-package-2020-10-01-preview"

--- a/specification/botservice/resource-manager/readme.typescript.md
+++ b/specification/botservice/resource-manager/readme.typescript.md
@@ -11,7 +11,7 @@ typescript:
   generate-metadata: true
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-botservice"
   output-folder: "$(typescript-sdks-folder)/sdk/botservice/arm-botservice"

--- a/specification/commerce/resource-manager/readme.typescript.md
+++ b/specification/commerce/resource-manager/readme.typescript.md
@@ -3,7 +3,7 @@
 These settings apply only when `--typescript` is specified on the command line.
 Please also specify `--typescript-sdks-folder=<path to root folder of your azure-sdk-for-js clone>`.
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   azure-arm: true
   package-name: "@azure/arm-commerce"
@@ -15,9 +15,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-commerce-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid"

--- a/specification/compute/resource-manager/readme.typescript.md
+++ b/specification/compute/resource-manager/readme.typescript.md
@@ -27,7 +27,7 @@ directive:
         replace(/[,|*] 'DummyOrchestrationServiceName'/g,'');
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
   package-name: "@azure/arm-compute"
   output-folder: "$(typescript-sdks-folder)/sdk/compute/arm-compute"
   clear-output-folder: true
@@ -36,9 +36,9 @@ directive:
 
 ### Profile: profile-hybrid-2019-03-01
 
-These settings apply only when `--profile=profile-hybrid-2019-03-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2019-03-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2019-03-01'
+``` yaml $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   package-name: "@azure/arm-compute-profile-2019-03-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/compute/arm-compute-profile-2019-03-01-hybrid"
@@ -48,9 +48,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-compute-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/compute/arm-compute-profile-2020-09-01-hybrid"

--- a/specification/databoxedge/resource-manager/readme.typescript.md
+++ b/specification/databoxedge/resource-manager/readme.typescript.md
@@ -3,7 +3,7 @@
 These settings apply only when `--typescript` is specified on the command line.
 Please also specify `--typescript-sdks-folder=<path to root folder of your azure-sdk-for-js clone>`.
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   azure-arm: true
   license-header: MICROSOFT_MIT_NO_VERSION
@@ -16,9 +16,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-databoxedge-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid"

--- a/specification/dns/resource-manager/readme.typescript.md
+++ b/specification/dns/resource-manager/readme.typescript.md
@@ -11,7 +11,7 @@ typescript:
   generate-metadata: true
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-dns"
   output-folder: "$(typescript-sdks-folder)/sdk/dns/arm-dns"
@@ -20,9 +20,9 @@ typescript:
 
 ### Profile: profile-hybrid-2019-03-01
 
-These settings apply only when `--profile=profile-hybrid-2019-03-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2019-03-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2019-03-01'
+``` yaml $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   package-name: "@azure/arm-dns-profile-2019-03-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/dns/arm-dns-profile-2019-03-01-hybrid"
@@ -33,9 +33,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-dns-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/dns/arm-dns-profile-2020-09-01-hybrid"

--- a/specification/eventhub/resource-manager/readme.typescript.md
+++ b/specification/eventhub/resource-manager/readme.typescript.md
@@ -3,7 +3,7 @@
 These settings apply only when `--typescript` is specified on the command line.
 Please also specify `--typescript-sdks-folder=<path to root folder of your azure-sdk-for-js clone>`.
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   azure-arm: true
   package-name: "@azure/arm-eventhub"
@@ -14,9 +14,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-eventhub-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid"

--- a/specification/hybridcompute/resource-manager/readme.typescript.md
+++ b/specification/hybridcompute/resource-manager/readme.typescript.md
@@ -17,7 +17,7 @@ directive:
     - Machines_Update
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
   package-name: "@azure/arm-hybridcompute"
   output-folder: "$(typescript-sdks-folder)/sdk/hybridcompute/arm-hybridcompute"
   clear-output-folder: true

--- a/specification/iothub/resource-manager/readme.typescript.md
+++ b/specification/iothub/resource-manager/readme.typescript.md
@@ -3,7 +3,7 @@
 These settings apply only when `--typescript` is specified on the command line.
 Please also specify `--typescript-sdks-folder=<path to root folder of your azure-sdk-for-js clone>`.
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   azure-arm: true
   package-name: "@azure/arm-iothub"
@@ -15,9 +15,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-iothub-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid"

--- a/specification/keyvault/resource-manager/readme.typescript.md
+++ b/specification/keyvault/resource-manager/readme.typescript.md
@@ -12,7 +12,7 @@ typescript:
   generate-readme-md: true
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-keyvault"
   output-folder: "$(typescript-sdks-folder)/sdk/keyvault/arm-keyvault"
@@ -22,9 +22,9 @@ typescript:
 
 ### Profile: profile-hybrid-2019-03-01
 
-These settings apply only when `--profile=profile-hybrid-2019-03-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2019-03-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2019-03-01'
+``` yaml $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   package-name: "@azure/arm-keyvault-profile-2019-03-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/keyvault/arm-keyvault-profile-2019-03-01-hybrid"
@@ -35,9 +35,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-keyvault-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid"

--- a/specification/monitor/resource-manager/readme.typescript.md
+++ b/specification/monitor/resource-manager/readme.typescript.md
@@ -12,7 +12,7 @@ typescript:
   payload-flattening-threshold: 1
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-monitor"
   output-folder: "$(typescript-sdks-folder)/sdk/monitor/arm-monitor"
@@ -21,9 +21,9 @@ typescript:
 
 ### Profile: hybrid_2019_03_01
 
-These settings apply only when `--profile=profile-hybrid-2019-03-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2019-03-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2019-03-01'
+``` yaml $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   package-name: "@azure/arm-monitor-profile-2019-03-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/monitor/arm-monitor-profile-2019-03-01-hybrid"
@@ -34,9 +34,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-monitor-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid"

--- a/specification/network/resource-manager/readme.typescript.md
+++ b/specification/network/resource-manager/readme.typescript.md
@@ -11,7 +11,7 @@ typescript:
   generate-metadata: true
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-network"
   output-folder: "$(typescript-sdks-folder)/sdk/network/arm-network"
@@ -20,9 +20,9 @@ typescript:
 
 ### Profile: profile-hybrid-2019-03-01
 
-These settings apply only when `--profile=profile-hybrid-2019-03-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2019-03-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2019-03-01'
+``` yaml $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   package-name: "@azure/arm-network-profile-2019-03-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/network/arm-network-profile-2019-03-01-hybrid"
@@ -33,9 +33,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-network-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/network/arm-network-profile-2020-09-01-hybrid"

--- a/specification/resources/resource-manager/readme.typescript.md
+++ b/specification/resources/resource-manager/readme.typescript.md
@@ -3,7 +3,7 @@
 These settings apply only when `--typescript` is specified on the command line.
 Please also specify `--typescript-sdks-folder=<path to root folder of your azure-sdk-for-js clone>`.
 
-```yaml $(typescript) && !$(profile)
+```yaml $(typescript) && !$(profile-content)
 typescript:
   azure-arm: true
   batch: true
@@ -17,49 +17,49 @@ batch:
   - package-managedapplications: true
 ```
 
-```yaml $(typescript) && $(package-features) && !$(profile)
+```yaml $(typescript) && $(package-features) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-features"
   output-folder: "$(typescript-sdks-folder)/sdk/features/arm-features"
   clear-output-folder: true
 ```
 
-```yaml $(typescript) && $(package-locks) && !$(profile)
+```yaml $(typescript) && $(package-locks) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-locks"
   output-folder: "$(typescript-sdks-folder)/sdk/locks/arm-locks"
   clear-output-folder: true
 ```
 
-```yaml $(typescript) && $(package-policy) && !$(profile)
+```yaml $(typescript) && $(package-policy) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-policy"
   output-folder: "$(typescript-sdks-folder)/sdk/policy/arm-policy"
   clear-output-folder: true
 ```
 
-```yaml $(typescript) && $(package-resources) && !$(profile)
+```yaml $(typescript) && $(package-resources) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-resources"
   output-folder: "$(typescript-sdks-folder)/sdk/resources/arm-resources"
   clear-output-folder: true
 ```
 
-```yaml $(typescript) && $(package-links) && !$(profile)
+```yaml $(typescript) && $(package-links) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-links"
   output-folder: "$(typescript-sdks-folder)/sdk/links/arm-links"
   clear-output-folder: true
 ```
 
-```yaml $(typescript) && $(package-managedapplications) && !$(profile)
+```yaml $(typescript) && $(package-managedapplications) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-managedapplications"
   output-folder: "$(typescript-sdks-folder)/sdk/managedapplications/arm-managedapplications"
   clear-output-folder: true
 ```
 
-```yaml $(tag)=='package-resources-2018-05' && $(profile)=='profile-hybrid-2019-03-01'
+```yaml $(tag)=='package-resources-2018-05' && $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   azure-arm: true
   generate-metadata: true
@@ -70,7 +70,7 @@ typescript:
     - tag: package-resources-2018-05
 ```
 
-```yaml $(tag)=='package-policy-2016-12' && $(profile)=='profile-hybrid-2019-03-01'
+```yaml $(tag)=='package-policy-2016-12' && $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   azure-arm: true
   generate-metadata: true
@@ -81,7 +81,7 @@ typescript:
     - tag: package-policy-2016-12
 ```
 
-```yaml $(tag)=='package-locks-2016-09' && $(profile)=='profile-hybrid-2019-03-01'
+```yaml $(tag)=='package-locks-2016-09' && $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   azure-arm: true
   generate-metadata: true
@@ -92,7 +92,7 @@ typescript:
     - tag: package-locks-2016-09
 ```
 
-```yaml $(tag)=='package-subscriptions-2016-06' && $(profile)=='profile-hybrid-2019-03-01'
+```yaml $(tag)=='package-subscriptions-2016-06' && $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   azure-arm: true
   generate-metadata: true
@@ -103,7 +103,7 @@ typescript:
     - tag: package-subscriptions-2016-06
 ```
 
-```yaml $(tag)=='package-resources-2019-10' && $(profile)=='profile-hybrid-2020-09-01'
+```yaml $(tag)=='package-resources-2019-10' && $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   azure-arm: true
   generate-metadata: true
@@ -114,7 +114,7 @@ typescript:
     - tag: package-resources-2019-10
 ```
 
-```yaml $(tag)=='package-policy-2016-12' && $(profile)=='profile-hybrid-2020-09-01'
+```yaml $(tag)=='package-policy-2016-12' && $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   azure-arm: true
   generate-metadata: true
@@ -125,7 +125,7 @@ typescript:
     - tag: package-policy-2016-12
 ```
 
-```yaml $(tag)=='package-locks-2016-09' && $(profile)=='profile-hybrid-2020-09-01'
+```yaml $(tag)=='package-locks-2016-09' && $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   azure-arm: true
   generate-metadata: true
@@ -136,7 +136,7 @@ typescript:
     - tag: package-locks-2016-09
 ```
 
-```yaml $(tag)=='package-subscriptions-2016-06' && $(profile)=='profile-hybrid-2020-09-01'
+```yaml $(tag)=='package-subscriptions-2016-06' && $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   azure-arm: true
   generate-metadata: true

--- a/specification/storage/resource-manager/readme.typescript.md
+++ b/specification/storage/resource-manager/readme.typescript.md
@@ -13,7 +13,7 @@ typescript:
   override-client-name: StorageManagementClient
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-storage"
   output-folder: "$(typescript-sdks-folder)/sdk/storage/arm-storage"
@@ -22,9 +22,9 @@ typescript:
 
 ### Profile: profile-hybrid-2019-03-01
 
-These settings apply only when `--profile=profile-hybrid-2019-03-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2019-03-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2019-03-01'
+``` yaml $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   package-name: "@azure/arm-storage-profile-2019-03-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/storage/arm-storage-profile-2019-03-01-hybrid"
@@ -35,9 +35,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-storage-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/storage/arm-storage-profile-2020-09-01-hybrid"

--- a/specification/web/resource-manager/readme.typescript.md
+++ b/specification/web/resource-manager/readme.typescript.md
@@ -12,7 +12,7 @@ typescript:
   payload-flattening-threshold: 1
 ```
 
-``` yaml $(typescript) && !$(profile)
+``` yaml $(typescript) && !$(profile-content)
 typescript:
   package-name: "@azure/arm-appservice"
   output-folder: "$(typescript-sdks-folder)/sdk/appservice/arm-appservice"
@@ -21,9 +21,9 @@ typescript:
 
 ### Profile: profile-hybrid-2019-03-01
 
-These settings apply only when `--profile=profile-hybrid-2019-03-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2019-03-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2019-03-01'
+``` yaml $(profile-content)=='profile-hybrid-2019-03-01'
 typescript:
   package-name: "@azure/arm-appservice-profile-2019-03-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/appservice/arm-appservice-profile-2019-03-01-hybrid"
@@ -34,9 +34,9 @@ typescript:
 
 ### Profile: profile-hybrid-2020-09-01
 
-These settings apply only when `--profile=profile-hybrid-2020-09-01` is specified on the command line.
+These settings apply only when `--profile-content=profile-hybrid-2020-09-01` is specified on the command line.
 
-``` yaml $(profile)=='profile-hybrid-2020-09-01'
+``` yaml $(profile-content)=='profile-hybrid-2020-09-01'
 typescript:
   package-name: "@azure/arm-appservice-profile-2020-09-01-hybrid"
   output-folder: "$(typescript-sdks-folder)/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid"


### PR DESCRIPTION
`profile` is a reserved word in autorest v3. see the disscussion in https://github.com/Azure/autorest/issues/4013

we need to change it to make sure track2 js sdk can generate codes.