### PR TITLE
[Language][Generate-Question-Answers] maxQACount instead of maxResultCount

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/questionanswering-generate.json
+++ b/dev/cognitiveservices/data-plane/Language/questionanswering-generate.json
@@ -268,9 +268,9 @@
           "type": "boolean",
           "description": "Specify this as true - if the documents have marker tags &lt;answer&gt; and &lt;/answer&gt; for marked answers. Example: Satya Nadella was born in &lt;answer&gt; Hyderabad &lt;/answer&gt; of present-day Telangana, India into a Telugu-speaking Hindu family."
         },
-        "maxResultCount": {
+        "maxQACount": {
           "type": "integer",
-          "description": "Maximum number of results (question answers) to be generated.",
+          "description": "Maximum number of question answers to be generated.",
           "format": "int32",
           "maximum": 30,
           "minimum": 1


### PR DESCRIPTION
maxQACount instead of maxResultCount as "result" is parent container object's name

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
