### PR TITLE
Update snapshot status selector to take multiple statuses.

### DIFF
--- a/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
@@ -662,7 +662,7 @@
             "$ref": "#/parameters/SnapshotFields"
           },
           {
-            "$ref": "#/parameters/SnapshotStatuses"
+            "$ref": "#/parameters/Status"
           }
         ],
         "responses": {
@@ -1871,8 +1871,8 @@
       "x-ms-parameter-location": "method",
       "collectionFormat": "csv"
     },
-    "SnapshotStatuses": {
-      "name": "Status",
+    "Status": {
+      "name": "status",
       "in": "query",
       "description": "Used to filter returned snapshots by their status property.",
       "type": "array",

--- a/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
@@ -665,7 +665,7 @@
             "name": "Status",
             "in": "query",
             "description": "Used to filter returned snapshots by their status property.",
-            "type": "string",
+            "type": "array",
             "enum": [
               "provisioning",
               "ready",
@@ -675,7 +675,8 @@
             "x-ms-enum": {
               "name": "SnapshotStatus",
               "modelAsString": true
-            }
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {

--- a/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
@@ -662,21 +662,7 @@
             "$ref": "#/parameters/SnapshotFields"
           },
           {
-            "name": "Status",
-            "in": "query",
-            "description": "Used to filter returned snapshots by their status property.",
-            "type": "array",
-            "enum": [
-              "provisioning",
-              "ready",
-              "archived",
-              "failed"
-            ],
-            "x-ms-enum": {
-              "name": "SnapshotStatus",
-              "modelAsString": true
-            },
-            "collectionFormat": "csv"
+            "$ref": "#/parameters/SnapshotStatuses"
           }
         ],
         "responses": {
@@ -1879,6 +1865,27 @@
         ],
         "x-ms-enum": {
           "name": "SnapshotFields",
+          "modelAsString": true
+        }
+      },
+      "x-ms-parameter-location": "method",
+      "collectionFormat": "csv"
+    },
+    "SnapshotStatuses": {
+      "name": "Status",
+      "in": "query",
+      "description": "Used to filter returned snapshots by their status property.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "provisioning",
+          "ready",
+          "archived",
+          "failed"
+        ],
+        "x-ms-enum": {
+          "name": "SnapshotStatus",
           "modelAsString": true
         }
       },

--- a/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
@@ -1872,7 +1872,7 @@
       "collectionFormat": "csv"
     },
     "Status": {
-      "name": "status",
+      "name": "Status",
       "in": "query",
       "description": "Used to filter returned snapshots by their status property.",
       "type": "array",


### PR DESCRIPTION
Updated snapshot status filter to allow csv for multiple status selection.

When filtering by status, multiple values can be provided. Example:
`GET /snapshots?status=ready,provisioning&api-version=2022-11-01-preview`

Without this change, the generated SDK is only capable of selecting a single status. Example: 
`GET /snapshots?status=ready&api-version=2022-11-01-preview`