### PR TITLE
Use azure-sdk-for-net-track2 for validation

### DIFF
--- a/specification/cognitiveservices/data-plane/Language/readme.md
+++ b/specification/cognitiveservices/data-plane/Language/readme.md
@@ -110,7 +110,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net
+  - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python
 ```
 


### PR DESCRIPTION
The azure-sdk-for-net repo for validation uses track 1 and is causing failures. Instead, use the azure-sdk-for-net-track2 repo for track 2 validation.
