### PR TITLE
Add type object to policy fragment definitions

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2022-04-01-preview/definitions.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2022-04-01-preview/definitions.json
@@ -4280,6 +4280,7 @@
       "description": "Descriptions of APIM policies."
     },
     "PolicyFragmentCollection": {
+      "type": "object",
       "properties": {
         "value": {
           "type": "array",
@@ -4301,6 +4302,7 @@
       "description": "The response of the get policy fragments operation."
     },
     "PolicyFragmentContract": {
+      "type": "object",
       "properties": {
         "properties": {
           "x-ms-client-flatten": true,
@@ -4316,6 +4318,7 @@
       "description": "Policy fragment contract details."
     },
     "PolicyFragmentContractProperties": {
+      "type": "object",
       "properties": {
         "value": {
           "type": "string",


### PR DESCRIPTION
Adds type object to all policy fragment definitions to fix [MissingTypeObject](https://github.com/Azure/azure-openapi-validator/blob/develop/docs/missing-type-object.md) error