### PR TITLE
Revert "chore: Add dependabot for NPM dependency updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#12602

The auto updating every package is not the effect we want, so I am deleting the config file to disable the bahavior.