### PR TITLE
The run.sh script requires git, which is not available by default

### DIFF
--- a/scripts/datacontainer/Dockerfile
+++ b/scripts/datacontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/mirror/docker.io/library/ubuntu:20.04
+FROM mcr.microsoft.com/oss/mirror/docker.io/library/ubuntu:22.04
 
 RUN apt-get -y update
 RUN apt-get -y install git

--- a/scripts/datacontainer/Dockerfile
+++ b/scripts/datacontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/oss/mirror/docker.io/library/ubuntu:20.04
 
+RUN apt-get -y update
+RUN apt-get -y install git
+
 RUN mkdir -p /usr/data/specrepo/
 
 COPY .git /usr/data/specrepo/.git


### PR DESCRIPTION
The run.sh script requires git, but git is not available by default in the base image

I've created a shell in the datacontainer and noticed that the run.sh script fails, because the git command is not found.  Without it, the datacontainer cannot check out the local clone of the repo and we end up with a completely empty/usr/data/openapispecs. This is currently blocking RPaaS api-validation service in Air-Gapped clouds, where we depend entirely on specs loaded from the data container.

I tested this change locally: WIth git being previously installed to the image, run.sh succeeds and /usr/data/openapispecs is properly populated with the repo contents.