### PR TITLE
Enable custom skypetoken expiration for a 2nd API in the new 2022-10-01 version

### DIFF
--- a/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
+++ b/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
@@ -47,7 +47,7 @@
           }
         },
         "x-ms-examples": {
-          "Create an Identity and optionally an access token with custom expiration time within the [60-1440] minutes range. If expiration time is not specified, the default values of 1440 minutes (24 hours) will be used.": {
+          "Create an Identity and optionally an access token with custom expiration time within the [60-1440] minutes range. If expiration time is not specified, the default value of 1440 minutes (24 hours) will be used.": {
             "$ref": "./examples/CreateIdentity.json"
           }
         }

--- a/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
+++ b/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
@@ -36,7 +36,7 @@
           "default": {
             "description": "Error",
             "schema": {
-              "$ref": "../../../Common/stable/2021-03-07/common.json#/definitions/CommunicationErrorResponse"
+              "$ref": "../../../Common/stable/2022-07-13/common.json#/definitions/CommunicationErrorResponse"
             }
           },
           "201": {
@@ -47,7 +47,7 @@
           }
         },
         "x-ms-examples": {
-          "Create an Identity": {
+          "Create an Identity and optionally an access token with custom expiration time within the [60-1440] minutes range. If expiration time is not specified, the default values of 1440 minutes (24 hours) will be used.": {
             "$ref": "./examples/CreateIdentity.json"
           }
         }
@@ -79,7 +79,7 @@
           "default": {
             "description": "Error",
             "schema": {
-              "$ref": "../../../Common/stable/2021-03-07/common.json#/definitions/CommunicationErrorResponse"
+              "$ref": "../../../Common/stable/2022-07-13/common.json#/definitions/CommunicationErrorResponse"
             }
           },
           "204": {
@@ -119,7 +119,7 @@
           "default": {
             "description": "Error",
             "schema": {
-              "$ref": "../../../Common/stable/2021-03-07/common.json#/definitions/CommunicationErrorResponse"
+              "$ref": "../../../Common/stable/2022-07-13/common.json#/definitions/CommunicationErrorResponse"
             }
           },
           "204": {
@@ -164,7 +164,7 @@
           "default": {
             "description": "Error",
             "schema": {
-              "$ref": "../../../Common/stable/2021-03-07/common.json#/definitions/CommunicationErrorResponse"
+              "$ref": "../../../Common/stable/2022-07-13/common.json#/definitions/CommunicationErrorResponse"
             }
           },
           "200": {
@@ -219,7 +219,7 @@
           "default": {
             "description": "Error",
             "schema": {
-              "$ref": "../../../Common/stable/2021-03-07/common.json#/definitions/CommunicationErrorResponse"
+              "$ref": "../../../Common/stable/2022-07-13/common.json#/definitions/CommunicationErrorResponse"
             }
           },
           "200": {
@@ -247,6 +247,7 @@
       "properties": {
         "id": {
           "description": "Identifier of the identity.",
+          "minLength": 1,
           "type": "string"
         }
       }
@@ -261,6 +262,7 @@
       "properties": {
         "token": {
           "description": "The access token issued for the identity.",
+          "minLength": 1,
           "type": "string"
         },
         "expiresOn": {
@@ -314,6 +316,11 @@
           "items": {
             "$ref": "#/definitions/CommunicationIdentityTokenScope"
           }
+        },
+        "expiresInMinutes": {
+          "format": "int32",
+          "description": "Optional custom validity period of the token within [60,1440] minutes range. If not provided, the default value of 1440 minutes (24 hours) will be used.",
+          "type": "integer"
         }
       }
     },
@@ -339,14 +346,17 @@
       "properties": {
         "token": {
           "description": "Azure AD access token of a Teams User to acquire a new Communication Identity access token.",
+          "minLength": 1,
           "type": "string"
         },
         "appId": {
           "description": "Client ID of an Azure AD application to be verified against the appid claim in the Azure AD access token.",
+          "minLength": 1,
           "type": "string"
         },
         "userId": {
           "description": "Object ID of an Azure AD user (Teams User) to be verified against the oid claim in the Azure AD access token.",
+          "minLength": 1,
           "type": "string"
         }
       }

--- a/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
+++ b/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
@@ -247,7 +247,6 @@
       "properties": {
         "id": {
           "description": "Identifier of the identity.",
-          "minLength": 1,
           "type": "string"
         }
       }
@@ -262,7 +261,6 @@
       "properties": {
         "token": {
           "description": "The access token issued for the identity.",
-          "minLength": 1,
           "type": "string"
         },
         "expiresOn": {
@@ -346,17 +344,14 @@
       "properties": {
         "token": {
           "description": "Azure AD access token of a Teams User to acquire a new Communication Identity access token.",
-          "minLength": 1,
           "type": "string"
         },
         "appId": {
           "description": "Client ID of an Azure AD application to be verified against the appid claim in the Azure AD access token.",
-          "minLength": 1,
           "type": "string"
         },
         "userId": {
           "description": "Object ID of an Azure AD user (Teams User) to be verified against the oid claim in the Azure AD access token.",
-          "minLength": 1,
           "type": "string"
         }
       }

--- a/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
+++ b/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
@@ -286,7 +286,10 @@
         "expiresInMinutes": {
           "format": "int32",
           "description": "Optional custom validity period of the token within [60,1440] minutes range. If not provided, the default value of 1440 minutes (24 hours) will be used.",
-          "type": "integer"
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 1440,
+          "default": 1440
         }
       }
     },

--- a/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
+++ b/specification/communication/data-plane/Identity/stable/2022-10-01/CommunicationIdentity.json
@@ -318,7 +318,10 @@
         "expiresInMinutes": {
           "format": "int32",
           "description": "Optional custom validity period of the token within [60,1440] minutes range. If not provided, the default value of 1440 minutes (24 hours) will be used.",
-          "type": "integer"
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 1440,
+          "default": 1440
         }
       }
     },

--- a/specification/communication/data-plane/Identity/stable/2022-10-01/examples/CreateIdentity.json
+++ b/specification/communication/data-plane/Identity/stable/2022-10-01/examples/CreateIdentity.json
@@ -6,7 +6,8 @@
     "body": {
       "createTokenWithScopes": [
         "chat"
-      ]
+      ],
+      "expiresInMinutes": 60
     }
   },
   "responses": {


### PR DESCRIPTION
Tracked with issue: #20040 
**Changes in this PR enable the possibility for the customers to issue skypetokens with a custom expiration time.**  
https://microsoft.sharepoint-df.com/:w:/t/IC3SDK/EYZbS36x9IVMq9NZfRhPqDgB3hhPAuoZEcbNIFJQOvWEJQ?e=Z25Rte

**This PR is a follow-up for the functionality reviewed here: https://github.com/Azure/azure-rest-api-specs/pull/19268
The functionality was not yet released. It has been recently decided to add the same functionality to a second API.
This PR updates the swagger to support the custom token expiration functionality on the second API.**

### Changelog
Add a changelog entry for this PR by answering the following questions:
  1. What's the purpose of the update?
      - [x] new API version
  2. When are you targeting to deploy the new service/feature to public regions? Please provide the date or, if the date is not yet available, the month.
  _October 2022_
  3. When do you expect to publish the swagger? Please provide date or, the date is not yet available, the month.
  _October 2022_
  4. If updating an existing version, please select the specific language SDKs and CLIs that must be refreshed after the swagger is published.
      - [x] SDK of .NET (need service team to ensure code readiness)
      - [x] SDK of Python
      - [x] SDK of Java
      - [x] SDK of Js

### Contribution checklist:
- [x] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of "no breaking changes"
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### Functionality description
The main goal of this feature is to allow developers who use ACS (directly or via SDKs) to customize the skypetokens validity. 
Until now, ACS only provided the possibility for customers to generate skypetokens for a predefined validity period of 24 hours. 
This functionality will introduce the possibility for customers to generate skypetokens with a custom validity period within the [1-24] hours range. 
Customers can make requests for issuing a skypetoken without providing a validity period. In this situation, we will generate a skypetoken with a default validity of 24 hours. 
Customers can make requests to issue skypetokens for a custom validity period by providing the validity interval in the request's body. Accepted values are within [1-24] hours range. 
For this, we are introducing a new optional integer parameter that will hold the validity time in minutes (expiresInMinutes).

**This optional parameter will be available in two APIs. The API for generation of skypetokend and the API for generation of identity together with a skypetoken.**

Customers that do not want to use this functionality will be able to issue skypetokens the same way they did before. 
No breaking change will be introduced.  

For behaviors on the API for generation of skypetokens, please see the previous PR. 

This PR introduces changes only to the API that generates and identity together with a skypetoken. 

### Old behavior - issue identity and access token for a predefined validity period of 24 hours 
ACS Auth receives a request to issue an identity with skypetoken. 
There is no possibility to specify a validity period. ACS Auth sets the validity for all skypetokens to a default value of 24 hours. 
ACS Auth generates and identity and then makes a request to Skypetoken Issuer to generate a skypetoken for this identity, valid for 24 hours. 
ACS Auth returns the new identity and skypetoken to the customer. 
![old flow - generate identity with token - predefined expiration time](https://user-images.githubusercontent.com/66410283/182163839-70d7343a-a4e7-4e9f-bbfa-02a9de68badd.PNG)


### New behavior - issue identity and access token for a custom validity 
ACS Auth receives a request to issue an identity with skypetoken. Customer can specify a validity period within the [1-24] hours range.

a. Customer does not specify a validity for the skypetoken 
ACS Auth sets the validity for current skypetoken to a default value of 24 hours. 
ACS Auth generates an identity and makes a request to Skypetoken Issuer to generate a skypetoken valid for 24 hours. 
ACS Auth returns the new identity and skypetoken to the customer. 

b. Customer specifies a custom token validity within the [1-24] hours range
ACS Auth generates an identity and makes a request to Skypetoken Issuer to generate a skypetoken valid for a custom validity. 
ACS Auth returns the new identity and skypetoken to the customer. 

If the specified custom validity is outside the permitted range of [1-24] hours, ACS Auth returns 400 BadRequest.

![new flow - generate identity with token - custom expiration time](https://user-images.githubusercontent.com/66410283/182164078-966e3c82-2d1a-4e13-86af-c73c2116d093.PNG)

### Review documentation
[Differences from previous version](https://github.com/Azure/azure-rest-api-specs/compare/8fea49a35b917ee194ee554cae04290a89633d8b..c63cf8a9b6aaebf5d111a4857f59afcd7c0c1d3f)
[Design document](https://microsoft.sharepoint-df.com/:w:/t/IC3SDK/EYZbS36x9IVMq9NZfRhPqDgB3hhPAuoZEcbNIFJQOvWEJQ?e=aTBcYb)

### Code snippet C#

**Previous version 2022-06-01**
**Generate an identity with token valid for 24 hours** 

// Issue an access token with the "voip" scope for a new identity
// Issue an identity and an access token with the "voip" scope for the new identity
var identityAndTokenResponse = await client.CreateUserAndTokenAsync(scopes: new[] { CommunicationTokenScope.VoIP });


// Get the token from the response
var token =  tokenResponse.Value.Token;
var expiresOn = tokenResponse.Value.ExpiresOn;


**New version 2022-10-01** 
**Generate a token valid for 24 hours** 

// Issue an access token with the "voip" scope for a new identity
var identityAndTokenResponse = await client.CreateUserAndTokenAsync(scopes: new[] { CommunicationTokenScope.VoIP });


**Generate an identity with a token valid for 60 min** 

// Issue an access token with the "voip" scope for an identity
var identityAndTokenResponse = await client.CreateUserAndTokenAsync(scopes: new[] { CommunicationTokenScope.VoIP },
TimeSpan.FromMinutes(60));



## ~~Breaking Change Review Checklist~~ No breaking changes

https://msazure.visualstudio.com/One/_workitems/edit/15336873

If any of the following scenarios apply to the PR, request approval from the Breaking Change Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 
- [ ] Removing API(s) in a stable version
- [ ] Removing properties in a stable version
- [ ] Removing API version(s) in a stable version
- [ ] Updating API in a stable or public preview version with Breaking Change Validation errors
- [ ] Updating API(s) in public preview over 1 year (refer to [Retirement of Previews](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37683/Retirement-of-Previews))

**Action**: to initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate). Addition details on the process and office hours are on the [Breaking change Wiki](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37684/Breaking-Changes).

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).
fix https://github.com/Azure/azure-rest-api-specs/issues/20093