### PR TITLE
[Cognitive Services / Language] Dynamic classification `class` to `classifications`

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/analyzetext.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzetext.json
@@ -752,6 +752,25 @@
     "ClassificationDocumentResult": {
       "type": "object",
       "properties": {
+        "class": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClassificationResult"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DocumentResult"
+        }
+      ],
+      "required": [
+        "class"
+      ]
+    },
+    "DynamicClassificationDocumentResult": {
+      "type": "object",
+      "properties": {
         "classifications": {
           "type": "array",
           "items": {
@@ -2480,7 +2499,7 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/definitions/ClassificationDocumentResult"
+                "$ref": "#/definitions/DynamicClassificationDocumentResult"
               }
             ]
           }

--- a/dev/cognitiveservices/data-plane/Language/analyzetext.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzetext.json
@@ -752,7 +752,7 @@
     "ClassificationDocumentResult": {
       "type": "object",
       "properties": {
-        "class": {
+        "classifications": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ClassificationResult"
@@ -765,7 +765,7 @@
         }
       ],
       "required": [
-        "class"
+        "classifications"
       ]
     },
     "HealthcareTaskParameters": {

--- a/dev/cognitiveservices/data-plane/Language/examples/text/SuccessfuDynamicClassificationRequest.json
+++ b/dev/cognitiveservices/data-plane/Language/examples/text/SuccessfuDynamicClassificationRequest.json
@@ -40,7 +40,7 @@
           "documents": [
             {
               "id": "1",
-              "class": [
+              "classifications": [
                 {
                   "category": "Health",
                   "confidenceScore": 0.9
@@ -62,7 +62,7 @@
             },
             {
               "id": "2",
-              "class": [
+              "classifications": [
                 {
                   "category": "Health",
                   "confidenceScore": 0.9

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/analyzetext.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/analyzetext.json
@@ -752,6 +752,25 @@
     "ClassificationDocumentResult": {
       "type": "object",
       "properties": {
+        "class": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClassificationResult"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DocumentResult"
+        }
+      ],
+      "required": [
+        "class"
+      ]
+    },
+    "DynamicClassificationDocumentResult": {
+      "type": "object",
+      "properties": {
         "classifications": {
           "type": "array",
           "items": {
@@ -2480,7 +2499,7 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/definitions/ClassificationDocumentResult"
+                "$ref": "#/definitions/DynamicClassificationDocumentResult"
               }
             ]
           }

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/analyzetext.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/analyzetext.json
@@ -752,7 +752,7 @@
     "ClassificationDocumentResult": {
       "type": "object",
       "properties": {
-        "class": {
+        "classifications": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ClassificationResult"
@@ -765,7 +765,7 @@
         }
       ],
       "required": [
-        "class"
+        "classifications"
       ]
     },
     "HealthcareTaskParameters": {

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/examples/text/SuccessfuDynamicClassificationRequest.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/examples/text/SuccessfuDynamicClassificationRequest.json
@@ -40,7 +40,7 @@
           "documents": [
             {
               "id": "1",
-              "class": [
+              "classifications": [
                 {
                   "category": "Health",
                   "confidenceScore": 0.9
@@ -62,7 +62,7 @@
             },
             {
               "id": "2",
-              "class": [
+              "classifications": [
                 {
                   "category": "Health",
                   "confidenceScore": 0.9


### PR DESCRIPTION
# Data Plane API - Pull Request
Is this review for (select one):

- [x] a private preview
- [ ] a public preview
- [ ] GA release

### Change Scope
<sup>This section will help us focus on the specific parts of your API that are new or have been modified. <br/>Please share a link to the design document for the new APIs, a link to the previous Open API document (swagger) if applicable, and the root paths that have been updated. </sup>

Renaming the property that contains the classification results for Dynamic Classification from `class` to `classifications`, this is a bug in the swagger, the actual served content has always been classifications, so no breaking change there (SDKs have not released yet and they need this change to be able to release).