### PR TITLE
remove the global deduplication for apimanagement

### DIFF
--- a/specification/apimanagement/resource-manager/readme.md
+++ b/specification/apimanagement/resource-manager/readme.md
@@ -31,12 +31,6 @@ openapi-type: arm
 tag: package-2021-08
 ```
 
-``` yaml
-modelerfour:
-  lenient-model-deduplication: true
-tag: package-2021-08
-```
-
 
 ### Tag: package-preview-2021-12
 


### PR DESCRIPTION
We should never have globally set deduplication, which is meant to be set individually by each SDK.
