### PR TITLE
[Hub Generated] add missing x-ms-client-id header for AD Auth in Creator preview/2.0

### DIFF
--- a/specification/maps/data-plane/Creator/preview/2.0/alias.json
+++ b/specification/maps/data-plane/Creator/preview/2.0/alias.json
@@ -94,6 +94,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/AliasApiVersionV2"
           },
           {
@@ -128,6 +131,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/AliasApiVersionV2"
           }
         ],
@@ -158,6 +164,9 @@
           }
         },
         "parameters": [
+          {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
           {
             "$ref": "#/parameters/AliasId"
           },
@@ -190,6 +199,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/AliasId"
           },
           {
@@ -214,6 +226,9 @@
           }
         },
         "parameters": [
+          {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
           {
             "$ref": "#/parameters/AliasId"
           },

--- a/specification/maps/data-plane/Creator/preview/2.0/dataset.json
+++ b/specification/maps/data-plane/Creator/preview/2.0/dataset.json
@@ -114,6 +114,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/DatasetApiVersionV2"
           },
           {
@@ -148,6 +151,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/DatasetApiVersionV2"
           }
         ],
@@ -179,6 +185,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/DatasetId"
           },
           {
@@ -206,6 +215,9 @@
           }
         },
         "parameters": [
+          {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
           {
             "$ref": "#/parameters/DatasetApiVersionV2"
           },
@@ -236,6 +248,9 @@
           }
         },
         "parameters": [
+          {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
           {
             "$ref": "#/parameters/DatasetApiVersionV2"
           },

--- a/specification/maps/data-plane/Creator/preview/2.0/featurestate.json
+++ b/specification/maps/data-plane/Creator/preview/2.0/featurestate.json
@@ -127,6 +127,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/FeaturestateApiVersionV2"
           },
           {
@@ -167,6 +170,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/FeaturestateApiVersionV2"
           }
         ],
@@ -197,6 +203,9 @@
           }
         },
         "parameters": [
+          {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
           {
             "$ref": "#/parameters/FeaturestateApiVersionV2"
           },
@@ -232,6 +241,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/FeaturestateApiVersionV2"
           },
           {
@@ -256,6 +268,9 @@
           }
         },
         "parameters": [
+          {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
           {
             "$ref": "#/parameters/FeaturestateApiVersionV2"
           },
@@ -286,6 +301,9 @@
           }
         },
         "parameters": [
+          {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
           {
             "$ref": "#/parameters/FeaturestateApiVersionV2"
           },
@@ -324,6 +342,9 @@
         },
         "parameters": [
           {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
+          {
             "$ref": "#/parameters/FeaturestateApiVersionV2"
           },
           {
@@ -354,6 +375,9 @@
           }
         },
         "parameters": [
+          {
+            "$ref": "../../../Common/preview/1.0/common.json#/parameters/ClientId"
+          },
           {
             "$ref": "#/parameters/FeaturestateApiVersionV2"
           },


### PR DESCRIPTION
This is a PR generated at [OpenAPI Hub](https://aka.ms/openapihub). You can view your [work branch via this link](https://portal.azure-devex-tools.com/branch/ambientlight/azure-rest-api-specs/fix%2Fmaps-Creator-2.0-missing-x-ms-client-id...master/).

Azure Maps Azure AD authentification requires an additional `x-ms-client-id` header described in [Configuring application Azure AD authentication](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication#configuring-application-azure-ad-authentication), this has been achieved by adding additional parameter to all requests defined at [common.json:L535](https://github.com/ambientlight/azure-rest-api-specs/blob/fix/maps-Creator-2.0-missing-x-ms-client-id/specification/maps/data-plane/Common/preview/1.0/common.json#L535-L541)

Some paths have been missing this parameter, which will result in `401 Unauthorized` when OAuth2 bearer applied for AD auth. This PR adds this parameter to remaining paths.

### Changelog
Please ensure to add changelog with this PR by answering the following questions.
  1. What's the purpose of the update?    
      - [X] Fix missing x-ms-client-id parameter 
  2. When you are targeting to deploy new service/feature to public regions?
    **Services are already deployed.**
  3. When you expect to publish swagger? **ASAP.**
  4. If it's an update to existing version,  please select SDKs of specific language and CLIs that require refresh after swagger is published.
  No data-plane SDKs are onboarded yet, so no refresh required.

### Contribution checklist:
- [x] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### Breaking Change Review Checklist 
If there are following updates in the PR, ensure to request an approval from Breaking Change Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 

- [ ] Removing API(s) in stable version
- [ ] Removing properties in stable version
- [ ] Removing API version(s) in stable version
- [x] Updating API in stable or public preview version with Breaking Change Validation errors
- [ ] Updating API(s) in public preview over 1 year (refer to [Retirement of Previews](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37683/Retirement-of-Previews))

**Action**: to initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate): 
**Submitted new intake:** https://msazure.visualstudio.com/One/_workitems/edit/10449415
