### PR TITLE
Fixed Storage File Copy Ignore Readonly

### DIFF
--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-10-02/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-10-02/file.json
@@ -6075,7 +6075,7 @@
       "description": "Specifies the option to copy file security descriptor from source file or to set it using the value which is defined by the header value of x-ms-file-permission or x-ms-file-permission-key."
     },
     "FileCopyIgnoreReadOnly": {
-      "name": "x-ms-file-copy-ignore-read-only",
+      "name": "x-ms-file-copy-ignore-readonly",
       "x-ms-client-name": "ignoreReadOnly",
       "in": "header",
       "required": false,

--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2021-02-12/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2021-02-12/file.json
@@ -6083,7 +6083,7 @@
       "description": "Specifies the option to copy file security descriptor from source file or to set it using the value which is defined by the header value of x-ms-file-permission or x-ms-file-permission-key."
     },
     "FileCopyIgnoreReadOnly": {
-      "name": "x-ms-file-copy-ignore-read-only",
+      "name": "x-ms-file-copy-ignore-readonly",
       "x-ms-client-name": "ignoreReadOnly",
       "in": "header",
       "required": false,

--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2021-04-10/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2021-04-10/file.json
@@ -6404,7 +6404,7 @@
       "description": "Specifies the option to copy file security descriptor from source file or to set it using the value which is defined by the header value of x-ms-file-permission or x-ms-file-permission-key."
     },
     "FileCopyIgnoreReadOnly": {
-      "name": "x-ms-file-copy-ignore-read-only",
+      "name": "x-ms-file-copy-ignore-readonly",
       "x-ms-client-name": "ignoreReadOnly",
       "in": "header",
       "required": false,


### PR DESCRIPTION
This is not a breaking change.  Previously the request header `x-ms-file-ignore-readonly` was incorrectly specified as `x-ms-file-ignore-read-only`.