### PR TITLE
Corect duplicate parent references in timeseriesinsights@2018-08-15-preview

### DIFF
--- a/specification/timeseriesinsights/resource-manager/Microsoft.TimeSeriesInsights/preview/2018-08-15-preview/timeseriesinsights.json
+++ b/specification/timeseriesinsights/resource-manager/Microsoft.TimeSeriesInsights/preview/2018-08-15-preview/timeseriesinsights.json
@@ -1612,9 +1612,6 @@
         },
         {
           "$ref": "#/definitions/EnvironmentResourceProperties"
-        },
-        {
-          "$ref": "#/definitions/ResourceProperties"
         }
       ],
       "required": [
@@ -1648,9 +1645,6 @@
       "allOf": [
         {
           "$ref": "#/definitions/EnvironmentResourceProperties"
-        },
-        {
-          "$ref": "#/definitions/ResourceProperties"
         }
       ],
       "description": "Properties of the long-term environment."

--- a/specification/timeseriesinsights/resource-manager/Microsoft.TimeSeriesInsights/preview/2018-08-15-preview/timeseriesinsights.json
+++ b/specification/timeseriesinsights/resource-manager/Microsoft.TimeSeriesInsights/preview/2018-08-15-preview/timeseriesinsights.json
@@ -1902,7 +1902,6 @@
     },
     "EventHubEventSourceUpdateParameters": {
       "type": "object",
-      "x-ms-discriminator-value": "Microsoft.EventHub",
       "properties": {
         "properties": {
           "x-ms-client-flatten": true,
@@ -1918,7 +1917,6 @@
       "description": "Parameters supplied to the Update Event Source operation to update an EventHub event source."
     },
     "IoTHubEventSourceUpdateParameters": {
-      "x-ms-discriminator-value": "Microsoft.IoTHub",
       "type": "object",
       "properties": {
         "properties": {


### PR DESCRIPTION
### Changelog
Add a changelog entry for this PR by answering the following questions:
  1. What's the purpose of the update?
      - [ ] new service onboarding
      - [ ] new API version
      - [ ] update existing version for new feature
      - [ ] update existing version to fix swagger quality issue in s360
      - [X] Other, please clarify

The 2018-08-15-preview version of TimeSeriesInsights is raising DuplicateParentReference errors in the ModelerFour Autorest plugin, which is preventing Bicep from regenerating code for this API.

  2. When are you targeting to deploy the new service/feature to public regions? Please provide the date or, if the date is not yet available, the month.

N/A

  4. When do you expect to publish the swagger? Please provide date or, the the date is not yet available, the month.

N/A

  6. If updating an existing version, please select the specific language SDKs and CLIs that must be refreshed after the swagger is published.
      - [ ] SDK of .NET (need service team to ensure code readiness)
      - [ ] SDK of Python
      - [ ] SDK of Java
      - [ ] SDK of Js
      - [ ] SDK of Go
      - [ ] PowerShell
      - [ ] CLI
      - [ ] Terraform
      - [X] Bicep
      - [ ] No refresh required for updates in this PR

### Contribution checklist:
- [X] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [X] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [ ] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).