### PR TITLE
[Language Text] Deduplicate TaskState schema

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/common.json
+++ b/dev/cognitiveservices/data-plane/Language/common.json
@@ -193,7 +193,7 @@
           ],
           "x-ms-enum": {
             "modelAsString": true,
-            "name": "TaskState"
+            "name": "State"
           }
         }
       },


### PR DESCRIPTION
It was duplicate with the definition at line 176 causing autorest to throw an error.