### PR TITLE
Added Blob Cold Tier

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2021-12-02/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2021-12-02/blob.json
@@ -9675,7 +9675,8 @@
         "Hot",
         "Cool",
         "Archive",
-        "Premium"
+        "Premium",
+        "Cold"
       ],
       "x-ms-enum": {
         "name": "AccessTier",
@@ -11188,7 +11189,8 @@
         "P80",
         "Hot",
         "Cool",
-        "Archive"
+        "Archive",
+        "Cold"
       ],
       "x-ms-enum": {
         "name": "AccessTier",
@@ -11217,7 +11219,8 @@
         "P80",
         "Hot",
         "Cool",
-        "Archive"
+        "Archive",
+        "Cold"
       ],
       "x-ms-enum": {
         "name": "AccessTier",


### PR DESCRIPTION
**This is not a breaking change.**

The 2021-12-02 service version is not public.  I introduced the 2021-12-02 blob swagger to the `feature/storage/stg85base` branch in a earlier PR, to make these feature PRs human readable.