### PR TITLE
Removed x-ms-content-type from File Rename

### DIFF
--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2021-04-10/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2021-04-10/file.json
@@ -5325,9 +5325,6 @@
           },
           {
             "$ref": "#/parameters/FilePermissionKey"
-          },
-          {
-            "$ref": "#/parameters/FileContentType"
           }
         ],
         "responses": {


### PR DESCRIPTION
This is not a breaking change, this API has not been publicly released yet.