### PR TITLE
ADLS Gen 2 Append and Flush Lease Operations

### DIFF
--- a/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
+++ b/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
@@ -2016,6 +2016,15 @@
             "$ref": "#/parameters/LeaseIdOptional"
           },
           {
+            "$ref": "#/parameters/LeaseAction"
+          },
+          {
+            "$ref": "#/parameters/LeaseDurationMethod"
+          },
+          {
+            "$ref": "#/parameters/ProposedLeaseIdOptional"
+          },
+          {
             "$ref": "#/parameters/CacheControl"
           },
           {

--- a/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
+++ b/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
@@ -2115,6 +2115,11 @@
                 "x-ms-client-name": "EncryptionKeySha256",
                 "type": "string",
                 "description": "The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key."
+              },
+              "x-ms-lease-renewed": {
+                "x-ms-client-name": "LeaseRenewed",
+                "type": "boolean",
+                "description": "If the lease was auto-renewed with this Append Request"
               }
             }
           },

--- a/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
+++ b/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
@@ -2180,6 +2180,15 @@
             "$ref": "#/parameters/LeaseIdOptional"
           },
           {
+            "$ref": "#/parameters/LeaseAction"
+          },
+          {
+            "$ref": "#/parameters/LeaseDurationMethod"
+          },
+          {
+            "$ref": "#/parameters/ProposedLeaseIdOptional"
+          },
+          {
             "$ref": "#/parameters/Body"
           },
           {
@@ -2703,6 +2712,25 @@
       "required": false,
       "type": "integer",
       "x-ms-parameter-location": "method"
+    },
+    "LeaseAction": {
+      "name": "x-ms-lease-action",
+      "x-ms-client-name": "leaseAction",
+      "in": "header",
+      "x-ms-parameter-location": "method",
+      "description": "Optional. If \"acquire\" it will acquire the lease. If \"auto-renew\" it will renew the lease. If \"release\" it will release the lease only on flush. If \"acquire-release\" it will acquire & complete the operation & release the lease once operation is done.",
+      "required": false,
+      "type": "string",
+      "enum": [
+        "acquire",
+        "auto-renew",
+        "release",
+        "acquire-release"
+      ],
+      "x-ms-enum": {
+        "name": "LeaseAction",
+        "modelAsString": false
+      }
     },
     "Prefix": {
       "name": "prefix",

--- a/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
+++ b/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
@@ -2119,7 +2119,7 @@
               "x-ms-lease-renewed": {
                 "x-ms-client-name": "LeaseRenewed",
                 "type": "boolean",
-                "description": "If the lease was auto-renewed with this Append Request"
+                "description": "If the lease was auto-renewed with this request"
               }
             }
           },
@@ -2275,7 +2275,7 @@
               "x-ms-lease-renewed": {
                 "x-ms-client-name": "LeaseRenewed",
                 "type": "boolean",
-                "description": "If the lease was auto-renewed with this Append Request"
+                "description": "If the lease was auto-renewed with this request"
               }
             }
           },

--- a/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
+++ b/specification/storage/data-plane/Azure.Storage.Files.DataLake/preview/2021-06-08/DataLakeStorage.json
@@ -2257,6 +2257,11 @@
                 "x-ms-client-name": "EncryptionKeySha256",
                 "type": "string",
                 "description": "The SHA-256 hash of the encryption key used to encrypt the blob. This header is only returned when the blob was encrypted with a customer-provided key."
+              },
+              "x-ms-lease-renewed": {
+                "x-ms-client-name": "LeaseRenewed",
+                "type": "boolean",
+                "description": "If the lease was auto-renewed with this Append Request"
               }
             }
           },


### PR DESCRIPTION
**This is not a breaking change**

These operations have been present since version 2020-08-04, but have not been activated until now.

**This is not a breaking change**