### PR TITLE
add AVS code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -246,6 +246,9 @@
 # PRLabel: %Network - Traffic Manager
 /specification/trafficmanager/ @allencal @hrkulkarmsft
 
+# PRLabel: %AVS
+/specification/vmware/ @cataggar
+
 # PRLabel: %Web Apps
 /specification/web/ @naveedaz @Azure/azure-app-service-control-plane
 


### PR DESCRIPTION
Based on #20646, this adds me as the code owner for `/specification/vmware/`, which is for AVS (Azure VMware Solution).