### PR TITLE
containerservice: making `dnsPrefix` required, since this is required

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-09-02-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-09-02-preview/fleets.json
@@ -641,6 +641,9 @@
     "FleetHubProfile": {
       "type": "object",
       "description": "The FleetHubProfile configures the fleet hub.",
+      "required": [
+        "dnsPrefix"
+      ],
       "properties": {
         "dnsPrefix": {
           "type": "string",


### PR DESCRIPTION
This is required in the API, so should be marked as Required