### PR TITLE
Document that public_exponent applies only to MHSM

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.2-preview/keys.json
@@ -1373,7 +1373,7 @@
         "public_exponent": {
           "type": "integer",
           "format": "int32",
-          "description": "The public exponent for a RSA key."
+          "description": "The public exponent for a RSA key. This applies only to keys created in a Managed HSM."
         },
         "key_ops": {
           "type": "array",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
@@ -1662,7 +1662,7 @@
         "public_exponent": {
           "type": "integer",
           "format": "int32",
-          "description": "The public exponent for a RSA key."
+          "description": "The public exponent for a RSA key. This applies only to keys created in a Managed HSM."
         },
         "key_ops": {
           "type": "array",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
@@ -1683,7 +1683,7 @@
         "public_exponent": {
           "type": "integer",
           "format": "int32",
-          "description": "The public exponent for a RSA key."
+          "description": "The public exponent for a RSA key. This applies only to keys created in a Managed HSM."
         },
         "key_ops": {
           "type": "array",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/keys.json
@@ -1373,7 +1373,7 @@
         "public_exponent": {
           "type": "integer",
           "format": "int32",
-          "description": "The public exponent for a RSA key."
+          "description": "The public exponent for a RSA key. This applies only to keys created in a Managed HSM."
         },
         "key_ops": {
           "type": "array",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
@@ -1663,7 +1663,7 @@
         "public_exponent": {
           "type": "integer",
           "format": "int32",
-          "description": "The public exponent for a RSA key."
+          "description": "The public exponent for a RSA key. This applies only to keys created in a Managed HSM."
         },
         "key_ops": {
           "type": "array",


### PR DESCRIPTION
Inspired by https://github.com/Azure/azure-sdk-for-go/issues/19624 and [this Microsoft Q&A](https://learn.microsoft.com/answers/questions/1105369/public-exponent-does-not-work-when-use-key-vault-t.html).