### PR TITLE
Fix the wrong value of queryId in MariaDB example files

### DIFF
--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-privatepreview/examples/QueryTextsGet.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/preview/2018-06-01-privatepreview/examples/QueryTextsGet.json
@@ -4,7 +4,7 @@
     "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
     "resourceGroupName": "testResourceGroupName",
     "serverName": "testServerName",
-    "queryId": 1
+    "queryId": "1"
   },
   "responses": {
     "200": {

--- a/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/examples/QueryTextsGet.json
+++ b/specification/mariadb/resource-manager/Microsoft.DBforMariaDB/stable/2018-06-01/examples/QueryTextsGet.json
@@ -4,7 +4,7 @@
     "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
     "resourceGroupName": "testResourceGroupName",
     "serverName": "testServerName",
-    "queryId": 1
+    "queryId": "1"
   },
   "responses": {
     "200": {


### PR DESCRIPTION
Modified the value of queryId from integer to string in MariaDB example files

To fix the [Linter Validation Error](https://portal.azure-devex-tools.com/amekpis/linting/detail?errorId=BB39371B-2B84-43DF-A28E-D46362F36F03)