### PR TITLE
[Communication] Adding ACS NetworkTraversal 2022-03-01-preview API

### DIFF
--- a/specification/communication/data-plane/NetworkTraversal/preview/2022-03-01-preview/CommunicationNetworkTraversal.json
+++ b/specification/communication/data-plane/NetworkTraversal/preview/2022-03-01-preview/CommunicationNetworkTraversal.json
@@ -1,0 +1,179 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "CommunicationNetworkTraversalClient",
+    "description": "Azure Communication Network Traversal Service",
+    "version": "2022-03-01-preview"
+  },
+  "paths": {
+    "/networkTraversal/:issueRelayConfiguration": {
+      "post": {
+        "tags": [
+          "Turn"
+        ],
+        "summary": "Issue a configuration for an STUN/TURN server.",
+        "operationId": "CommunicationNetworkTraversal_IssueRelayConfiguration",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "description": "Optional request for providing the id and/or route type for the returned relay configuration.",
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/definitions/CommunicationRelayConfigurationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/CommunicationRelayConfiguration"
+            }
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "../../../Common/stable/2021-03-07/common.json#/definitions/CommunicationErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Issue Relay Configuration": {
+            "$ref": "./examples/IssueRelayConfiguration.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "CommunicationRelayConfigurationRequest": {
+      "description": "Request for a CommunicationRelayConfiguration.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "An identity to be associated with telemetry for data relayed using the returned credentials. Must be an existing ACS user identity. If not provided, the telemetry will not contain an associated identity value.",
+          "type": "string"
+        },
+        "routeType": {
+          "description": "Filter the routing methodology returned. If not provided, will return all route types in separate ICE servers.",
+          "$ref": "#/definitions/RouteType"
+        },
+        "ttl": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The credential Time-To-Live (TTL), in seconds. The default value will be used if given value exceeds it.",
+          "minimum": 0,
+          "maximum": 172800,
+          "default": 172800
+        }
+      }
+    },
+    "CommunicationIceServer": {
+      "description": "An instance of a STUN/TURN server with credentials to be used for ICE negotiation.",
+      "required": [
+        "credential",
+        "urls",
+        "username",
+        "routeType"
+      ],
+      "type": "object",
+      "properties": {
+        "urls": {
+          "description": "List of STUN/TURN server URLs.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "description": "User account name which uniquely identifies the credentials.",
+          "type": "string"
+        },
+        "credential": {
+          "description": "Credential for the server.",
+          "type": "string"
+        },
+        "routeType": {
+          "$ref": "#/definitions/RouteType"
+        }
+      }
+    },
+    "CommunicationRelayConfiguration": {
+      "description": "A relay configuration containing the STUN/TURN URLs and credentials.",
+      "required": [
+        "expiresOn",
+        "iceServers"
+      ],
+      "type": "object",
+      "properties": {
+        "expiresOn": {
+          "format": "date-time",
+          "description": "The date for which the username and credentials are not longer valid. Will be 48 hours from request time.",
+          "type": "string"
+        },
+        "iceServers": {
+          "description": "An array representing the credentials and the STUN/TURN server URLs for use in ICE negotiations.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CommunicationIceServer"
+          }
+        }
+      }
+    },
+    "RouteType": {
+      "description": "The routing methodology to where the ICE server will be located from the client. \"any\" will have higher reliability while \"nearest\" will have lower latency. It is recommended to default to use the \"any\" routing method unless there are specific scenarios which minimizing latency is critical.",
+      "enum": [
+        "any",
+        "nearest"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "RouteType",
+        "modelAsString": true
+      }
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "in": "query",
+      "name": "api-version",
+      "description": "Version of API to invoke.",
+      "required": true,
+      "type": "string"
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "x-ms-parameterized-host": {
+    "hostTemplate": "{endpoint}",
+    "useSchemePrefix": false,
+    "parameters": [
+      {
+        "name": "endpoint",
+        "description": "The communication resource, for example https://my-resource.communication.azure.com",
+        "required": true,
+        "type": "string",
+        "in": "path",
+        "x-ms-skip-url-encoding": true,
+        "x-ms-parameter-location": "client"
+      }
+    ]
+  }
+}

--- a/specification/communication/data-plane/NetworkTraversal/preview/2022-03-01-preview/examples/IssueRelayConfiguration.json
+++ b/specification/communication/data-plane/NetworkTraversal/preview/2022-03-01-preview/examples/IssueRelayConfiguration.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2022-03-01-preview",
+    "content-type": "application/json",
+    "body": {
+      "id": "8:acs:2dee53b4-368b-45b4-ab52-8493fb117652_00000005-14a2-493b-8a72-5a3a0d000081",
+      "ttl": 3600
+    },
+    "endpoint": "https://my-resource.communication.azure.com"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "expiresOn": "2022-03-01T21:39:39.3244584+00:00",
+        "iceServers": [
+          {
+            "urls": [
+              "turn:131.107.255.255:3478",
+              "stun:131.107.255.255:3478"
+            ],
+            "username": "AgAAJNOeygwB1uVGvuwAVMHV4PLhYDgY66Fg1dUZvQ4AAAAEhXrhc8uJFjOK8lxEsZk3KIpWxc0=",
+            "credential": "9rl8ablFWj6/aqSuPLgLykLZKqw=",
+            "routeType": "any"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/communication/data-plane/NetworkTraversal/readme.md
+++ b/specification/communication/data-plane/NetworkTraversal/readme.md
@@ -58,7 +58,14 @@ input-file:
   - preview/2021-10-08-preview/CommunicationNetworkTraversal.json
 ```
 
----
+### Tag: package-2022-03-01-preview
+
+These settings apply only when `--tag=package-2022-03-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2022-03-01-preview'
+input-file:
+  - preview/2022-03-01-preview/CommunicationNetworkTraversal.json
+```
 
 # Code Generation
 


### PR DESCRIPTION
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

This swagger introduces an optional request parameter to the ACS NetworkTraversal API allowing users to specify the TTL for TURN credentials when fetching a Relay Configuration.

### Changelog
Add a changelog entry for this PR by answering the following questions:
  1. What's the purpose of the update?
      - [ ] new service onboarding
      - [X] new API version
      - [ ] update existing version for new feature
      - [ ] update existing version to fix swagger quality issue in s360
      - [ ] Other, please clarify
  2. When are you targeting to deploy the new service/feature to public regions? Please provide the date or, if the date is not yet available, the month.
  2022-02-30
  3. When do you expect to publish the swagger? Please provide date or, the the date is not yet available, the month.
 2022-03-01
  4. If updating an existing version, please select the specific langauge SDKs and CLIs that must be refreshed after the swagger is published.
      - [x] SDK of .NET (need service team to ensure code readiness)
      - [x] SDK of Python
      - [x] SDK of Java
      - [x] SDK of Js
      
### Contribution checklist:
- [X] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [X] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [X] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).
