### PR TITLE
Fix wrong URL for Ubuntu

### DIFF
--- a/scripts/datacontainer/Dockerfile
+++ b/scripts/datacontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/mirror/docker.io/library/ubuntu:22.04
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
 
 RUN apt-get -y update
 RUN apt-get -y install git


### PR DESCRIPTION
The URL for **Ubuntu 22.04** in MCR is slightly different from what we had before for Ubuntu 20.04... tthis is breaking the Docker build, as we can see in the screenshot below:

![image](https://user-images.githubusercontent.com/4016782/212448708-da3dba7a-23a8-4860-beaf-72950efd4a4e.png)

This PR replaces the wrong URL with the new and correct one.

![image](https://user-images.githubusercontent.com/4016782/212448741-4fa370b1-44a8-444c-abda-b675bfb926c9.png)
