### PR TITLE
keyvault: fixing the duplicate constant types

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/certificates.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/certificates.json
@@ -1630,7 +1630,7 @@
             "AutoRenew"
           ],
           "x-ms-enum": {
-            "name": "ActionType",
+            "name": "CertificateActionType",
             "modelAsString": false
           }
         }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
@@ -2200,7 +2200,7 @@
             "notify"
           ],
           "x-ms-enum": {
-            "name": "ActionType",
+            "name": "LifetimeActionType",
             "modelAsString": false,
             "values": [
               {


### PR DESCRIPTION
Fixes this:

```
$ autorest --tag=package-7.3 --go --verbose --use-onever --version=2.0.4421 --go.license-header=MICROSOFT_MIT_NO_VERSION --enum-prefix --openapi-type=data-plane --output-folder=../../sdk/keyvault/7.3/keyvault ../../config/key-vault/readme.md

FATAL: System.InvalidOperationException: Swagger document contains two or more x-ms-enum extensions with the same name 'ActionType' and different values: EmailContacts,AutoRenew vs. rotate,notify
```