### PR TITLE
[Language - QA authoring] correct `source` to required param for update sources

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/examples/questionanswering/authoring/SuccessfulDeleteProject.json
+++ b/dev/cognitiveservices/data-plane/Language/examples/questionanswering/authoring/SuccessfulDeleteProject.json
@@ -7,6 +7,11 @@
     "projectName": "proj1"
   },
   "responses": {
-    "202": {}
+    "202": {
+      "description": "A successful call results with an Operation-Location header used to check the status of the analysis job.",
+      "headers": {
+        "Operation-Location": "https://<resource-endpoint>/language/authoring/query-knowledgebases/projects/deletion-jobs/job1?api-version=2023-05-01"
+      }
+    }
   }
 }

--- a/dev/cognitiveservices/data-plane/Language/examples/questionanswering/authoring/SuccessfulGetSources.json
+++ b/dev/cognitiveservices/data-plane/Language/examples/questionanswering/authoring/SuccessfulGetSources.json
@@ -15,14 +15,16 @@
             "displayName": "source1",
             "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview",
             "sourceKind": "url",
-            "lastUpdatedDateTime": "2021-05-01T15:13:22Z"
+            "lastUpdatedDateTime": "2021-05-01T15:13:22Z",
+            "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview"
           },
           {
             "displayName": "source2",
             "sourceUri": "https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf",
             "sourceKind": "file",
             "contentStructureKind": "unstructured",
-            "lastUpdatedDateTime": "2021-05-01T15:13:22Z"
+            "lastUpdatedDateTime": "2021-05-01T15:13:22Z",
+            "source": "surface-guide.pdf"
           }
         ]
       }

--- a/dev/cognitiveservices/data-plane/Language/examples/questionanswering/authoring/SuccessfulUpdateSources.json
+++ b/dev/cognitiveservices/data-plane/Language/examples/questionanswering/authoring/SuccessfulUpdateSources.json
@@ -11,7 +11,8 @@
         "value": {
           "displayName": "source3",
           "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-support-options?context=/azure/cognitive-services/qnamaker/context/context",
-          "sourceKind": "url"
+          "sourceKind": "url",
+          "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-support-options?context=/azure/cognitive-services/qnamaker/context/context"
         }
       },
       {
@@ -20,7 +21,8 @@
           "displayName": "source1",
           "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview",
           "sourceKind": "url",
-          "refresh": true
+          "refresh": true,
+          "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview"
         }
       },
       {
@@ -28,7 +30,8 @@
         "value": {
           "displayName": "source2",
           "sourceUri": "https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf",
-          "sourceKind": "file"
+          "sourceKind": "file",
+          "source": "surface-guide.pdf"
         }
       }
     ]

--- a/dev/cognitiveservices/data-plane/Language/questionanswering-authoring.json
+++ b/dev/cognitiveservices/data-plane/Language/questionanswering-authoring.json
@@ -1650,7 +1650,8 @@
       "additionalProperties": false,
       "required": [
         "sourceUri",
-        "sourceKind"
+        "sourceKind",
+        "source"
       ],
       "properties": {
         "displayName": {

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/examples/questionanswering/authoring/SuccessfulDeleteProject.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/examples/questionanswering/authoring/SuccessfulDeleteProject.json
@@ -7,6 +7,11 @@
     "projectName": "proj1"
   },
   "responses": {
-    "202": {}
+    "202": {
+      "description": "A successful call results with an Operation-Location header used to check the status of the analysis job.",
+      "headers": {
+        "Operation-Location": "https://<resource-endpoint>/language/authoring/query-knowledgebases/projects/deletion-jobs/job1?api-version=2022-07-01-preview"
+      }
+    }
   }
 }

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/examples/questionanswering/authoring/SuccessfulGetSources.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/examples/questionanswering/authoring/SuccessfulGetSources.json
@@ -15,14 +15,16 @@
             "displayName": "source1",
             "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview",
             "sourceKind": "url",
-            "lastUpdatedDateTime": "2021-05-01T15:13:22Z"
+            "lastUpdatedDateTime": "2021-05-01T15:13:22Z",
+            "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview"
           },
           {
             "displayName": "source2",
             "sourceUri": "https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf",
             "sourceKind": "file",
             "contentStructureKind": "unstructured",
-            "lastUpdatedDateTime": "2021-05-01T15:13:22Z"
+            "lastUpdatedDateTime": "2021-05-01T15:13:22Z",
+            "source": "surface-guide.pdf"
           }
         ]
       }

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/examples/questionanswering/authoring/SuccessfulProjectSubmitExportJob.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/examples/questionanswering/authoring/SuccessfulProjectSubmitExportJob.json
@@ -13,6 +13,18 @@
     }
   },
   "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "errors": [],
+        "createdDateTime": "2021-05-01T17:21:14Z",
+        "expirationDateTime": "2021-05-01T17:21:14Z",
+        "jobId": "635c2741-15c4-4c2c-9f78-bfd30b6b2a4a",
+        "lastUpdatedDateTime": "2021-05-01T17:21:14Z",
+        "status": "succeeded",
+        "resultUrl": "https://<resource-endpoint>/language/authoring/query-knowledgebases/projects/proj1/export/jobs/job1/result?api-version=2022-07-01-preview"
+      }
+    },
     "202": {
       "description": "A successful call results with an Operation-Location header used to check the status of the analysis job.",
       "headers": {

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/examples/questionanswering/authoring/SuccessfulUpdateSources.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/examples/questionanswering/authoring/SuccessfulUpdateSources.json
@@ -11,7 +11,8 @@
         "value": {
           "displayName": "source3",
           "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-support-options?context=/azure/cognitive-services/qnamaker/context/context",
-          "sourceKind": "url"
+          "sourceKind": "url",
+          "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-support-options?context=/azure/cognitive-services/qnamaker/context/context"
         }
       },
       {
@@ -20,7 +21,8 @@
           "displayName": "source1",
           "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview",
           "sourceKind": "url",
-          "refresh": true
+          "refresh": true,
+          "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview"
         }
       },
       {
@@ -28,7 +30,8 @@
         "value": {
           "displayName": "source2",
           "sourceUri": "https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf",
-          "sourceKind": "file"
+          "sourceKind": "file",
+          "source": "surface-guide.pdf"
         }
       }
     ]

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/questionanswering-authoring.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-07-01-preview/questionanswering-authoring.json
@@ -1649,7 +1649,8 @@
       "additionalProperties": false,
       "required": [
         "sourceUri",
-        "sourceKind"
+        "sourceKind",
+        "source"
       ],
       "properties": {
         "displayName": {

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/examples/questionanswering/authoring/SuccessfulDeleteProject.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/examples/questionanswering/authoring/SuccessfulDeleteProject.json
@@ -7,6 +7,11 @@
     "projectName": "proj1"
   },
   "responses": {
-    "202": {}
+    "202": {
+      "description": "A successful call results with an Operation-Location header used to check the status of the analysis job.",
+      "headers": {
+        "Operation-Location": "https://<resource-endpoint>/language/authoring/query-knowledgebases/projects/deletion-jobs/job1?api-version=2022-10-01-preview"
+      }
+    }
   }
 }

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/examples/questionanswering/authoring/SuccessfulGetSources.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/examples/questionanswering/authoring/SuccessfulGetSources.json
@@ -15,14 +15,16 @@
             "displayName": "source1",
             "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview",
             "sourceKind": "url",
-            "lastUpdatedDateTime": "2021-05-01T15:13:22Z"
+            "lastUpdatedDateTime": "2021-05-01T15:13:22Z",
+            "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview"
           },
           {
             "displayName": "source2",
             "sourceUri": "https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf",
             "sourceKind": "file",
             "contentStructureKind": "unstructured",
-            "lastUpdatedDateTime": "2021-05-01T15:13:22Z"
+            "lastUpdatedDateTime": "2021-05-01T15:13:22Z",
+            "source": "surface-guide.pdf"
           }
         ]
       }

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/examples/questionanswering/authoring/SuccessfulUpdateSources.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/examples/questionanswering/authoring/SuccessfulUpdateSources.json
@@ -11,7 +11,8 @@
         "value": {
           "displayName": "source3",
           "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-support-options?context=/azure/cognitive-services/qnamaker/context/context",
-          "sourceKind": "url"
+          "sourceKind": "url",
+          "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-support-options?context=/azure/cognitive-services/qnamaker/context/context"
         }
       },
       {
@@ -20,7 +21,8 @@
           "displayName": "source1",
           "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview",
           "sourceKind": "url",
-          "refresh": true
+          "refresh": true,
+          "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview"
         }
       },
       {
@@ -28,7 +30,8 @@
         "value": {
           "displayName": "source2",
           "sourceUri": "https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf",
-          "sourceKind": "file"
+          "sourceKind": "file",
+          "source": "surface-guide.pdf"
         }
       }
     ]

--- a/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/questionanswering-authoring.json
+++ b/specification/cognitiveservices/data-plane/Language/preview/2022-10-01-preview/questionanswering-authoring.json
@@ -1650,7 +1650,8 @@
       "additionalProperties": false,
       "required": [
         "sourceUri",
-        "sourceKind"
+        "sourceKind",
+        "source"
       ],
       "properties": {
         "displayName": {

--- a/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/examples/questionanswering/authoring/SuccessfulDeleteProject.json
+++ b/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/examples/questionanswering/authoring/SuccessfulDeleteProject.json
@@ -7,6 +7,11 @@
     "projectName": "proj1"
   },
   "responses": {
-    "202": {}
+    "202": {
+      "description": "A successful call results with an Operation-Location header used to check the status of the analysis job.",
+      "headers": {
+        "Operation-Location": "https://<resource-endpoint>/language/authoring/query-knowledgebases/projects/deletion-jobs/job1?api-version=2021-10-01"
+      }
+    }
   }
 }

--- a/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/examples/questionanswering/authoring/SuccessfulGetSources.json
+++ b/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/examples/questionanswering/authoring/SuccessfulGetSources.json
@@ -15,14 +15,16 @@
             "displayName": "source1",
             "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview",
             "sourceKind": "url",
-            "lastUpdatedDateTime": "2021-05-01T15:13:22Z"
+            "lastUpdatedDateTime": "2021-05-01T15:13:22Z",
+            "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview"
           },
           {
             "displayName": "source2",
             "sourceUri": "https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf",
             "sourceKind": "file",
             "contentStructureKind": "unstructured",
-            "lastUpdatedDateTime": "2021-05-01T15:13:22Z"
+            "lastUpdatedDateTime": "2021-05-01T15:13:22Z",
+            "source": "surface-guide.pdf"
           }
         ]
       }

--- a/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/examples/questionanswering/authoring/SuccessfulProjectSubmitExportJob.json
+++ b/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/examples/questionanswering/authoring/SuccessfulProjectSubmitExportJob.json
@@ -13,10 +13,22 @@
     }
   },
   "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "errors": [],
+        "createdDateTime": "2021-05-01T17:21:14Z",
+        "expirationDateTime": "2021-05-01T17:21:14Z",
+        "jobId": "635c2741-15c4-4c2c-9f78-bfd30b6b2a4a",
+        "lastUpdatedDateTime": "2021-05-01T17:21:14Z",
+        "status": "succeeded",
+        "resultUrl": "https://<resource-endpoint>/language/authoring/query-knowledgebases/projects/proj1/export/jobs/job1/result?api-version=2021-10-01"
+      }
+    },
     "202": {
       "description": "A successful call results with an Operation-Location header used to check the status of the analysis job.",
       "headers": {
-        "Operation-Location": "job1"
+        "Operation-Location": "https://<resource-endpoint>/language/authoring/query-knowledgebases/projects/proj1/export/jobs/job1?api-version=2021-10-01"
       }
     }
   }

--- a/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/examples/questionanswering/authoring/SuccessfulUpdateSources.json
+++ b/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/examples/questionanswering/authoring/SuccessfulUpdateSources.json
@@ -11,7 +11,8 @@
         "value": {
           "displayName": "source3",
           "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-support-options?context=/azure/cognitive-services/qnamaker/context/context",
-          "sourceKind": "url"
+          "sourceKind": "url",
+          "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-support-options?context=/azure/cognitive-services/qnamaker/context/context"
         }
       },
       {
@@ -20,7 +21,8 @@
           "displayName": "source1",
           "sourceUri": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview",
           "sourceKind": "url",
-          "refresh": true
+          "refresh": true,
+          "source": "https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview"
         }
       },
       {
@@ -28,7 +30,8 @@
         "value": {
           "displayName": "source2",
           "sourceUri": "https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf",
-          "sourceKind": "file"
+          "sourceKind": "file",
+          "source": "surface-guide.pdf"
         }
       }
     ]

--- a/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/questionanswering-authoring.json
+++ b/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/questionanswering-authoring.json
@@ -1635,7 +1635,8 @@
       "additionalProperties": false,
       "required": [
         "sourceUri",
-        "sourceKind"
+        "sourceKind",
+        "source"
       ],
       "properties": {
         "displayName": {


### PR DESCRIPTION
Related issue: https://github.com/Azure/azure-sdk-for-python/issues/27998

Updates `source` to be a required parameter for QA authoring API versions 2021-10-01 and forward.
