### PR TITLE
[Language Text] Fix SentimentResponse detected language

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/analyzetext.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzetext.json
@@ -1127,9 +1127,6 @@
       "allOf": [
         {
           "$ref": "#/definitions/AnalyzeTextTaskResult"
-        },
-        {
-          "$ref": "#/definitions/DocumentDetectedLanguage"
         }
       ],
       "required": [
@@ -1147,6 +1144,9 @@
             "allOf": [
               {
                 "$ref": "#/definitions/SentimentDocumentResult"
+              },
+              {
+                "$ref": "#/definitions/DocumentDetectedLanguage"
               }
             ]
           }

--- a/dev/cognitiveservices/data-plane/Language/analyzetext.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzetext.json
@@ -820,6 +820,9 @@
             "allOf": [
               {
                 "$ref": "#/definitions/HealthcareEntitiesDocumentResult"
+              },
+              {
+                "$ref": "#/definitions/DocumentDetectedLanguage"
               }
             ]
           }


### PR DESCRIPTION
- Detected language should be at the document level.
- Adds auto LD for healthcare because healthcare supports a [variety of languages](https://docs.microsoft.com/en-us/azure/cognitive-services/language-service/text-analytics-for-health/language-support)