### PR TITLE
added the Microsoft-SecurityEvent destination

### DIFF
--- a/specification/monitor/resource-manager/Microsoft.Insights/stable/2021-04-01/dataCollectionRules_API.json
+++ b/specification/monitor/resource-manager/Microsoft.Insights/stable/2021-04-01/dataCollectionRules_API.json
@@ -479,7 +479,8 @@
               "Microsoft-InsightsMetrics",
               "Microsoft-Perf",
               "Microsoft-Syslog",
-              "Microsoft-WindowsEvent"
+              "Microsoft-WindowsEvent",
+              "Microsoft-SecurityEvent"
             ],
             "type": "string",
             "x-ms-enum": {
@@ -630,7 +631,8 @@
               "Microsoft-InsightsMetrics",
               "Microsoft-Perf",
               "Microsoft-Syslog",
-              "Microsoft-WindowsEvent"
+              "Microsoft-WindowsEvent",
+              "Microsoft-SecurityEvent"
             ],
             "type": "string",
             "x-ms-enum": {


### PR DESCRIPTION
# Pull Request
Minor change.

The data collection stream endpoint Microsoft-SecurityEvent is missing from this module.
This is a required endpoint for the Azure Sentinel connector which makes use of the Azure Monitor Agent.

## API Info: The Basics

Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [x] GA release


