### PR TITLE
Embedding in Azure do not support integer

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/embeddings.create.cadl
+++ b/specification/cognitiveservices/OpenAI.Inference/models/embeddings.create.cadl
@@ -16,10 +16,14 @@ alias EmbeddingsRequest = {
     "model"?: string;
 
     @doc("""
-    An input to embed, encoded as a string, a list of strings, or a list of token
-    lists
+    Input text to get embeddings for, encoded as a string.
+    To get embeddings for multiple inputs in a single request, pass an array of strings.
+    Each input must not exceed 2048 tokens in length.
+
+    Unless you are embedding code, we suggest replacing newlines (\\n) in your input with a single space,
+    as we have observed inferior results when newlines are present.
     """)
-    input: string | string[] | integer[] | integer[][];
+    input: string | string[];
 };
 
 model Embeddings {


### PR DESCRIPTION
Talking with Chris Hoder, the Azure version do not support int, see the lines in the OAIv3 spec:
https://github.com/Azure/azure-rest-api-specs/blob/61a8b1a62420c393fe5276c47373ea8dce74a985/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2022-12-01/inference.json#L64-L82

I also took the opportunity to change the doc string to be accurate to that behavior