### PR TITLE
{AzureRecoveryServices} fixes Azure/azure-sdk-for-python#27977 recovery_point_id property description

### DIFF
--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/bms.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2022-10-01/bms.json
@@ -7403,7 +7403,7 @@
       ],
       "properties": {
         "recoveryPointId": {
-          "description": "ID of the backup copy to be recovered.",
+          "description": "Recovery Point ID Name of the backup copy to be recovered.",
           "type": "string"
         },
         "recoveryType": {


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-for-python/issues/27977 recovery_point_id property description

The current description for recovery_point_id property says "ID of the backup copy to be recovered." This is very confusing. Users might confuse it for the resource ID. The description should be made clear that it is "Recovery Point ID Name of the backup copy to be recovered."

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
