### PR TITLE
[Cognitive Language] Add SDK v-team as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 #########
 
 # PRLabel: %Cognitive Services
-/dev/cognitiveservices/data-plane/Language/ @assafi @rokulka @ChongTang @annatisch @heaths @Azure/api-stewardship-board
+/dev/cognitiveservices/data-plane/Language/ @assafi @rokulka @ChongTang @annatisch @heaths @deyaaeldeen @kristapratico @mssfang @Azure/api-stewardship-board
 
 /specification/adp/ @Azure/adp
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,7 +52,7 @@
 /specification/cognitiveservices/ @felixwa @yangyuan
 
 # PRLabel: %Cognitive - Language
-/specification/cognitiveservices/data-plane/Language/ @assafi @rokulka @ChongTang @annatisch @heaths @Azure/api-stewardship-board
+/specification/cognitiveservices/data-plane/Language/ @assafi @rokulka @ChongTang @annatisch @heaths @deyaaeldeen @kristapratico @mssfang @Azure/api-stewardship-board
 
 # PRLabel: %Compute
 /specification/compute/ @bilaakpan-ms @sandido @dkulkarni-ms @haagha @madewithsmiles @MS-syh2qs @grizzlytheodore @hyonholee @mabhard @danielli90 @smotwani @ppatwa @vikramd-ms @savyasachisamal @yunusm @ZhidongPeng @nkuchta @maheshnemichand @najams @changov


### PR DESCRIPTION
Adding Language SDK v-team as code owners for Language swaggers. I didn't add anyone from .NET since we're still waiting to hear who is going to fill that role.