### PR TITLE
modify path and package-name in readme.typescript.md from networkfunc…

### DIFF
--- a/specification/networkfunction/resource-manager/readme.typescript.md
+++ b/specification/networkfunction/resource-manager/readme.typescript.md
@@ -10,6 +10,5 @@ typescript:
   output-folder: "$(typescript-sdks-folder)/sdk/networkfunction/arm-networkfunction"
   payload-flattening-threshold: 1
   generate-metadata: true
-title: 
-  AzureTrafficCollectorClient
+title: AzureTrafficCollectorClient
 ```

--- a/specification/networkfunction/resource-manager/readme.typescript.md
+++ b/specification/networkfunction/resource-manager/readme.typescript.md
@@ -10,4 +10,6 @@ typescript:
   output-folder: "$(typescript-sdks-folder)/sdk/networkfunction/arm-networkfunction"
   payload-flattening-threshold: 1
   generate-metadata: true
+title: 
+  AzureTrafficCollectorClient
 ```

--- a/specification/networkfunction/resource-manager/readme.typescript.md
+++ b/specification/networkfunction/resource-manager/readme.typescript.md
@@ -6,8 +6,8 @@ Please also specify `--typescript-sdks-folder=<path to root folder of your azure
 ```yaml $(typescript)
 typescript:
   azure-arm: true
-  package-name: "networkfunction"
-  output-folder: "$(typescript-sdks-folder)/packages/networkfunction"
+  package-name: "@azure/arm-networkfunction"
+  output-folder: "$(typescript-sdks-folder)/sdk/networkfunction/arm-networkfunction"
   payload-flattening-threshold: 1
   generate-metadata: true
 ```


### PR DESCRIPTION
When I released from this rp:https://github.com/Azure/sdk-release-request/issues/2980, I found that there's nothing generated in sdk folder. So I observed the corresponding readme.md. I found the output-folder and the package-name wrong.
Now I modify them.