### PR TITLE
Add CODEOWNERS entry for FarmBeats

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,6 +10,9 @@
 
 /specification/adp/ @Azure/adp
 
+# PRLabel: %FarmBeats
+/specification/agrifood/data-plane @Azure/api-stewardship-board
+
 # PRLabel: %Analysis Services
 /specification/analysisservices/ @taiwu
 


### PR DESCRIPTION
This PR adds an entry to the CODEOWNERS file for the AgriFood/FarmBeats service.