### PR TITLE
Change config of SDK automation for Go

### DIFF
--- a/documentation/samplefiles/samplereadme.md
+++ b/documentation/samplefiles/samplereadme.md
@@ -51,7 +51,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions

--- a/specification/advisor/resource-manager/readme.md
+++ b/specification/advisor/resource-manager/readme.md
@@ -97,7 +97,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/agrifood/resource-manager/readme.md
+++ b/specification/agrifood/resource-manager/readme.md
@@ -50,7 +50,7 @@ This is not used by Autorest itself.
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-powershell
 ```

--- a/specification/alertsmanagement/resource-manager/readme.md
+++ b/specification/alertsmanagement/resource-manager/readme.md
@@ -163,7 +163,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-libraries-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-trenton
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/analysisservices/resource-manager/readme.md
+++ b/specification/analysisservices/resource-manager/readme.md
@@ -79,7 +79,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/apimanagement/resource-manager/readme.md
+++ b/specification/apimanagement/resource-manager/readme.md
@@ -638,7 +638,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/app/resource-manager/readme.md
+++ b/specification/app/resource-manager/readme.md
@@ -117,7 +117,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions

--- a/specification/appconfiguration/resource-manager/readme.md
+++ b/specification/appconfiguration/resource-manager/readme.md
@@ -117,7 +117,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-ruby
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_app_configuration']

--- a/specification/applicationinsights/resource-manager/readme.md
+++ b/specification/applicationinsights/resource-manager/readme.md
@@ -608,7 +608,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/appplatform/resource-manager/readme.md
+++ b/specification/appplatform/resource-manager/readme.md
@@ -135,7 +135,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-ruby
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_appplatform']

--- a/specification/attestation/resource-manager/readme.md
+++ b/specification/attestation/resource-manager/readme.md
@@ -70,7 +70,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-java
   - repo: azure-resource-manager-schemas

--- a/specification/authorization/resource-manager/readme.md
+++ b/specification/authorization/resource-manager/readme.md
@@ -438,7 +438,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/automanage/resource-manager/readme.md
+++ b/specification/automanage/resource-manager/readme.md
@@ -91,7 +91,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/automation/resource-manager/readme.md
+++ b/specification/automation/resource-manager/readme.md
@@ -369,7 +369,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/azure-kusto/resource-manager/readme.md
+++ b/specification/azure-kusto/resource-manager/readme.md
@@ -207,7 +207,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-java
   - repo: azure-cli-extensions
   - repo: azure-resource-manager-schemas

--- a/specification/azureactivedirectory/resource-manager/readme.md
+++ b/specification/azureactivedirectory/resource-manager/readme.md
@@ -120,7 +120,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/azurearcdata/resource-manager/readme.md
+++ b/specification/azurearcdata/resource-manager/readme.md
@@ -95,7 +95,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-ruby

--- a/specification/azuredata/resource-manager/readme.md
+++ b/specification/azuredata/resource-manager/readme.md
@@ -60,7 +60,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-ruby

--- a/specification/azurestack/resource-manager/readme.md
+++ b/specification/azurestack/resource-manager/readme.md
@@ -99,7 +99,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/azurestackhci/resource-manager/readme.md
+++ b/specification/azurestackhci/resource-manager/readme.md
@@ -137,7 +137,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/baremetalinfrastructure/resource-manager/readme.md
+++ b/specification/baremetalinfrastructure/resource-manager/readme.md
@@ -61,7 +61,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/batch/resource-manager/readme.md
+++ b/specification/batch/resource-manager/readme.md
@@ -243,7 +243,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/billing/resource-manager/readme.md
+++ b/specification/billing/resource-manager/readme.md
@@ -141,7 +141,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/blockchain/resource-manager/readme.md
+++ b/specification/blockchain/resource-manager/readme.md
@@ -52,7 +52,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-java

--- a/specification/blueprint/resource-manager/readme.md
+++ b/specification/blueprint/resource-manager/readme.md
@@ -61,7 +61,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python-track2
   - repo: azure-resource-manager-schemas

--- a/specification/botservice/resource-manager/readme.md
+++ b/specification/botservice/resource-manager/readme.md
@@ -139,7 +139,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-resource-manager-schemas
   - repo: azure-sdk-for-js
   - repo: azure-powershell

--- a/specification/cdn/resource-manager/readme.md
+++ b/specification/cdn/resource-manager/readme.md
@@ -165,7 +165,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/changeanalysis/resource-manager/readme.md
+++ b/specification/changeanalysis/resource-manager/readme.md
@@ -70,7 +70,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/chaos/resource-manager/readme.md
+++ b/specification/chaos/resource-manager/readme.md
@@ -64,7 +64,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions

--- a/specification/cognitiveservices/resource-manager/readme.md
+++ b/specification/cognitiveservices/resource-manager/readme.md
@@ -93,7 +93,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/communication/resource-manager/readme.md
+++ b/specification/communication/resource-manager/readme.md
@@ -73,7 +73,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-java
   - repo: azure-cli-extensions

--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -1180,7 +1180,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/confidentialledger/resource-manager/readme.md
+++ b/specification/confidentialledger/resource-manager/readme.md
@@ -71,7 +71,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_confidentialledger']

--- a/specification/confluent/resource-manager/readme.md
+++ b/specification/confluent/resource-manager/readme.md
@@ -89,7 +89,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/consumption/resource-manager/readme.md
+++ b/specification/consumption/resource-manager/readme.md
@@ -239,7 +239,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js

--- a/specification/containerinstance/resource-manager/readme.md
+++ b/specification/containerinstance/resource-manager/readme.md
@@ -179,7 +179,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/containerregistry/resource-manager/readme.md
+++ b/specification/containerregistry/resource-manager/readme.md
@@ -329,7 +329,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/containerservice/resource-manager/readme.md
+++ b/specification/containerservice/resource-manager/readme.md
@@ -814,7 +814,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-node

--- a/specification/cosmos-db/resource-manager/readme.md
+++ b/specification/cosmos-db/resource-manager/readme.md
@@ -491,7 +491,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/cost-management/resource-manager/readme.md
+++ b/specification/cost-management/resource-manager/readme.md
@@ -295,7 +295,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/cpim/resource-manager/readme.md
+++ b/specification/cpim/resource-manager/readme.md
@@ -72,7 +72,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2  
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-powershell
 ```
 

--- a/specification/customerlockbox/resource-manager/readme.md
+++ b/specification/customerlockbox/resource-manager/readme.md
@@ -53,6 +53,6 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-powershell
 ```

--- a/specification/customproviders/resource-manager/readme.md
+++ b/specification/customproviders/resource-manager/readme.md
@@ -53,7 +53,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-trenton
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js

--- a/specification/dashboard/resource-manager/readme.md
+++ b/specification/dashboard/resource-manager/readme.md
@@ -46,7 +46,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python-track2
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-resource-manager-schemas
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-java

--- a/specification/databox/resource-manager/readme.md
+++ b/specification/databox/resource-manager/readme.md
@@ -126,7 +126,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/databoxedge/resource-manager/readme.md
+++ b/specification/databoxedge/resource-manager/readme.md
@@ -160,7 +160,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/databricks/resource-manager/readme.md
+++ b/specification/databricks/resource-manager/readme.md
@@ -112,7 +112,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/datacatalog/resource-manager/readme.md
+++ b/specification/datacatalog/resource-manager/readme.md
@@ -52,7 +52,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/datadog/resource-manager/readme.md
+++ b/specification/datadog/resource-manager/readme.md
@@ -60,7 +60,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/datafactory/resource-manager/readme.md
+++ b/specification/datafactory/resource-manager/readme.md
@@ -70,7 +70,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-cli-extensions

--- a/specification/datalake-analytics/resource-manager/readme.md
+++ b/specification/datalake-analytics/resource-manager/readme.md
@@ -86,7 +86,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/datalake-store/resource-manager/readme.md
+++ b/specification/datalake-store/resource-manager/readme.md
@@ -79,7 +79,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/dataprotection/resource-manager/readme.md
+++ b/specification/dataprotection/resource-manager/readme.md
@@ -160,7 +160,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/datashare/resource-manager/readme.md
+++ b/specification/datashare/resource-manager/readme.md
@@ -89,7 +89,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-cli-extensions
   - repo: azure-powershell
 ```

--- a/specification/deploymentmanager/resource-manager/readme.md
+++ b/specification/deploymentmanager/resource-manager/readme.md
@@ -110,7 +110,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/desktopvirtualization/resource-manager/readme.md
+++ b/specification/desktopvirtualization/resource-manager/readme.md
@@ -160,7 +160,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/deviceprovisioningservices/resource-manager/readme.md
+++ b/specification/deviceprovisioningservices/resource-manager/readme.md
@@ -118,7 +118,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/deviceupdate/resource-manager/readme.md
+++ b/specification/deviceupdate/resource-manager/readme.md
@@ -76,7 +76,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_deviceupdate']
   - repo: azure-powershell

--- a/specification/devops/resource-manager/readme.md
+++ b/specification/devops/resource-manager/readme.md
@@ -62,7 +62,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-trenton
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/devtestlabs/resource-manager/readme.md
+++ b/specification/devtestlabs/resource-manager/readme.md
@@ -74,7 +74,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/digitaltwins/resource-manager/readme.md
+++ b/specification/digitaltwins/resource-manager/readme.md
@@ -89,7 +89,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/dns/resource-manager/readme.md
+++ b/specification/dns/resource-manager/readme.md
@@ -162,7 +162,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-typescript
   - repo: azure-sdk-for-js

--- a/specification/dnsresolver/resource-manager/readme.md
+++ b/specification/dnsresolver/resource-manager/readme.md
@@ -49,7 +49,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python-track2
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-powershell
 ```
 

--- a/specification/domainservices/resource-manager/readme.md
+++ b/specification/domainservices/resource-manager/readme.md
@@ -90,7 +90,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-powershell

--- a/specification/dynatrace/resource-manager/readme.md
+++ b/specification/dynatrace/resource-manager/readme.md
@@ -50,7 +50,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-powershell
 ```

--- a/specification/edgeorder/resource-manager/readme.md
+++ b/specification/edgeorder/resource-manager/readme.md
@@ -64,7 +64,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-powershell
 ```
 

--- a/specification/edgeorderpartner/resource-manager/readme.md
+++ b/specification/edgeorderpartner/resource-manager/readme.md
@@ -47,6 +47,6 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-powershell
 ```

--- a/specification/education/resource-manager/readme.md
+++ b/specification/education/resource-manager/readme.md
@@ -51,7 +51,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions

--- a/specification/elastic/resource-manager/readme.md
+++ b/specification/elastic/resource-manager/readme.md
@@ -79,7 +79,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
   - repo: azure-sdk-for-ruby

--- a/specification/elasticsan/resource-manager/readme.md
+++ b/specification/elasticsan/resource-manager/readme.md
@@ -52,7 +52,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_storagepool']

--- a/specification/eventgrid/resource-manager/readme.md
+++ b/specification/eventgrid/resource-manager/readme.md
@@ -213,7 +213,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/eventhub/resource-manager/readme.md
+++ b/specification/eventhub/resource-manager/readme.md
@@ -205,7 +205,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/extendedlocation/resource-manager/readme.md
+++ b/specification/extendedlocation/resource-manager/readme.md
@@ -72,7 +72,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/frontdoor/resource-manager/readme.md
+++ b/specification/frontdoor/resource-manager/readme.md
@@ -206,7 +206,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-libraries-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/guestconfiguration/resource-manager/readme.md
+++ b/specification/guestconfiguration/resource-manager/readme.md
@@ -132,7 +132,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-cli-extensions
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/hanaonazure/resource-manager/readme.md
+++ b/specification/hanaonazure/resource-manager/readme.md
@@ -65,7 +65,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/hardwaresecuritymodules/resource-manager/readme.md
+++ b/specification/hardwaresecuritymodules/resource-manager/readme.md
@@ -65,7 +65,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-resource-manager-schemas
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-powershell
   - repo: azure-sdk-for-java
 ```

--- a/specification/hdinsight/resource-manager/readme.md
+++ b/specification/hdinsight/resource-manager/readme.md
@@ -174,7 +174,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-js

--- a/specification/healthbot/resource-manager/readme.md
+++ b/specification/healthbot/resource-manager/readme.md
@@ -111,7 +111,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_healthbot']
   - repo: azure-cli-extensions

--- a/specification/healthcareapis/resource-manager/readme.md
+++ b/specification/healthcareapis/resource-manager/readme.md
@@ -126,7 +126,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/hybridcompute/resource-manager/readme.md
+++ b/specification/hybridcompute/resource-manager/readme.md
@@ -180,7 +180,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-cli-extensions
   - repo: azure-resource-manager-schemas

--- a/specification/hybridconnectivity/resource-manager/readme.md
+++ b/specification/hybridconnectivity/resource-manager/readme.md
@@ -69,7 +69,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions

--- a/specification/hybriddatamanager/resource-manager/readme.md
+++ b/specification/hybriddatamanager/resource-manager/readme.md
@@ -69,7 +69,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/hybridkubernetes/resource-manager/readme.md
+++ b/specification/hybridkubernetes/resource-manager/readme.md
@@ -85,7 +85,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-ruby
   - repo: azure-sdk-for-net
     after_scripts:

--- a/specification/hybridnetwork/resource-manager/readme.md
+++ b/specification/hybridnetwork/resource-manager/readme.md
@@ -85,7 +85,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/imagebuilder/resource-manager/readme.md
+++ b/specification/imagebuilder/resource-manager/readme.md
@@ -98,7 +98,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/iotcentral/resource-manager/readme.md
+++ b/specification/iotcentral/resource-manager/readme.md
@@ -97,7 +97,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/iothub/resource-manager/readme.md
+++ b/specification/iothub/resource-manager/readme.md
@@ -271,7 +271,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/iotsecurity/resource-manager/readme.md
+++ b/specification/iotsecurity/resource-manager/readme.md
@@ -81,7 +81,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-net
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-powershell
 ```
 

--- a/specification/keyvault/resource-manager/readme.md
+++ b/specification/keyvault/resource-manager/readme.md
@@ -213,7 +213,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/kubernetesconfiguration/resource-manager/readme.md
+++ b/specification/kubernetesconfiguration/resource-manager/readme.md
@@ -275,7 +275,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/labservices/resource-manager/readme.md
+++ b/specification/labservices/resource-manager/readme.md
@@ -87,7 +87,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/loadtestservice/resource-manager/readme.md
+++ b/specification/loadtestservice/resource-manager/readme.md
@@ -59,7 +59,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/logic/resource-manager/readme.md
+++ b/specification/logic/resource-manager/readme.md
@@ -130,7 +130,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-trenton
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/logz/resource-manager/readme.md
+++ b/specification/logz/resource-manager/readme.md
@@ -75,7 +75,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions

--- a/specification/m365securityandcompliance/resource-manager/readme.md
+++ b/specification/m365securityandcompliance/resource-manager/readme.md
@@ -59,7 +59,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-python-track2

--- a/specification/machinelearningservices/resource-manager/readme.md
+++ b/specification/machinelearningservices/resource-manager/readme.md
@@ -254,7 +254,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js

--- a/specification/maintenance/resource-manager/readme.md
+++ b/specification/maintenance/resource-manager/readme.md
@@ -97,7 +97,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-libraries-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/managedservices/resource-manager/readme.md
+++ b/specification/managedservices/resource-manager/readme.md
@@ -99,7 +99,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/managementgroups/resource-manager/readme.md
+++ b/specification/managementgroups/resource-manager/readme.md
@@ -114,7 +114,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-cli-extensions

--- a/specification/managementpartner/resource-manager/readme.md
+++ b/specification/managementpartner/resource-manager/readme.md
@@ -74,7 +74,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/maps/resource-manager/readme.md
+++ b/specification/maps/resource-manager/readme.md
@@ -99,7 +99,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/mariadb/resource-manager/readme.md
+++ b/specification/mariadb/resource-manager/readme.md
@@ -115,7 +115,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/marketplace/resource-manager/readme.md
+++ b/specification/marketplace/resource-manager/readme.md
@@ -119,7 +119,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-net
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell
 ```

--- a/specification/marketplaceordering/resource-manager/readme.md
+++ b/specification/marketplaceordering/resource-manager/readme.md
@@ -89,7 +89,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/mediaservices/resource-manager/readme.md
+++ b/specification/mediaservices/resource-manager/readme.md
@@ -252,7 +252,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/mixedreality/resource-manager/readme.md
+++ b/specification/mixedreality/resource-manager/readme.md
@@ -165,7 +165,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-java
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/mobilenetwork/resource-manager/readme.md
+++ b/specification/mobilenetwork/resource-manager/readme.md
@@ -81,7 +81,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/monitor/resource-manager/readme.md
+++ b/specification/monitor/resource-manager/readme.md
@@ -938,7 +938,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/msi/resource-manager/readme.md
+++ b/specification/msi/resource-manager/readme.md
@@ -83,7 +83,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-ruby
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_msi']

--- a/specification/mysql/resource-manager/readme.md
+++ b/specification/mysql/resource-manager/readme.md
@@ -173,7 +173,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas

--- a/specification/netapp/resource-manager/readme.md
+++ b/specification/netapp/resource-manager/readme.md
@@ -254,7 +254,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-trenton  
   - repo: azure-resource-manager-schemas

--- a/specification/network/resource-manager/readme.md
+++ b/specification/network/resource-manager/readme.md
@@ -2418,7 +2418,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/networkfunction/resource-manager/readme.md
+++ b/specification/networkfunction/resource-manager/readme.md
@@ -62,7 +62,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/notificationhubs/resource-manager/readme.md
+++ b/specification/notificationhubs/resource-manager/readme.md
@@ -88,7 +88,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/oep/resource-manager/readme.md
+++ b/specification/oep/resource-manager/readme.md
@@ -73,7 +73,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-cli-extensions
 ```

--- a/specification/operationalinsights/resource-manager/readme.md
+++ b/specification/operationalinsights/resource-manager/readme.md
@@ -272,7 +272,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/operationsmanagement/resource-manager/readme.md
+++ b/specification/operationsmanagement/resource-manager/readme.md
@@ -55,7 +55,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-python-track2

--- a/specification/orbital/resource-manager/readme.md
+++ b/specification/orbital/resource-manager/readme.md
@@ -60,7 +60,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions

--- a/specification/peering/resource-manager/readme.md
+++ b/specification/peering/resource-manager/readme.md
@@ -114,7 +114,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/policyinsights/resource-manager/readme.md
+++ b/specification/policyinsights/resource-manager/readme.md
@@ -254,7 +254,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java

--- a/specification/portal/resource-manager/readme.md
+++ b/specification/portal/resource-manager/readme.md
@@ -81,7 +81,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/postgresql/resource-manager/readme.md
+++ b/specification/postgresql/resource-manager/readme.md
@@ -222,7 +222,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/postgresqlhsc/resource-manager/readme.md
+++ b/specification/postgresqlhsc/resource-manager/readme.md
@@ -54,7 +54,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/powerbidedicated/resource-manager/readme.md
+++ b/specification/powerbidedicated/resource-manager/readme.md
@@ -62,7 +62,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-python-track2

--- a/specification/powerbiembedded/resource-manager/readme.md
+++ b/specification/powerbiembedded/resource-manager/readme.md
@@ -55,7 +55,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/powerbiprivatelinks/resource-manager/readme.md
+++ b/specification/powerbiprivatelinks/resource-manager/readme.md
@@ -49,7 +49,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
 ```

--- a/specification/privatedns/resource-manager/readme.md
+++ b/specification/privatedns/resource-manager/readme.md
@@ -69,7 +69,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
   - repo: azure-resource-manager-schemas

--- a/specification/providerhub/resource-manager/readme.md
+++ b/specification/providerhub/resource-manager/readme.md
@@ -96,7 +96,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/purview/resource-manager/readme.md
+++ b/specification/purview/resource-manager/readme.md
@@ -62,7 +62,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell
 ```

--- a/specification/quantum/resource-manager/readme.md
+++ b/specification/quantum/resource-manager/readme.md
@@ -61,7 +61,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-powershell
 ```

--- a/specification/quota/resource-manager/readme.md
+++ b/specification/quota/resource-manager/readme.md
@@ -72,7 +72,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-cli-extensions

--- a/specification/recommendationsservice/resource-manager/readme.md
+++ b/specification/recommendationsservice/resource-manager/readme.md
@@ -51,7 +51,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-net

--- a/specification/recoveryservices/resource-manager/readme.md
+++ b/specification/recoveryservices/resource-manager/readme.md
@@ -261,7 +261,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/recoveryservicesbackup/resource-manager/readme.md
+++ b/specification/recoveryservicesbackup/resource-manager/readme.md
@@ -313,7 +313,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/recoveryservicessiterecovery/resource-manager/readme.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.md
@@ -212,7 +212,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/redhatopenshift/resource-manager/readme.md
+++ b/specification/redhatopenshift/resource-manager/readme.md
@@ -69,7 +69,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell
 ```

--- a/specification/redis/resource-manager/readme.md
+++ b/specification/redis/resource-manager/readme.md
@@ -125,7 +125,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/redisenterprise/resource-manager/readme.md
+++ b/specification/redisenterprise/resource-manager/readme.md
@@ -89,7 +89,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/relay/resource-manager/readme.md
+++ b/specification/relay/resource-manager/readme.md
@@ -90,7 +90,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/reservations/resource-manager/readme.md
+++ b/specification/reservations/resource-manager/readme.md
@@ -131,7 +131,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-cli-extensions

--- a/specification/resourcegraph/resource-manager/readme.md
+++ b/specification/resourcegraph/resource-manager/readme.md
@@ -125,7 +125,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-trenton
   - repo: azure-resource-manager-schemas

--- a/specification/resourcehealth/resource-manager/readme.md
+++ b/specification/resourcehealth/resource-manager/readme.md
@@ -97,7 +97,6 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-python-track2

--- a/specification/resourcemover/resource-manager/readme.md
+++ b/specification/resourcemover/resource-manager/readme.md
@@ -70,7 +70,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -893,7 +893,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas

--- a/specification/saas/resource-manager/readme.md
+++ b/specification/saas/resource-manager/readme.md
@@ -51,7 +51,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/scheduler/resource-manager/readme.md
+++ b/specification/scheduler/resource-manager/readme.md
@@ -74,7 +74,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-ruby
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_scheduler']

--- a/specification/scvmm/resource-manager/readme.md
+++ b/specification/scvmm/resource-manager/readme.md
@@ -52,7 +52,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-ruby

--- a/specification/search/resource-manager/readme.md
+++ b/specification/search/resource-manager/readme.md
@@ -106,7 +106,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/security/resource-manager/readme.md
+++ b/specification/security/resource-manager/readme.md
@@ -557,7 +557,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/securityinsights/resource-manager/readme.md
+++ b/specification/securityinsights/resource-manager/readme.md
@@ -294,7 +294,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/serialconsole/resource-manager/readme.md
+++ b/specification/serialconsole/resource-manager/readme.md
@@ -47,7 +47,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/servicebus/resource-manager/readme.md
+++ b/specification/servicebus/resource-manager/readme.md
@@ -183,7 +183,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/servicefabric/resource-manager/readme.md
+++ b/specification/servicefabric/resource-manager/readme.md
@@ -191,7 +191,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/servicefabricmesh/resource-manager/readme.md
+++ b/specification/servicefabricmesh/resource-manager/readme.md
@@ -71,7 +71,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/servicelinker/resource-manager/readme.md
+++ b/specification/servicelinker/resource-manager/readme.md
@@ -82,7 +82,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/signalr/resource-manager/readme.md
+++ b/specification/signalr/resource-manager/readme.md
@@ -169,7 +169,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-ruby
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_signalr']

--- a/specification/solutions/resource-manager/readme.md
+++ b/specification/solutions/resource-manager/readme.md
@@ -58,7 +58,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/sql/resource-manager/readme.md
+++ b/specification/sql/resource-manager/readme.md
@@ -1783,7 +1783,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/sqlvirtualmachine/resource-manager/readme.md
+++ b/specification/sqlvirtualmachine/resource-manager/readme.md
@@ -63,7 +63,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-java
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/storage/resource-manager/readme.md
+++ b/specification/storage/resource-manager/readme.md
@@ -621,7 +621,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/storagecache/resource-manager/readme.md
+++ b/specification/storagecache/resource-manager/readme.md
@@ -123,7 +123,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/storageimportexport/resource-manager/readme.md
+++ b/specification/storageimportexport/resource-manager/readme.md
@@ -75,7 +75,6 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js

--- a/specification/storagepool/resource-manager/readme.md
+++ b/specification/storagepool/resource-manager/readme.md
@@ -72,7 +72,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/storagesync/resource-manager/readme.md
+++ b/specification/storagesync/resource-manager/readme.md
@@ -134,7 +134,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-cli-extensions

--- a/specification/streamanalytics/resource-manager/readme.md
+++ b/specification/streamanalytics/resource-manager/readme.md
@@ -141,7 +141,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/subscription/resource-manager/readme.md
+++ b/specification/subscription/resource-manager/readme.md
@@ -141,7 +141,6 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js

--- a/specification/support/resource-manager/readme.md
+++ b/specification/support/resource-manager/readme.md
@@ -71,7 +71,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/synapse/resource-manager/readme.md
+++ b/specification/synapse/resource-manager/readme.md
@@ -357,7 +357,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
   - repo: azure-powershell

--- a/specification/testbase/resource-manager/readme.md
+++ b/specification/testbase/resource-manager/readme.md
@@ -57,7 +57,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/trafficmanager/resource-manager/readme.md
+++ b/specification/trafficmanager/resource-manager/readme.md
@@ -185,7 +185,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-libraries-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/vi/resource-manager/readme.md
+++ b/specification/vi/resource-manager/readme.md
@@ -100,7 +100,7 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-go-track2
+  - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
   - repo: azure-cli-extensions

--- a/specification/videoanalyzer/resource-manager/readme.md
+++ b/specification/videoanalyzer/resource-manager/readme.md
@@ -81,7 +81,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-java
   - repo: azure-resource-manager-schemas

--- a/specification/visualstudio/resource-manager/readme.md
+++ b/specification/visualstudio/resource-manager/readme.md
@@ -58,7 +58,6 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas

--- a/specification/vmware/resource-manager/readme.md
+++ b/specification/vmware/resource-manager/readme.md
@@ -224,7 +224,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-java
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/vmwarecloudsimple/resource-manager/readme.md
+++ b/specification/vmwarecloudsimple/resource-manager/readme.md
@@ -52,7 +52,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
   - repo: azure-sdk-for-net

--- a/specification/web/resource-manager/readme.md
+++ b/specification/web/resource-manager/readme.md
@@ -1837,7 +1837,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby

--- a/specification/webpubsub/resource-manager/readme.md
+++ b/specification/webpubsub/resource-manager/readme.md
@@ -124,7 +124,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-ruby
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_webpubsub']

--- a/specification/windowsesu/resource-manager/readme.md
+++ b/specification/windowsesu/resource-manager/readme.md
@@ -53,7 +53,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/windowsiot/resource-manager/readme.md
+++ b/specification/windowsiot/resource-manager/readme.md
@@ -61,7 +61,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/workloadmonitor/resource-manager/readme.md
+++ b/specification/workloadmonitor/resource-manager/readme.md
@@ -83,7 +83,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/workloads/resource-manager/readme.md
+++ b/specification/workloads/resource-manager/readme.md
@@ -57,7 +57,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-go-track2
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-net
   - repo: azure-resource-manager-schemas

--- a/specificationRepositoryConfiguration.json
+++ b/specificationRepositoryConfiguration.json
@@ -4,10 +4,6 @@
   "sdkRepositoryMappings": {
     "azure-sdk-for-go": {
       "integrationRepository": "azure-sdk/azure-sdk-for-go",
-      "mainRepository": "Azure/azure-sdk-for-go"
-    },
-    "azure-sdk-for-go-track2": {
-      "integrationRepository": "azure-sdk/azure-sdk-for-go",
       "mainRepository": "Azure/azure-sdk-for-go",
       "configFilePath": "eng/swagger_to_sdk_config.json"
     },
@@ -50,10 +46,6 @@
     "Azure/azure-rest-api-specs-pr": {
       "sdkRepositoryMappings": {
         "azure-sdk-for-go": {
-          "integrationRepository": "azure-sdk/azure-sdk-for-go-pr",
-          "mainRepository": "Azure/azure-sdk-for-go-pr"
-        },
-        "azure-sdk-for-go-track2": {
           "integrationRepository": "azure-sdk/azure-sdk-for-go-pr",
           "mainRepository": "Azure/azure-sdk-for-go-pr",
           "configFilePath": "eng/swagger_to_sdk_config.json"


### PR DESCRIPTION
Regarding we have GAed track2 mgmt. plane SDK for Go and will not release any track1 packages, it is no use for running track1 SDK automation for Go. This PR will remove the config of track1 SDK automation for Go and merge two version of SDK automation for Go into one for every RP's readme config.