### PR TITLE
remove properties with no purpose from examples

### DIFF
--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2018-11-20/examples/createOrUpdateGuestConfigurationAssignment.json
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2018-11-20/examples/createOrUpdateGuestConfigurationAssignment.json
@@ -21,13 +21,7 @@
               "name": "[InstalledApplication]bwhitelistedapp;Name",
               "value": "NotePad,sql"
             }
-          ],
-          "configurationSetting": {
-            "rebootIfNeeded": false,
-            "actionAfterReboot": "ContinueConfiguration",
-            "configurationModeFrequencyMins": 15,
-            "configurationMode": "MonitorOnly"
-          }
+          ]
         }
       }
     }
@@ -56,13 +50,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }
@@ -91,13 +79,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }

--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2018-11-20/examples/createOrUpdateGuestConfigurationHCRPAssignment.json
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2018-11-20/examples/createOrUpdateGuestConfigurationHCRPAssignment.json
@@ -21,13 +21,7 @@
               "name": "[InstalledApplication]bwhitelistedapp;Name",
               "value": "NotePad,sql"
             }
-          ],
-          "configurationSetting": {
-            "rebootIfNeeded": false,
-            "actionAfterReboot": "ContinueConfiguration",
-            "configurationModeFrequencyMins": 15,
-            "configurationMode": "MonitorOnly"
-          }
+          ]
         }
       }
     }
@@ -56,13 +50,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }
@@ -91,13 +79,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }

--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2020-06-25/examples/createOrUpdateGuestConfigurationAssignment.json
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2020-06-25/examples/createOrUpdateGuestConfigurationAssignment.json
@@ -21,13 +21,7 @@
               "name": "[InstalledApplication]bwhitelistedapp;Name",
               "value": "NotePad,sql"
             }
-          ],
-          "configurationSetting": {
-            "rebootIfNeeded": false,
-            "actionAfterReboot": "ContinueConfiguration",
-            "configurationModeFrequencyMins": 15,
-            "configurationMode": "MonitorOnly"
-          }
+          ]
         }
       }
     }
@@ -56,13 +50,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }
@@ -91,13 +79,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }

--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2020-06-25/examples/createOrUpdateGuestConfigurationHCRPAssignment.json
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2020-06-25/examples/createOrUpdateGuestConfigurationHCRPAssignment.json
@@ -21,13 +21,7 @@
               "name": "[InstalledApplication]bwhitelistedapp;Name",
               "value": "NotePad,sql"
             }
-          ],
-          "configurationSetting": {
-            "rebootIfNeeded": false,
-            "actionAfterReboot": "ContinueConfiguration",
-            "configurationModeFrequencyMins": 15,
-            "configurationMode": "MonitorOnly"
-          }
+          ]
         }
       }
     }
@@ -56,13 +50,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }
@@ -91,13 +79,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }

--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2021-01-25/examples/createOrUpdateGuestConfigurationAssignment.json
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2021-01-25/examples/createOrUpdateGuestConfigurationAssignment.json
@@ -21,13 +21,7 @@
               "name": "[InstalledApplication]bwhitelistedapp;Name",
               "value": "NotePad,sql"
             }
-          ],
-          "configurationSetting": {
-            "rebootIfNeeded": false,
-            "actionAfterReboot": "ContinueConfiguration",
-            "configurationModeFrequencyMins": 15,
-            "configurationMode": "MonitorOnly"
-          }
+          ]
         }
       }
     }
@@ -56,13 +50,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }
@@ -91,13 +79,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }

--- a/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2021-01-25/examples/createOrUpdateGuestConfigurationHCRPAssignment.json
+++ b/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2021-01-25/examples/createOrUpdateGuestConfigurationHCRPAssignment.json
@@ -21,13 +21,7 @@
               "name": "[InstalledApplication]bwhitelistedapp;Name",
               "value": "NotePad,sql"
             }
-          ],
-          "configurationSetting": {
-            "rebootIfNeeded": false,
-            "actionAfterReboot": "ContinueConfiguration",
-            "configurationModeFrequencyMins": 15,
-            "configurationMode": "MonitorOnly"
-          }
+          ]
         }
       }
     }
@@ -56,13 +50,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }
@@ -91,13 +79,7 @@
                 "name": "[InstalledApplication]bwhitelistedapp;Name",
                 "value": "NotePad,sql"
               }
-            ],
-            "configurationSetting": {
-              "rebootIfNeeded": false,
-              "actionAfterReboot": "ContinueConfiguration",
-              "configurationModeFrequencyMins": 15,
-              "configurationMode": "MonitorOnly"
-            }
+            ]
           },
           "provisioningState": "Succeeded"
         }


### PR DESCRIPTION
Does not make any changes to the API, only to the examples. For this set of properties, even if they are included in a template, writing them from the API will not have any effect. The settings are ignored by the service and agent. In a future version of the API, if the properties are used by the service, we will add them to the new examples.