### PR TITLE
Renamed ShareFileRequestIntent and made it an extensible enum

### DIFF
--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2022-11-02/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2022-11-02/file.json
@@ -6956,12 +6956,11 @@
       "required": false,
       "type": "string",
       "enum": [
-        "none",
         "backup"
       ],
       "x-ms-enum": {
-        "name": "ShareFileRequestIntent",
-        "modelAsString": false
+        "name": "ShareTokenIntent",
+        "modelAsString": true
       }
     },
     "FileType": {


### PR DESCRIPTION
**This is not a breaking change**

This is a result of feedback from the SDK arch board on how we expose this parameter to the customer in the data plane storage SDKs.

**This is not a breaking change**