### PR TITLE
[DRAFT] Explicitly Support Chaptering

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2231,12 +2231,12 @@
         "maxChapterLengthInCharacters":{
           "type": "integer",
           "format": "int32",
-          "description": "The maximum number of characters in each chapter. If not specified, the model will determine the chapter length smartly."
+          "description": "The maximum number of characters in each chapter. If not specified, the model will determine the chapter length automatically."
         },
         "minChapterLengthInCharacters":{
           "type": "integer",
           "format": "int32",
-          "description": "The minimum number of characters in each chapter. If not specified, the model will determine the chapter length smartly."
+          "description": "The minimum number of characters in each chapter. If not specified, the model will determine the chapter length automatically."
         }
       }
     },
@@ -2250,6 +2250,11 @@
         },
         "startTimeTick": {
           "description": "Chapter start time offset from start of speech audio, in ticks. 1 tick = 100 ns. This field is only available if the input transcript has conversation item level audio timing.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "durationTick": {
+          "description": "Chapter duration in ticks. 1 tick = 100 ns. This field is only available if the input transcript has conversation item level audio timing.",
           "type": "integer",
           "format": "int64"
         },

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2240,18 +2240,23 @@
       "type": "object",
       "description": "The parameters to control the chaptering on specific level.",
       "properties": {
-        "maxChaptersCount": {
+        "minChapterCount": {
+          "description": "The minimum number of chapters under the parent node. If not specified, the service will determine automatically.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "maxChapterCount": {
           "description": "The maximum number of chapters under the parent node. If not specified, the service will determine automatically.",
           "type": "integer",
           "format": "int32"
         },
-        "minTokens": {
-          "description": "The recommended minimum of tokens of each chapter in this level.",
+        "minCharacters": {
+          "description": "The requested minimum of characters of each chapter in this level. Note this is just a hint to the model.",
           "type": "integer",
           "format": "int32"
         },
-        "maxTokens": {
-          "description": "The recommended maximum of tokens of each chapter in this level.",
+        "maxCharacters": {
+          "description": "The requested maximum of characters of each chapter in this level. Note this is just a hint to the model.",
           "type": "integer",
           "format": "int32"
         },

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2199,7 +2199,7 @@
       "properties": {
         "summaries": {
           "type": "array",
-          "description": "This summaries field will be deprecated and clients should start to use chapters field.",
+          "description": "Conversation level summaries.",
           "items": {
             "$ref": "#/definitions/SummaryResultItem"
           }
@@ -2227,12 +2227,29 @@
           "format": "int32",
           "description": " The supported values are 0, 1, 2. If not specified, the value is determined automatically by the service. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters."
         },
-        "maxChaptersCountOnEachLevel": {
-          "description": "The maximum number of top level chapters on each level under the parent node. The array length must be the same as levels. For example, levels=2, maxChaptersCountOnEachLevel=[6,3] means client need at most 6 high level chapters, each of them has at most 3 child sub chapters. If not specified, the service will determine the chapters count automatically on all levels. If the array element is -1, the service will determine the chapters count automatically on that level. For example, levels=2, maxChaptersCountOnEachLevel=[3,-1], it means at most 3 high level chapters, each of them can have any number of sub chapters.",
+        "parametersOnEachLevel": {
+          "description": "The parameters on each level. The array length must be the same as levels.",
           "type": "array",
           "items": {
-            "type": "integer",
-            "format": "int32"
+            "$ref": "#/definitions/ChapteringParametersOnOneLevel"
+          }
+        }
+      }
+    },
+    "ChapteringParametersOnOneLevel": {
+      "type": "object",
+      "description": "The parameters to control the chaptering on specific level.",
+      "properties": {
+        "maxChaptersCount": {
+          "description": "The maximum number of chapters under the parent node. If not specified, the service will determine automatically.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "summaryAspects": {
+          "description": "The summary aspects to enable on current level",
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -2257,7 +2274,7 @@
         },
         "summaries": {
           "type": "array",
-          "description": "A list of summaries, one for each requested aspect.",
+          "description": "A list of summaries, 0 or multiple for each requested aspect.",
           "items": {
             "$ref": "#/definitions/SummaryResultItem"
           }

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2110,7 +2110,7 @@
         "summaryAspects"
       ],
       "properties": {
-        "chapteringParameters":{
+        "chapteringParameters": {
           "$ref": "#/definitions/ChapteringParameters"
         },
         "summaryAspects": {
@@ -2202,12 +2202,14 @@
       "properties": {
         "summaries": {
           "type": "array",
+          "description": "Summaries describe the aspect and text of the summaries with precise context of the generated text.",
           "items": {
             "$ref": "#/definitions/SummaryResultItem"
           }
         },
         "chapters": {
           "type": "array",
+          "description": "Chapters describe the tree-like semantic structure of the conversation.",
           "items": {
             "$ref": "#/definitions/Chapter"
           }
@@ -2219,24 +2221,19 @@
         }
       ]
     },
-    "ChapteringParameters":{
+    "ChapteringParameters": {
       "type": "object",
       "description": "The parameters to control the chaptering.",
       "properties": {
-        "levels":{
+        "levels": {
           "type": "integer",
           "format": "int32",
-          "description": "The default value is 0. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters. In result, the summaries field is populated if level is 0 or no specified, and the chapters field is populated if level > 0."
+          "description": " The supported values are 0, 1, 2. The default value is 0. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters."
         },
-        "maxChapterLengthInCharacters":{
+        "maxTopLevelChaptersCount": {
           "type": "integer",
           "format": "int32",
-          "description": "The maximum number of characters in each chapter. If not specified, the model will determine the chapter length automatically."
-        },
-        "minChapterLengthInCharacters":{
-          "type": "integer",
-          "format": "int32",
-          "description": "The minimum number of characters in each chapter. If not specified, the model will determine the chapter length automatically."
+          "description": "The maximum number of top level chapters. Applicable only if levels > 1."
         }
       }
     },
@@ -2258,11 +2255,11 @@
           "type": "integer",
           "format": "int64"
         },
-        "summaries": {
+        "summaryIds": {
           "type": "array",
           "description": "A list of summaries, one for each requested aspect.",
           "items": {
-            "$ref": "#/definitions/SummaryResultItem"
+            "type": "string"
           }
         },
         "subChapters": {
@@ -2277,6 +2274,9 @@
     "SummaryResultItem": {
       "type": "object",
       "properties": {
+        "id": {
+          "type": "string"
+        },
         "aspect": {
           "type": "string"
         },

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2262,12 +2262,12 @@
           "description": "Reference the first conversation item of the chapter.",
           "type": "string"
         },
-        "startTimeTick": {
+        "startTimeTicks": {
           "description": "Chapter start time offset from start of speech audio, in ticks. 1 tick = 100 ns. This field is only available if the input transcript has conversation item level audio timing.",
           "type": "integer",
           "format": "int64"
         },
-        "durationTick": {
+        "durationTicks": {
           "description": "Chapter duration in ticks. 1 tick = 100 ns. This field is only available if the input transcript has conversation item level audio timing.",
           "type": "integer",
           "format": "int64"

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2242,9 +2242,13 @@
     },
     "Chapter": {
       "type": "object",
-      "description": "A predicted chapter of the conversation. Only used for client application CTS, MCU, SCIS and MeTA.",
+      "description": "A predicted chapter of the conversation. It is guaranteed the chapters is a partition - which means the conversation item ids are consecutive, no overlap with other chapter, and no missing",
       "properties": {
-        "chapterStartTimeTick": {
+        "firstConversationItemId": {
+          "description": "Reference the first conversation item of the chapter.",
+          "type": "string"
+        },
+        "startTimeTick": {
           "description": "Chapter start time offset from start of speech audio, in ticks. 1 tick = 100 ns. This field is only available if the input transcript has conversation item level audio timing.",
           "type": "integer",
           "format": "int64"

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2110,6 +2110,9 @@
         "summaryAspects"
       ],
       "properties": {
+        "chapteringParameters":{
+          "$ref": "#/definitions/ChapteringParameters"
+        },
         "summaryAspects": {
           "type": "array",
           "items": {
@@ -2202,6 +2205,12 @@
           "items": {
             "$ref": "#/definitions/SummaryResultItem"
           }
+        },
+        "chapters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Chapter"
+          }
         }
       },
       "allOf": [
@@ -2209,6 +2218,52 @@
           "$ref": "#/definitions/ConversationResultBase"
         }
       ]
+    },
+    "ChapteringParameters":{
+      "type": "object",
+      "description": "The parameters to control the chaptering.",
+      "properties": {
+        "levels":{
+          "type": "integer",
+          "format": "int32",
+          "description": "The default value is 0. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters."
+        },
+        "maxChapterLengthInCharacters":{
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of characters in each chapter. If not specified, the model will determine the chapter length smartly."
+        },
+        "minChapterLengthInCharacters":{
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum number of characters in each chapter. If not specified, the model will determine the chapter length smartly."
+        }
+      }
+    },
+    "Chapter": {
+      "type": "object",
+      "description": "A predicted chapter of the conversation. Only used for client application CTS, MCU, SCIS and MeTA.",
+      "properties": {
+        "chapterStartTimeTick": {
+          "description": "Chapter start time offset from start of speech audio, in ticks. 1 tick = 100 ns. This field is only available if the input transcript has conversation item level audio timing.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "summaries": {
+          "type": "array",
+          "description": "A list of summaries, one for each requested aspect.",
+          "items": {
+            "$ref": "#/definitions/SummaryResultItem"
+          }
+        },
+        "subChapters": {
+          "type": "array",
+          "description": "A list of sub chapters.",
+          "items": {
+            "$ref": "#/definitions/Chapter"
+          }
+        }
+      }
     },
     "SummaryResultItem": {
       "type": "object",

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2226,7 +2226,7 @@
         "levels":{
           "type": "integer",
           "format": "int32",
-          "description": "The default value is 0. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters."
+          "description": "The default value is 0. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters. In result, the summaries field is populated if level is 0 or no specified, and the chapters field is populated if level > 0."
         },
         "maxChapterLengthInCharacters":{
           "type": "integer",

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2106,9 +2106,6 @@
     "ConversationSummarizationTaskParameters": {
       "type": "object",
       "description": "Supported parameters for an conversational summarization task.",
-      "required": [
-        "summaryAspects"
-      ],
       "properties": {
         "chapteringParameters": {
           "$ref": "#/definitions/ChapteringParameters"
@@ -2202,7 +2199,7 @@
       "properties": {
         "summaries": {
           "type": "array",
-          "description": "Summaries describe the aspect and text of the summaries with precise context of the generated text.",
+          "description": "Summaries describe the aspect and text of the summaries with precise context of the generated text. This summary field will be deprecated and clients should start to use chapters field.",
           "items": {
             "$ref": "#/definitions/SummaryResultItem"
           }
@@ -2230,10 +2227,13 @@
           "format": "int32",
           "description": " The supported values are 0, 1, 2. If not specified, the value is determined automatically by the service. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters."
         },
-        "maxTopLevelChaptersCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The maximum number of top level chapters. Applicable only if levels > 1."
+        "maxChaptersCountOnEachLevel": {
+          "description": "The maximum number of top level chapters on each level under the parent node. The array length must be the same as levels. For example, levels=2, maxChaptersCountOnEachLevel=[6,3] means client need at most 6 high level chapters, each of them has at most 3 child sub chapters. If not specified, the service will determine the chapters count automatically on all levels. If the array element is -1, the service will determine the chapters count automatically on that level. For example, levels=2, maxChaptersCountOnEachLevel=[3,-1], it means at most 3 high level chapters, each of them can have any number of sub chapters.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
         }
       }
     },
@@ -2255,11 +2255,11 @@
           "type": "integer",
           "format": "int64"
         },
-        "summaryIds": {
+        "summaries": {
           "type": "array",
           "description": "A list of summaries, one for each requested aspect.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/SummaryResultItem"
           }
         },
         "subChapters": {
@@ -2285,7 +2285,7 @@
         },
         "contexts": {
           "type": "array",
-          "description": "The context list of the summary.",
+          "description": "The context list of the summary. Comparing the parent chapter scope, the summary context can be more precise.",
           "items": {
             "$ref": "#/definitions/ItemizedSummaryContext"
           }

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2225,7 +2225,7 @@
         "levels": {
           "type": "integer",
           "format": "int32",
-          "description": " The supported values are 0, 1, 2. If not specified, the value is determined automatically by the service. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters."
+          "description": " The supported values are 0, 1, 2 and 3. If not specified, the value is determined automatically by the service. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters. The 3rd level is the raw segmentation result without any post processing."
         },
         "parametersOnEachLevel": {
           "description": "The parameters on each level. The array length must be the same as levels.",
@@ -2242,6 +2242,16 @@
       "properties": {
         "maxChaptersCount": {
           "description": "The maximum number of chapters under the parent node. If not specified, the service will determine automatically.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "minTokens": {
+          "description": "The recommended minimum of tokens of each chapter in this level.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "maxTokens": {
+          "description": "The recommended maximum of tokens of each chapter in this level.",
           "type": "integer",
           "format": "int32"
         },

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2228,7 +2228,7 @@
         "levels": {
           "type": "integer",
           "format": "int32",
-          "description": " The supported values are 0, 1, 2. The default value is 0. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters."
+          "description": " The supported values are 0, 1, 2. If not specified, the value is determined automatically by the service. 0 level means only 1 summary is generated for the whole input and no chaptering is performed. 1 level means flat chapters. 2 levels means each high level chapter can have child low level sub chapters."
         },
         "maxTopLevelChaptersCount": {
           "type": "integer",

--- a/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
+++ b/dev/cognitiveservices/data-plane/Language/analyzeconversations.json
@@ -2199,7 +2199,7 @@
       "properties": {
         "summaries": {
           "type": "array",
-          "description": "Summaries describe the aspect and text of the summaries with precise context of the generated text. This summary field will be deprecated and clients should start to use chapters field.",
+          "description": "This summaries field will be deprecated and clients should start to use chapters field.",
           "items": {
             "$ref": "#/definitions/SummaryResultItem"
           }
@@ -2274,9 +2274,6 @@
     "SummaryResultItem": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
-        },
         "aspect": {
           "type": "string"
         },


### PR DESCRIPTION
Design consideration:
1. This PR is draft and target for next api-version, not 2022-10-01-preview.
2. In current api-version 2022-10-01-preview, client can access the new features only if the labFeatures.clientApplication is "CTS", "SCIS", "MCU" or "MeTA".
3. When labFeatures.clientApplication is specified with valid value, we will apply the parameters based on pre-defined configuration, so the client doesn't need to specify the parameters. This is easier for client to integrate, and easier fo summarization service to iterate the API changes, for example, we might change the underlying parameters without introducing any breaking change.
4. Chapter length control is using chars, rather than audio timing because audio timing is not available for `text` modality input.
5. Why there is no conversation item id list in the `Chapter` object? It is guaranteed the chapters is a partition - which means the conversation item ids are consecutive, no overlap with other chapter, and no missing. Thus the first conversation item id is sufficient.
6. Is chapters[i].summaries[j].contexts redundent with chapters[i].firstConversationItemId? No contexts doesn't guaranteed to be a partition, it can reference anywhere of the transcript to make sense the summary.
