### PR TITLE
add missing Configuration Tags to operationalinsights readme

### DIFF
--- a/specification/operationalinsights/data-plane/readme.md
+++ b/specification/operationalinsights/data-plane/readme.md
@@ -43,6 +43,8 @@ directive:
     remove-operation: Query_Get
 ```
 
+### Tag: 20171001
+
 ``` yaml $(tag) == '20171001'
 input-file:
 - Microsoft.OperationalInsights/preview/2017-10-01/swagger.json
@@ -51,6 +53,8 @@ directive:
     where-operation: Query_Post
     transform: $.operationId = "Query"
 ```
+
+### Tag: 20210519
 
 ``` yaml $(tag) == '20210519'
 input-file:


### PR DESCRIPTION
The readme.md for operationalinsights is missing two `Tag:` entries in the `readme.md`. This pull request adds them.

This will allow code generated tools to generate code for those two newer API specs.
https://github.com/Azure/azure-sdk-for-rust/pull/550