### PR TITLE
Update docs for supportOrdering property

### DIFF
--- a/specification/servicebus/data-plane/servicebus-swagger.json
+++ b/specification/servicebus/data-plane/servicebus-swagger.json
@@ -721,7 +721,7 @@
           }
         },
         "supportOrdering": {
-          "description": "Indicates if messages are sequenced or received in the same order they are sent. For queues, defaults to true and setting it to false has no effect.",
+          "description": "Indicates if messages are received in the same order they are sent. For queues, defaults to true and setting it to false has no effect.",
           "type": "boolean",
           "xml": {
             "name": "SupportOrdering",
@@ -1076,7 +1076,7 @@
           }
         },
         "supportOrdering": {
-          "description": "Indicates if messages are sequenced or received in the same order they are sent. If partitioned topics, defaults to false and setting it to true has no effect. For non-partitioned topics, setting it to false will improve perf, but messages may not received in the order they are sent.",
+          "description": "Indicates if messages are received in the same order they are sent. If partitioned topics, defaults to false and setting it to true has no effect. For non-partitioned topics, setting it to false will improve perf, but messages may not received in the order they are sent.",
           "type": "boolean",
           "xml": {
             "name": "SupportOrdering",

--- a/specification/servicebus/data-plane/servicebus-swagger.json
+++ b/specification/servicebus/data-plane/servicebus-swagger.json
@@ -1076,7 +1076,7 @@
           }
         },
         "supportOrdering": {
-          "description": "Indicates if messages are received in the same order they are sent. If partitioned topics, defaults to false and setting it to true has no effect. For non-partitioned topics, setting it to false will improve perf, but messages may not received in the order they are sent.",
+          "description": "Indicates if messages are received in the same order they are sent. If partitioned topics, defaults to false, and setting it to true has no effect. For unpartitioned topics, setting it to false will improve perf, but messages may not be received in the order they are sent.",
           "type": "boolean",
           "xml": {
             "name": "SupportOrdering",

--- a/specification/servicebus/data-plane/servicebus-swagger.json
+++ b/specification/servicebus/data-plane/servicebus-swagger.json
@@ -721,7 +721,7 @@
           }
         },
         "supportOrdering": {
-          "description": "A value that indicates whether the queue supports ordering.",
+          "description": "Indicates if messages are sequenced or received in the same order they are sent. For queues, defaults to true and setting it to false has no effect.",
           "type": "boolean",
           "xml": {
             "name": "SupportOrdering",
@@ -1076,7 +1076,7 @@
           }
         },
         "supportOrdering": {
-          "description": "A value that indicates whether the topic supports ordering.",
+          "description": "Indicates if messages are sequenced or received in the same order they are sent. If partitioned topics, defaults to false and setting it to true has no effect. For non-partitioned topics, setting it to false will improve perf, but messages may not received in the order they are sent.",
           "type": "boolean",
           "xml": {
             "name": "SupportOrdering",


### PR DESCRIPTION
As discussed in https://github.com/Azure/azure-sdk-for-js/issues/11859, the `supportOrdering` property is not of much use on queues. This PR updates the docs on this property to indicate this.

I chose to update the docs rather than remove the property as the latter approach will cause breaking changes to the generated code

cc @yunhaoling 