### PR TITLE
Enable validator for CostManagement

### DIFF
--- a/specification/cost-management/resource-manager/readme.md
+++ b/specification/cost-management/resource-manager/readme.md
@@ -27,7 +27,6 @@ These are the global settings for the Cost Management API.
 ``` yaml
 openapi-type: arm
 tag: package-2022-05
-azure-validator: false
 ```
 
 ---


### PR DESCRIPTION
This PR just re-enables the azure-validator for CostManagement ARM API.

There are no actual API changes.