### PR TITLE
keyvault: fixing the duplicate constant types

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/certificates.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/certificates.json
@@ -1629,7 +1629,7 @@
             "AutoRenew"
           ],
           "x-ms-enum": {
-            "name": "ActionType",
+            "name": "CertificateActionType",
             "modelAsString": false
           }
         }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
@@ -2227,7 +2227,7 @@
             "notify"
           ],
           "x-ms-enum": {
-            "name": "ActionType",
+            "name": "LifetimeActionType",
             "modelAsString": false,
             "values": [
               {


### PR DESCRIPTION
Fixes this:
```
$ autorest --tag=package-preview-7.4-preview.1 --go --verbose --use-onever --version=2.0.4421 --go.license-header=MICROSOFT_MIT_NO_VERSION --enum-prefix --openapi-type=data-plane --output-folder=../../sdk/keyvault/7.4/keyvault readme.md

FATAL: System.InvalidOperationException: Swagger document contains two or more x-ms-enum extensions with the same name 'ActionType' and different values: EmailContacts,AutoRenew vs. rotate,notify
```

By adding this to a preview version I hoped to circumvent the freeze on API SDK output as imposed on #21137, let me know if this is the case or otherwise to request this change for the final version.