### PR TITLE
[Do Not Merge] Changed response type from String to File

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/dscConfiguration.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/dscConfiguration.json
@@ -306,7 +306,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "string"
+              "type": "file"
             }
           },
           "default": {


### PR DESCRIPTION
# Issue

We got the bug for this response type change. 

DscConfigurationClient.GetContent is broken since 2020-01-13-preview/automation API version
https://github.com/Azure/azure-sdk-for-go/issues/17591

# Fix

Reverted the response type from String to FIle.
