### PR TITLE
fix mixedreality readme

### DIFF
--- a/specification/mixedreality/resource-manager/readme.md
+++ b/specification/mixedreality/resource-manager/readme.md
@@ -34,7 +34,7 @@ openapi-type: arm
 tag: package-2021-03-01-preview
 ```
 
-## Suppression
+### Suppression
 ``` yaml
 directive:
   - suppress: SECRET_PROPERTY


### PR DESCRIPTION
This just fixed the readme. `Tag`s must be under `Configuration`, not `Suppression`. This allows code generation to occur in the Aure SDK for Rust.