### PR TITLE
[pipeline][python] remove configuration for track1

### DIFF
--- a/specificationRepositoryConfiguration.json
+++ b/specificationRepositoryConfiguration.json
@@ -29,11 +29,6 @@
       "mainRepository": "Azure/azure-sdk-for-net",
       "configFilePath": "eng/swagger_to_sdk_config.json"
     },
-    "azure-sdk-for-python": {
-      "integrationRepository": "AzureSDKAutomation/azure-sdk-for-python",
-      "mainRepository": "Azure/azure-sdk-for-python",
-      "mainBranch": "release/v3"
-    },
     "azure-sdk-for-python-track2": {
       "integrationRepository": "AzureSDKAutomation/azure-sdk-for-python",
       "mainRepository": "Azure/azure-sdk-for-python"
@@ -71,11 +66,6 @@
         "azure-sdk-for-net": {
           "integrationRepository": "azure-sdk/azure-sdk-for-net-pr",
           "mainRepository": "Azure/azure-sdk-for-net-pr"
-        },
-        "azure-sdk-for-python": {
-          "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",
-          "mainRepository": "Azure/azure-sdk-for-python-pr",
-          "mainBranch": "release/v3"
         },
         "azure-sdk-for-python-track2": {
           "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",

--- a/specificationRepositoryConfiguration.json
+++ b/specificationRepositoryConfiguration.json
@@ -29,6 +29,10 @@
       "mainRepository": "Azure/azure-sdk-for-net",
       "configFilePath": "eng/swagger_to_sdk_config.json"
     },
+    "azure-sdk-for-python": {
+      "integrationRepository": "AzureSDKAutomation/azure-sdk-for-python",
+      "mainRepository": "Azure/azure-sdk-for-python"
+    },
     "azure-sdk-for-python-track2": {
       "integrationRepository": "AzureSDKAutomation/azure-sdk-for-python",
       "mainRepository": "Azure/azure-sdk-for-python"
@@ -66,6 +70,10 @@
         "azure-sdk-for-net": {
           "integrationRepository": "azure-sdk/azure-sdk-for-net-pr",
           "mainRepository": "Azure/azure-sdk-for-net-pr"
+        },
+        "azure-sdk-for-python": {
+          "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",
+          "mainRepository": "Azure/azure-sdk-for-python-pr"
         },
         "azure-sdk-for-python-track2": {
           "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",


### PR DESCRIPTION
Python has not maintained track1 anymore so it is ok to remove the configuration.
This PR could also reduces pressure on ADO pool.

test link: https://github.com/Azure/azure-rest-api-specs/pull/17934