### PR TITLE
Clarify AKV's description for the maxresults parameter across all DP ApiVersions.

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.0/keyvault.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.0/keyvault.json
@@ -298,7 +298,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -345,7 +345,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -825,7 +825,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1185,7 +1185,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1239,7 +1239,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1286,7 +1286,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1536,7 +1536,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -1738,7 +1738,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2074,7 +2074,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2579,7 +2579,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -2750,7 +2750,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2797,7 +2797,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -3286,7 +3286,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -3341,7 +3341,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/certificates.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/certificates.json
@@ -44,7 +44,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -246,7 +246,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -582,7 +582,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1087,7 +1087,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/keys.json
@@ -298,7 +298,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -345,7 +345,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -825,7 +825,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/secrets.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/secrets.json
@@ -239,7 +239,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -293,7 +293,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/storage.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/storage.json
@@ -43,7 +43,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -90,7 +90,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -579,7 +579,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -634,7 +634,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/certificates.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/certificates.json
@@ -44,7 +44,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -246,7 +246,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -582,7 +582,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1087,7 +1087,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/keys.json
@@ -298,7 +298,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -345,7 +345,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -825,7 +825,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/secrets.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/secrets.json
@@ -239,7 +239,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -293,7 +293,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/storage.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/storage.json
@@ -43,7 +43,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -90,7 +90,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -579,7 +579,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -634,7 +634,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/certificates.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/certificates.json
@@ -44,7 +44,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -246,7 +246,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -582,7 +582,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1087,7 +1087,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -387,7 +387,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -925,7 +925,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/secrets.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/secrets.json
@@ -239,7 +239,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -293,7 +293,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/storage.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/storage.json
@@ -43,7 +43,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -90,7 +90,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -579,7 +579,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -634,7 +634,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/certificates.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/certificates.json
@@ -44,7 +44,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -246,7 +246,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"
@@ -582,7 +582,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"
@@ -1087,7 +1087,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"
@@ -387,7 +387,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"
@@ -925,7 +925,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/secrets.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/secrets.json
@@ -239,7 +239,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"
@@ -293,7 +293,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/storage.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/storage.json
@@ -43,7 +43,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"
@@ -90,7 +90,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"
@@ -579,7 +579,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"
@@ -634,7 +634,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "common.json#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/2015-06-01/keyvault.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/2015-06-01/keyvault.json
@@ -267,7 +267,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -308,7 +308,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -904,7 +904,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -952,7 +952,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -993,7 +993,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1158,7 +1158,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1452,7 +1452,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/2016-10-01/keyvault.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/2016-10-01/keyvault.json
@@ -273,7 +273,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -315,7 +315,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -750,7 +750,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1070,7 +1070,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1119,7 +1119,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1161,7 +1161,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1381,7 +1381,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1551,7 +1551,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1852,7 +1852,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2227,7 +2227,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2371,7 +2371,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2654,7 +2654,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.0/keyvault.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.0/keyvault.json
@@ -298,7 +298,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -345,7 +345,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -825,7 +825,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1185,7 +1185,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1239,7 +1239,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1286,7 +1286,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1536,7 +1536,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -1738,7 +1738,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2074,7 +2074,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2579,7 +2579,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -2750,7 +2750,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -2797,7 +2797,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -3286,7 +3286,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -3341,7 +3341,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/certificates.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/certificates.json
@@ -44,7 +44,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -246,7 +246,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -582,7 +582,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1087,7 +1087,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/keys.json
@@ -298,7 +298,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -345,7 +345,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -825,7 +825,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/secrets.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/secrets.json
@@ -239,7 +239,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -293,7 +293,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/storage.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/storage.json
@@ -43,7 +43,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -90,7 +90,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -579,7 +579,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -634,7 +634,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/certificates.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/certificates.json
@@ -44,7 +44,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -246,7 +246,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -582,7 +582,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1087,7 +1087,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/keys.json
@@ -298,7 +298,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -345,7 +345,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -825,7 +825,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/secrets.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/secrets.json
@@ -239,7 +239,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -293,7 +293,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/storage.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/storage.json
@@ -43,7 +43,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -90,7 +90,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -579,7 +579,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -634,7 +634,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/certificates.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/certificates.json
@@ -44,7 +44,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",
@@ -246,7 +246,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -582,7 +582,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -1087,7 +1087,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "name": "includePending",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -387,7 +387,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -925,7 +925,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/secrets.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/secrets.json
@@ -239,7 +239,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -293,7 +293,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified, the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -340,7 +340,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/storage.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/storage.json
@@ -43,7 +43,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -90,7 +90,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -579,7 +579,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -634,7 +634,7 @@
             "format": "int32",
             "minimum": 1,
             "maximum": 25,
-            "description": "Maximum number of results to return in a page. If not specified the service will return up to 25 results."
+            "description": "Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than 25 results in error response code 400 (Bad Request). If there are additional results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service might return fewer results than specified by maxresults (even 0 results) and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should enumerate all pages until the nextLink becomes null."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"


### PR DESCRIPTION
This is a PR generated at [OpenAPI Hub](https://aka.ms/openapihub). You can view your [work branch via this link](https://portal.azure-devex-tools.com/branch/adarce/azure-rest-api-specs/dev-keyvault-Microsoft.KeyVault-7.3...main/).
# Data Plane API - Pull Request

As a follow-up repair item from a previous customer-reported incident, this PR updates the description of the "maxresults" parameter used by AKV's data plane (across all API versions) to clarify exactly how this parameter works. Service functionality has not changed - this is only meant to improve documentation.