### PR TITLE
Revert "Making Application Gateway rule priority a required field"

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/applicationGateway.json
@@ -2396,9 +2396,6 @@
           "description": "The provisioning state of the request routing rule resource."
         }
       },
-      "required": [
-        "priority"
-      ],
       "description": "Properties of request routing rule of the application gateway."
     },
     "ApplicationGatewayRequestRoutingRule": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/ApplicationGatewayCreate.json
@@ -559,7 +559,6 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "ruleType": "Basic",
-                "priority": 10,
                 "httpListener": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
                 },
@@ -583,7 +582,6 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "ruleType": "PathBasedRouting",
-                "priority": 20,
                 "httpListener": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
                 },
@@ -902,7 +900,6 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "ruleType": "Basic",
-                "priority": 10,
                 "httpListener": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
                 },
@@ -925,7 +922,6 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
               "properties": {
                 "provisioningState": "Succeeded",
-                "priority": 20,
                 "ruleType": "PathBasedRouting",
                 "httpListener": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/ApplicationGatewayList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/ApplicationGatewayList.json
@@ -104,7 +104,6 @@
                   "name": "appgwrule",
                   "properties": {
                     "ruleType": "Basic",
-                    "priority": 10,
                     "httpListener": {
                       "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
                     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/ApplicationGatewayListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/ApplicationGatewayListAll.json
@@ -103,7 +103,6 @@
                   "name": "appgwrule",
                   "properties": {
                     "ruleType": "Basic",
-                    "priority": 10,
                     "httpListener": {
                       "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
                     },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/ApplicationGatewayUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2021-08-01/examples/ApplicationGatewayUpdateTags.json
@@ -127,7 +127,6 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "ruleType": "Basic",
-                "priority": 10,
                 "httpListener": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/AppGw/httpListeners/listener1"
                 },


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#19007

'Priority' field cannot be made required since Application Gateway V1 SKU and V2 SKU have the same api spec but V1 sku does not support this field and would break the V1 gateways. Only V2 sku needs to have the 'Priority' field as mandatory and there is no way to conditionally make the field optional/required based on the SKU. Hence reverting this change.