### PR TITLE
Fix Runbook Name patter as per public doc 

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2022-08-08/runbook.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2022-08-08/runbook.json
@@ -70,7 +70,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -124,7 +124,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "name": "runbookContent",
@@ -200,7 +200,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -253,7 +253,7 @@
             "required": true,
             "type": "string",
             "description": "The parameters supplied to the publish runbook operation.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -310,7 +310,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -366,7 +366,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -419,7 +419,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -473,7 +473,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "name": "parameters",
@@ -539,7 +539,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "name": "parameters",
@@ -599,7 +599,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -700,7 +700,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "name": "jobStreamId",
@@ -760,7 +760,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "name": "$filter",
@@ -823,7 +823,7 @@
             "required": true,
             "type": "string",
             "description": "The parameters supplied to the create test job operation.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "name": "parameters",
@@ -883,7 +883,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -936,7 +936,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -986,7 +986,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
@@ -1036,7 +1036,7 @@
             "required": true,
             "type": "string",
             "description": "The runbook name.",
-            "pattern": "^[a-zA-Z]*-*[a-zA-Z0-9]*$"
+            "pattern": "^[a-zA-Z][a-zA-Z-_0-9]*$"
           },
           {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"


### PR DESCRIPTION
…/en-us/azure/automation/manage-runbooks

# Changes

With recent changes made to swagger https://github.com/Azure/azure-rest-api-specs/pull/21128/files#diff-8a2476001660339cd88481fb4f06109174b32e1be800923813a9c5ecd0fe53fd

Pattern rule was added to Runbook Name resource to mandatory requirement . However this pattern didnt matched with what is mentioned in public document and whats already being used by customer.

https://learn.microsoft.com/en-us/azure/automation/manage-runbooks

<img width="574" alt="image" src="https://user-images.githubusercontent.com/25101734/215441077-433a85a4-0325-4669-b46f-ad9d2ff40d10.png">

This introduced a bug in new  cmdlets generated by usingthis swagger version for few customer.

The changes are used to fix the Name as per doc and fix breaking changes 

