### PR TITLE
recoveryservicessiterecovery: fixing an inconsistency in the segment naming

### DIFF
--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/RecoveryPoints_Get.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/RecoveryPoints_Get.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/RecoveryPoints_ListByReplicationProtectedItems.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/RecoveryPoints_ListByReplicationProtectedItems.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_AddDisks.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_AddDisks.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_ApplyRecoveryPoint.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_ApplyRecoveryPoint.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Create.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Create.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Delete.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Delete.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "c0c14913-3d7a-48ea-9531-cc99e0e686e6",
+    "replicationProtectedItemName": "c0c14913-3d7a-48ea-9531-cc99e0e686e6",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_FailoverCancel.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_FailoverCancel.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_FailoverCommit.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_FailoverCommit.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Get.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Get.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_PlannedFailover.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_PlannedFailover.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Purge.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Purge.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "c0c14913-3d7a-48ea-9531-cc99e0e686e6",
+    "replicationProtectedItemName": "c0c14913-3d7a-48ea-9531-cc99e0e686e6",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_RemoveDisks.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_RemoveDisks.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_RepairReplication.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_RepairReplication.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Reprotect.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Reprotect.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_ResolveHealthErrors.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_ResolveHealthErrors.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_SwitchProvider.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_SwitchProvider.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_TestFailover.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_TestFailover.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_TestFailoverCleanup.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_TestFailoverCleanup.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_UnplannedFailover.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_UnplannedFailover.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Update.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_Update.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
+    "replicationProtectedItemName": "f8491e4f-817a-40dd-a90c-af773978c75b",
     "protectionContainerName": "cloud_6d224fc6-f326-5d35-96de-fbf51efb3179",
     "fabricName": "cloud1",
     "resourceName": "vault1",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_UpdateAppliance.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_UpdateAppliance.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "idclab-vcen67_50158124-8857-3e08-0893-2ddf8ebb8c1f",
+    "replicationProtectedItemName": "idclab-vcen67_50158124-8857-3e08-0893-2ddf8ebb8c1f",
     "protectionContainerName": "Ayan-0106-SA-Vaultreplicationcontainer",
     "fabricName": "Ayan-0106-SA-Vaultreplicationfabric",
     "resourceName": "Ayan-0106-SA-Vault",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_UpdateMobilityService.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectedItems_UpdateMobilityService.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "79dd20ab-2b40-11e7-9791-0050568f387e",
+    "replicationProtectedItemName": "79dd20ab-2b40-11e7-9791-0050568f387e",
     "protectionContainerName": "cloud_c6780228-83bd-4f3e-a70e-cb46b7da33a0",
     "fabricName": "WIN-JKKJ31QI8U2",
     "resourceName": "WCUSVault",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectionContainers_SwitchProtection.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/ReplicationProtectionContainers_SwitchProtection.json
@@ -8,7 +8,7 @@
     "subscriptionId": "42195872-7e70-4f8a-837f-84b28ecbb78b",
     "switchInput": {
       "properties": {
-        "replicatedProtectedItemName": "a2aSwapOsVm",
+        "replicationProtectedItemName": "a2aSwapOsVm",
         "providerSpecificDetails": {
           "instanceType": "A2A"
         }

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/TargetComputeSizes_ListByReplicationProtectedItems.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/examples/TargetComputeSizes_ListByReplicationProtectedItems.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2022-10-01",
-    "replicatedProtectedItemName": "468c912d-b1ab-4ea2-97eb-4b5095155db2",
+    "replicationProtectedItemName": "468c912d-b1ab-4ea2-97eb-4b5095155db2",
     "protectionContainerName": "asr-a2a-default-centraluseuap-container",
     "fabricName": "asr-a2a-default-centraluseuap",
     "resourceName": "avraiMgDiskVault",

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/service.json
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/service.json
@@ -2880,7 +2880,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}": {
       "get": {
         "tags": [
           "ReplicationProtectedItems"
@@ -2919,7 +2919,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -2981,7 +2981,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "A name for the replication protected item.",
             "required": true,
@@ -3050,7 +3050,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -3113,7 +3113,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -3148,7 +3148,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/addDisks": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/addDisks": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3190,7 +3190,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -3225,7 +3225,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/applyRecoveryPoint": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/applyRecoveryPoint": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3267,7 +3267,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "The replicated protected item name.",
             "required": true,
@@ -3302,7 +3302,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/failoverCancel": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/failoverCancel": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3341,7 +3341,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -3367,7 +3367,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/failoverCommit": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/failoverCommit": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3406,7 +3406,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -3432,7 +3432,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/plannedFailover": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/plannedFailover": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3474,7 +3474,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -3509,7 +3509,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/recoveryPoints": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/recoveryPoints": {
       "get": {
         "tags": [
           "RecoveryPoints"
@@ -3548,7 +3548,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "The replication protected item name.",
             "required": true,
@@ -3573,7 +3573,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/recoveryPoints/{recoveryPointName}": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/recoveryPoints/{recoveryPointName}": {
       "get": {
         "tags": [
           "RecoveryPoints"
@@ -3612,7 +3612,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "The replication protected item name.",
             "required": true,
@@ -3641,7 +3641,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/remove": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/remove": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3680,7 +3680,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -3712,7 +3712,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/removeDisks": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/removeDisks": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3754,7 +3754,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -3789,7 +3789,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/repairReplication": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/repairReplication": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3828,7 +3828,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "The name of the replication protected item.",
             "required": true,
@@ -3854,7 +3854,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/reProtect": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/reProtect": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3896,7 +3896,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -3931,7 +3931,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/resolveHealthErrors": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/resolveHealthErrors": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -3973,7 +3973,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -4008,7 +4008,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/switchProvider": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/switchProvider": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -4050,7 +4050,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -4088,7 +4088,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/targetComputeSizes": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/targetComputeSizes": {
       "get": {
         "tags": [
           "TargetComputeSizes"
@@ -4127,7 +4127,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -4152,7 +4152,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/testFailover": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/testFailover": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -4194,7 +4194,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -4229,7 +4229,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/testFailoverCleanup": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/testFailoverCleanup": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -4271,7 +4271,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -4306,7 +4306,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/unplannedFailover": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/unplannedFailover": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -4348,7 +4348,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -4383,7 +4383,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/updateAppliance": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/updateAppliance": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -4425,7 +4425,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "Replication protected item name.",
             "required": true,
@@ -4460,7 +4460,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/updateMobilityService": {
+    "/Subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicationProtectedItemName}/updateMobilityService": {
       "post": {
         "tags": [
           "ReplicationProtectedItems"
@@ -4502,7 +4502,7 @@
             "type": "string"
           },
           {
-            "name": "replicatedProtectedItemName",
+            "name": "replicationProtectedItemName",
             "in": "path",
             "description": "The name of the protected item on which the agent is to be updated.",
             "required": true,


### PR DESCRIPTION
This being named both `replicatedProtectedItemName` and `replicationProtectedItemName` leads to spurious diff's, as can be seen here:

https://github.com/hashicorp/pandora/pull/1876/files#diff-769ff618512efcaf7271a5282d8cac1250e3ad381b060f86f2d6f209cedf8cf4L15