### PR TITLE
Update workflow config to support armReview

### DIFF
--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -81,10 +81,9 @@
 - rule:
     type: label
     label: Approved-BreakingChange
-    booleanFilterExpression: !(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)
+    booleanFilterExpression: !(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview
     onLabeledAddLabels:
         - WaitForARMFeedback
-        - ARMReview
       
         
 - rule:

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -77,7 +77,6 @@
     onLabeledComments: "Please ensure to respond feedbacks from the ARM API reviewer. When you are ready to continue the ARM API review, please remove `ARMChangesRequested`"
     onLabeledRemoveLabels:
         - WaitForARMFeedback
-        - ARMReview
 
 - rule:
     type: label

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -3,7 +3,7 @@
     type: checkbox
     keywords:
       - "WaitForARMFeedback"
-    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)"
+    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit||BreakingChangeReviewRequired)"
     onCheckedLabels:
       - WaitForARMFeedback
       - ARMReview
@@ -77,6 +77,15 @@
     onLabeledComments: "Please ensure to respond feedbacks from the ARM API reviewer. When you are ready to continue the ARM API review, please remove `ARMChangesRequested`"
     onLabeledRemoveLabels:
         - WaitForARMFeedback
+        - ARMReview
+
+- rule:
+    type: label
+    label: Approved-BreakingChange
+    booleanFilterExpression: !(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)
+    onLabeledAddLabels:
+        - WaitForARMFeedback
+        - ARMReview
       
         
 - rule:


### PR DESCRIPTION
If both arm review and breaking change review existing, arm review happened after breaking change review approval.

