### PR TITLE
Fix the wrong value of queryId in example files

### DIFF
--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2018-06-01-privatepreview/examples/QueryTextsGet.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/preview/2018-06-01-privatepreview/examples/QueryTextsGet.json
@@ -4,7 +4,7 @@
     "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
     "resourceGroupName": "testResourceGroupName",
     "serverName": "testServerName",
-    "queryId": 1
+    "queryId": "1"
   },
   "responses": {
     "200": {

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/stable/2018-06-01/examples/QueryTextsGet.json
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/stable/2018-06-01/examples/QueryTextsGet.json
@@ -4,7 +4,7 @@
     "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
     "resourceGroupName": "testResourceGroupName",
     "serverName": "testServerName",
-    "queryId": 1
+    "queryId": "1"
   },
   "responses": {
     "200": {


### PR DESCRIPTION
Modified the value of queryId from integer to string in example files
To fix the [Linter Validation Error](https://portal.azure-devex-tools.com/amekpis/linting/detail?errorId=BEFC198B-B909-45E6-9C00-58F4F747AFF9)