### PR TITLE
[Communication] Making NetworkTraversal RouteType a definition

### DIFF
--- a/specification/communication/data-plane/NetworkTraversal/preview/2021-10-08-preview/CommunicationNetworkTraversal.json
+++ b/specification/communication/data-plane/NetworkTraversal/preview/2021-10-08-preview/CommunicationNetworkTraversal.json
@@ -63,12 +63,7 @@
           "type": "string"
         },
         "routeType": {
-          "description": "The routing methodology to where the ICE server will be located from the client.",
-          "type": "string",
-          "enum": [
-            "any",
-            "nearest"
-          ]
+          "$ref": "#/definitions/RouteType"
         }
       }
     },
@@ -98,12 +93,7 @@
           "type": "string"
         },
         "routeType": {
-          "description": "The routing methodology to where the ICE server will be located from the client.",
-          "type": "string",
-          "enum": [
-            "any",
-            "nearest"
-          ]
+          "$ref": "#/definitions/RouteType"
         }
       }
     },
@@ -127,6 +117,18 @@
             "$ref": "#/definitions/CommunicationIceServer"
           }
         }
+      }
+    },
+    "RouteType": {
+      "description": "The routing methodology to where the ICE server will be located from the client.",
+      "enum": [
+        "any",
+        "nearest"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "RouteType",
+        "modelAsString": true
       }
     }
   },


### PR DESCRIPTION
Make the `RouteType` type a definition and have it referenced in the request and response.

This also adds the `x-ms-enum` property
```json
"x-ms-enum": {          
  "name": "RouteType",  
  "modelAsString": true 
}                       
```