### PR TITLE
redis: adding the missing `notify-keyspace-events` value

### DIFF
--- a/specification/redis/resource-manager/Microsoft.Cache/preview/2023-05-01-preview/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/preview/2023-05-01-preview/redis.json
@@ -2216,6 +2216,10 @@
               "description": "The max clients config",
               "readOnly": true
             },
+            "notify-keyspace-events": {
+              "type": "string",
+              "description": "The keyspace events which should be monitored."
+            },
             "preferred-data-archive-auth-method": {
               "type": "string",
               "description": "Preferred auth method to communicate to storage account used for data archive, specify SAS or ManagedIdentity, default value is SAS",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2021-06-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2021-06-01/redis.json
@@ -1933,6 +1933,10 @@
               "description": "The max clients config",
               "readOnly": true
             },
+            "notify-keyspace-events": {
+              "type": "string",
+              "description": "The KeySpace Events which should be monitored."
+            },
             "preferred-data-archive-auth-method": {
               "type": "string",
               "description": "Preferred auth method to communicate to storage account used for data archive, specify SAS or ManagedIdentity, default value is SAS",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2021-06-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2021-06-01/redis.json
@@ -1935,7 +1935,7 @@
             },
             "notify-keyspace-events": {
               "type": "string",
-              "description": "The KeySpace Events which should be monitored."
+              "description": "The keyspace events which should be monitored."
             },
             "preferred-data-archive-auth-method": {
               "type": "string",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2022-05-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2022-05-01/redis.json
@@ -1947,6 +1947,10 @@
               "description": "The max clients config",
               "readOnly": true
             },
+            "notify-keyspace-events": {
+              "type": "string",
+              "description": "The KeySpace Events which should be monitored."
+            },
             "preferred-data-archive-auth-method": {
               "type": "string",
               "description": "Preferred auth method to communicate to storage account used for data archive, specify SAS or ManagedIdentity, default value is SAS",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2022-05-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2022-05-01/redis.json
@@ -1949,7 +1949,7 @@
             },
             "notify-keyspace-events": {
               "type": "string",
-              "description": "The KeySpace Events which should be monitored."
+              "description": "The keyspace events which should be monitored."
             },
             "preferred-data-archive-auth-method": {
               "type": "string",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json
@@ -1947,6 +1947,10 @@
               "description": "The max clients config",
               "readOnly": true
             },
+            "notify-keyspace-events": {
+              "type": "string",
+              "description": "The KeySpace Events which should be monitored."
+            },
             "preferred-data-archive-auth-method": {
               "type": "string",
               "description": "Preferred auth method to communicate to storage account used for data archive, specify SAS or ManagedIdentity, default value is SAS",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2022-06-01/redis.json
@@ -1949,7 +1949,7 @@
             },
             "notify-keyspace-events": {
               "type": "string",
-              "description": "The KeySpace Events which should be monitored."
+              "description": "The keyspace events which should be monitored."
             },
             "preferred-data-archive-auth-method": {
               "type": "string",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -2286,6 +2286,10 @@
               "description": "The max clients config",
               "readOnly": true
             },
+            "notify-keyspace-events": {
+              "type": "string",
+              "description": "The keyspace events which should be monitored."
+            },
             "preferred-data-archive-auth-method": {
               "type": "string",
               "description": "Preferred auth method to communicate to storage account used for data archive, specify SAS or ManagedIdentity, default value is SAS",


### PR DESCRIPTION
Whilst this value can currently be defined via the additionalProperties in the Track1 Go SDK, since it's included in the description presumably this should also be an explicitly defined field? Description:

> "description": "All Redis Settings. Few possible keys: rdb-backup-enabled,rdb-storage-connection-string,rdb-backup-frequency,maxmemory-delta,maxmemory-policy,notify-keyspace-events,maxmemory-samples,slowlog-log-slower-than,slowlog-max-len,list-max-ziplist-entries,list-max-ziplist-value,hash-max-ziplist-entries,hash-max-ziplist-value,set-max-intset-entries,zset-max-ziplist-entries,zset-max-ziplist-value etc."

As it stands today this field can be set via adding this to/parsing this from the dictionary, however since other properties have been defined explicitly, presumably this one should be too?

More details:

* [Azure Redis blog post](https://techcommunity.microsoft.com/t5/azure-paas-blog/redis-keyspace-events-notifications/ba-p/1551134)
* [Redis documentation](https://redis.io/docs/manual/keyspace-notifications/)