### PR TITLE
Set codeowners for Cognitive Lanugage swaggers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,7 @@
 /specification/billing/ @wilcobmsft @asarkar84
 /specification/cdn/ @jorinmejia @yunhemsft @jessicl-ms @sinadell @rrahulms @t-bzhan
 /specification/cognitiveservices/ @felixwa @yangyuan
+/specification/cognitiveservices/data-plane/Language/ @rokulka @ChongTang @annatisch @heaths @Azure/api-stewardship-board
 /specification/compute/ @bilaakpan-ms @sandido @dkulkarni-ms @haagha @madewithsmiles @MS-syh2qs @grizzlytheodore @hyonholee @mabhard @danielli90 @smotwani @ppatwa @vikramd-ms @savyasachisamal @yunusm @ZhidongPeng @nkuchta @maheshnemichand @najams @changov
 /specification/consumption/ @kjeur @panda-wang
 /specification/containerinstance/ @novinc


### PR DESCRIPTION
Is in `main`, but this branch was created after that change was merged.