### PR TITLE
Embeddings model and field documentation and fix to models

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/embeddings.create.cadl
+++ b/specification/cognitiveservices/OpenAI.Inference/models/embeddings.create.cadl
@@ -5,7 +5,7 @@ using Cadl.Http;
 
 namespace Azure.OpenAI.Embeddings;
 
-@doc("Post body schema to create a prompt completion from a deployment")
+@doc("Schema to create a prompt completion from a deployment")
 model EmbeddingsOptions {
     @doc("The ID of the end-user, for use in tracking and rate-limiting.")
     user?: string;

--- a/specification/cognitiveservices/OpenAI.Inference/models/embeddings.create.cadl
+++ b/specification/cognitiveservices/OpenAI.Inference/models/embeddings.create.cadl
@@ -5,6 +5,7 @@ using Cadl.Http;
 
 namespace Azure.OpenAI.Embeddings;
 
+@doc("Post body schema to create a prompt completion from a deployment")
 model EmbeddingsOptions {
     @doc("The ID of the end-user, for use in tracking and rate-limiting.")
     user?: string;
@@ -24,19 +25,32 @@ model EmbeddingsOptions {
     as we have observed inferior results when newlines are present.
     """)
     input: string | string[];
+};
+
+@doc("Expected response schema to embeddings request")
+model Embeddings {
+    @doc("Type of the data field")
+    object: "list",
+
+    @doc("Embedding values for the prompts submitted in the request")
+    data: EmbeddingItem[],
+
+    @doc("ID of the model to use")
+    "model"?: string;
 
     @doc("Usage counts for tokens input using the embeddings API")
     usage: EmbeddingsUsage;
-};
-
-model Embeddings {
-    object: "list",
-    data: EmbeddingItem[],
 }
 
+@doc("Expected response schema to ebeddings object list item request")
 model EmbeddingItem {
+    @doc("Name of the field in which the embedding is contained")
     object: "embedding",
+
+    @doc("List of embeddings value for the input prompt. These represents a measurement of releated of text strings")
     embedding: float32[];
+
+    @doc("Index of the prompt to which the EmbeddingItem corresponds")
     index: int32;
 }
 

--- a/specification/cognitiveservices/OpenAI.Inference/models/embeddings.create.cadl
+++ b/specification/cognitiveservices/OpenAI.Inference/models/embeddings.create.cadl
@@ -42,7 +42,7 @@ model Embeddings {
     usage: EmbeddingsUsage;
 }
 
-@doc("Expected response schema to ebeddings object list item request")
+@doc("Expected response schema to embeddings object list item request")
 model EmbeddingItem {
     @doc("Name of the field in which the embedding is contained")
     object: "embedding",


### PR DESCRIPTION
- `EmbeddingsOptions.Usage` was misplaced as part of the request model. It should actually be part of the response object `Embeddings.Usage`
- Added some basic documentation to fields and models to everything "embeddings related"