### PR TITLE
Add restler config to improve coverage of appconfig traffic validation

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1796,6 +1796,7 @@ resourceregion
 resourcetype
 Responsys
 RESTAPI
+restler
 restoreheartbeat
 Restproxy
 restrant

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2022-05-01/restler/annotations.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2022-05-01/restler/annotations.json
@@ -23,6 +23,6 @@
       "consumer_method": "POST",
       "producer_resource_name": "/value/[0]/id",
       "consumer_param": "/id"
-    },
+    }
   ]
 }

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2022-05-01/restler/annotations.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2022-05-01/restler/annotations.json
@@ -1,0 +1,28 @@
+{
+  "x-restler-global-annotations": [
+    {
+      "producer_endpoint": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}",
+      "producer_method": "DELETE",
+      "consumer_endpoint": "/subscriptions/{subscriptionId}/providers/Microsoft.AppConfiguration/locations/{location}/deletedConfigurationStores/{configStoreName}",
+      "consumer_method": "GET",
+      "producer_resource_name": "configStoreName",
+      "consumer_param": "configStoreName"
+    },
+    {
+      "producer_endpoint": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/privateLinkResources",
+      "producer_method": "GET",
+      "consumer_endpoint": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/privateLinkResources/{groupName}",
+      "consumer_method": "GET",
+      "producer_resource_name": "/value/[0]/name",
+      "consumer_param": "groupName"
+    },
+    {
+      "producer_endpoint": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/listKeys",
+      "producer_method": "POST",
+      "consumer_endpoint": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/regenerateKey",
+      "consumer_method": "POST",
+      "producer_resource_name": "/value/[0]/id",
+      "consumer_param": "/id"
+    },
+  ]
+}


### PR DESCRIPTION
This PR adds an annotations.json file for appconfiguration mgmt plane API to improve the coverage of traffic validation PR check.