### PR TITLE
Add x-ms-arm-id-details extension to select resources

### DIFF
--- a/specification/batch/resource-manager/Microsoft.Batch/stable/2021-01-01/BatchManagement.json
+++ b/specification/batch/resource-manager/Microsoft.Batch/stable/2021-01-01/BatchManagement.json
@@ -2241,6 +2241,14 @@
       "properties": {
         "storageAccountId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          },
           "description": "The resource ID of the storage account to be used for auto-storage account."
         }
       },
@@ -2323,6 +2331,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          },
           "description": "The resource ID of the Azure key vault associated with the Batch account."
         },
         "url": {

--- a/specification/batch/resource-manager/Microsoft.Batch/stable/2021-06-01/BatchManagement.json
+++ b/specification/batch/resource-manager/Microsoft.Batch/stable/2021-06-01/BatchManagement.json
@@ -2408,6 +2408,14 @@
       "properties": {
         "storageAccountId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          },
           "description": "The resource ID of the storage account to be used for auto-storage account."
         },
         "authenticationMode": {
@@ -2565,6 +2573,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          },
           "description": "The resource ID of the Azure key vault associated with the Batch account."
         },
         "url": {

--- a/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
+++ b/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
@@ -2497,6 +2497,14 @@
       "properties": {
         "storageAccountId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          },
           "description": "The resource ID of the storage account to be used for auto-storage account."
         },
         "authenticationMode": {
@@ -2654,6 +2662,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          },
           "description": "The resource ID of the Azure key vault associated with the Batch account."
         },
         "url": {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/disk.json
@@ -1977,6 +1977,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2075,6 +2083,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         }
       },
@@ -2206,6 +2222,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          },
           "description": "Resource Id"
         }
       },
@@ -2264,6 +2288,14 @@
       "properties": {
         "diskEncryptionSetId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "description": "ResourceId of the disk encryption set to use for enabling encryption at rest."
         },
         "type": {
@@ -2356,6 +2388,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2531,6 +2571,7 @@
         },
         "sourceResourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "If createOption is Copy, this is the ARM id of the source snapshot or disk."
         },
         "sourceUniqueId": {
@@ -2558,6 +2599,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "A relative uri containing either a Platform Image Repository or user image reference."
         },
         "lun": {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2020-12-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2020-12-01/compute.json
@@ -10624,6 +10624,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The ARM resource id in the form of /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/..."
         }
       },
@@ -12342,6 +12343,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource Id"
         }
       },

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2020-12-01/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2020-12-01/disk.json
@@ -2156,6 +2156,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2267,6 +2275,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "supportsHibernation": {
@@ -2412,6 +2428,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          },
           "description": "Resource Id"
         }
       },
@@ -2470,6 +2494,14 @@
       "properties": {
         "diskEncryptionSetId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "description": "ResourceId of the disk encryption set to use for enabling encryption at rest."
         },
         "type": {
@@ -2562,6 +2594,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2754,6 +2794,7 @@
         },
         "sourceResourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "If createOption is Copy, this is the ARM id of the source snapshot or disk."
         },
         "sourceUniqueId": {
@@ -2781,6 +2822,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "A relative uri containing either a Platform Image Repository or user image reference."
         },
         "lun": {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2021-03-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2021-03-01/compute.json
@@ -11767,6 +11767,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The ARM resource id in the form of /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/..."
         }
       },
@@ -13591,6 +13592,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource Id"
         }
       },

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2021-04-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2021-04-01/compute.json
@@ -12700,6 +12700,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The ARM resource id in the form of /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/..."
         }
       },
@@ -14536,6 +14537,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource Id"
         }
       },

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2021-04-01/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2021-04-01/disk.json
@@ -2169,6 +2169,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2291,6 +2299,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "supportsHibernation": {
@@ -2448,6 +2464,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          },
           "description": "Resource Id"
         }
       },
@@ -2506,6 +2530,14 @@
       "properties": {
         "diskEncryptionSetId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "description": "ResourceId of the disk encryption set to use for enabling encryption at rest."
         },
         "type": {
@@ -2620,6 +2652,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2685,6 +2725,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "supportsHibernation": {
@@ -2837,6 +2885,7 @@
         },
         "sourceResourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "If createOption is Copy, this is the ARM id of the source snapshot or disk."
         },
         "sourceUniqueId": {
@@ -2864,6 +2913,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "A relative uri containing either a Platform Image Repository or user image reference."
         },
         "lun": {
@@ -3478,6 +3528,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "completionPercent": {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2021-07-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2021-07-01/compute.json
@@ -12815,6 +12815,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The ARM resource id in the form of /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/..."
         }
       },
@@ -14659,6 +14660,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource Id"
         }
       },

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2021-08-01/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2021-08-01/disk.json
@@ -2190,6 +2190,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2312,6 +2320,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "securityProfile": {
@@ -2479,6 +2495,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          },
           "description": "Resource Id"
         }
       },
@@ -2542,6 +2566,14 @@
       "properties": {
         "diskEncryptionSetId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "description": "ResourceId of the disk encryption set to use for enabling encryption at rest."
         },
         "type": {
@@ -2656,6 +2688,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2721,6 +2761,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "supportsHibernation": {
@@ -2887,6 +2935,7 @@
         },
         "sourceResourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "If createOption is Copy, this is the ARM id of the source snapshot or disk."
         },
         "sourceUniqueId": {
@@ -2918,6 +2967,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "A relative uri containing either a Platform Image Repository or user image reference."
         },
         "lun": {
@@ -3560,6 +3610,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "completionPercent": {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2021-11-01/compute.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2021-11-01/compute.json
@@ -14647,6 +14647,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The ARM resource id in the form of /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/..."
         }
       },
@@ -16535,6 +16536,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource Id"
         }
       },

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2021-12-01/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2021-12-01/disk.json
@@ -2196,6 +2196,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2321,6 +2329,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "securityProfile": {
@@ -2491,6 +2507,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          },
           "description": "Resource Id"
         }
       },
@@ -2554,6 +2578,14 @@
       "properties": {
         "diskEncryptionSetId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "description": "ResourceId of the disk encryption set to use for enabling encryption at rest."
         },
         "type": {
@@ -2690,6 +2722,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "tier": {
@@ -2758,6 +2798,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "supportsHibernation": {
@@ -2927,6 +2975,7 @@
         },
         "sourceResourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "If createOption is Copy, this is the ARM id of the source snapshot or disk."
         },
         "sourceUniqueId": {
@@ -2958,6 +3007,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "A relative uri containing either a Platform Image Repository or user image reference."
         },
         "lun": {
@@ -3612,6 +3662,14 @@
         },
         "diskAccessId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskAccesses"
+              }
+            ]
+          },
           "description": "ARM id of the DiskAccess resource for using private endpoints on disks."
         },
         "completionPercent": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-01-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-01-02-preview/managedClusters.json
@@ -2388,6 +2388,14 @@
     },
     "ContainerServiceVnetSubnetID": {
       "type": "string",
+      "format": "arm-id",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Network/virtualNetworks/subnets"
+          }
+        ]
+      },
       "description": "specifies a subnet's resource id with subscription, resource group, vnet and subnet name"
     },
     "ContainerServiceVMSize": {
@@ -2675,11 +2683,27 @@
         },
         "vnetSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which agent pool nodes and optionally pods will join on startup.",
           "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
         "podSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which pods will join when launched.",
           "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
@@ -3596,6 +3620,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The fully qualified Azure resource id."
         }
       },
@@ -3943,6 +3968,14 @@
         },
         "diskEncryptionSetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "title": "The Resource ID of the disk encryption set to use for enabling encryption at rest.",
           "description": "This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'"
         },
@@ -4114,6 +4147,14 @@
       "properties": {
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "The resource ID of the user assigned identity."
         },
         "clientId": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-05-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-05-01/managedClusters.json
@@ -2059,6 +2059,14 @@
     },
     "ContainerServiceVnetSubnetID": {
       "type": "string",
+      "format": "arm-id",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Network/virtualNetworks/subnets"
+          }
+        ]
+      },
       "description": "specifies a subnet's resource id with subscription, resource group, vnet and subnet name"
     },
     "ContainerServiceVMSize": {
@@ -2338,11 +2346,27 @@
         },
         "vnetSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which agent pool nodes and optionally pods will join on startup.",
           "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
         "podSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which pods will join when launched.",
           "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
@@ -3115,6 +3139,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The fully qualified Azure resource id."
         }
       },
@@ -3452,6 +3477,14 @@
         },
         "diskEncryptionSetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "title": "The Resource ID of the disk encryption set to use for enabling encryption at rest.",
           "description": "This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'"
         },
@@ -3605,6 +3638,14 @@
       "properties": {
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "The resource ID of the user assigned identity."
         },
         "clientId": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-07-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-07-01/managedClusters.json
@@ -2065,6 +2065,14 @@
     },
     "ContainerServiceVnetSubnetID": {
       "type": "string",
+      "format": "arm-id",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Network/virtualNetworks/subnets"
+          }
+        ]
+      },
       "description": "specifies a subnet's resource id with subscription, resource group, vnet and subnet name"
     },
     "ContainerServiceVMSize": {
@@ -2344,11 +2352,27 @@
         },
         "vnetSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which agent pool nodes and optionally pods will join on startup.",
           "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
         "podSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which pods will join when launched.",
           "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
@@ -3179,6 +3203,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The fully qualified Azure resource id."
         }
       },
@@ -3512,6 +3537,14 @@
         },
         "diskEncryptionSetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "title": "The Resource ID of the disk encryption set to use for enabling encryption at rest.",
           "description": "This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'"
         },
@@ -3666,6 +3699,14 @@
       "properties": {
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "The resource ID of the user assigned identity."
         },
         "clientId": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-08-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-08-01/managedClusters.json
@@ -2344,6 +2344,14 @@
     },
     "ContainerServiceVnetSubnetID": {
       "type": "string",
+      "format": "arm-id",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Network/virtualNetworks/subnets"
+          }
+        ]
+      },
       "description": "specifies a subnet's resource id with subscription, resource group, vnet and subnet name"
     },
     "ContainerServiceVMSize": {
@@ -2626,11 +2634,27 @@
         },
         "vnetSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which agent pool nodes and optionally pods will join on startup.",
           "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
         "podSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which pods will join when launched.",
           "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
@@ -3469,6 +3493,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The fully qualified Azure resource id."
         }
       },
@@ -3802,6 +3827,14 @@
         },
         "diskEncryptionSetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "title": "The Resource ID of the disk encryption set to use for enabling encryption at rest.",
           "description": "This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'"
         },
@@ -3973,6 +4006,14 @@
       "properties": {
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "The resource ID of the user assigned identity."
         },
         "clientId": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-09-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-09-01/managedClusters.json
@@ -2353,6 +2353,14 @@
     },
     "ContainerServiceVnetSubnetID": {
       "type": "string",
+      "format": "arm-id",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Network/virtualNetworks/subnets"
+          }
+        ]
+      },
       "description": "specifies a subnet's resource id with subscription, resource group, vnet and subnet name"
     },
     "ContainerServiceVMSize": {
@@ -2635,11 +2643,27 @@
         },
         "vnetSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which agent pool nodes and optionally pods will join on startup.",
           "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
         "podSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which pods will join when launched.",
           "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
@@ -3501,6 +3525,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The fully qualified Azure resource id."
         }
       },
@@ -3834,6 +3859,14 @@
         },
         "diskEncryptionSetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "title": "The Resource ID of the disk encryption set to use for enabling encryption at rest.",
           "description": "This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'"
         },
@@ -4005,6 +4038,14 @@
       "properties": {
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "The resource ID of the user assigned identity."
         },
         "clientId": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-10-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2021-10-01/managedClusters.json
@@ -2370,6 +2370,14 @@
     },
     "ContainerServiceVnetSubnetID": {
       "type": "string",
+      "format": "arm-id",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Network/virtualNetworks/subnets"
+          }
+        ]
+      },
       "description": "specifies a subnet's resource id with subscription, resource group, vnet and subnet name"
     },
     "ContainerServiceVMSize": {
@@ -2652,11 +2660,27 @@
         },
         "vnetSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which agent pool nodes and optionally pods will join on startup.",
           "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
         "podSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which pods will join when launched.",
           "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
@@ -3561,6 +3585,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The fully qualified Azure resource id."
         }
       },
@@ -3898,6 +3923,14 @@
         },
         "diskEncryptionSetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "title": "The Resource ID of the disk encryption set to use for enabling encryption at rest.",
           "description": "This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'"
         },
@@ -4069,6 +4102,14 @@
       "properties": {
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "The resource ID of the user assigned identity."
         },
         "clientId": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-01-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-01-01/managedClusters.json
@@ -2370,6 +2370,14 @@
     },
     "ContainerServiceVnetSubnetID": {
       "type": "string",
+      "format": "arm-id",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Network/virtualNetworks/subnets"
+          }
+        ]
+      },
       "description": "specifies a subnet's resource id with subscription, resource group, vnet and subnet name"
     },
     "ContainerServiceVMSize": {
@@ -2652,11 +2660,27 @@
         },
         "vnetSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which agent pool nodes and optionally pods will join on startup.",
           "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
         "podSubnetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "title": "The ID of the subnet which pods will join when launched.",
           "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
         },
@@ -3559,6 +3583,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "The fully qualified Azure resource id."
         }
       },
@@ -3892,6 +3917,14 @@
         },
         "diskEncryptionSetID": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          },
           "title": "The Resource ID of the disk encryption set to use for enabling encryption at rest.",
           "description": "This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'"
         },
@@ -4063,6 +4096,14 @@
       "properties": {
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "The resource ID of the user assigned identity."
         },
         "clientId": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-05-15/cosmos-db.json
@@ -7847,6 +7847,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "description": "Resource ID of a subnet, for example: /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}."
         },
         "ignoreMissingVNetServiceEndpoint": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-06-15/cosmos-db.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-06-15/cosmos-db.json
@@ -7894,6 +7894,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "description": "Resource ID of a subnet, for example: /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}."
         },
         "ignoreMissingVNetServiceEndpoint": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2021-10-15/cosmos-db.json
@@ -7993,6 +7993,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "description": "Resource ID of a subnet, for example: /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}."
         },
         "ignoreMissingVNetServiceEndpoint": {

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/stable/2020-06-01/EventGrid.json
@@ -3415,7 +3415,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource ID of the storage account that is the destination of the deadletter events",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          }
         },
         "blobContainerName": {
           "description": "The name of the Storage blob container that is the destination of the deadletter events",
@@ -3739,7 +3747,8 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource Id that represents the endpoint of an Event Hub destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id"
         }
       }
     },
@@ -3766,7 +3775,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource ID of the storage account that contains the queue that is the destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts/queues"
+              }
+            ]
+          }
         },
         "queueName": {
           "description": "The name of the Storage queue under a storage account that is the destination of an event subscription.",
@@ -3797,7 +3814,8 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource ID of an hybrid connection that is the destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id"
         }
       }
     },
@@ -3824,7 +3842,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource Id that represents the endpoint of the Service Bus destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ServiceBus/namespaces/queues"
+              }
+            ]
+          }
         }
       }
     },
@@ -3851,7 +3877,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource Id that represents the endpoint of the Service Bus Topic destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ServiceBus/namespaces/topics"
+              }
+            ]
+          }
         }
       }
     },
@@ -3878,7 +3912,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource Id that represents the endpoint of the Azure Function destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Web/sites/functions"
+              }
+            ]
+          }
         },
         "maxEventsPerBatch": {
           "format": "int32",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/stable/2021-12-01/EventGrid.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/stable/2021-12-01/EventGrid.json
@@ -4491,7 +4491,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource ID of the storage account that is the destination of the deadletter events",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          }
         },
         "blobContainerName": {
           "description": "The name of the Storage blob container that is the destination of the deadletter events",
@@ -4997,7 +5005,8 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource Id that represents the endpoint of an Event Hub destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id"
         },
         "deliveryAttributeMappings": {
           "description": "Delivery attribute details.",
@@ -5031,7 +5040,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource ID of the storage account that contains the queue that is the destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts/queues"
+              }
+            ]
+          }
         },
         "queueName": {
           "description": "The name of the Storage queue under a storage account that is the destination of an event subscription.",
@@ -5067,7 +5084,8 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource ID of an hybrid connection that is the destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id"
         },
         "deliveryAttributeMappings": {
           "description": "Delivery attribute details.",
@@ -5101,7 +5119,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource Id that represents the endpoint of the Service Bus destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ServiceBus/namespaces/queues"
+              }
+            ]
+          }
         },
         "deliveryAttributeMappings": {
           "description": "Delivery attribute details.",
@@ -5135,7 +5161,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource Id that represents the endpoint of the Service Bus Topic destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ServiceBus/namespaces/topics"
+              }
+            ]
+          }
         },
         "deliveryAttributeMappings": {
           "description": "Delivery attribute details.",
@@ -5169,7 +5203,15 @@
       "properties": {
         "resourceId": {
           "description": "The Azure Resource Id that represents the endpoint of the Azure Function destination of an event subscription.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Web/sites/functions"
+              }
+            ]
+          }
         },
         "maxEventsPerBatch": {
           "format": "int32",

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/eventhubs.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/eventhubs.json
@@ -369,6 +369,14 @@
           "properties": {
             "storageAccountResourceId": {
               "type": "string",
+              "format": "arm-id",
+              "x-ms-arm-id-details": {
+                "allowedResources": [
+                  {
+                    "type": "Microsoft.Storage/storageAccounts"
+                  }
+                ]
+              },
               "description": "Resource id of the storage account to be used to create the blobs"
             },
             "blobContainer": {

--- a/specification/eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/namespaces-preview.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/stable/2021-11-01/namespaces-preview.json
@@ -638,6 +638,14 @@
             },
             "clusterArmId": {
               "type": "string",
+              "format": "arm-id",
+              "x-ms-arm-id-details": {
+                "allowedResources": [
+                  {
+                    "type": "Microsoft.EventHub/clusters"
+                  }
+                ]
+              },
               "description": "Cluster ARM ID of the Namespace."
             },
             "metricId": {
@@ -895,7 +903,15 @@
       "properties": {
         "id": {
           "description": "The ARM identifier for Private Endpoint.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/privateEndpoints"
+              }
+            ]
+          }
         }
       }
     },
@@ -1005,6 +1021,14 @@
       "properties": {
         "userAssignedIdentity": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "ARM ID of user Identity selected for encryption"
         }
       }

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/stable/2021-05-01/mysql.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/stable/2021-05-01/mysql.json
@@ -1637,10 +1637,26 @@
         },
         "delegatedSubnetResourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "description": "Delegated subnet resource id used to setup vnet for a server."
         },
         "privateDnsZoneResourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/privateDnsZones"
+              }
+            ]
+          },
           "description": "Private DNS zone resource id."
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2020-11-01/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2020-11-01/network.json
@@ -172,6 +172,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource ID."
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2020-11-01/virtualNetworkGateway.json
@@ -2485,6 +2485,7 @@
         },
         "vNetExtendedLocationResourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "Customer vnet resource id. VirtualNetworkGateway of type local gateway is associated with the customer vnet."
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-02-01/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-02-01/network.json
@@ -172,6 +172,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource ID."
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-02-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-02-01/virtualNetworkGateway.json
@@ -2800,6 +2800,7 @@
         },
         "vNetExtendedLocationResourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "Customer vnet resource id. VirtualNetworkGateway of type local gateway is associated with the customer vnet."
         },
         "natRules": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-03-01/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-03-01/network.json
@@ -172,6 +172,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource ID."
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-03-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-03-01/virtualNetworkGateway.json
@@ -2800,6 +2800,7 @@
         },
         "vNetExtendedLocationResourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "Customer vnet resource id. VirtualNetworkGateway of type local gateway is associated with the customer vnet."
         },
         "natRules": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-05-01/network.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-05-01/network.json
@@ -172,6 +172,7 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource ID."
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-05-01/virtualNetworkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-05-01/virtualNetworkGateway.json
@@ -2804,6 +2804,7 @@
         },
         "vNetExtendedLocationResourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "Customer vnet resource id. VirtualNetworkGateway of type local gateway is associated with the customer vnet."
         },
         "natRules": {

--- a/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/postgresql.json
+++ b/specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/stable/2021-06-01/postgresql.json
@@ -1436,6 +1436,14 @@
         },
         "sourceServerResourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.DBforPostgreSQL/flexibleServers"
+              }
+            ]
+          },
           "description": "The source server resource ID to restore from. It's required when 'createMode' is 'PointInTimeRestore'.",
           "x-ms-mutability": [
             "create"
@@ -1684,6 +1692,14 @@
         },
         "delegatedSubnetResourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "default": "",
           "description": "delegated subnet arm resource id.",
           "x-ms-mutability": [
@@ -1693,6 +1709,14 @@
         },
         "privateDnsZoneArmResourceId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/privateDnsZones"
+              }
+            ]
+          },
           "default": "",
           "description": "private dns zone arm resource id.",
           "x-ms-mutability": [

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2020-12-01/redis.json
@@ -1951,6 +1951,17 @@
         },
         "subnetId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              },
+              {
+                "type": "Microsoft.ClassicNetwork/virtualNetworks/subnets"
+              }
+            ]
+          },
           "pattern": "^/subscriptions/[^/]*/resourceGroups/[^/]*/providers/Microsoft.(ClassicNetwork|Network)/virtualNetworks/[^/]*/subnets/[^/]*$",
           "description": "The full resource ID of a subnet in a virtual network to deploy the Redis cache in. Example format: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/Microsoft.{Network|ClassicNetwork}/VirtualNetworks/vnet1/subnets/subnet1"
         },
@@ -2534,6 +2545,14 @@
       "properties": {
         "linkedRedisCacheId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Cache/Redis"
+              }
+            ]
+          },
           "description": "Fully qualified resourceId of the linked redis cache."
         },
         "linkedRedisCacheLocation": {

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2021-06-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2021-06-01/redis.json
@@ -2006,6 +2006,17 @@
         },
         "subnetId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              },
+              {
+                "type": "Microsoft.ClassicNetwork/virtualNetworks/subnets"
+              }
+            ]
+          },
           "pattern": "^/subscriptions/[^/]*/resourceGroups/[^/]*/providers/Microsoft.(ClassicNetwork|Network)/virtualNetworks/[^/]*/subnets/[^/]*$",
           "description": "The full resource ID of a subnet in a virtual network to deploy the Redis cache in. Example format: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/Microsoft.{Network|ClassicNetwork}/VirtualNetworks/vnet1/subnets/subnet1"
         },
@@ -2605,6 +2616,14 @@
       "properties": {
         "linkedRedisCacheId": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Cache/Redis"
+              }
+            ]
+          },
           "description": "Fully qualified resourceId of the linked redis cache."
         },
         "linkedRedisCacheLocation": {

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/namespace-preview.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/stable/2021-11-01/namespace-preview.json
@@ -1124,6 +1124,14 @@
       "properties": {
         "userAssignedIdentity": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "ARM ID of user Identity selected for encryption"
         }
       }

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2021-04-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2021-04-01/storage.json
@@ -2248,6 +2248,14 @@
       "properties": {
         "userAssignedIdentity": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account.",
           "x-ms-client-name": "EncryptionUserAssignedIdentity"
         }
@@ -2277,6 +2285,7 @@
         },
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource Id"
         }
       },
@@ -2286,6 +2295,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "x-ms-client-name": "VirtualNetworkResourceId",
           "description": "Resource ID of a subnet, for example: /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}."
         },

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2021-06-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2021-06-01/storage.json
@@ -2362,6 +2362,14 @@
       "properties": {
         "userAssignedIdentity": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account.",
           "x-ms-client-name": "EncryptionUserAssignedIdentity"
         }
@@ -2391,6 +2399,7 @@
         },
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource Id"
         }
       },
@@ -2400,6 +2409,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "x-ms-client-name": "VirtualNetworkResourceId",
           "description": "Resource ID of a subnet, for example: /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}."
         },

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2021-08-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2021-08-01/storage.json
@@ -2655,6 +2655,14 @@
       "properties": {
         "userAssignedIdentity": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          },
           "description": "Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account.",
           "x-ms-client-name": "EncryptionUserAssignedIdentity"
         },
@@ -2689,6 +2697,7 @@
         },
         "resourceId": {
           "type": "string",
+          "format": "arm-id",
           "description": "Resource Id"
         }
       },
@@ -2698,6 +2707,14 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          },
           "x-ms-client-name": "VirtualNetworkResourceId",
           "description": "Resource ID of a subnet, for example: /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}."
         },


### PR DESCRIPTION
### Changelog
Add a changelog entry for this PR by answering the following questions:
  1. What's the purpose of the update?
      - [ ] new service onboarding
      - [ ] new API version
      - [ ] update existing version for new feature
      - [ ] update existing version to fix swagger quality issue in s360
      - [x] Other, please clarify: Document ARM ID references for a few key services:
  2. When are you targeting to deploy the new service/feature to public regions? **N/A**
  3. When do you expect to publish the swagger? **N/A**
  4. If updating an existing version, please select the specific language SDKs and CLIs that must be refreshed after the swagger is published.
      - [ ] SDK of .NET (need service team to ensure code readiness)
      - [ ] SDK of Python
      - [ ] SDK of Java
      - [ ] SDK of Js
      - [ ] SDK of Go
      - [ ] PowerShell
      - [ ] CLI
      - [ ] Terraform
      - [x] No refresh required for updates in this PR

### Contribution checklist:
- [x] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

This adds some new `x-ms-arm-id-details` extensions to various RPs Swagger for fields that are ARM references. This is _not_ comprehensive and may not cover all references in all Swaggers. The intent is to bootstrap some important references for some important resources. See https://github.com/Azure/autorest/pull/4150 and the [extension documentation](https://github.com/Azure/autorest/tree/main/docs/extensions#x-ms-arm-id-details). Where there were multiple Swaggers for a service all less than ~1yr old, I made the update for all of the Swaggers within the last year, not just the latest.

I will be working with @leni-msft on linter rules that will help improve the quality of this annotation across all service Swaggers, this is just a starting point.