### PR TITLE
Added action to prepend medium-like reading times for long markdown documents.

### DIFF
--- a/.github/workflows/reading-time.yml
+++ b/.github/workflows/reading-time.yml
@@ -1,0 +1,38 @@
+name: Reading Time
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.md"
+
+jobs:
+  calculate-reading-time:
+    runs-on: ubuntu-latest
+    name: Calculate Reading Time
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Calculate & Prepend Reading Time
+        uses: harunrst/reading-time-action@v1.0
+        with:
+          strategy: all
+
+      - name: Commit Changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: Edited markdown files with reading times.
+          push: false
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Update markdown files with reading time.
+          body: Auto-generated Pull Request by [reading-time-action](https://github.com/harunrst/reading-time-action).
+          branch: reading-time-action


### PR DESCRIPTION
# Reading Time Action

I was lost inside the documents in this repository. I recently I published an action to give medium-like insights to people, so I applied it here. It automatically calculates and prepends to the markdown files, then makes a pull request with changes.

**Example PR:** https://github.com/harunrst/Progressium-Api/pull/19

**See here for more:** https://github.com/marketplace/actions/reading-time

![image](https://user-images.githubusercontent.com/26141403/221877377-24e6892a-e1a0-40ef-ac58-595c98290c75.png)

**For merger:**

1. In repository settings, allow actions to create PR.
2. Run manually once you merge it for the first run, then it will create PR automatically when there is any change on any markdown file.