### PR TITLE
S360 swagger correctness - added missing property totalCount

### DIFF
--- a/specification/billing/resource-manager/Microsoft.Billing/stable/2021-10-01/billingSubscription.json
+++ b/specification/billing/resource-manager/Microsoft.Billing/stable/2021-10-01/billingSubscription.json
@@ -647,6 +647,12 @@
             "$ref": "#/definitions/BillingSubscription"
           }
         },
+        "totalCount": {
+          "description": "Total number of records.",
+          "type": "number",
+          "format": "int32",
+          "readOnly": true
+        },
         "nextLink": {
           "description": "The link (url) to the next page of results.",
           "type": "string",

--- a/specification/billing/resource-manager/Microsoft.Billing/stable/2021-10-01/examples/BillingSubscriptionsListByBillingAccount.json
+++ b/specification/billing/resource-manager/Microsoft.Billing/stable/2021-10-01/examples/BillingSubscriptionsListByBillingAccount.json
@@ -6,6 +6,7 @@
   "responses": {
     "200": {
       "body": {
+        "totalCount": 3,
         "value": [
           {
             "id": "/providers/Microsoft.Billing/BillingAccounts/{billingAccountName}/billingSubscriptions/418b0e9c-5dc3-4260-918f-30b90619fe07",


### PR DESCRIPTION
# Data Plane API - Pull Request
Adding missing property due to which api is marked on S360 dashboard for swagger correctness
https://portal.azure-devex-tools.com/amekpis/correctness/detail?errorId=123BD26F-B79D-46C1-A1FB-C6DF79F07763

## API Info: The Basics


Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [X] GA release

### Change Scope
<sup>This section will help us focus on the specific parts of your API that are new or have been modified. <br/>Please share a link to the design document for the new APIs, a link to the previous Open API document (swagger) if applicable, and the root paths that have been updated. </sup>
* Design Document:
* Previous Open API Doc:
* Updated paths:

## ❔Got questions? Need additional info?? We are here to help!

<details>
  <summary> Contact us!</summary>

The [Azure API Review Board](https://aka.ms/azapi) is dedicated to helping you create amazing APIs. You can read about our mission and learn more about our process on our [wiki](https://aka.ms/azapi).
* 💬 [Teams Channel](https://teams.microsoft.com/l/channel/19%3a3ebb18fded0e47938f998e196a52952f%40thread.tacv2/General?groupId=1a10b50c-e870-4fe0-8483-bf5542a8d2d8&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
* 💌 [email](mailto://azureapirbcore@microsoft.com)

</details>

<details>
  <summary>Click here for links to tools, specs, guidelines & other good stuff</summary>

### Tooling
 * [Open API validation tools](https://aka.ms/swaggertools) were run on this PR. Go here to see [how to fix errors](https://aka.ms/ci-fix)
 * [Spectral Linting](https://aka.ms/style)
 * [Open API Hub](https://aka.ms/openapiportal)

### Guidelines & Specifications
 * [Azure REST API Guidelines](https://aka.ms/guidelines)
 * [OpenAPI Style Guidelines](https://aka.ms/style)
 * [Azure Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy)

### Helpful Links
 * [Azure DevTools Wiki](https://aka.ms/azapi)

</details>
