### PR TITLE
updated Spark version from 2.4 to 3.3

### DIFF
--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/BigDataPools_Get.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/BigDataPools_Get.json
@@ -9,7 +9,7 @@
       "body": {
         "properties": {
           "creationDate": "2020-07-14T10:09:52.5133333Z",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 3,
           "nodeSize": "Small",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/BigDataPools_List.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/BigDataPools_List.json
@@ -10,7 +10,7 @@
           {
             "properties": {
               "creationDate": "2020-07-14T10:09:52.5133333Z",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 3,
               "nodeSize": "Small",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_Create.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_Create.json
@@ -10,7 +10,7 @@
           "referenceName": "exampleBigDataPool",
           "type": "BigDataPoolReference"
         },
-        "requiredSparkVersion": "2.4",
+        "requiredSparkVersion": "3.3",
         "jobProperties": {
           "name": "exampleSparkJobDefinition",
           "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",
@@ -61,7 +61,7 @@
             "referenceName": "exampleBigDataPool",
             "type": "BigDataPoolReference"
           },
-          "requiredSparkVersion": "2.4",
+          "requiredSparkVersion": "3.3",
           "jobProperties": {
             "name": "exampleSparkJobDefinition",
             "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_Debug.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_Debug.json
@@ -8,7 +8,7 @@
           "referenceName": "exampleBigDataPool",
           "type": "BigDataPoolReference"
         },
-        "requiredSparkVersion": "2.4",
+        "requiredSparkVersion": "3.3",
         "jobProperties": {
           "name": "exampleSparkJobDefinition",
           "file": "https://somestorage.blob.core.windows.net/main.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_Get.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_Get.json
@@ -24,7 +24,7 @@
             "referenceName": "exampleBigDataPool",
             "type": "BigDataPoolReference"
           },
-          "requiredSparkVersion": "2.4",
+          "requiredSparkVersion": "3.3",
           "jobProperties": {
             "name": "exampleSparkJobDefinition",
             "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_ListByWorkspace.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_ListByWorkspace.json
@@ -24,7 +24,7 @@
                 "referenceName": "exampleBigDataPool",
                 "type": "BigDataPoolReference"
               },
-              "requiredSparkVersion": "2.4",
+              "requiredSparkVersion": "3.3",
               "jobProperties": {
                 "name": "exampleSparkJobDefinition",
                 "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_Update.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2019-06-01-preview/examples/SparkJobDefinitions_Update.json
@@ -10,7 +10,7 @@
           "referenceName": "exampleBigDataPool",
           "type": "BigDataPoolReference"
         },
-        "requiredSparkVersion": "2.4",
+        "requiredSparkVersion": "3.3",
         "jobProperties": {
           "name": "exampleSparkJobDefinition",
           "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",
@@ -61,7 +61,7 @@
             "referenceName": "exampleBigDataPool",
             "type": "BigDataPoolReference"
           },
-          "requiredSparkVersion": "2.4",
+          "requiredSparkVersion": "3.3",
           "jobProperties": {
             "name": "exampleSparkJobDefinition",
             "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/BigDataPools_Get.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/BigDataPools_Get.json
@@ -9,7 +9,7 @@
       "body": {
         "properties": {
           "creationDate": "2020-07-14T10:09:52.5133333Z",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 3,
           "nodeSize": "Small",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/BigDataPools_List.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/BigDataPools_List.json
@@ -10,7 +10,7 @@
           {
             "properties": {
               "creationDate": "2020-07-14T10:09:52.5133333Z",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 3,
               "nodeSize": "Small",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_Create.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_Create.json
@@ -10,7 +10,7 @@
           "referenceName": "exampleBigDataPool",
           "type": "BigDataPoolReference"
         },
-        "requiredSparkVersion": "2.4",
+        "requiredSparkVersion": "3.3",
         "jobProperties": {
           "name": "exampleSparkJobDefinition",
           "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",
@@ -61,7 +61,7 @@
             "referenceName": "exampleBigDataPool",
             "type": "BigDataPoolReference"
           },
-          "requiredSparkVersion": "2.4",
+          "requiredSparkVersion": "3.3",
           "jobProperties": {
             "name": "exampleSparkJobDefinition",
             "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_Debug.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_Debug.json
@@ -8,7 +8,7 @@
           "referenceName": "exampleBigDataPool",
           "type": "BigDataPoolReference"
         },
-        "requiredSparkVersion": "2.4",
+        "requiredSparkVersion": "3.3",
         "jobProperties": {
           "name": "exampleSparkJobDefinition",
           "file": "https://somestorage.blob.core.windows.net/main.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_Get.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_Get.json
@@ -24,7 +24,7 @@
             "referenceName": "exampleBigDataPool",
             "type": "BigDataPoolReference"
           },
-          "requiredSparkVersion": "2.4",
+          "requiredSparkVersion": "3.3",
           "jobProperties": {
             "name": "exampleSparkJobDefinition",
             "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_ListByWorkspace.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_ListByWorkspace.json
@@ -24,7 +24,7 @@
                 "referenceName": "exampleBigDataPool",
                 "type": "BigDataPoolReference"
               },
-              "requiredSparkVersion": "2.4",
+              "requiredSparkVersion": "3.3",
               "jobProperties": {
                 "name": "exampleSparkJobDefinition",
                 "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_Update.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/preview/2021-06-01-preview/examples/SparkJobDefinitions_Update.json
@@ -10,7 +10,7 @@
           "referenceName": "exampleBigDataPool",
           "type": "BigDataPoolReference"
         },
-        "requiredSparkVersion": "2.4",
+        "requiredSparkVersion": "3.3",
         "jobProperties": {
           "name": "exampleSparkJobDefinition",
           "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",
@@ -61,7 +61,7 @@
             "referenceName": "exampleBigDataPool",
             "type": "BigDataPoolReference"
           },
-          "requiredSparkVersion": "2.4",
+          "requiredSparkVersion": "3.3",
           "jobProperties": {
             "name": "exampleSparkJobDefinition",
             "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/BigDataPools_Get.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/BigDataPools_Get.json
@@ -9,7 +9,7 @@
       "body": {
         "properties": {
           "creationDate": "2020-07-14T10:09:52.5133333Z",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 3,
           "nodeSize": "Small",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/BigDataPools_List.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/BigDataPools_List.json
@@ -10,7 +10,7 @@
           {
             "properties": {
               "creationDate": "2020-07-14T10:09:52.5133333Z",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 3,
               "nodeSize": "Small",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_Create.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_Create.json
@@ -10,7 +10,7 @@
           "referenceName": "exampleBigDataPool",
           "type": "BigDataPoolReference"
         },
-        "requiredSparkVersion": "2.4",
+        "requiredSparkVersion": "3.3",
         "jobProperties": {
           "name": "exampleSparkJobDefinition",
           "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",
@@ -61,7 +61,7 @@
             "referenceName": "exampleBigDataPool",
             "type": "BigDataPoolReference"
           },
-          "requiredSparkVersion": "2.4",
+          "requiredSparkVersion": "3.3",
           "jobProperties": {
             "name": "exampleSparkJobDefinition",
             "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_Debug.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_Debug.json
@@ -8,7 +8,7 @@
           "referenceName": "exampleBigDataPool",
           "type": "BigDataPoolReference"
         },
-        "requiredSparkVersion": "2.4",
+        "requiredSparkVersion": "3.3",
         "jobProperties": {
           "name": "exampleSparkJobDefinition",
           "file": "https://somestorage.blob.core.windows.net/main.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_Get.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_Get.json
@@ -24,7 +24,7 @@
             "referenceName": "exampleBigDataPool",
             "type": "BigDataPoolReference"
           },
-          "requiredSparkVersion": "2.4",
+          "requiredSparkVersion": "3.3",
           "jobProperties": {
             "name": "exampleSparkJobDefinition",
             "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_ListByWorkspace.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_ListByWorkspace.json
@@ -24,7 +24,7 @@
                 "referenceName": "exampleBigDataPool",
                 "type": "BigDataPoolReference"
               },
-              "requiredSparkVersion": "2.4",
+              "requiredSparkVersion": "3.3",
               "jobProperties": {
                 "name": "exampleSparkJobDefinition",
                 "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_Update.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/examples/SparkJobDefinitions_Update.json
@@ -10,7 +10,7 @@
           "referenceName": "exampleBigDataPool",
           "type": "BigDataPoolReference"
         },
-        "requiredSparkVersion": "2.4",
+        "requiredSparkVersion": "3.3",
         "jobProperties": {
           "name": "exampleSparkJobDefinition",
           "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",
@@ -61,7 +61,7 @@
             "referenceName": "exampleBigDataPool",
             "type": "BigDataPoolReference"
           },
-          "requiredSparkVersion": "2.4",
+          "requiredSparkVersion": "3.3",
           "jobProperties": {
             "name": "exampleSparkJobDefinition",
             "file": "abfss://test@test.dfs.core.windows.net/artefacts/sample.jar",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/CreateOrUpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/CreateOrUpdateBigDataPool.json
@@ -11,7 +11,7 @@
       },
       "location": "West US 2",
       "properties": {
-        "sparkVersion": "2.4",
+        "sparkVersion": "3.3",
         "nodeCount": 4,
         "nodeSize": "Medium",
         "nodeSizeFamily": "MemoryOptimized",
@@ -45,7 +45,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -80,7 +80,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/DeleteBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/DeleteBigDataPool.json
@@ -17,7 +17,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -50,7 +50,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/GetBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/GetBigDataPool.json
@@ -16,7 +16,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/ListBigDataPoolsInWorkspace.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/ListBigDataPoolsInWorkspace.json
@@ -17,7 +17,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",
@@ -48,7 +48,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/UpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/UpdateBigDataPool.json
@@ -23,7 +23,7 @@
         },
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/CreateOrUpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/CreateOrUpdateBigDataPool.json
@@ -11,7 +11,7 @@
       },
       "location": "West US 2",
       "properties": {
-        "sparkVersion": "2.4",
+        "sparkVersion": "3.3",
         "nodeCount": 4,
         "nodeSize": "Medium",
         "nodeSizeFamily": "MemoryOptimized",
@@ -45,7 +45,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -81,7 +81,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/DeleteBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/DeleteBigDataPool.json
@@ -17,7 +17,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -50,7 +50,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/GetBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/GetBigDataPool.json
@@ -16,7 +16,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/ListBigDataPoolsInWorkspace.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/ListBigDataPoolsInWorkspace.json
@@ -17,7 +17,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",
@@ -48,7 +48,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/UpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/UpdateBigDataPool.json
@@ -23,7 +23,7 @@
         },
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/CreateOrUpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/CreateOrUpdateBigDataPool.json
@@ -11,7 +11,7 @@
       },
       "location": "West US 2",
       "properties": {
-        "sparkVersion": "2.4",
+        "sparkVersion": "3.3",
         "nodeCount": 4,
         "nodeSize": "Medium",
         "nodeSizeFamily": "MemoryOptimized",
@@ -46,7 +46,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -83,7 +83,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/DeleteBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/DeleteBigDataPool.json
@@ -20,7 +20,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -57,7 +57,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/GetBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/GetBigDataPool.json
@@ -16,7 +16,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/ListBigDataPoolsInWorkspace.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/ListBigDataPoolsInWorkspace.json
@@ -17,7 +17,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",
@@ -49,7 +49,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/UpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/UpdateBigDataPool.json
@@ -23,7 +23,7 @@
         },
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/CreateOrUpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/CreateOrUpdateBigDataPool.json
@@ -11,7 +11,7 @@
       },
       "location": "West US 2",
       "properties": {
-        "sparkVersion": "2.4",
+        "sparkVersion": "3.3",
         "nodeCount": 4,
         "nodeSize": "Medium",
         "nodeSizeFamily": "MemoryOptimized",
@@ -45,7 +45,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -81,7 +81,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/DeleteBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/DeleteBigDataPool.json
@@ -17,7 +17,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -50,7 +50,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/GetBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/GetBigDataPool.json
@@ -16,7 +16,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/ListBigDataPoolsInWorkspace.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/ListBigDataPoolsInWorkspace.json
@@ -17,7 +17,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",
@@ -48,7 +48,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/UpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/UpdateBigDataPool.json
@@ -23,7 +23,7 @@
         },
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/CreateOrUpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/CreateOrUpdateBigDataPool.json
@@ -11,7 +11,7 @@
       },
       "location": "West US 2",
       "properties": {
-        "sparkVersion": "2.4",
+        "sparkVersion": "3.3",
         "nodeCount": 4,
         "nodeSize": "Medium",
         "nodeSizeFamily": "MemoryOptimized",
@@ -45,7 +45,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -81,7 +81,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/DeleteBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/DeleteBigDataPool.json
@@ -17,7 +17,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -50,7 +50,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/GetBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/GetBigDataPool.json
@@ -16,7 +16,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/ListBigDataPoolsInWorkspace.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/ListBigDataPoolsInWorkspace.json
@@ -17,7 +17,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",
@@ -48,7 +48,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/UpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/UpdateBigDataPool.json
@@ -23,7 +23,7 @@
         },
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/CreateOrUpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/CreateOrUpdateBigDataPool.json
@@ -11,7 +11,7 @@
       },
       "location": "West US 2",
       "properties": {
-        "sparkVersion": "2.4",
+        "sparkVersion": "3.3",
         "nodeCount": 4,
         "nodeSize": "Medium",
         "nodeSizeFamily": "MemoryOptimized",
@@ -45,7 +45,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -81,7 +81,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/DeleteBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/DeleteBigDataPool.json
@@ -17,7 +17,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -50,7 +50,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/GetBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/GetBigDataPool.json
@@ -16,7 +16,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/ListBigDataPoolsInWorkspace.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/ListBigDataPoolsInWorkspace.json
@@ -17,7 +17,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",
@@ -48,7 +48,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/UpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/UpdateBigDataPool.json
@@ -23,7 +23,7 @@
         },
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/CreateOrUpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/CreateOrUpdateBigDataPool.json
@@ -11,7 +11,7 @@
       },
       "location": "West US 2",
       "properties": {
-        "sparkVersion": "2.4",
+        "sparkVersion": "3.3",
         "nodeCount": 4,
         "nodeSize": "Medium",
         "nodeSizeFamily": "MemoryOptimized",
@@ -46,7 +46,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -83,7 +83,7 @@
         },
         "properties": {
           "provisioningState": "Provisioning",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/DeleteBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/DeleteBigDataPool.json
@@ -20,7 +20,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",
@@ -57,7 +57,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Deleting",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/GetBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/GetBigDataPool.json
@@ -16,7 +16,7 @@
         "tags": {},
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/ListBigDataPoolsInWorkspace.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/ListBigDataPoolsInWorkspace.json
@@ -17,7 +17,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",
@@ -49,7 +49,7 @@
             "tags": {},
             "properties": {
               "provisioningState": "Succeeded",
-              "sparkVersion": "2.4",
+              "sparkVersion": "3.3",
               "nodeCount": 4,
               "nodeSize": "Medium",
               "nodeSizeFamily": "MemoryOptimized",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/UpdateBigDataPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/UpdateBigDataPool.json
@@ -23,7 +23,7 @@
         },
         "properties": {
           "provisioningState": "Succeeded",
-          "sparkVersion": "2.4",
+          "sparkVersion": "3.3",
           "nodeCount": 4,
           "nodeSize": "Medium",
           "nodeSizeFamily": "MemoryOptimized",


### PR DESCRIPTION
updated Spark version from 2.4 to 3.3 in both dataplane and control plane examples. Spark version 2.4 is close to end of life.
