### PR TITLE
Change UbuntuLTS urnAlias to point to Ubuntu 22.04 LTS

### DIFF
--- a/arm-compute/quickstart-templates/aliases.json
+++ b/arm-compute/quickstart-templates/aliases.json
@@ -53,8 +53,8 @@
           },
           "UbuntuLTS": {
             "publisher": "Canonical",
-            "offer": "UbuntuServer",
-            "sku": "18.04-LTS",
+            "offer": "0001-com-ubuntu-server-jammy",
+            "sku": "22_04-lts-gen2",
             "version": "latest",
             "architecture": "x64"
           }


### PR DESCRIPTION
Ubuntu 18.04 LTS will reach end of standard (free) support in April 2023. Ubuntu 22.04 LTS will be supported until April 2027 (see https://wiki.ubuntu.com/Releases)

I open this PR as a starting point for this discussion. Moving away from 18.04 is critical but I don't know how much preparatory work is needed from Microsoft before merging this PR. Also I am not certain this change is the only one needed to update the URN alias. I managed to track the alias down to here by reading the code of [azure-cli](https://github.com/Azure/azure-cli) and [azure-sdk-for-python](https://github.com/Azure/azure-sdk-for-python/).