### PR TITLE
[Maps Search] Update names based on APIView feedback for Preview 1.0

### DIFF
--- a/specification/maps/data-plane/Common/preview/1.0/common.json
+++ b/specification/maps/data-plane/Common/preview/1.0/common.json
@@ -118,7 +118,7 @@
       "properties": {
         "statusCode": {
           "description": "HTTP request status code.",
-          "type": "number",
+          "type": "integer",
           "readOnly": true,
           "example": 200
         }

--- a/specification/maps/data-plane/Search/preview/1.0/search.json
+++ b/specification/maps/data-plane/Search/preview/1.0/search.json
@@ -155,6 +155,7 @@
     },
     "SearchIndexSet": {
       "name": "idxSet",
+      "x-ms-client-name": "indexFilter",
       "in": "query",
       "description": "A comma separated list of indexes which should be utilized for the search. Item order does not matter. Available indexes are: Addr = Address range interpolation, Geo = Geographies, PAD = Point Addresses, POI = Points of interest, Str = Streets, Xstr = Cross Streets (intersections)",
       "type": "array",
@@ -453,7 +454,7 @@
           {
             "name": "geometries",
             "in": "query",
-            "x-ms-client-name": "geometryIds",
+            "x-ms-client-name": "listPolygons",
             "description": "Comma separated list of geometry UUIDs, previously retrieved from an Online Search request.",
             "required": true,
             "type": "array",
@@ -1400,6 +1401,7 @@
           },
           {
             "name": "searchFuzzyBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of search fuzzy queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1450,6 +1452,7 @@
           },
           {
             "name": "searchFuzzyBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of search fuzzy queries/requests to process. The list can contain a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1533,6 +1536,7 @@
           },
           {
             "name": "searchAddressBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of address geocoding queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1583,6 +1587,7 @@
           },
           {
             "name": "searchAddressBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of address geocoding queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1666,6 +1671,7 @@
           },
           {
             "name": "searchAddressReverseBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of reverse geocoding queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1716,6 +1722,7 @@
           },
           {
             "name": "searchAddressReverseBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of reverse geocoding queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1800,11 +1807,6 @@
       "properties": {
         "providerID": {
           "description": "ID of the returned entity",
-          "type": "string",
-          "readOnly": true
-        },
-        "error": {
-          "description": "Reason for the failure to obtain data for this provider.",
           "type": "string",
           "readOnly": true
         },
@@ -2577,6 +2579,7 @@
       ]
     },
     "DataSources": {
+      "x-ms-client-name": "DataSource",
       "description": "Optional section. Reference ids for use with the [Get Search Polygon](https://docs.microsoft.com/rest/api/maps/search/getsearchpolygon) API.",
       "type": "object",
       "readOnly": true,
@@ -2587,6 +2590,7 @@
       }
     },
     "Geometry": {
+      "x-ms-client-name": "GeometryIdentifier",
       "description": "Information about the geometric shape of the result. Only present if type == Geography.",
       "type": "object",
       "properties": {
@@ -2598,6 +2602,7 @@
       }
     },
     "SearchAddressBatchProcessResult": {
+      "x-ms-client-name": "SearchAddressBatchResult",
       "description": "This object is returned from a successful Search Address Batch service call.",
       "type": "object",
       "allOf": [

--- a/specification/maps/data-plane/Search/preview/1.0/search.json
+++ b/specification/maps/data-plane/Search/preview/1.0/search.json
@@ -454,7 +454,7 @@
           {
             "name": "geometries",
             "in": "query",
-            "x-ms-client-name": "listPolygons",
+            "x-ms-client-name": "geometryIds",
             "description": "Comma separated list of geometry UUIDs, previously retrieved from an Online Search request.",
             "required": true,
             "type": "array",
@@ -1965,7 +1965,7 @@
           "$ref": "../../../Common/preview/1.0/common.json#/definitions/LatLongPairAbbreviated"
         },
         "viewport": {
-          "$ref": "#/definitions/Viewport"
+          "$ref": "#/definitions/BoundingBox"
         },
         "entryPoints": {
           "description": "Array of EntryPoints. Those describe the types of entrances available at the location. The type can be \"main\" for main entrances such as a front door, or a lobby, and \"minor\", for side and back doors.",

--- a/specification/maps/data-plane/Search/preview/1.0/search.json
+++ b/specification/maps/data-plane/Search/preview/1.0/search.json
@@ -155,6 +155,7 @@
     },
     "SearchIndexSet": {
       "name": "idxSet",
+      "x-ms-client-name": "indexFilter",
       "in": "query",
       "description": "A comma separated list of indexes which should be utilized for the search. Item order does not matter. Available indexes are: Addr = Address range interpolation, Geo = Geographies, PAD = Point Addresses, POI = Points of interest, Str = Streets, Xstr = Cross Streets (intersections)",
       "type": "array",
@@ -453,7 +454,7 @@
           {
             "name": "geometries",
             "in": "query",
-            "x-ms-client-name": "geometryIds",
+            "x-ms-client-name": "listPolygons",
             "description": "Comma separated list of geometry UUIDs, previously retrieved from an Online Search request.",
             "required": true,
             "type": "array",
@@ -1400,6 +1401,7 @@
           },
           {
             "name": "searchFuzzyBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of search fuzzy queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1450,6 +1452,7 @@
           },
           {
             "name": "searchFuzzyBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of search fuzzy queries/requests to process. The list can contain a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1533,6 +1536,7 @@
           },
           {
             "name": "searchAddressBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of address geocoding queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1583,6 +1587,7 @@
           },
           {
             "name": "searchAddressBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of address geocoding queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1666,6 +1671,7 @@
           },
           {
             "name": "searchAddressReverseBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of reverse geocoding queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1716,6 +1722,7 @@
           },
           {
             "name": "searchAddressReverseBatchRequestBody",
+            "x-ms-client-name": "batchRequest",
             "in": "body",
             "description": "The list of reverse geocoding queries/requests to process. The list can contain  a max of 10,000 queries and must contain at least 1 query.",
             "required": true,
@@ -1800,11 +1807,6 @@
       "properties": {
         "providerID": {
           "description": "ID of the returned entity",
-          "type": "string",
-          "readOnly": true
-        },
-        "error": {
-          "description": "Reason for the failure to obtain data for this provider.",
           "type": "string",
           "readOnly": true
         },
@@ -1963,7 +1965,7 @@
           "$ref": "../../../Common/preview/1.0/common.json#/definitions/LatLongPairAbbreviated"
         },
         "viewport": {
-          "$ref": "#/definitions/Viewport"
+          "$ref": "#/definitions/BoundingBox"
         },
         "entryPoints": {
           "description": "Array of EntryPoints. Those describe the types of entrances available at the location. The type can be \"main\" for main entrances such as a front door, or a lobby, and \"minor\", for side and back doors.",
@@ -2577,6 +2579,7 @@
       ]
     },
     "DataSources": {
+      "x-ms-client-name": "DataSource",
       "description": "Optional section. Reference ids for use with the [Get Search Polygon](https://docs.microsoft.com/rest/api/maps/search/getsearchpolygon) API.",
       "type": "object",
       "readOnly": true,
@@ -2587,6 +2590,7 @@
       }
     },
     "Geometry": {
+      "x-ms-client-name": "GeometryIdentifier",
       "description": "Information about the geometric shape of the result. Only present if type == Geography.",
       "type": "object",
       "properties": {
@@ -2598,6 +2602,7 @@
       }
     },
     "SearchAddressBatchProcessResult": {
+      "x-ms-client-name": "SearchAddressBatchResult",
       "description": "This object is returned from a successful Search Address Batch service call.",
       "type": "object",
       "allOf": [


### PR DESCRIPTION
This is a PR generated at [OpenAPI Hub](https://aka.ms/openapihub). You can view your [work branch via this link](https://portal.azure-devex-tools.com/branch/alankashiwa/azure-rest-api-specs/maps-geolocation-improvement-for-sdk...main/).


### Changelog
Add a changelog entry for this PR by answering the following questions:
  1. What's the purpose of the update?
      - [x] **To improve swagger for generated clients and address some issues from [this review in ApiView](https://apiview.dev/Assemblies/Review/0ab748be5297432eaf27d512e2d1b998)**
  2. When are you targeting to deploy the new service/feature to public regions? **Services already deployed.**
  3. When do you expect to publish the swagger? **ASAP**
  4. If updating an existing version, please select the specific language SDKs and CLIs that must be refreshed after the swagger is published. **No data-plane SDKs are onboarded yet, so no refresh is required.**

### Contribution checklist:
- [x] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further questions about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### Breaking Change Review Checklist 
If any of the following scenarios apply to the PR, request approval from the Breaking Change Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 
- [ ] Removing API(s) in a stable version
- [ ] Removing properties in a stable version
- [ ] Removing API version(s) in a stable version
- [x] Updating API in a stable or public preview version with Breaking Change Validation errors
- [ ] Updating API(s) in public preview over 1 year (refer to [Retirement of Previews](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37683/Retirement-of-Previews))

**Action**: to initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate). Addition details on the process and office hours are on the [Breaking change Wiki](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37684/Breaking-Changes).
