### PR TITLE
AOAI: fix CompletionsUsage model

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/completions.create.cadl
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions.create.cadl
@@ -162,10 +162,13 @@ model CompletionsLogProbs {
     text_offset?: int32[];
 }
 
-@doc("Measurment of the amount of tokens used in this request and response")
+@doc("""
+Representation of the token counts processed for a completions request.
+Counts consider all tokens across prompts, choices, choice alternates, best_of generations, and other consumers.
+""")
 model CompletionsUsage {
     @doc("Number of tokens received in the completion")
-    completion_token: int32,
+    completion_tokens: int32,
     @doc("Number of tokens sent in the original request")
     prompt_tokens: int32,
     @doc("Total number of tokens transacted in this request/response")


### PR DESCRIPTION
*\<\<Skipping template for topic-to-topic PR\>\>*

This addresses an error/inconsistency in the model definition for `CompletionsUsage` in Azure.AI.OpenAI's Inference area.

Specifically, a live service interaction demonstrates that a JSON key we want to process is named `completion_tokens`:

```
{"completion_tokens":75,"prompt_tokens":9,"total_tokens":84}
```

The model, meanwhile, expresses `completion_token` (no terminating 's') and the emitted projection code thus fails to deserialize the data.

In lieu of correcting a typo in the model comment, I replaced it with my own verbiage that I think adds a small amount of value.