### PR TITLE
Update setting and protected settings to object as string fails for l…

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2021-03-01/cloudService.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2021-03-01/cloudService.json
@@ -2185,11 +2185,11 @@
         },
         "settings": {
           "description": "Public settings for the extension. For JSON extensions, this is the JSON settings for the extension. For XML Extension (like RDP), this is the XML setting for the extension.",
-          "type": "string"
+          "type": "object"
         },
         "protectedSettings": {
           "description": "Protected settings for the extension which are encrypted before sent to the role instance.",
-          "type": "string"
+          "type": "object"
         },
         "protectedSettingsFromKeyVault": {
           "$ref": "#/definitions/CloudServiceVaultAndSecretReference"


### PR DESCRIPTION
Update setting and protected settings to object as string fails for list calls when retrieved values are object. The API entity model for extensions can take both strings and object values based on type of extension (xml vs json).

### Changelog
Add a changelog entry for this PR by answering the following questions:
  1. What's the purpose of the update?

Fix swagger sdk failures due to incorrect object type.
