### PR TITLE
Update specificationRepositoryConfiguration.json

### DIFF
--- a/specificationRepositoryConfiguration.json
+++ b/specificationRepositoryConfiguration.json
@@ -29,11 +29,6 @@
       "mainRepository": "Azure/azure-sdk-for-net",
       "configFilePath": "eng/swagger_to_sdk_config.json"
     },
-    "azure-sdk-for-python": {
-      "integrationRepository": "AzureSDKAutomation/azure-sdk-for-python",
-      "mainRepository": "Azure/azure-sdk-for-python",
-      "mainBranch": "release/v3"
-    },
     "azure-sdk-for-python-track2": {
       "integrationRepository": "AzureSDKAutomation/azure-sdk-for-python",
       "mainRepository": "Azure/azure-sdk-for-python"
@@ -71,11 +66,6 @@
         "azure-sdk-for-net": {
           "integrationRepository": "azure-sdk/azure-sdk-for-net-pr",
           "mainRepository": "Azure/azure-sdk-for-net-pr"
-        },
-        "azure-sdk-for-python": {
-          "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",
-          "mainRepository": "Azure/azure-sdk-for-python-pr",
-          "mainBranch": "release/v3"
         },
         "azure-sdk-for-python-track2": {
           "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",


### PR DESCRIPTION
python has not maintained track1 SDK anymore, so there is no need to keep the track1 generation pipeline
test link: https://github.com/Azure/azure-rest-api-specs/pull/18523