### PR TITLE
Fix example for XmsClientNameParameter rule

### DIFF
--- a/documentation/openapi-authoring-automated-guidelines.md
+++ b/documentation/openapi-authoring-automated-guidelines.md
@@ -501,27 +501,12 @@ Links: [Index](#index) | [Error vs. Warning](#error-vs-warning) | [Automated Rul
 
 **Examples**:
 ```json
-"parameters": {
-    "ApiVersionParameter": {
-      "name": "x-ms-version",
-      "x-ms-client-name": "version",
-      "in": "header",
-      "required": false,
+  "headers": {
+    "x-ms-request-id": {
+      "x-ms-client-name": "requestId",
       "type": "string",
-      "x-ms-global": true,
-      "enum": [
-        "2015-04-05",
-        "2014-02-14",
-        "2013-08-15",
-        "2012-02-12",
-        "2011-08-18",
-        "2009-09-19",
-        "2009-07-17",
-        "2009-04-14"
-      ],
-      "default": "2015-04-05",
-      "description": "Specifies the version of the operation to use for this request."
-    }
+      "description": "This header uniquely identifies the request that was made and can be used for troubleshooting the request."
+    },
 ```
 
 Links: [Index](#index) | [Error vs. Warning](#error-vs-warning) | [Automated Rules](#automated-rules) | [ARM](#arm-violations): [Errors](#arm-errors) or [Warnings](#arm-warnings) | [SDK](#sdk-violations): [Errors](#sdk-errors) or [Warnings](#sdk-warnings)

--- a/documentation/openapi-authoring-automated-guidelines.md
+++ b/documentation/openapi-authoring-automated-guidelines.md
@@ -501,11 +501,14 @@ Links: [Index](#index) | [Error vs. Warning](#error-vs-warning) | [Automated Rul
 
 **Examples**:
 ```json
-  "headers": {
-    "x-ms-request-id": {
-      "x-ms-client-name": "requestId",
+  "parameters": [
+    {
+      "name": "If-Match",
+      "in": "header",
+      "required": false,
       "type": "string",
-      "description": "This header uniquely identifies the request that was made and can be used for troubleshooting the request."
+      "x-ms-client-name": "IfMatch",
+      "description": "The ETag of the resource to match."
     },
 ```
 


### PR DESCRIPTION
This PR replaces the example for the `XmsClientNameParameter` rule with a more concise and focused example.

It seems that some teams used the prior example as a pattern for declaring the `api-version` parameter, leading to a number of errors, such as declaring `api-version` as optional and using an outdated `x-ms-global` extension.  Further, the example contained many extraneous details that were unnecessary for illustrating the point of the rule -- that the value of `x-ms-client-name` must be different than the property/parameter name.