### PR TITLE
{AzureCXP} fixes Azure/azure-sdk-for-python#24694

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/runbook.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/runbook.json
@@ -1085,7 +1085,9 @@
             "PowerShellWorkflow",
             "PowerShell",
             "GraphPowerShellWorkflow",
-            "GraphPowerShell"
+            "GraphPowerShell",
+            "Python2",
+            "Python3"
           ],
           "x-ms-enum": {
             "name": "RunbookTypeEnum",
@@ -1233,7 +1235,9 @@
             "PowerShellWorkflow",
             "PowerShell",
             "GraphPowerShellWorkflow",
-            "GraphPowerShell"
+            "GraphPowerShell",
+            "Python2",
+            "Python3"
           ],
           "x-ms-enum": {
             "name": "RunbookTypeEnum",
@@ -1564,7 +1568,9 @@
             "PowerShellWorkflow",
             "PowerShell",
             "GraphPowerShellWorkflow",
-            "GraphPowerShell"
+            "GraphPowerShell",
+            "Python2",
+            "Python3"
           ],
           "x-ms-enum": {
             "name": "RunbookTypeEnum",

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2018-06-30/runbook.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2018-06-30/runbook.json
@@ -1160,7 +1160,9 @@
             "PowerShellWorkflow",
             "PowerShell",
             "GraphPowerShellWorkflow",
-            "GraphPowerShell"
+            "GraphPowerShell",
+            "Python2",
+            "Python3"
           ],
           "x-ms-enum": {
             "name": "RunbookTypeEnum",
@@ -1308,7 +1310,9 @@
             "PowerShellWorkflow",
             "PowerShell",
             "GraphPowerShellWorkflow",
-            "GraphPowerShell"
+            "GraphPowerShell",
+            "Python2",
+            "Python3"
           ],
           "x-ms-enum": {
             "name": "RunbookTypeEnum",
@@ -1639,7 +1643,9 @@
             "PowerShellWorkflow",
             "PowerShell",
             "GraphPowerShellWorkflow",
-            "GraphPowerShell"
+            "GraphPowerShell",
+            "Python2",
+            "Python3"
           ],
           "x-ms-enum": {
             "name": "RunbookTypeEnum",

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/runbook.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/runbook.json
@@ -1157,7 +1157,9 @@
             "PowerShellWorkflow",
             "PowerShell",
             "GraphPowerShellWorkflow",
-            "GraphPowerShell"
+            "GraphPowerShell",
+            "Python2",
+            "Python3"
           ],
           "x-ms-enum": {
             "name": "RunbookTypeEnum",
@@ -1305,7 +1307,9 @@
             "PowerShellWorkflow",
             "PowerShell",
             "GraphPowerShellWorkflow",
-            "GraphPowerShell"
+            "GraphPowerShell",
+            "Python2",
+            "Python3"
           ],
           "x-ms-enum": {
             "name": "RunbookTypeEnum",
@@ -1636,7 +1640,9 @@
             "PowerShellWorkflow",
             "PowerShell",
             "GraphPowerShellWorkflow",
-            "GraphPowerShell"
+            "GraphPowerShell",
+            "Python2",
+            "Python3"
           ],
           "x-ms-enum": {
             "name": "RunbookTypeEnum",


### PR DESCRIPTION
Including the possible values for the enum of the runbook types

Docs Link: https://docs.microsoft.com/en-us/python/api/azure-mgmt-automation/azure.mgmt.automation.models.runbook?view=azure-python#parameters

fixes Azure/azure-sdk-for-python#24694

In this PR  https://github.com/Azure/azure-sdk-for-python/pull/24745, we were asked to fix the REST API Specs before the changes are implemented in SDK.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
