### PR TITLE
Added featuresmode to spec

### DIFF
--- a/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
+++ b/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
@@ -241,7 +241,7 @@
               ]
             },
             "x-nullable": false,
-            "description": "A value that specifies if your query will return result feaetures used to compute the relevance score of a document in relation to the query, default is 'disabled'",
+            "description": "A value that specifies if your query will return result features used to compute the relevance score of a document in relation to the query, default is 'disabled'",
             "x-ms-parameter-grouping": {
               "name": "SearchOptions"
             }

--- a/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
+++ b/specification/search/data-plane/Azure.Search/preview/2021-04-30-Preview/searchindex.json
@@ -217,6 +217,36 @@
             }
           },
           {
+            "name": "featuresMode",
+            "in": "query",
+            "type": "string",
+            "enum": [
+              "disabled",
+              "enabled"
+            ],
+            "x-ms-enum": {
+              "name": "FeaturesMode",
+              "modelAsString": false,
+              "values": [
+                {
+                  "value": "disabled",
+                  "name": "Disabled",
+                  "description": "Set 'disabled' to not include query result features."
+                },
+                {
+                  "value": "enabled",
+                  "name": "Enabled",
+                  "description": "Use 'disabled' to expose more query result features: per field similarity score, per field term frequency, and per field number of unique tokens matched."
+                }
+              ]
+            },
+            "x-nullable": false,
+            "description": "A value that specifies if your query will return result feaetures used to compute the relevance score of a document in relation to the query, default is 'disabled'",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
             "name": "scoringParameter",
             "in": "query",
             "type": "array",


### PR DESCRIPTION
# Data Plane API - Pull Request

FeaturesMode is not on the search index spec, This PR adds it, one thing to keep in mind is that is show as in preview in the azure portal, [link](https://docs.microsoft.com/en-us/rest/api/searchservice/preview-api/search-documents)

## API Info: The Basics

Is this review for (select one):

- [ ] a private preview
- [x] a public preview
- [ ] GA release

### Change Scope
No paths were updated, only change was add featuresMode to azure search index spec
