### PR TITLE
Adding ReadOnlyDatabase object to Synapse model.

### DIFF
--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/kustoPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/kustoPool.json
@@ -2954,6 +2954,72 @@
       },
       "description": "Class representing the Kusto database properties."
     },
+    "ReadOnlyFollowingDatabase": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "description": "The database properties.",
+          "$ref": "#/definitions/ReadOnlyFollowingDatabaseProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Database"
+        }
+      ],
+      "description": "Class representing a read only following database.",
+      "x-ms-discriminator-value": "ReadOnlyFollowing"
+    },
+    "ReadOnlyFollowingDatabaseProperties": {
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ResourceProvisioningState",
+          "readOnly": true,
+          "description": "The provisioned state of the resource."
+        },
+        "softDeletePeriod": {
+          "type": "string",
+          "readOnly": true,
+          "format": "duration",
+          "description": "The time the data should be kept before it stops being accessible to queries in TimeSpan."
+        },
+        "hotCachePeriod": {
+          "type": "string",
+          "format": "duration",
+          "description": "The time the data should be kept in cache for fast queries in TimeSpan."
+        },
+        "statistics": {
+          "$ref": "#/definitions/DatabaseStatistics",
+          "readOnly": true,
+          "description": "The statistics of the database."
+        },
+        "leaderClusterResourceId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The name of the leader cluster"
+        },
+        "attachedDatabaseConfigurationName": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The name of the attached database configuration cluster"
+        },
+        "principalsModificationKind": {
+          "type": "string",
+          "readOnly": true,
+          "enum": [
+            "Union",
+            "Replace",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "PrincipalsModificationKind",
+            "modelAsString": true
+          },
+          "description": "The principals modification kind of the database"
+        }
+      },
+      "description": "Class representing the Kusto database properties."
+    },
     "DatabaseStatistics": {
       "type": "object",
       "readOnly": true,

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/kustoPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/kustoPool.json
@@ -2955,6 +2955,7 @@
       "description": "Class representing the Kusto database properties."
     },
     "ReadOnlyFollowingDatabase": {
+      "type": "object",
       "properties": {
         "properties": {
           "x-ms-client-flatten": true,
@@ -2971,6 +2972,7 @@
       "x-ms-discriminator-value": "ReadOnlyFollowing"
     },
     "ReadOnlyFollowingDatabaseProperties": {
+      "type": "object",
       "properties": {
         "provisioningState": {
           "$ref": "#/definitions/ResourceProvisioningState",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/sqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/sqlPool.json
@@ -6122,8 +6122,7 @@
         "storageAccountSubscriptionId": {
           "format": "uuid",
           "description": "Specifies the blob storage subscription Id.",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "isStorageSecondaryKeyInUse": {
           "description": "Specifies whether storageAccountAccessKey value is the storage's secondary key.",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/sqlServer.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/sqlServer.json
@@ -1237,8 +1237,7 @@
         "storageAccountSubscriptionId": {
           "format": "uuid",
           "description": "Specifies the blob storage subscription Id.",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "isStorageSecondaryKeyInUse": {
           "description": "Specifies whether storageAccountAccessKey value is the storage's secondary key.",


### PR DESCRIPTION
### Changelog

This PR updates an existing API version and adds a missing object.  
It adds ReadOnlyDatabase (and its properties object) to the Synapse model which is similar to the ReadOnlyDatabase in Kusto model.