### PR TITLE
devhub: fixing the constant name to be unique

### DIFF
--- a/specification/developerhub/resource-manager/Microsoft.DevHub/preview/2022-04-01-preview/workflow.json
+++ b/specification/developerhub/resource-manager/Microsoft.DevHub/preview/2022-04-01-preview/workflow.json
@@ -695,7 +695,7 @@
       ],
       "readOnly": true,
       "x-ms-enum": {
-        "name": "ManifestType",
+        "name": "AuthorizationStatus",
         "modelAsString": true,
         "values": [
           {


### PR DESCRIPTION
This conflicts with the existing constant named `ManifestType`