### PR TITLE
[AKS] Use enum for TrustedAccessRoleBinding's ProvisioningState

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-04-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-04-02-preview/managedClusters.json
@@ -6564,7 +6564,17 @@
         "provisioningState": {
           "type": "string",
           "readOnly": true,
-          "description": "The current provisioning state of trusted access role binding."
+          "description": "The current provisioning state of trusted access role binding.",
+          "enum": [
+            "Succeeded",
+            "Failed",
+            "Updating",
+            "Deleting"
+          ],
+          "x-ms-enum": {
+            "name": "TrustedAccessRoleBindingProvisioningState",
+            "modelAsString": true
+          }
         },
         "sourceResourceId": {
           "type": "string",


### PR DESCRIPTION
Address comment in https://github.com/Azure/azure-rest-api-specs/pull/18900

Use enum for provisioningState