### PR TITLE
media: fixing the Swagger Tag for consistency

### DIFF
--- a/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2020-05-01/streamingservice.json
+++ b/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2020-05-01/streamingservice.json
@@ -863,7 +863,7 @@
       },
       "patch": {
         "tags": [
-          "StreamingEndpoint"
+          "StreamingEndpoints"
         ],
         "summary": "Update StreamingEndpoint",
         "description": "Updates a existing streaming endpoint.",

--- a/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2021-06-01/streamingservice.json
+++ b/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2021-06-01/streamingservice.json
@@ -854,7 +854,7 @@
       },
       "patch": {
         "tags": [
-          "StreamingEndpoint"
+          "StreamingEndpoints"
         ],
         "summary": "Update StreamingEndpoint",
         "description": "Updates a existing streaming endpoint.",

--- a/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2021-11-01/streamingservice.json
+++ b/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2021-11-01/streamingservice.json
@@ -854,7 +854,7 @@
       },
       "patch": {
         "tags": [
-          "StreamingEndpoint"
+          "StreamingEndpoints"
         ],
         "summary": "Update StreamingEndpoint",
         "description": "Updates a existing streaming endpoint.",

--- a/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2022-08-01/streamingservice.json
+++ b/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2022-08-01/streamingservice.json
@@ -1053,7 +1053,7 @@
       },
       "patch": {
         "tags": [
-          "StreamingEndpoint"
+          "StreamingEndpoints"
         ],
         "summary": "Update StreamingEndpoint",
         "description": "Updates a existing streaming endpoint.",


### PR DESCRIPTION
The other Swagger Tags for this Operation are `StreamingEndpoints`, this is a typo for the Update operation and should be consistent