### PR TITLE
[monitor]modify api version in readme.md

### DIFF
--- a/specification/monitor/resource-manager/readme.md
+++ b/specification/monitor/resource-manager/readme.md
@@ -53,8 +53,8 @@ input-file:
 - Microsoft.Insights/stable/2016-03-01/alertRulesIncidents_API.json
 - Microsoft.Insights/stable/2016-03-01/alertRules_API.json
 - Microsoft.Insights/stable/2016-03-01/logProfiles_API.json
-- Microsoft.Insights/preview/2017-05-01-preview/diagnosticsSettings_API.json
-- Microsoft.Insights/preview/2017-05-01-preview/diagnosticsSettingsCategories_API.json
+- Microsoft.Insights/preview/2021-05-01-preview/diagnosticsSettings_API.json
+- Microsoft.Insights/preview/2021-05-01-preview/diagnosticsSettingsCategories_API.json
 - Microsoft.Insights/stable/2022-06-01/actionGroups_API.json
 - Microsoft.Insights/stable/2015-04-01/activityLogs_API.json
 - Microsoft.Insights/stable/2015-04-01/eventCategories_API.json


### PR DESCRIPTION
The cause is this issue： https://github.com/Azure/azure-sdk-for-js/issues/22325 and https://github.com/Azure/azure-sdk-for-js/issues/22655
The version of 2017-05-01-preview can't list the result of diagnosticsSettings. So I change it to 2021-05-01-preview. And after my test，it can be listed by diagnosticsSettings.list()