### PR TITLE
Revert "Added flush conn to nsg"

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/NetworkSecurityGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/NetworkSecurityGroupCreate.json
@@ -17,7 +17,6 @@
         "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
-          "flushConnection": false,
           "securityRules": [],
           "defaultSecurityRules": [
             {
@@ -128,7 +127,6 @@
         "location": "eastus",
         "properties": {
           "provisioningState": "Succeeded",
-          "flushConnection": false,
           "securityRules": [],
           "defaultSecurityRules": [
             {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/networkSecurityGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/networkSecurityGroup.json
@@ -870,10 +870,6 @@
     },
     "NetworkSecurityGroupPropertiesFormat": {
       "properties": {
-        "flushConnection": {
-          "type": "boolean",
-          "description": "When enabled, flows created from Network Security Group connections will be re-evaluated when rules are updates. Initial enablement will trigger re-evaluation."
-        },
         "securityRules": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#18393

There is a breaking bug in the current NRP release version which would block any further PutNsg calls. Please prioritise this revert.