### PR TITLE
Update eTag property description

### DIFF
--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/stable/2022-10-01/scheduledActions.json
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/stable/2022-10-01/scheduledActions.json
@@ -655,7 +655,7 @@
         "eTag": {
           "type": "string",
           "readOnly": true,
-          "description": "Resource Etag. For update calls, eTag is mandatory. Fetch the resource's eTag by doing a 'GET' call first and then including the latest eTag as part of the request body or 'If-Match' header while performing the update. For create calls, eTag is not required."
+          "description": "Resource Etag. For update calls, eTag is optional and can be specified to achieve optimistic concurrency. Fetch the resource's eTag by doing a 'GET' call first and then including the latest eTag as part of the request body or 'If-Match' header while performing the update. For create calls, eTag is not required."
         },
         "kind": {
           "$ref": "#/definitions/ScheduledActionKind",
@@ -924,7 +924,7 @@
       "name": "If-Match",
       "in": "header",
       "required": false,
-      "description": "ETag of the Entity. Not required when creating an entity, but required when updating an entity.",
+      "description": "ETag of the Entity. Not required when creating an entity. Optional when updating an entity and can be specified to achieve optimistic concurrency.",
       "type": "string",
       "x-ms-parameter-location": "method"
     }


### PR DESCRIPTION
Update Microsoft.CostManagement Scheduled actions eTag property description to call out eTag is optional and can be specified during update operation to achieve optimistic concurrency.
