### PR TITLE
[AKS] Fix credential format typo in 0102 preview

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-02-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-02-02-preview/managedClusters.json
@@ -308,9 +308,6 @@
           },
           {
             "$ref": "#/parameters/ServerFqdnParameter"
-          },
-          {
-            "$ref": "#/parameters/CredentialFormatParameter"
           }
         ],
         "responses": {
@@ -356,6 +353,9 @@
           },
           {
             "$ref": "#/parameters/ServerFqdnParameter"
+          },
+          {
+            "$ref": "#/parameters/CredentialFormatParameter"
           }
         ],
         "responses": {


### PR DESCRIPTION
In 2022-01-02 preview swagger, there was a typo - the `CredentialFormat` query parameter was added to list admin credential handler, whereas it should be added to list user credential handler. This PR fixes the repo in new version API 2022-02-02 preview swagger.