### PR TITLE
Remove supportOrdering for queues in Service Bus

### DIFF
--- a/specification/servicebus/data-plane/servicebus-swagger.json
+++ b/specification/servicebus/data-plane/servicebus-swagger.json
@@ -720,14 +720,6 @@
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
         },
-        "supportOrdering": {
-          "description": "A value that indicates whether the queue supports ordering.",
-          "type": "boolean",
-          "xml": {
-            "name": "SupportOrdering",
-            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-          }
-        },
         "messageCountDetails": {
           "$ref": "#/definitions/MessageCountDetails"
         },


### PR DESCRIPTION
As discussed in https://github.com/Azure/azure-sdk-for-js/issues/11859, the `supportOrdering` property is not of much use on queues. This PR removes this property for the queue and retains it for topics

@yunhaoling 