### PR TITLE
[CLU] Adding x-ms-client-names properties for confidenceScore

### DIFF
--- a/specification/cognitiveservices/data-plane/Language/preview/2021-11-01-preview/analyzeconversations.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2021-11-01-preview/analyzeconversations.json
@@ -365,6 +365,7 @@
         "confidenceScore": {
           "type": "number",
           "format": "double",
+          "x-ms-client-name": "confidence",
           "description": "The prediction score and it ranges from 0.0 to 1.0.",
           "minimum": 0,
           "maximum": 1
@@ -455,6 +456,7 @@
         },
         "confidenceScore": {
           "format": "float",
+          "x-ms-client-name": "confidence",
           "description": "The confidence score of the class from 0.0 to 1.0.",
           "type": "number",
           "minimum": 0,
@@ -493,6 +495,7 @@
         },
         "confidenceScore": {
           "format": "float",
+          "x-ms-client-name": "confidence",
           "description": "The entity confidence score.",
           "type": "number"
         },


### PR DESCRIPTION
To ensure consistency with question answering, any mention of confidenceScore should be renamed to `confidence` in the SDK. Since the question answering SDK implements this using the swagger "x-ms-client-name" property, we would like to add it to the conversations swagger as well. This change should be considered after the release of the PuP later today.

Manually adding folks for review.

@heaths @ChongTang @annatisch 

I've also caught the following bug:
The QuestionAnsweringTargetIntentResult references  [the 2021-07-15-preview question answering swagger in this line of code](https://github.com/Azure/azure-rest-api-specs/blob/6c79b92d089275facf8378629e3ec0b873d440e9/specification/cognitiveservices/data-plane/Language/preview/2021-11-01-preview/analyzeconversations.json#L540), which does not have the renames for the `confidenceScore` properties. We would ideally like this to reference the [stable question answering swagger](https://github.com/Azure/azure-rest-api-specs/blob/34a2c0723155d134311419fd997925ce96b85bec/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/questionanswering.json). Should we bring the stable question answering swagger to this branch and reference it? Or should we add a static reference to the swagger on the other branch?