### PR TITLE
Add entry to CODEOWNERS for Code Signing and Purview service

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -166,6 +166,9 @@
 
 /specification/powerbidedicated/ @tarostok
 
+% PRLabel: %Purview
+/specification/purview/data-plane
+
 # PRLabel: %PostgreSQL
 /specification/provisioningservices/ @kvish
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,8 @@
 # PRLabel: %Monitor - Exporter
 /specification/applicationinsights/data-plane/Monitor.Exporters/ @ramthi @trask @hectorhdzg @lzchen @Azure/api-stewardship-board
 
+# PRLabel: %Code Signing
+/specification/codesigning/data-plane @Azure/api-stewardship-board
 
 /specification/asazure/ @athipp
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -166,7 +166,7 @@
 
 /specification/powerbidedicated/ @tarostok
 
-% PRLabel: %Purview
+# PRLabel: %Purview
 /specification/purview/data-plane
 
 # PRLabel: %PostgreSQL


### PR DESCRIPTION
This PR adds an entry to the CODEOWNERS file to label PRs for the Code Signing service.
