### PR TITLE
Update specificationRepositoryConfiguration.json

### DIFF
--- a/specificationRepositoryConfiguration.json
+++ b/specificationRepositoryConfiguration.json
@@ -31,8 +31,7 @@
     },
     "azure-sdk-for-python": {
       "integrationRepository": "AzureSDKAutomation/azure-sdk-for-python",
-      "mainRepository": "Azure/azure-sdk-for-python",
-      "mainBranch": "release/v3"
+      "mainRepository": "Azure/azure-sdk-for-python"
     },
     "azure-sdk-for-python-track2": {
       "integrationRepository": "AzureSDKAutomation/azure-sdk-for-python",
@@ -75,7 +74,6 @@
         "azure-sdk-for-python": {
           "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",
           "mainRepository": "Azure/azure-sdk-for-python-pr",
-          "mainBranch": "release/v3"
         },
         "azure-sdk-for-python-track2": {
           "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",

--- a/specificationRepositoryConfiguration.json
+++ b/specificationRepositoryConfiguration.json
@@ -73,7 +73,7 @@
         },
         "azure-sdk-for-python": {
           "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",
-          "mainRepository": "Azure/azure-sdk-for-python-pr",
+          "mainRepository": "Azure/azure-sdk-for-python-pr"
         },
         "azure-sdk-for-python-track2": {
           "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",


### PR DESCRIPTION
Python has dropped track1 so there is no need to run pipeline for track1.
https://github.com/Azure/azure-sdk-for-python/issues/23423