### PR TITLE
[Search] Add client names for ResetSkills and ResetDocs

### DIFF
--- a/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/examples/SearchServiceResetSkills.json
+++ b/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/examples/SearchServiceResetSkills.json
@@ -3,10 +3,12 @@
     "endpoint": "https://myservice.search.windows.net",
     "skillsetName": "mySkillset",
     "api-version": "2021-04-30-preview",
-    "skillNames": [
-      "skillName1",
-      "skillName2"
-    ]
+    "skillNames": {
+      "skillNames": [
+        "skillName1",
+        "skillName2"
+      ]
+    }
   },
   "responses": {
     "204": {}

--- a/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
@@ -361,6 +361,7 @@
             "required": false,
             "schema": {
               "type": "object",
+              "x-ms-client-name": "DocumentKeysOrIds",
               "properties": {
                 "documentKeys": {
                   "type": "array",
@@ -1061,6 +1062,8 @@
             "in": "body",
             "required": true,
             "schema": {
+              "type": "object",
+              "x-ms-client-name": "SkillNames",
               "properties": {
                 "skillNames": {
                   "type": "array",

--- a/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
@@ -1062,16 +1062,9 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "x-ms-client-name": "SkillNames",
-              "properties": {
-                "skillNames": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "the names of skills to be reset."
-                }
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
             "description": "The names of skills to reset."

--- a/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
@@ -1073,8 +1073,7 @@
                   "description": "the names of skills to be reset."
                 }
               }
-            },
-            "description": "The names of skills to reset."
+            }
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"

--- a/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
@@ -1062,9 +1062,16 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
+              "type": "object",
+              "x-ms-client-name": "SkillNames",
+              "properties": {
+                "skillNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "the names of skills to be reset."
+                }
               }
             },
             "description": "The names of skills to reset."

--- a/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchservice.json
@@ -1073,7 +1073,8 @@
                   "description": "the names of skills to be reset."
                 }
               }
-            }
+            },
+            "description": "The names of skills to reset."
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"


### PR DESCRIPTION
Without any name provided in the spec, CodeGen sets names like "Paths1Ju2XepSkillsetsSkillsetnameSearchResetskillsPostRequestbodyContentApplicationJsonSchema" and "Paths1Cj7DxmIndexersIndexernameSearchResetdocsPostRequestbodyContentApplicationJsonSchema"