### PR TITLE
mgmt monitor, revert CategoryType

### DIFF
--- a/specification/monitor/resource-manager/readme.java.md
+++ b/specification/monitor/resource-manager/readme.java.md
@@ -10,4 +10,8 @@ directive:
       $.ActionGroup["x-ms-client-name"] = "ActivityLogAlertActionGroup";
       $.AlertRuleAllOfCondition["x-ms-client-name"] = "ActivityLogAlertAllOfCondition";
       $.AlertRuleAnyOfOrLeafCondition["x-ms-client-name"] = "ActivityLogAlertLeafCondition";
+  - from: diagnosticsSettingsCategories_API.json
+    where: '$.definitions.DiagnosticSettingsCategory.properties.categoryType'
+    transform: >
+      $["x-ms-enum"].modelAsString = false
 ```


### PR DESCRIPTION
Revert `Category` type from class to enum to avoid breaking changes.
Locally tested.

