### PR TITLE
batch: the storageAccountId field is no longer required

### DIFF
--- a/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
+++ b/specification/batch/resource-manager/Microsoft.Batch/stable/2022-01-01/BatchManagement.json
@@ -2536,9 +2536,6 @@
           "$ref": "#/definitions/ComputeNodeIdentityReference"
         }
       },
-      "required": [
-        "storageAccountId"
-      ],
       "description": "The properties related to the auto-storage account."
     },
     "BatchAccountUpdateProperties": {


### PR DESCRIPTION
This needs to be Optional so that it can be `null` during an Update to remove this value

The current Azure SDK outputs this as `*string` rather than `string` which is a bug in the SDK Generator: https://github.com/Azure/azure-sdk-for-go/blob/297f2c8b6d448f01b09fbc5c7fad393922c9ccda/services/batch/mgmt/2022-01-01/batch/models.go#L872

However since this needs to be `null` we should make this Optional
