### PR TITLE
recoveryservicesbackup: marking the LRO operations as LROs

### DIFF
--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2021-07-01/bms.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2021-07-01/bms.json
@@ -1440,6 +1440,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Enable Protection on Azure IaasVm": {
             "$ref": "./examples/AzureIaasVm/ConfigureProtection.json"
@@ -1510,6 +1511,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Delete Protection from Azure Virtual Machine": {
             "$ref": "./examples/Common/ProtectedItem_Delete.json"

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2021-08-01/bms.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2021-08-01/bms.json
@@ -1440,6 +1440,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Enable Protection on Azure IaasVm": {
             "$ref": "./examples/AzureIaasVm/ConfigureProtection.json"
@@ -1510,6 +1511,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Delete Protection from Azure Virtual Machine": {
             "$ref": "./examples/Common/ProtectedItem_Delete.json"

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2021-10-01/bms.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2021-10-01/bms.json
@@ -1440,6 +1440,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Enable Protection on Azure IaasVm": {
             "$ref": "./examples/AzureIaasVm/ConfigureProtection.json"
@@ -1510,6 +1511,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Delete Protection from Azure Virtual Machine": {
             "$ref": "./examples/Common/ProtectedItem_Delete.json"

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2021-12-01/bms.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2021-12-01/bms.json
@@ -1440,6 +1440,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Enable Protection on Azure IaasVm": {
             "$ref": "./examples/AzureIaasVm/ConfigureProtection.json"
@@ -1510,6 +1511,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Delete Protection from Azure Virtual Machine": {
             "$ref": "./examples/Common/ProtectedItem_Delete.json"

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2022-01-01/bms.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2022-01-01/bms.json
@@ -1440,6 +1440,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Enable Protection on Azure IaasVm": {
             "$ref": "./examples/AzureIaasVm/ConfigureProtection.json"
@@ -1510,6 +1511,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Delete Protection from Azure Virtual Machine": {
             "$ref": "./examples/Common/ProtectedItem_Delete.json"


### PR DESCRIPTION
These not being marked as an LRO means that consumers of the API need to instead manually parse the header
to make these work, as can be seen in this commit:

https://github.com/hashicorp/terraform-provider-azurerm/blob/4d39dde5bd2ff7b40ecbed0db93d35bf4ea5646d/internal/services/recoveryservices/backup_container_storage_account_resource.go#L97-L117

This PR fixes this by correctly marking these operations as LROs - which is a bug as the operation description explicitly defines these operations are an LRO