### PR TITLE
[Language - analyze text] fix duplicate schema for JobState

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/common.json
+++ b/dev/cognitiveservices/data-plane/Language/common.json
@@ -270,7 +270,7 @@
           "type": "string",
           "x-ms-enum": {
             "modelAsString": true,
-            "name": "JobState"
+            "name": "State"
           }
         },
         "errors": {


### PR DESCRIPTION
Same fix as https://github.com/Azure/azure-rest-api-specs/pull/20676 but for JobState to fix the autorest error. This matches how this was previously defined in 2022-05-01.