### PR TITLE
{OperationalInsight} Ingestion value was removed from the DataSourceT…

### DIFF
--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/stable/2020-08-01/LinkedStorageAccounts.json
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/stable/2020-08-01/LinkedStorageAccounts.json
@@ -206,6 +206,7 @@
             "CustomLogs",
             "AzureWatson",
             "Query",
+            "Ingestion",
             "Alerts"
           ],
           "x-ms-enum": {
@@ -263,6 +264,7 @@
         "CustomLogs",
         "AzureWatson",
         "Query",
+        "Ingestion",
         "Alerts"
       ],
       "x-ms-enum": {


### PR DESCRIPTION
…ype enum

The API version 2020-03-01-preview supported DataSourceType enum with 'Ingestion' as one of the valid values for log analytics linked storage account.
However, this value was removed in 2020-08-01 leading to 'Invalid value' error when storage accounts are linked to a workspace where the data source type is specified as Ingestion.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

fixes Azure/azure-sdk-for-go#18322