### PR TITLE
Rename the operation ID for /:analyze-conversations path

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -43,7 +43,7 @@
   "paths": {
     "/:analyze-conversations": {
       "post": {
-        "operationId": "ConversationAnalysis_AnalyzeConversation",
+        "operationId": "AnalyzeConversation",
         "description": "Analyzes the input conversation utterance.",
         "parameters": [
           {

--- a/dev/cognitiveservices/data-plane/Language/questionanswering-authoring.json
+++ b/dev/cognitiveservices/data-plane/Language/questionanswering-authoring.json
@@ -32,7 +32,7 @@
     }
   ],
   "x-ms-parameterized-host": {
-    "hostTemplate": "{Endpoint}/language/authoring",
+    "hostTemplate": "{Endpoint}/language",
     "useSchemePrefix": false,
     "parameters": [
       {
@@ -41,7 +41,7 @@
     ]
   },
   "paths": {
-    "/query-knowledgebases/projects": {
+    "/authoring/query-knowledgebases/projects": {
       "get": {
         "summary": "Gets all projects for a user.",
         "operationId": "QuestionAnsweringProjects_ListProjects",
@@ -90,7 +90,7 @@
         }
       }
     },
-    "/query-knowledgebases/projects/{projectName}": {
+    "/authoring/query-knowledgebases/projects/{projectName}": {
       "get": {
         "summary": "Get the requested project metadata.",
         "operationId": "QuestionAnsweringProjects_GetProjectDetails",
@@ -221,7 +221,7 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/query-knowledgebases/projects/deletion-jobs/{jobId}": {
+    "/authoring/query-knowledgebases/projects/deletion-jobs/{jobId}": {
       "get": {
         "summary": "Gets the status of a Project delete job.",
         "operationId": "QuestionAnsweringProjects_GetDeleteStatus",
@@ -260,7 +260,7 @@
         }
       }
     },
-    "/query-knowledgebases/projects/{projectName}/:export": {
+    "/authoring/query-knowledgebases/projects/{projectName}/:export": {
       "post": {
         "summary": "Export project metadata and assets.",
         "operationId": "QuestionAnsweringProjects_Export",
@@ -314,7 +314,7 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/query-knowledgebases/projects/{projectName}/export/jobs/{jobId}": {
+    "/authoring/query-knowledgebases/projects/{projectName}/export/jobs/{jobId}": {
       "get": {
         "summary": "Gets the status of an Export job, once job completes, returns the project metadata, and assets.",
         "operationId": "QuestionAnsweringProjects_GetExportStatus",
@@ -356,7 +356,7 @@
         }
       }
     },
-    "/query-knowledgebases/projects/{projectName}/:import": {
+    "/authoring/query-knowledgebases/projects/{projectName}/:import": {
       "post": {
         "summary": "Import project assets.",
         "operationId": "QuestionAnsweringProjects_Import",
@@ -412,7 +412,7 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/query-knowledgebases/projects/{projectName}/import/jobs/{jobId}": {
+    "/authoring/query-knowledgebases/projects/{projectName}/import/jobs/{jobId}": {
       "get": {
         "summary": "Gets the status of an Import job.",
         "operationId": "QuestionAnsweringProjects_GetImportStatus",
@@ -454,7 +454,7 @@
         }
       }
     },
-    "/query-knowledgebases/projects/{projectName}/deployments/{deploymentName}": {
+    "/authoring/query-knowledgebases/projects/{projectName}/deployments/{deploymentName}": {
       "put": {
         "summary": "Deploy project to production.",
         "operationId": "QuestionAnsweringProjects_DeployProject",
@@ -499,7 +499,7 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/query-knowledgebases/projects/{projectName}/deployments/{deploymentName}/jobs/{jobId}": {
+    "/authoring/query-knowledgebases/projects/{projectName}/deployments/{deploymentName}/jobs/{jobId}": {
       "get": {
         "summary": "Gets the status of a Deploy job.",
         "operationId": "QuestionAnsweringProjects_GetDeployStatus",
@@ -544,7 +544,7 @@
         }
       }
     },
-    "/query-knowledgebases/projects/{projectName}/deployments": {
+    "/authoring/query-knowledgebases/projects/{projectName}/deployments": {
       "get": {
         "summary": "List all deployments of a project.",
         "operationId": "QuestionAnsweringProjects_ListDeployments",
@@ -596,7 +596,7 @@
         }
       }
     },
-    "/query-knowledgebases/projects/{projectName}/synonyms": {
+    "/authoring/query-knowledgebases/projects/{projectName}/synonyms": {
       "get": {
         "summary": "Gets all the synonyms of a project.",
         "operationId": "QuestionAnsweringProjects_GetSynonyms",
@@ -691,7 +691,7 @@
         }
       }
     },
-    "/query-knowledgebases/projects/{projectName}/sources": {
+    "/authoring/query-knowledgebases/projects/{projectName}/sources": {
       "get": {
         "summary": "Gets all the sources of a project.",
         "operationId": "QuestionAnsweringProjects_GetSources",
@@ -792,7 +792,7 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/query-knowledgebases/projects/{projectName}/sources/jobs/{jobId}": {
+    "/authoring/query-knowledgebases/projects/{projectName}/sources/jobs/{jobId}": {
       "get": {
         "summary": "Gets the status of update sources job.",
         "operationId": "QuestionAnsweringProjects_GetUpdateSourcesStatus",
@@ -834,7 +834,7 @@
         }
       }
     },
-    "/query-knowledgebases/projects/{projectName}/qnas": {
+    "/authoring/query-knowledgebases/projects/{projectName}/qnas": {
       "get": {
         "summary": "Gets all the QnAs of a project.",
         "operationId": "QuestionAnsweringProjects_GetQnas",
@@ -938,7 +938,7 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/query-knowledgebases/projects/{projectName}/qnas/jobs/{jobId}": {
+    "/authoring/query-knowledgebases/projects/{projectName}/qnas/jobs/{jobId}": {
       "get": {
         "summary": "Gets the status of update QnAs job.",
         "operationId": "QuestionAnsweringProjects_GetUpdateQnasStatus",
@@ -980,7 +980,7 @@
         }
       }
     },
-    "/query-knowledgebases/projects/{projectName}/feedback": {
+    "/authoring/query-knowledgebases/projects/{projectName}/feedback": {
       "post": {
         "summary": "Update Active Learning feedback.",
         "operationId": "QuestionAnsweringProjects_AddFeedback",


### PR DESCRIPTION
Rename the operation ID for /:analyze-conversations path for supporting better organization of documents. As the operation ID between sync and async vary, the documents are not organized together for sync and async unlike the "Analyze-Text" operations.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
