### PR TITLE
Resourceconnector : Remove stable folder for go sdk output

### DIFF
--- a/specification/resourceconnector/resource-manager/readme.go.md
+++ b/specification/resourceconnector/resource-manager/readme.go.md
@@ -50,5 +50,5 @@ Please also specify `--go-sdks-folder=<path to the root directory of your azure-
 
 ```yaml $(tag) == 'package-2022-10-27' && $(go)
 namespace: resourceconnector
-output-folder: $(go-sdk-folder)/services/stable/$(namespace)/mgmt/2022-10-27/$(namespace)
+output-folder: $(go-sdk-folder)/services/$(namespace)/mgmt/2022-10-27/$(namespace)
 ```


### PR DESCRIPTION
##Description
Update typo in the go SDK output folder for recently merged API