### PR TITLE
Add vmScanners to defenderForServersGcpOffering configuration

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/preview/2023-02-01-preview/securityConnectors.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2023-02-01-preview/securityConnectors.json
@@ -1176,6 +1176,40 @@
               }
             }
           }
+        },
+        "vmScanners": {
+          "type": "object",
+          "description": "The Microsoft Defender for Server VM scanning configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Is Microsoft Defender for Server VM scanning enabled"
+            },
+            "configuration": {
+              "type": "object",
+              "description": "configuration for Microsoft Defender for Server VM scanning",
+              "properties": {
+                "scanningMode": {
+                  "type": "string",
+                  "description": "The scanning mode for the vm scan.",
+                  "enum": [
+                    "Default"
+                  ],
+                  "x-ms-enum": {
+                    "name": "scanningMode",
+                    "modelAsString": true
+                  }
+                },
+                "exclusionTags": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "VM tags that indicates that VM should not be scanned"
+                }
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Add vmScanners to defenderForServersGcpOffering configuration for Microsoft.Security version preview/2023-02-01-preview.
The change is based on [Pull request 7374803: Add VM Scanner configuration to GCP security connector](https://msazure.visualstudio.com/One/_git/Rome-Multi-Cloud-Security-Onboarding/pullrequest/7374803)
This will be merged into PR #23043