### PR TITLE
[Databricks] [Labservices] update client name

### DIFF
--- a/specification/databricks/resource-manager/readme.python.md
+++ b/specification/databricks/resource-manager/readme.python.md
@@ -4,6 +4,7 @@ These settings apply only when `--python` is specified on the command line.
 Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
 
 ``` yaml $(python)
+title: DatabricksClient
 azure-arm: true
 license-header: MICROSOFT_MIT_NO_VERSION
 package-name: azure-mgmt-databricks

--- a/specification/labservices/resource-manager/readme.python.md
+++ b/specification/labservices/resource-manager/readme.python.md
@@ -5,6 +5,7 @@ Please also specify `--python-sdks-folder=<path to the root directory of your az
 Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
 
 ``` yaml $(python)
+title: ManagedLabsClient
 azure-arm: true
 license-header: MICROSOFT_MIT_NO_VERSION
 namespace: azure.mgmt.labservices


### PR DESCRIPTION
azure-mgmt-databricks: 1.0.0 -> 1.1.0b1. The client name is changed from `DatabricksClient` to `AzureDatabricksManagementClient`. https://pypi.org/project/azure-mgmt-databricks/1.1.0b1/
azure-mgmt-labservices: 1.0.0->2.0.0b1. The client name is changed from `ManagedLabsClient` to `LabServicesClient`. https://pypi.org/project/azure-mgmt-labservices/2.0.0b1/#history

We hope to pin the client name so as to reduce the user's breaking change and restore it before GA.