### PR TITLE
Autorest related fix to data-plane API of Azure Load Testing

### DIFF
--- a/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2021-07-01-preview/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2021-07-01-preview/loadtestservice.json
@@ -294,6 +294,7 @@
           {
             "in": "formData",
             "name": "file",
+            "description": "Input test file",
             "required": true,
             "type": "file"
           }
@@ -999,6 +1000,7 @@
           {
             "in": "formData",
             "name": "file",
+            "description": "Input test file",
             "required": true,
             "type": "file"
           }

--- a/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2021-07-01-preview/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2021-07-01-preview/loadtestservice.json
@@ -1000,7 +1000,7 @@
           {
             "in": "formData",
             "name": "file",
-            "description": "Input test file",
+            "description": "Artifact to upload as input for test",
             "required": true,
             "type": "file"
           }


### PR DESCRIPTION
Autorest python SDK generator requires `description` for every entity in Swagger API document. This PR adds the missing `description` fields in Azure Load Testing data-plane API to enable Autorest Python SDK generation.

Linked Issue: Azure/autorest.azure-functions-python#2

Review Request: @abranj1219 @krishna1s @mikekistler