### PR TITLE
applicationinsights: updating the swagger to match the breaking api change

### DIFF
--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/examples/WebTestCreate.json
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/examples/WebTestCreate.json
@@ -59,6 +59,38 @@
           "provisioningState": "Succeeded"
         }
       }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/my-resource-group/providers/Microsoft.Insights/webtests/my-webtest-my-component",
+        "name": "my-webtest-my-component",
+        "type": "Microsoft.Insights/webtests",
+        "location": "southcentralus",
+        "tags": {
+          "hidden-link:/subscriptions/subid/resourceGroups/my-resource-group/providers/Microsoft.Insights/components/my-component": "Resource",
+          "hidden-link:/subscriptions/subid/resourceGroups/my-resource-group/providers/Microsoft.Web/sites/mytestwebapp": "Resource"
+        },
+        "kind": "ping",
+        "properties": {
+          "Name": "my-webtest-my-component",
+          "SyntheticMonitorId": "my-webtest-my-component",
+          "Description": "Ping web test alert for mytestwebapp",
+          "Enabled": true,
+          "Frequency": 900,
+          "Timeout": 120,
+          "Kind": "ping",
+          "RetryEnabled": true,
+          "Locations": [
+            {
+              "Id": "us-fl-mia-edge"
+            }
+          ],
+          "Configuration": {
+            "WebTest": "<WebTest Name=\"my-webtest\" Id=\"678ddf96-1ab8-44c8-9274-123456789abc\" Enabled=\"True\" CssProjectStructure=\"\" CssIteration=\"\" Timeout=\"120\" WorkItemIds=\"\" xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\" Description=\"\" CredentialUserName=\"\" CredentialPassword=\"\" PreAuthenticate=\"True\" Proxy=\"default\" StopOnError=\"False\" RecordedResultFile=\"\" ResultsLocale=\"\" ><Items><Request Method=\"GET\" Guid=\"a4162485-9114-fcfc-e086-123456789abc\" Version=\"1.1\" Url=\"http://my-component.azurewebsites.net\" ThinkTime=\"0\" Timeout=\"120\" ParseDependentRequests=\"True\" FollowRedirects=\"True\" RecordResult=\"True\" Cache=\"False\" ResponseTimeGoal=\"0\" Encoding=\"utf-8\" ExpectedHttpStatusCode=\"200\" ExpectedResponseUrl=\"\" ReportingName=\"\" IgnoreHttpStatusCode=\"False\" /></Items></WebTest>"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
     }
   }
 }

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/webTests_API.json
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/stable/2015-05-01/webTests_API.json
@@ -131,6 +131,12 @@
             "schema": {
               "$ref": "#/definitions/WebTest"
             }
+          },
+          "201": {
+            "description": "Adding the Application Insights web test was successful. Web test properties are updated and returned.",
+            "schema": {
+              "$ref": "#/definitions/WebTest"
+            }
           }
         },
         "x-ms-examples": {


### PR DESCRIPTION
As [per this comment](https://github.com/hashicorp/terraform-provider-azurerm/issues/16805#issuecomment-1128496426) the API now returns a 201 when it previously used to return a 200 - as such both a 200 and 201 should be documented in the Swagger to match the API definition.

The breaking API change should also be reverted, but that's a separate problem.

FYI @JeffreyRichter @jhendrixMSFT