### PR TITLE
Revert "Add adminUsers in aadprofile"

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-01-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-01-01/managedClusters.json
@@ -4222,13 +4222,6 @@
           },
           "description": "The list of AAD group object IDs that will have admin role of the cluster."
         },
-        "adminUsers": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The list of admin users that will have admin role of the cluster. For users in the same tenant, user principal name should be used; for users in different tenant, user object ID should be used."
-        },
         "clientAppID": {
           "type": "string",
           "description": "The client AAD application ID."


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#17402

AKS internal is not on the same page upon this feature, revert the change firstly.