### PR TITLE
Added documentation for the default value of disableLocalAuth in Azure App Configuration.

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/preview/2021-03-01-preview/appconfiguration.json
@@ -1129,7 +1129,8 @@
         },
         "disableLocalAuth": {
           "type": "boolean",
-          "description": "Disables all authentication methods other than AAD authentication."
+          "description": "Disables all authentication methods other than AAD authentication.",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
Added documentation for the default value of disableLocalAuth in Azure App Configuration.

If this property is not provided by the client when creating a configuration store resource then the value is set to `false`.