### PR TITLE
[Draft] Controllable and Interactive Summarization

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/analyzetext.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzetext.json
@@ -3709,6 +3709,13 @@
       "type": "object",
       "description": "An object representing the summarization result of a single document.",
       "properties": {
+        "recommendedControlPhrases": {
+          "type": "array",
+          "description": "Recommended control phrases for user to choose to be used in the next round of summarization.",
+          "items": {
+            "$ref": "common.json#/definitions/PhraseControl"
+          }
+        },
         "summaries": {
           "type": "array",
           "description": "A list of abstractive summaries.",

--- a/dev/cognitiveservices/data-plane/Language/common.json
+++ b/dev/cognitiveservices/data-plane/Language/common.json
@@ -823,9 +823,13 @@
           "type": "string",
           "description": "The session id for interactive summarization experience. We cache the session state on service side and the session expires in 48 hours. The session state we cache includes but not limited to the previous document, parameters and generated summaries."
         },
+        "enableControlPhrasesRecommendation": {
+          "type": "boolean",
+          "description": "By enabling control phrases recommendation, the result will include the suggested phrases for control."
+        },
         "enableInteractiveSummarizationSession": {
           "type": "boolean",
-          "description": "By enabling interactive summarization session, the service will return suggested keywords for encourage and discourage, and cache the session state by session id."
+          "description": "By enabling interactive summarization session, the service will cache the session state by session id."
         },
         "prefix": {
           "type": "string",

--- a/dev/cognitiveservices/data-plane/Language/common.json
+++ b/dev/cognitiveservices/data-plane/Language/common.json
@@ -823,9 +823,8 @@
           "type": "string",
           "description": "The session id for interactive summarization experience. We cache the session state on service side and the session expires in 48 hours. The session state we cache includes but not limited to the previous document, parameters and generated summaries."
         },
-        "enableControlPhrasesRecommendation": {
-          "type": "boolean",
-          "description": "By enabling control phrases recommendation, the result will include the suggested phrases for control."
+        "phraseControlsRecommendationOption": {
+          "$ref": "#/definitions/PhraseControlsRecommendationOption"
         },
         "enableInteractiveSummarizationSession": {
           "type": "boolean",
@@ -842,6 +841,33 @@
         "stringIndexType": {
           "$ref": "#/definitions/StringIndexType"
         }
+      }
+    },
+    "PhraseControlsRecommendationOption":{
+      "enum": [
+        "SummaryAndPhraseControlsRecommendation",
+        "SummaryOnly",
+        "PhraseControlsRecommendationOnly"
+      ],
+      "type": "string",
+      "description": "The option of phrase controls recommendation. The default value is SummaryOnly.",
+      "x-ms-enum": {
+        "modelAsString": false,
+        "name": "PhraseControlsRecommendationOption",
+        "values": [
+          {
+            "value": "SummaryAndPhraseControlsRecommendation",
+            "description": "Output both summary and phrase controls recommendation."
+          },
+          {
+            "value": "SummaryOnly",
+            "description": "Output summary only."
+          },
+          {
+            "value": "PhraseControlsRecommendationOnly",
+            "description": "Output phrase controls recommendation only."
+          }
+        ]
       }
     },
     "PhraseControl": {

--- a/dev/cognitiveservices/data-plane/Language/common.json
+++ b/dev/cognitiveservices/data-plane/Language/common.json
@@ -808,9 +808,9 @@
           "format": "int32",
           "description": "It controls the approximate number of sentences in the output summaries."
         },
-        "detailLevel": {
-          "$ref": "#/definitions/DetailLevel",
-          "description": "It controls the detail level of the summary. Use this parameter exclusively with sentenceCount parameter."
+        "summaryLength": {
+          "$ref": "#/definitions/SummaryLength",
+          "description": "It controls the approximate length of the summary by buckets. Use this parameter exclusively with sentenceCount parameter."
         },
         "phraseControls": {
           "type": "array",
@@ -887,29 +887,29 @@
         }
       }
     },
-    "DetailLevel":{
+    "SummaryLength":{
       "enum": [
-        "high",
+        "short",
         "medium",
-        "low"
+        "long"
       ],
       "type": "string",
-      "description": "The detail level of the summary.",
+      "description": "The length of the summary.",
       "x-ms-enum": {
         "modelAsString": false,
-        "name": "DetailLevel",
+        "name": "SummaryLength",
         "values": [
           {
-            "value": "high",
-            "description": "High level summary is usually shorter and contains less details."
+            "value": "short",
+            "description": "Short summary"
           },
           {
             "value": "medium",
-            "description": "Medium level summary is in between high level and low level."
+            "description": "Medium length summary"
           },
           {
-            "value": "low",
-            "description": "Low level summary is usually longer and contains more details."
+            "value": "long",
+            "description": "Long summary"
           }
         ]
       }

--- a/dev/cognitiveservices/data-plane/Language/common.json
+++ b/dev/cognitiveservices/data-plane/Language/common.json
@@ -808,9 +808,63 @@
           "format": "int32",
           "description": "It controls the approximate number of sentences in the output summaries."
         },
+        "phraseControls": {
+          "type": "array",
+          "description": "Control the phrases to be used in the summary.",
+          "items": {
+            "$ref": "#/definitions/PhraseControl"
+          }
+        },
+        "prefix": {
+          "type": "string",
+          "description": "The prefix comes before the inserted summary text."
+        },
+        "suffix": {
+          "type": "string",
+          "description": "The suffix comes after the inserted summary text."
+        },
         "stringIndexType": {
           "$ref": "#/definitions/StringIndexType"
         }
+      }
+    },
+    "PhraseControl": {
+      "type": "object",
+      "description": "Control the phrases to be used in the summary.",
+      "required": [
+        "targetPhrase",
+        "strategy"
+      ],
+      "properties": {
+        "targetPhrase": {
+          "type": "string",
+          "description": "The target phrase to control."
+        },
+        "strategy": {
+          "$ref": "#/definitions/PhraseControlStrategy"
+        }
+      }
+    },
+    "PhraseControlStrategy": {
+      "enum": [
+        "encourage",
+        "discourage"
+      ],
+      "type": "string",
+      "description": "The strategy to use in phrase control.",
+      "x-ms-enum": {
+        "modelAsString": false,
+        "name": "PhraseControlStrategy",
+        "values": [
+          {
+            "value": "encourage",
+            "description": "The model will have higher probability to select the target phrase in the summary if there are multiple alternates."
+          },
+          {
+            "value": "discourage",
+            "description": "The model will have lower probability to select the target phrase in the summary if there are multiple alternates."
+          }
+        ]
       }
     },
     "SummaryContext": {

--- a/dev/cognitiveservices/data-plane/Language/common.json
+++ b/dev/cognitiveservices/data-plane/Language/common.json
@@ -808,6 +808,10 @@
           "format": "int32",
           "description": "It controls the approximate number of sentences in the output summaries."
         },
+        "detailLevel": {
+          "$ref": "#/definitions/DetailLevel",
+          "description": "It controls the detail level of the summary. Use this parameter exclusively with sentenceCount parameter."
+        },
         "phraseControls": {
           "type": "array",
           "description": "Control the phrases to be used in the summary.",
@@ -815,13 +819,21 @@
             "$ref": "#/definitions/PhraseControl"
           }
         },
+        "sessionId": {
+          "type": "string",
+          "description": "The session id for interactive summarization experience. We cache the session state on service side and the session expires in 48 hours. The session state we cache includes but not limited to the previous document, parameters and generated summaries."
+        },
+        "enableInteractiveSummarizationSession": {
+          "type": "boolean",
+          "description": "By enabling interactive summarization session, the service will return suggested keywords for encourage and discourage, and cache the session state by session id."
+        },
         "prefix": {
           "type": "string",
-          "description": "The prefix comes before the inserted summary text."
+          "description": "The prefix comes before the inserted summary text. Used for the insert in the middle summarization experience."
         },
         "suffix": {
           "type": "string",
-          "description": "The suffix comes after the inserted summary text."
+          "description": "The suffix comes after the inserted summary text. Used for the insert in the middle summarization experience."
         },
         "stringIndexType": {
           "$ref": "#/definitions/StringIndexType"
@@ -843,6 +855,33 @@
         "strategy": {
           "$ref": "#/definitions/PhraseControlStrategy"
         }
+      }
+    },
+    "DetailLevel":{
+      "enum": [
+        "high",
+        "medium",
+        "low"
+      ],
+      "type": "string",
+      "description": "The detail level of the summary.",
+      "x-ms-enum": {
+        "modelAsString": false,
+        "name": "DetailLevel",
+        "values": [
+          {
+            "value": "high",
+            "description": "High level summary is usually shorter and contains less details."
+          },
+          {
+            "value": "medium",
+            "description": "Medium level summary is in between high level and low level."
+          },
+          {
+            "value": "low",
+            "description": "Low level summary is usually longer and contains more details."
+          }
+        ]
       }
     },
     "PhraseControlStrategy": {


### PR DESCRIPTION
Design consideration:
1. This PR is draft and target for next api-version, not 2022-10-01-preview.
2. In current api-version 2022-10-01-preview, client can access the new features only if the labFeatures.clientApplication is "Editor".
3. We rely on sessionId to retrieve previous summary, because the revision history has to include document snapshots, which is too large to send via request.
4. phrase control, phrase control suggestion, insert in the middel and interactive session are separate features that is decoupled in API.
