### PR TITLE
Fixed bug where path etag was not deserialized correctly

### DIFF
--- a/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2020-06-12/DataLakeStorage.json
+++ b/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2020-06-12/DataLakeStorage.json
@@ -3094,7 +3094,7 @@
         "lastModified": {
           "type": "string"
         },
-        "eTag": {
+        "etag": {
           "type": "string"
         },
         "contentLength": {

--- a/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2020-10-02/DataLakeStorage.json
+++ b/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2020-10-02/DataLakeStorage.json
@@ -3218,7 +3218,7 @@
         "lastModified": {
           "type": "string"
         },
-        "eTag": {
+        "etag": {
           "type": "string"
         },
         "contentLength": {

--- a/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-04-10/DataLakeStorage.json
+++ b/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-04-10/DataLakeStorage.json
@@ -3218,7 +3218,7 @@
         "lastModified": {
           "type": "string"
         },
-        "eTag": {
+        "etag": {
           "type": "string"
         },
         "contentLength": {

--- a/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
+++ b/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
@@ -3229,7 +3229,7 @@
         "lastModified": {
           "type": "string"
         },
-        "eTag": {
+        "etag": {
           "type": "string"
         },
         "contentLength": {


### PR DESCRIPTION
**This is NOT a breaking change.  The storage service has always returned etag with a lower case t, the swagger specs were incorrect.**