### PR TITLE
[Tables] Adjust some enum settings to the latest autorest

### DIFF
--- a/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/table.json
+++ b/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/table.json
@@ -1065,6 +1065,9 @@
           "enum": [
             "service"
           ],
+          "x-ms-enum": {
+            "modelAsString": false
+          },
           "description": "Required query string to set the service properties."
         },
         {
@@ -1075,6 +1078,9 @@
           "enum": [
             "properties"
           ],
+          "x-ms-enum": {
+            "modelAsString": false
+          },
           "description": "Required query string to set the service properties."
         }
       ],
@@ -1211,6 +1217,9 @@
           "enum": [
             "service"
           ],
+          "x-ms-enum": {
+            "modelAsString": false
+          },
           "description": "Required query string to get service stats."
         },
         {
@@ -1221,6 +1230,9 @@
           "enum": [
             "stats"
           ],
+          "x-ms-enum": {
+            "modelAsString": false
+          },
           "description": "Required query string to get service stats."
         }
       ],
@@ -1748,7 +1760,10 @@
       "description": "Specifies the version of the operation to use for this request.",
       "enum": [
         "2019-02-02"
-      ]
+      ],
+      "x-ms-enum": {
+        "modelAsString": false
+      }
     },
     "ClientRequestId": {
       "name": "x-ms-client-request-id",
@@ -1768,7 +1783,10 @@
       "x-ms-parameter-location": "method",
       "enum": [
         "3.0"
-      ]
+      ],
+      "x-ms-enum": {
+        "modelAsString": false
+      }
     },
     "TableProperties": {
       "name": "tableProperties",
@@ -1864,6 +1882,9 @@
       "enum": [
         "acl"
       ],
+      "x-ms-enum": {
+        "modelAsString": false
+      },
       "x-ms-parameter-location": "method",
       "description": "Required query string to handle stored access policies for the table that may be used with Shared Access Signatures."
     },

--- a/specification/cosmos-db/data-plane/readme.python.md
+++ b/specification/cosmos-db/data-plane/readme.python.md
@@ -13,7 +13,7 @@ python:
   no-namespace-folders: true
   enable-xml: true
   vanilla: true
-  output-folder: "$(python-sdks-folder)/sdk/cosmos/azure-cosmos-table/azure/table/_generated"
+  output-folder: "$(python-sdks-folder)/sdk/tables/azure-data-tables/azure/data/tables/_generated"
   package-version: "2019-02-02"
 ```
 


### PR DESCRIPTION
Set some enums to be `"modelAsString": false` while generating with flag "--models-mode=msrest".