### PR TITLE
Move catch-all for data-plane codeowners to top of file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,11 @@
 # Specification
 #########
 
+#########
+# Codeowner assignments are made from the _last_ matching entry in CODEOWNERS, so catch-all entries must come first
+#########
+/specification/*/data-plane/ @Azure/api-stewardship-board
+
 # PRLabel: %Cognitive Services
 /dev/cognitiveservices/data-plane/Language/ @assafi @rokulka @ChongTang @annatisch @heaths @deyaaeldeen @kristapratico @mssfang @Azure/api-stewardship-board
 
@@ -241,4 +246,3 @@
 /specification/**/resource-manager/**/readme.cli.md @jsntcy @qiaozha
 /specification/**/resource-manager/**/readme.go.md @ArcturusZhang
 /specification/**/resource-manager/**/readme.python.md @msyyc @BigCat20196
-/specification/*/data-plane/ @Azure/api-stewardship-board


### PR DESCRIPTION
This PR fixes an error in the CODEOWNERS file that puts the "catch-all" for data-plane assignments at the end of the file.