### PR TITLE
added x-ms-mutability for sku

### DIFF
--- a/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
+++ b/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
@@ -1128,13 +1128,6 @@
       "description": "FarmBeats update request.",
       "type": "object",
       "properties": {
-        "sku": {
-          "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/Sku",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
-        },
         "location": {
           "description": "Geo-location where the resource lives.",
           "type": "string"

--- a/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
+++ b/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
@@ -1128,6 +1128,13 @@
       "description": "FarmBeats update request.",
       "type": "object",
       "properties": {
+        "sku": {
+          "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/Sku",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
         "location": {
           "description": "Geo-location where the resource lives.",
           "type": "string"

--- a/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
+++ b/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
@@ -1107,6 +1107,13 @@
         }
       ],
       "properties": {
+        "sku": {
+          "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
         "systemData": {
           "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/systemData"
         },

--- a/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
+++ b/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
@@ -1128,6 +1128,9 @@
       "description": "FarmBeats update request.",
       "type": "object",
       "properties": {
+        "sku": {
+          "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/Sku"
+        },
         "location": {
           "description": "Geo-location where the resource lives.",
           "type": "string"

--- a/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
+++ b/specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/agfood.json
@@ -1108,7 +1108,7 @@
       ],
       "properties": {
         "sku": {
-          "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/",
+          "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/Sku",
           "x-ms-mutability": [
             "read",
             "create"


### PR DESCRIPTION
This is to fix [OBJECT_ADDITIONAL_PROPERTIES](https://github.com/Azure/oav/blob/master/documentation/oav-errors-reference.md#OBJECT_ADDITIONAL_PROPERTIES) for sku field. [link](https://portal.azure-devex-tools.com/tools/api-live-validation/errors?apiVersion=2020-05-12-preview&commitHash=d5ff2c358382dfa75282bf3c13aa00dd92c38d71&endDate=2022-11-07&operationId=FarmBeatsModels_Get&resourceProvider=microsoft.agfoodplatform&specsRepo=https%3A%2F%2Fgithub.com%2FAzure%2Fazure-rest-api-specs&startDate=2022-11-01&validationId=ARM&validatorName=default-early)

Let me know if anything else is needed. Would want to close this ASAP so a s to close SDK signoff we need for public preview PLR criteria.

Reason for this change:
	
This property has already been there since day 1. It's not a new property that we are newly introducing. We chose to not have it in swagger so that always default one is used. Because of the live validation error, we need to add it now which if not done it would raise issues in getting management plane SDK signoff needed for public PLR. hence the ask.
