### PR TITLE
make compilationJobs name segment consistent and ARM spec conformant

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/dscCompilationJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/dscCompilationJob.json
@@ -204,7 +204,7 @@
         "x-ms-odata": "#/definitions/DscCompilationJob"
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/compilationjobs/{jobId}/streams": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/compilationjobs/{compilationJobName}/streams": {
       "get": {
         "tags": [
           "DscCompilationJob"
@@ -257,7 +257,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/compilationjobs/{jobId}/streams/{jobStreamId}": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/compilationjobs/{compilationJobName}/streams/{jobStreamId}": {
       "get": {
         "tags": [
           "DscCompilationJob"

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/dscCompilationJob.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/dscCompilationJob.json
@@ -227,12 +227,12 @@
             "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
           },
           {
-            "name": "jobId",
+            "name": "compilationJobName",
             "in": "path",
             "required": true,
             "type": "string",
             "format": "uuid",
-            "description": "The job id."
+            "description": "The DSC configuration Id."
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/SubscriptionIdParameter"
@@ -280,12 +280,12 @@
             "$ref": "../../common/v1/definitions.json#/parameters/AutomationAccountNameParameter"
           },
           {
-            "name": "jobId",
+            "name": "compilationJobName",
             "in": "path",
             "required": true,
             "type": "string",
             "format": "uuid",
-            "description": "The job id."
+            "description": "The DSC configuration Id."
           },
           {
             "name": "jobStreamId",

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/compilationJobStreamByJobStreamId.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/compilationJobStreamByJobStreamId.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "rg",
     "automationAccountName": "myAutomationAccount33",
     "api-version": "2019-06-01",
-    "jobId": "836d4e06-2d88-46b4-8500-7febd4906838",
+    "compilationJobName": "836d4e06-2d88-46b4-8500-7febd4906838",
     "jobStreamId": "836d4e06-2d88-46b4-8500-7febd4906838_00636481062421684835_00000000000000000008"
   },
   "responses": {

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/compilationJobStreamList.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2019-06-01/examples/compilationJobStreamList.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "rg",
     "automationAccountName": "myAutomationAccount33",
     "api-version": "2019-06-01",
-    "jobId": "836d4e06-2d88-46b4-8500-7febd4906838"
+    "compilationJobName": "836d4e06-2d88-46b4-8500-7febd4906838"
   },
   "responses": {
     "200": {


### PR DESCRIPTION
Corrects the user specified ID segment for `compilationjobs` to be consistent with the parent resource ID.