### PR TITLE
recoveryservicessiterecovery @ 2022-10-01: adding a base type for `ProviderSpecificInput`

### DIFF
--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/service.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/service.json
@@ -10879,10 +10879,25 @@
         }
       }
     },
-    "DisableProtectionProviderSpecificInput": {
-      "description": "Disable protection provider specific input.",
+    "ProviderSpecificInput": {
+      "type": "object",
       "required": [
         "instanceType"
+      ],
+      "properties": {
+        "instanceType": {
+          "description": "The class type.",
+          "type": "string"
+        }
+      },
+      "discriminator": "instanceType"
+    },
+    "DisableProtectionProviderSpecificInput": {
+      "description": "Disable protection provider specific input.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProviderSpecificInput"
+        }
       ],
       "type": "object",
       "properties": {
@@ -10891,7 +10906,7 @@
           "type": "string"
         }
       },
-      "discriminator": "instanceType"
+      "x-ms-discriminator-value": "DisableProtectionProviderSpecificInput"
     },
     "DiscoverProtectableItemRequest": {
       "description": "Request to add a physical machine as a protectable item in a container.",
@@ -14524,7 +14539,7 @@
       "type": "object",
       "allOf": [
         {
-          "$ref": "#/definitions/DisableProtectionProviderSpecificInput"
+          "$ref": "#/definitions/ProviderSpecificInput"
         }
       ],
       "properties": {


### PR DESCRIPTION
At this point `DisableProtectionProviderSpecificInput` isn't a valid discriminator, see https://github.com/hashicorp/pandora/issues/1864 for info
