### PR TITLE
Fix `x-ms-rename-source` docs to include SAS info

### DIFF
--- a/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
@@ -885,7 +885,7 @@
           {
             "name": "x-ms-rename-source",
             "in": "header",
-            "description": "An optional file or directory to be renamed.  The value must have the following format: \"/{filesystem}/{path}\", or \"/{filesystem}/{path}?SAS\". when using shared key authorization.  If \"x-ms-properties\" is specified, the properties will overwrite the existing properties; otherwise, the existing properties will be preserved. This value must be a URL percent-encoded string. Note that the string may only contain ASCII characters in the ISO-8859-1 character set.",
+            "description": "An optional file or directory to be renamed.  The value must have the following format: \"/{filesystem}/{path}\", or \"/{filesystem}/{path}?sastoken\" when using a SAS token.  If \"x-ms-properties\" is specified, the properties will overwrite the existing properties; otherwise, the existing properties will be preserved. This value must be a URL percent-encoded string. Note that the string may only contain ASCII characters in the ISO-8859-1 character set.",
             "required": false,
             "type": "string"
           },

--- a/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
@@ -885,7 +885,7 @@
           {
             "name": "x-ms-rename-source",
             "in": "header",
-            "description": "An optional file or directory to be renamed.  The value must have the following format: \"/{filesystem}/{path}\".  If \"x-ms-properties\" is specified, the properties will overwrite the existing properties; otherwise, the existing properties will be preserved. This value must be a URL percent-encoded string. Note that the string may only contain ASCII characters in the ISO-8859-1 character set.",
+            "description": "An optional file or directory to be renamed.  The value must have the following format: \"/{filesystem}/{path}\", or \"/{filesystem}/{path}?SAS\". when using shared key authorization.  If \"x-ms-properties\" is specified, the properties will overwrite the existing properties; otherwise, the existing properties will be preserved. This value must be a URL percent-encoded string. Note that the string may only contain ASCII characters in the ISO-8859-1 character set.",
             "required": false,
             "type": "string"
           },


### PR DESCRIPTION
This PR aims to add an example of what the `x-ms-rename-source` header should look like if using a SAS. 