### PR TITLE
iothub: fixing a constant naming bug

### DIFF
--- a/specification/iothub/resource-manager/Microsoft.Devices/preview/2022-04-30-preview/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/preview/2022-04-30-preview/iothub.json
@@ -3295,22 +3295,7 @@
           "pattern": "^[A-Za-z0-9-._]{1,64}$"
         },
         "source": {
-          "description": "The source that the routing rule is to be applied to, such as DeviceMessages.",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DigitalTwinChangeEvents",
-            "DeviceConnectionStateEvents",
-            "MqttBrokerMessages"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "condition": {
           "description": "The condition that is evaluated to apply the routing rule. If no condition is provided, it evaluates to true by default. For grammar, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language",
@@ -3352,7 +3337,7 @@
           ],
           "type": "string",
           "x-ms-enum": {
-            "name": "RoutingSource",
+            "name": "FallbackRoutingSource",
             "modelAsString": true
           }
         },
@@ -4090,22 +4075,7 @@
       "type": "object",
       "properties": {
         "routingSource": {
-          "description": "Routing source",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DigitalTwinChangeEvents",
-            "DeviceConnectionStateEvents",
-            "MqttBrokerMessages"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "message": {
           "description": "Routing message",
@@ -4589,6 +4559,24 @@
           "format": "date-time",
           "description": "the last update time to root certificate flag."
         }
+      }
+    },
+    "RoutingSource": {
+      "description": "The source to which the routing rule is to be applied to. For example, DeviceMessages",
+      "enum": [
+        "Invalid",
+        "DeviceMessages",
+        "TwinChangeEvents",
+        "DeviceLifecycleEvents",
+        "DeviceJobLifecycleEvents",
+        "DigitalTwinChangeEvents",
+        "DeviceConnectionStateEvents",
+        "MqttBrokerMessages"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "RoutingSource",
+        "modelAsString": true
       }
     }
   },

--- a/specification/iothub/resource-manager/Microsoft.Devices/preview/2022-11-15-preview/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/preview/2022-11-15-preview/iothub.json
@@ -3318,21 +3318,7 @@
         },
         "source": {
           "description": "The source that the routing rule is to be applied to, such as DeviceMessages.",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DigitalTwinChangeEvents",
-            "DeviceConnectionStateEvents",
-            "MqttBrokerMessages"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "condition": {
           "description": "The condition that is evaluated to apply the routing rule. If no condition is provided, it evaluates to true by default. For grammar, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language",
@@ -3359,6 +3345,24 @@
         "isEnabled"
       ]
     },
+    "RoutingSource": {
+      "enum": [
+        "Invalid",
+        "DeviceMessages",
+        "TwinChangeEvents",
+        "DeviceLifecycleEvents",
+        "DeviceJobLifecycleEvents",
+        "DigitalTwinChangeEvents",
+        "DeviceConnectionStateEvents",
+        "MqttBrokerMessages"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "RoutingSource",
+        "modelAsString": true
+      }
+    },
+
     "FallbackRouteProperties": {
       "description": "The properties of the fallback route. IoT Hub uses these properties when it routes messages to the fallback endpoint.",
       "type": "object",
@@ -3374,7 +3378,7 @@
           ],
           "type": "string",
           "x-ms-enum": {
-            "name": "RoutingSource",
+            "name": "FallbackRoutingSource",
             "modelAsString": true
           }
         },
@@ -4113,21 +4117,7 @@
       "properties": {
         "routingSource": {
           "description": "Routing source",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DigitalTwinChangeEvents",
-            "DeviceConnectionStateEvents",
-            "MqttBrokerMessages"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "message": {
           "description": "Routing message",

--- a/specification/iothub/resource-manager/Microsoft.Devices/preview/2022-11-15-preview/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/preview/2022-11-15-preview/iothub.json
@@ -3362,7 +3362,6 @@
         "modelAsString": true
       }
     },
-
     "FallbackRouteProperties": {
       "description": "The properties of the fallback route. IoT Hub uses these properties when it routes messages to the fallback endpoint.",
       "type": "object",

--- a/specification/iothub/resource-manager/Microsoft.Devices/preview/2023-06-30-preview/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/preview/2023-06-30-preview/iothub.json
@@ -3317,22 +3317,7 @@
           "pattern": "^[A-Za-z0-9-._]{1,64}$"
         },
         "source": {
-          "description": "The source that the routing rule is to be applied to, such as DeviceMessages.",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DigitalTwinChangeEvents",
-            "DeviceConnectionStateEvents",
-            "MqttBrokerMessages"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "condition": {
           "description": "The condition that is evaluated to apply the routing rule. If no condition is provided, it evaluates to true by default. For grammar, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language",
@@ -3374,7 +3359,7 @@
           ],
           "type": "string",
           "x-ms-enum": {
-            "name": "RoutingSource",
+            "name": "FallbackRoutingSource",
             "modelAsString": true
           }
         },
@@ -4112,22 +4097,7 @@
       "type": "object",
       "properties": {
         "routingSource": {
-          "description": "Routing source",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DigitalTwinChangeEvents",
-            "DeviceConnectionStateEvents",
-            "MqttBrokerMessages"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "message": {
           "description": "Routing message",
@@ -4137,6 +4107,22 @@
           "description": "Routing Twin Reference",
           "$ref": "#/definitions/RoutingTwin"
         }
+      }
+    },
+    "RoutingSource": {
+      "description": "The source that the routing rule is to be applied to, such as DeviceMessages.",
+      "enum": [
+        "Invalid",
+        "DeviceMessages",
+        "TwinChangeEvents",
+        "DeviceLifecycleEvents",
+        "DeviceJobLifecycleEvents",
+        "DeviceConnectionStateEvents"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "RoutingSource",
+        "modelAsString": true
       }
     },
     "RoutingTwin": {

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2021-07-02/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2021-07-02/iothub.json
@@ -3178,20 +3178,7 @@
           "pattern": "^[A-Za-z0-9-._]{1,64}$"
         },
         "source": {
-          "description": "The source that the routing rule is to be applied to, such as DeviceMessages.",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DeviceConnectionStateEvents"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "condition": {
           "description": "The condition that is evaluated to apply the routing rule. If no condition is provided, it evaluates to true by default. For grammar, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language",
@@ -3233,7 +3220,7 @@
           ],
           "type": "string",
           "x-ms-enum": {
-            "name": "RoutingSource",
+            "name": "FallbackRoutingSource",
             "modelAsString": true
           }
         },
@@ -3974,25 +3961,28 @@
         }
       }
     },
+    "RoutingSource": {
+      "description": "Routing source",
+      "enum": [
+        "Invalid",
+        "DeviceMessages",
+        "TwinChangeEvents",
+        "DeviceLifecycleEvents",
+        "DeviceJobLifecycleEvents",
+        "DeviceConnectionStateEvents"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "RoutingSource",
+        "modelAsString": true
+      }
+    },
     "TestAllRoutesInput": {
       "description": "Input for testing all routes",
       "type": "object",
       "properties": {
         "routingSource": {
-          "description": "Routing source",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DeviceConnectionStateEvents"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "message": {
           "description": "Routing message",

--- a/specification/iothub/resource-manager/Microsoft.Devices/stable/2023-06-30/iothub.json
+++ b/specification/iothub/resource-manager/Microsoft.Devices/stable/2023-06-30/iothub.json
@@ -3292,20 +3292,7 @@
           "pattern": "^[A-Za-z0-9-._]{1,64}$"
         },
         "source": {
-          "description": "The source that the routing rule is to be applied to, such as DeviceMessages.",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DeviceConnectionStateEvents"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "condition": {
           "description": "The condition that is evaluated to apply the routing rule. If no condition is provided, it evaluates to true by default. For grammar, see: https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language",
@@ -3347,7 +3334,7 @@
           ],
           "type": "string",
           "x-ms-enum": {
-            "name": "RoutingSource",
+            "name": "FallbackRoutingSource",
             "modelAsString": true
           }
         },
@@ -4093,20 +4080,7 @@
       "type": "object",
       "properties": {
         "routingSource": {
-          "description": "Routing source",
-          "enum": [
-            "Invalid",
-            "DeviceMessages",
-            "TwinChangeEvents",
-            "DeviceLifecycleEvents",
-            "DeviceJobLifecycleEvents",
-            "DeviceConnectionStateEvents"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "RoutingSource",
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/RoutingSource"
         },
         "message": {
           "description": "Routing message",
@@ -4116,6 +4090,22 @@
           "description": "Routing Twin Reference",
           "$ref": "#/definitions/RoutingTwin"
         }
+      }
+    },
+    "RoutingSource": {
+      "description": "The source that the routing rule is to be applied to, such as DeviceMessages.",
+      "enum": [
+        "Invalid",
+        "DeviceMessages",
+        "TwinChangeEvents",
+        "DeviceLifecycleEvents",
+        "DeviceJobLifecycleEvents",
+        "DeviceConnectionStateEvents"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "RoutingSource",
+        "modelAsString": true
       }
     },
     "RoutingTwin": {

--- a/specification/iothub/resource-manager/readme.md
+++ b/specification/iothub/resource-manager/readme.md
@@ -37,6 +37,15 @@ These settings apply only when `--tag=package-2023-06` is specified on the comma
 ```yaml $(tag) == 'package-2023-06'
 input-file:
   - Microsoft.Devices/stable/2023-06-30/iothub.json
+
+directive:
+  - from: swagger-document
+    where: $.definitions.FallbackRouteProperties.properties.source
+    transform: >
+      $['x-ms-enum'] = {
+        "name": "RoutingSource",
+        "modelAsString": true
+      };
 ```
 
 ### Tag: package-preview-2023-06
@@ -46,6 +55,15 @@ These settings apply only when `--tag=package-preview-2023-06` is specified on t
 ```yaml $(tag) == 'package-preview-2023-06'
 input-file:
   - Microsoft.Devices/preview/2023-06-30-preview/iothub.json
+
+directive:
+  - from: swagger-document
+    where: $.definitions.FallbackRouteProperties.properties.source
+    transform: >
+      $['x-ms-enum'] = {
+        "name": "RoutingSource",
+        "modelAsString": true
+      };
 ```
 
 ### Tag: package-preview-2022-11

--- a/specification/iothub/resource-manager/readme.md
+++ b/specification/iothub/resource-manager/readme.md
@@ -91,6 +91,15 @@ These settings apply only when `--tag=package-2021-07-02` is specified on the co
 ``` yaml $(tag) == 'package-2021-07-02'
 input-file:
   - Microsoft.Devices/stable/2021-07-02/iothub.json
+
+directive:
+  - from: swagger-document
+    where: $.definitions.FallbackRouteProperties.properties.source
+    transform: >
+      $['x-ms-enum'] = {
+        "name": "RoutingSource",
+        "modelAsString": true
+      };
 ```
 
 ### Tag: package-preview-2021-07-02

--- a/specification/iothub/resource-manager/readme.md
+++ b/specification/iothub/resource-manager/readme.md
@@ -55,6 +55,15 @@ These settings apply only when `--tag=package-preview-2022-11` is specified on t
 ```yaml $(tag) == 'package-preview-2022-11'
 input-file:
   - Microsoft.Devices/preview/2022-11-15-preview/iothub.json
+
+directive:
+  - from: swagger-document
+    where: $.definitions.FallbackRouteProperties.properties.source
+    transform: >
+      $['x-ms-enum'] = {
+        "name": "RoutingSource",
+        "modelAsString": true
+      };
 ```
 
 ### Tag: package-preview-2022-04-30
@@ -64,6 +73,15 @@ These settings apply only when `--tag=package-preview-2022-04-30` is specified o
 ``` yaml $(tag) == 'package-preview-2022-04-30'
 input-file:
   - Microsoft.Devices/preview/2022-04-30-preview/iothub.json
+
+directive:
+  - from: swagger-document
+    where: $.definitions.FallbackRouteProperties.properties.source
+    transform: >
+      $['x-ms-enum'] = {
+        "name": "RoutingSource",
+        "modelAsString": true
+      };
 ```
 
 ### Tag: package-2021-07-02


### PR DESCRIPTION
These two constants have the same name but different values, thus aren't valid.