### PR TITLE
remove loadDistributionPolicy from appgw PUT request body example

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
@@ -505,40 +505,6 @@
           "routingRules": [],
           "probes": [],
           "redirectConfigurations": [],
-          "privateLinkConfigurations": [
-            {
-              "name": "privateLink1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "ipConfigurations": [
-                  {
-                    "name": "natNicIpconfig1",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig1",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "privateIPAllocationMethod": "Dynamic",
-                      "primary": true,
-                      "subnet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
-                      }
-                    }
-                  },
-                  {
-                    "name": "natNicIpconfig2",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig2",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
           "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
@@ -603,9 +569,6 @@
                 "privateIPAllocationMethod": "Dynamic",
                 "publicIPAddress": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
-                },
-                "privateLinkConfiguration": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLinkConfig1"
                 }
               }
             }
@@ -803,40 +766,6 @@
           "routingRules": [],
           "probes": [],
           "redirectConfigurations": [],
-          "privateLinkConfigurations": [
-            {
-              "name": "privateLink1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "ipConfigurations": [
-                  {
-                    "name": "natNicIpconfig1",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig1",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "privateIPAllocationMethod": "Dynamic",
-                      "primary": true,
-                      "subnet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
-                      }
-                    }
-                  },
-                  {
-                    "name": "natNicIpconfig2",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig2",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
           "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
@@ -399,6 +399,8 @@
               }
             }
           ],
+          "loadDistributionPolicies": [],
+          "backendSettingsCollection": [],
           "httpListeners": [
             {
               "name": "appgwhl",
@@ -436,6 +438,7 @@
               }
             }
           ],
+          "listeners": [],
           "urlPathMaps": [],
           "requestRoutingRules": [
             {
@@ -455,9 +458,6 @@
                 },
                 "rewriteRuleSet": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "loadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
                 }
               }
             }
@@ -503,8 +503,11 @@
               }
             }
           ],
+          "routingRules": [],
           "probes": [],
-          "loadDistributionPolicies": [],
+          "redirectConfigurations": [],
+          "privateLinkConfigurations": [],
+          "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true
@@ -662,6 +665,8 @@
               }
             }
           ],
+          "loadDistributionPolicies": [],
+          "backendSettingsCollection": [],
           "httpListeners": [
             {
               "name": "appgwhl",
@@ -699,6 +704,7 @@
               }
             }
           ],
+          "listeners": [],
           "urlPathMaps": [],
           "requestRoutingRules": [
             {
@@ -718,9 +724,6 @@
                 },
                 "rewriteRuleSet": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "loadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
                 }
               }
             }
@@ -766,8 +769,11 @@
               }
             }
           ],
+          "routingRules": [],
           "probes": [],
-          "loadDistributionPolicies": [],
+          "redirectConfigurations": [],
+          "privateLinkConfigurations": [],
+          "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
@@ -108,8 +108,12 @@
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
             "properties": {
               "backendAddresses": [
-                "10.0.0.1",
-                "10.0.0.2"
+                {
+                  "ipAddress": "10.0.0.1"
+                },
+                {
+                  "ipAddress": "10.0.0.2"
+                }
               ]
             }
           }
@@ -180,48 +184,6 @@
             }
           }
         ],
-        "urlPathMaps": [
-          {
-            "name": "pathMap1",
-            "properties": {
-              "defaultBackendAddressPool": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-              },
-              "defaultBackendHttpSettings": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-              },
-              "defaultRewriteRuleSet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-              },
-              "defaultLoadDistributionPolicy": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-              },
-              "pathRules": [
-                {
-                  "name": "apiPaths",
-                  "properties": {
-                    "paths": [
-                      "/api",
-                      "/v1/api"
-                    ],
-                    "backendAddressPool": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                    },
-                    "backendHttpSettings": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                    },
-                    "rewriteRuleSet": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                    },
-                    "loadDistributionPolicy": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        ],
         "requestRoutingRules": [
           {
             "name": "appgwrule",
@@ -239,22 +201,6 @@
               },
               "rewriteRuleSet": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-              },
-              "loadDistributionPolicy": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-              }
-            }
-          },
-          {
-            "name": "appgwPathBasedRule",
-            "properties": {
-              "ruleType": "PathBasedRouting",
-              "priority": 20,
-              "httpListener": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
-              },
-              "urlPathMap": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
               }
             }
           }
@@ -290,34 +236,6 @@
                     ],
                     "urlConfiguration": {
                       "modifiedPath": "/abc"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        ],
-        "loadDistributionPolicies": [
-          {
-            "name": "ldp1",
-            "properties": {
-              "loadDistributionAlgorithm": "RoundRobin",
-              "loadDistributionTargets": [
-                {
-                  "name": "ld11",
-                  "properties": {
-                    "weightPerServer": 40,
-                    "backendAddressPool": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                    }
-                  }
-                },
-                {
-                  "name": "ld11",
-                  "properties": {
-                    "weightPerServer": 60,
-                    "backendAddressPool": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
                     }
                   }
                 }
@@ -417,7 +335,14 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
               "properties": {
                 "provisioningState": "Succeeded",
-                "backendAddresses": []
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ]
               }
             },
             {
@@ -426,12 +351,17 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "backendAddresses": [
-                  "10.0.0.1",
-                  "10.0.0.2"
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
                 ]
               }
             }
           ],
+          "loadDistributionPolicies": [],
           "backendHttpSettingsCollection": [
             {
               "name": "appgwbhs",
@@ -507,52 +437,8 @@
               }
             }
           ],
-          "urlPathMaps": [
-            {
-              "name": "pathMap1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "defaultBackendAddressPool": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                },
-                "defaultBackendHttpSettings": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                },
-                "defaultRewriteRuleSet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "defaultLoadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                },
-                "pathRules": [
-                  {
-                    "name": "apiPaths",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "paths": [
-                        "/api",
-                        "/v1/api"
-                      ],
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      },
-                      "backendHttpSettings": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                      },
-                      "rewriteRuleSet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                      },
-                      "loadDistributionPolicy": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "listeners": [],
+          "urlPathMaps": [],
           "requestRoutingRules": [
             {
               "name": "appgwrule",
@@ -571,23 +457,6 @@
                 },
                 "rewriteRuleSet": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "loadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                }
-              }
-            },
-            {
-              "name": "appgwPathBasedRule",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "ruleType": "PathBasedRouting",
-                "httpListener": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
-                },
-                "urlPathMap": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
               }
             }
@@ -633,38 +502,10 @@
               }
             }
           ],
+          "routingRules": [],
           "probes": [],
-          "loadDistributionPolicies": [
-            {
-              "name": "ldp1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
-              "properties": {
-                "loadDistributionAlgorithm": "RoundRobin",
-                "loadDistributionTargets": [
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 40,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      }
-                    }
-                  },
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 60,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "redirectConfigurations": [],
+          "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true
@@ -704,7 +545,7 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
               "properties": {
                 "provisioningState": "Succeeded",
-                "publicCertData": "******"
+                "publicCertData": "*****"
               }
             }
           ],
@@ -728,9 +569,6 @@
                 "privateIPAllocationMethod": "Dynamic",
                 "publicIPAddress": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
-                },
-                "privateLinkConfiguration": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLinkConfig1"
                 }
               }
             }
@@ -759,7 +597,14 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
               "properties": {
                 "provisioningState": "Succeeded",
-                "backendAddresses": []
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ]
               }
             },
             {
@@ -768,12 +613,17 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "backendAddresses": [
-                  "10.0.0.1",
-                  "10.0.0.2"
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
                 ]
               }
             }
           ],
+          "loadDistributionPolicies": [],
           "backendHttpSettingsCollection": [
             {
               "name": "appgwbhs",
@@ -848,52 +698,8 @@
               }
             }
           ],
-          "urlPathMaps": [
-            {
-              "name": "pathMap1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "defaultBackendAddressPool": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                },
-                "defaultBackendHttpSettings": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                },
-                "defaultRewriteRuleSet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "defaultLoadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                },
-                "pathRules": [
-                  {
-                    "name": "apiPaths",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "paths": [
-                        "/api",
-                        "/v1/api"
-                      ],
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      },
-                      "backendHttpSettings": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                      },
-                      "rewriteRuleSet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                      },
-                      "loadDistributionPolicy": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "listeners": [],
+          "urlPathMaps": [],
           "requestRoutingRules": [
             {
               "name": "appgwrule",
@@ -912,23 +718,6 @@
                 },
                 "rewriteRuleSet": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "loadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                }
-              }
-            },
-            {
-              "name": "appgwPathBasedRule",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "ruleType": "PathBasedRouting",
-                "httpListener": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
-                },
-                "urlPathMap": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
               }
             }
@@ -974,38 +763,10 @@
               }
             }
           ],
+          "routingRules": [],
           "probes": [],
-          "loadDistributionPolicies": [
-            {
-              "name": "ldp1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
-              "properties": {
-                "loadDistributionAlgorithm": "RoundRobin",
-                "loadDistributionTargets": [
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 40,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      }
-                    }
-                  },
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 60,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "redirectConfigurations": [],
+          "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
@@ -108,8 +108,12 @@
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
             "properties": {
               "backendAddresses": [
-                "10.0.0.1",
-                "10.0.0.2"
+                {
+                  "ipAddress": "10.0.0.1"
+                },
+                {
+                  "ipAddress": "10.0.0.2"
+                }
               ]
             }
           }
@@ -180,48 +184,6 @@
             }
           }
         ],
-        "urlPathMaps": [
-          {
-            "name": "pathMap1",
-            "properties": {
-              "defaultBackendAddressPool": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-              },
-              "defaultBackendHttpSettings": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-              },
-              "defaultRewriteRuleSet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-              },
-              "defaultLoadDistributionPolicy": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-              },
-              "pathRules": [
-                {
-                  "name": "apiPaths",
-                  "properties": {
-                    "paths": [
-                      "/api",
-                      "/v1/api"
-                    ],
-                    "backendAddressPool": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                    },
-                    "backendHttpSettings": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                    },
-                    "rewriteRuleSet": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                    },
-                    "loadDistributionPolicy": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        ],
         "requestRoutingRules": [
           {
             "name": "appgwrule",
@@ -239,22 +201,6 @@
               },
               "rewriteRuleSet": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-              },
-              "loadDistributionPolicy": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-              }
-            }
-          },
-          {
-            "name": "appgwPathBasedRule",
-            "properties": {
-              "ruleType": "PathBasedRouting",
-              "priority": 20,
-              "httpListener": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
-              },
-              "urlPathMap": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
               }
             }
           }
@@ -290,34 +236,6 @@
                     ],
                     "urlConfiguration": {
                       "modifiedPath": "/abc"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        ],
-        "loadDistributionPolicies": [
-          {
-            "name": "ldp1",
-            "properties": {
-              "loadDistributionAlgorithm": "RoundRobin",
-              "loadDistributionTargets": [
-                {
-                  "name": "ld11",
-                  "properties": {
-                    "weightPerServer": 40,
-                    "backendAddressPool": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                    }
-                  }
-                },
-                {
-                  "name": "ld11",
-                  "properties": {
-                    "weightPerServer": 60,
-                    "backendAddressPool": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
                     }
                   }
                 }
@@ -417,7 +335,14 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
               "properties": {
                 "provisioningState": "Succeeded",
-                "backendAddresses": []
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ]
               }
             },
             {
@@ -426,8 +351,12 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "backendAddresses": [
-                  "10.0.0.1",
-                  "10.0.0.2"
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
                 ]
               }
             }
@@ -507,52 +436,7 @@
               }
             }
           ],
-          "urlPathMaps": [
-            {
-              "name": "pathMap1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "defaultBackendAddressPool": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                },
-                "defaultBackendHttpSettings": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                },
-                "defaultRewriteRuleSet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "defaultLoadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                },
-                "pathRules": [
-                  {
-                    "name": "apiPaths",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "paths": [
-                        "/api",
-                        "/v1/api"
-                      ],
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      },
-                      "backendHttpSettings": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                      },
-                      "rewriteRuleSet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                      },
-                      "loadDistributionPolicy": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "urlPathMaps": [],
           "requestRoutingRules": [
             {
               "name": "appgwrule",
@@ -574,20 +458,6 @@
                 },
                 "loadDistributionPolicy": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                }
-              }
-            },
-            {
-              "name": "appgwPathBasedRule",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "ruleType": "PathBasedRouting",
-                "httpListener": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
-                },
-                "urlPathMap": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
               }
             }
@@ -634,37 +504,7 @@
             }
           ],
           "probes": [],
-          "loadDistributionPolicies": [
-            {
-              "name": "ldp1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
-              "properties": {
-                "loadDistributionAlgorithm": "RoundRobin",
-                "loadDistributionTargets": [
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 40,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      }
-                    }
-                  },
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 60,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "loadDistributionPolicies": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true
@@ -759,7 +599,14 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
               "properties": {
                 "provisioningState": "Succeeded",
-                "backendAddresses": []
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ]
               }
             },
             {
@@ -768,8 +615,12 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "backendAddresses": [
-                  "10.0.0.1",
-                  "10.0.0.2"
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
                 ]
               }
             }
@@ -848,52 +699,7 @@
               }
             }
           ],
-          "urlPathMaps": [
-            {
-              "name": "pathMap1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "defaultBackendAddressPool": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                },
-                "defaultBackendHttpSettings": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                },
-                "defaultRewriteRuleSet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "defaultLoadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                },
-                "pathRules": [
-                  {
-                    "name": "apiPaths",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "paths": [
-                        "/api",
-                        "/v1/api"
-                      ],
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      },
-                      "backendHttpSettings": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                      },
-                      "rewriteRuleSet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                      },
-                      "loadDistributionPolicy": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "urlPathMaps": [],
           "requestRoutingRules": [
             {
               "name": "appgwrule",
@@ -915,20 +721,6 @@
                 },
                 "loadDistributionPolicy": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                }
-              }
-            },
-            {
-              "name": "appgwPathBasedRule",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "ruleType": "PathBasedRouting",
-                "httpListener": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
-                },
-                "urlPathMap": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
               }
             }
@@ -975,37 +767,7 @@
             }
           ],
           "probes": [],
-          "loadDistributionPolicies": [
-            {
-              "name": "ldp1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
-              "properties": {
-                "loadDistributionAlgorithm": "RoundRobin",
-                "loadDistributionTargets": [
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 40,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      }
-                    }
-                  },
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 60,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "loadDistributionPolicies": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
@@ -400,8 +400,6 @@
               }
             }
           ],
-          "loadDistributionPolicies": [],
-          "backendSettingsCollection": [],
           "httpListeners": [
             {
               "name": "appgwhl",
@@ -667,8 +665,6 @@
               }
             }
           ],
-          "loadDistributionPolicies": [],
-          "backendSettingsCollection": [],
           "httpListeners": [
             {
               "name": "appgwhl",

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
@@ -505,7 +505,40 @@
           "routingRules": [],
           "probes": [],
           "redirectConfigurations": [],
-          "privateLinkConfigurations": [],
+          "privateLinkConfigurations": [
+            {
+              "name": "privateLink1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "ipConfigurations": [
+                  {
+                    "name": "natNicIpconfig1",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig1",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "privateIPAllocationMethod": "Dynamic",
+                      "primary": true,
+                      "subnet": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  },
+                  {
+                    "name": "natNicIpconfig2",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig2",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
           "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
@@ -770,7 +803,40 @@
           "routingRules": [],
           "probes": [],
           "redirectConfigurations": [],
-          "privateLinkConfigurations": [],
+          "privateLinkConfigurations": [
+            {
+              "name": "privateLink1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "ipConfigurations": [
+                  {
+                    "name": "natNicIpconfig1",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig1",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "privateIPAllocationMethod": "Dynamic",
+                      "primary": true,
+                      "subnet": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  },
+                  {
+                    "name": "natNicIpconfig2",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig2",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
           "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
@@ -108,8 +108,12 @@
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
             "properties": {
               "backendAddresses": [
-                "10.0.0.1",
-                "10.0.0.2"
+                {
+                  "ipAddress": "10.0.0.1"
+                },
+                {
+                  "ipAddress": "10.0.0.2"
+                }
               ]
             }
           }
@@ -180,48 +184,6 @@
             }
           }
         ],
-        "urlPathMaps": [
-          {
-            "name": "pathMap1",
-            "properties": {
-              "defaultBackendAddressPool": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-              },
-              "defaultBackendHttpSettings": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-              },
-              "defaultRewriteRuleSet": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-              },
-              "defaultLoadDistributionPolicy": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-              },
-              "pathRules": [
-                {
-                  "name": "apiPaths",
-                  "properties": {
-                    "paths": [
-                      "/api",
-                      "/v1/api"
-                    ],
-                    "backendAddressPool": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                    },
-                    "backendHttpSettings": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                    },
-                    "rewriteRuleSet": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                    },
-                    "loadDistributionPolicy": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        ],
         "requestRoutingRules": [
           {
             "name": "appgwrule",
@@ -239,22 +201,6 @@
               },
               "rewriteRuleSet": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-              },
-              "loadDistributionPolicy": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-              }
-            }
-          },
-          {
-            "name": "appgwPathBasedRule",
-            "properties": {
-              "ruleType": "PathBasedRouting",
-              "priority": 20,
-              "httpListener": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
-              },
-              "urlPathMap": {
-                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
               }
             }
           }
@@ -290,34 +236,6 @@
                     ],
                     "urlConfiguration": {
                       "modifiedPath": "/abc"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        ],
-        "loadDistributionPolicies": [
-          {
-            "name": "ldp1",
-            "properties": {
-              "loadDistributionAlgorithm": "RoundRobin",
-              "loadDistributionTargets": [
-                {
-                  "name": "ld11",
-                  "properties": {
-                    "weightPerServer": 40,
-                    "backendAddressPool": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                    }
-                  }
-                },
-                {
-                  "name": "ld11",
-                  "properties": {
-                    "weightPerServer": 60,
-                    "backendAddressPool": {
-                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
                     }
                   }
                 }
@@ -417,7 +335,14 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
               "properties": {
                 "provisioningState": "Succeeded",
-                "backendAddresses": []
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ]
               }
             },
             {
@@ -426,12 +351,17 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "backendAddresses": [
-                  "10.0.0.1",
-                  "10.0.0.2"
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
                 ]
               }
             }
           ],
+          "loadDistributionPolicies": [],
           "backendHttpSettingsCollection": [
             {
               "name": "appgwbhs",
@@ -507,52 +437,8 @@
               }
             }
           ],
-          "urlPathMaps": [
-            {
-              "name": "pathMap1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "defaultBackendAddressPool": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                },
-                "defaultBackendHttpSettings": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                },
-                "defaultRewriteRuleSet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "defaultLoadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                },
-                "pathRules": [
-                  {
-                    "name": "apiPaths",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "paths": [
-                        "/api",
-                        "/v1/api"
-                      ],
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      },
-                      "backendHttpSettings": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                      },
-                      "rewriteRuleSet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                      },
-                      "loadDistributionPolicy": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "listeners": [],
+          "urlPathMaps": [],
           "requestRoutingRules": [
             {
               "name": "appgwrule",
@@ -571,23 +457,6 @@
                 },
                 "rewriteRuleSet": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "loadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                }
-              }
-            },
-            {
-              "name": "appgwPathBasedRule",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "ruleType": "PathBasedRouting",
-                "httpListener": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
-                },
-                "urlPathMap": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
               }
             }
@@ -633,38 +502,11 @@
               }
             }
           ],
+          "routingRules": [],
           "probes": [],
-          "loadDistributionPolicies": [
-            {
-              "name": "ldp1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
-              "properties": {
-                "loadDistributionAlgorithm": "RoundRobin",
-                "loadDistributionTargets": [
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 40,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      }
-                    }
-                  },
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 60,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "redirectConfigurations": [],
+          "privateLinkConfigurations": [],
+          "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true
@@ -759,7 +601,14 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
               "properties": {
                 "provisioningState": "Succeeded",
-                "backendAddresses": []
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ]
               }
             },
             {
@@ -768,12 +617,17 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "backendAddresses": [
-                  "10.0.0.1",
-                  "10.0.0.2"
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
                 ]
               }
             }
           ],
+          "loadDistributionPolicies": [],
           "backendHttpSettingsCollection": [
             {
               "name": "appgwbhs",
@@ -848,52 +702,8 @@
               }
             }
           ],
-          "urlPathMaps": [
-            {
-              "name": "pathMap1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "defaultBackendAddressPool": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                },
-                "defaultBackendHttpSettings": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                },
-                "defaultRewriteRuleSet": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "defaultLoadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                },
-                "pathRules": [
-                  {
-                    "name": "apiPaths",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
-                    "properties": {
-                      "provisioningState": "Succeeded",
-                      "paths": [
-                        "/api",
-                        "/v1/api"
-                      ],
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      },
-                      "backendHttpSettings": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
-                      },
-                      "rewriteRuleSet": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                      },
-                      "loadDistributionPolicy": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "listeners": [],
+          "urlPathMaps": [],
           "requestRoutingRules": [
             {
               "name": "appgwrule",
@@ -912,23 +722,6 @@
                 },
                 "rewriteRuleSet": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
-                },
-                "loadDistributionPolicy": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
-                }
-              }
-            },
-            {
-              "name": "appgwPathBasedRule",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "ruleType": "PathBasedRouting",
-                "httpListener": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
-                },
-                "urlPathMap": {
-                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
               }
             }
@@ -974,38 +767,11 @@
               }
             }
           ],
+          "routingRules": [],
           "probes": [],
-          "loadDistributionPolicies": [
-            {
-              "name": "ldp1",
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
-              "properties": {
-                "loadDistributionAlgorithm": "RoundRobin",
-                "loadDistributionTargets": [
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 40,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
-                      }
-                    }
-                  },
-                  {
-                    "name": "ld11",
-                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
-                    "properties": {
-                      "weightPerServer": 60,
-                      "backendAddressPool": {
-                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "redirectConfigurations": [],
+          "privateLinkConfigurations": [],
+          "privateEndpointConnections": [],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayCreate.json
@@ -108,12 +108,8 @@
             "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
             "properties": {
               "backendAddresses": [
-                {
-                  "ipAddress": "10.0.0.1"
-                },
-                {
-                  "ipAddress": "10.0.0.2"
-                }
+                "10.0.0.1",
+                "10.0.0.2"
               ]
             }
           }
@@ -184,6 +180,48 @@
             }
           }
         ],
+        "urlPathMaps": [
+          {
+            "name": "pathMap1",
+            "properties": {
+              "defaultBackendAddressPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+              },
+              "defaultBackendHttpSettings": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+              },
+              "defaultRewriteRuleSet": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+              },
+              "defaultLoadDistributionPolicy": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+              },
+              "pathRules": [
+                {
+                  "name": "apiPaths",
+                  "properties": {
+                    "paths": [
+                      "/api",
+                      "/v1/api"
+                    ],
+                    "backendAddressPool": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                    },
+                    "backendHttpSettings": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                    },
+                    "rewriteRuleSet": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                    },
+                    "loadDistributionPolicy": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ],
         "requestRoutingRules": [
           {
             "name": "appgwrule",
@@ -201,6 +239,22 @@
               },
               "rewriteRuleSet": {
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+              },
+              "loadDistributionPolicy": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+              }
+            }
+          },
+          {
+            "name": "appgwPathBasedRule",
+            "properties": {
+              "ruleType": "PathBasedRouting",
+              "priority": 20,
+              "httpListener": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+              },
+              "urlPathMap": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
               }
             }
           }
@@ -236,6 +290,34 @@
                     ],
                     "urlConfiguration": {
                       "modifiedPath": "/abc"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "loadDistributionPolicies": [
+          {
+            "name": "ldp1",
+            "properties": {
+              "loadDistributionAlgorithm": "RoundRobin",
+              "loadDistributionTargets": [
+                {
+                  "name": "ld11",
+                  "properties": {
+                    "weightPerServer": 40,
+                    "backendAddressPool": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                    }
+                  }
+                },
+                {
+                  "name": "ld11",
+                  "properties": {
+                    "weightPerServer": 60,
+                    "backendAddressPool": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
                     }
                   }
                 }
@@ -335,14 +417,7 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
               "properties": {
                 "provisioningState": "Succeeded",
-                "backendAddresses": [
-                  {
-                    "ipAddress": "10.0.1.1"
-                  },
-                  {
-                    "ipAddress": "10.0.1.2"
-                  }
-                ]
+                "backendAddresses": []
               }
             },
             {
@@ -351,17 +426,12 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "backendAddresses": [
-                  {
-                    "ipAddress": "10.0.0.1"
-                  },
-                  {
-                    "ipAddress": "10.0.0.2"
-                  }
+                  "10.0.0.1",
+                  "10.0.0.2"
                 ]
               }
             }
           ],
-          "loadDistributionPolicies": [],
           "backendHttpSettingsCollection": [
             {
               "name": "appgwbhs",
@@ -437,8 +507,52 @@
               }
             }
           ],
-          "listeners": [],
-          "urlPathMaps": [],
+          "urlPathMaps": [
+            {
+              "name": "pathMap1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "defaultRewriteRuleSet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "defaultLoadDistributionPolicy": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "pathRules": [
+                  {
+                    "name": "apiPaths",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "paths": [
+                        "/api",
+                        "/v1/api"
+                      ],
+                      "backendAddressPool": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "rewriteRuleSet": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                      },
+                      "loadDistributionPolicy": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
           "requestRoutingRules": [
             {
               "name": "appgwrule",
@@ -457,6 +571,23 @@
                 },
                 "rewriteRuleSet": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "loadDistributionPolicy": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                }
+              }
+            },
+            {
+              "name": "appgwPathBasedRule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "ruleType": "PathBasedRouting",
+                "httpListener": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "urlPathMap": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
               }
             }
@@ -502,10 +633,38 @@
               }
             }
           ],
-          "routingRules": [],
           "probes": [],
-          "redirectConfigurations": [],
-          "privateEndpointConnections": [],
+          "loadDistributionPolicies": [
+            {
+              "name": "ldp1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
+              "properties": {
+                "loadDistributionAlgorithm": "RoundRobin",
+                "loadDistributionTargets": [
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "weightPerServer": 40,
+                      "backendAddressPool": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      }
+                    }
+                  },
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "weightPerServer": 60,
+                      "backendAddressPool": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true
@@ -545,7 +704,7 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
               "properties": {
                 "provisioningState": "Succeeded",
-                "publicCertData": "*****"
+                "publicCertData": "******"
               }
             }
           ],
@@ -569,6 +728,9 @@
                 "privateIPAllocationMethod": "Dynamic",
                 "publicIPAddress": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                },
+                "privateLinkConfiguration": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLinkConfig1"
                 }
               }
             }
@@ -597,14 +759,7 @@
               "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
               "properties": {
                 "provisioningState": "Succeeded",
-                "backendAddresses": [
-                  {
-                    "ipAddress": "10.0.1.1"
-                  },
-                  {
-                    "ipAddress": "10.0.1.2"
-                  }
-                ]
+                "backendAddresses": []
               }
             },
             {
@@ -613,17 +768,12 @@
               "properties": {
                 "provisioningState": "Succeeded",
                 "backendAddresses": [
-                  {
-                    "ipAddress": "10.0.0.1"
-                  },
-                  {
-                    "ipAddress": "10.0.0.2"
-                  }
+                  "10.0.0.1",
+                  "10.0.0.2"
                 ]
               }
             }
           ],
-          "loadDistributionPolicies": [],
           "backendHttpSettingsCollection": [
             {
               "name": "appgwbhs",
@@ -698,8 +848,52 @@
               }
             }
           ],
-          "listeners": [],
-          "urlPathMaps": [],
+          "urlPathMaps": [
+            {
+              "name": "pathMap1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "defaultRewriteRuleSet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "defaultLoadDistributionPolicy": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "pathRules": [
+                  {
+                    "name": "apiPaths",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
+                    "properties": {
+                      "provisioningState": "Succeeded",
+                      "paths": [
+                        "/api",
+                        "/v1/api"
+                      ],
+                      "backendAddressPool": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "rewriteRuleSet": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                      },
+                      "loadDistributionPolicy": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
           "requestRoutingRules": [
             {
               "name": "appgwrule",
@@ -718,6 +912,23 @@
                 },
                 "rewriteRuleSet": {
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "loadDistributionPolicy": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                }
+              }
+            },
+            {
+              "name": "appgwPathBasedRule",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "ruleType": "PathBasedRouting",
+                "httpListener": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "urlPathMap": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
               }
             }
@@ -763,10 +974,38 @@
               }
             }
           ],
-          "routingRules": [],
           "probes": [],
-          "redirectConfigurations": [],
-          "privateEndpointConnections": [],
+          "loadDistributionPolicies": [
+            {
+              "name": "ldp1",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
+              "properties": {
+                "loadDistributionAlgorithm": "RoundRobin",
+                "loadDistributionTargets": [
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "weightPerServer": 40,
+                      "backendAddressPool": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      }
+                    }
+                  },
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "weightPerServer": 60,
+                      "backendAddressPool": {
+                        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
           "globalConfiguration": {
             "enableRequestBuffering": true,
             "enableResponseBuffering": true

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayPrivateEndpointConnectionUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayPrivateEndpointConnectionUpdate.json
@@ -22,7 +22,7 @@
     "200": {
       "body": {
         "name": "testPlePeConnection",
-        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkResources/testPlePeConnection",
         "properties": {
           "privateEndpoint": {
             "id": "/subscriptions/subId/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/testPe"

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayPrivateEndpointConnectionUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/examples/ApplicationGatewayPrivateEndpointConnectionUpdate.json
@@ -22,6 +22,7 @@
     "200": {
       "body": {
         "name": "testPlePeConnection",
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
         "properties": {
           "privateEndpoint": {
             "id": "/subscriptions/subId/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/testPe"


### PR DESCRIPTION
Problam: Customer got below error when creating a new Application Gateway with loadDistributionPolicies.
{
"error": {
"code": "SubscriptionNotRegisteredForFeature",
"message": "Subscription /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//providers/Microsoft.Network/subscriptions/ is not registered for feature LoadDistributionPolicy required to carry out the requested operation.",
"details": []
}
}

Currently LoadDisctibutionPolicy feature of ApplicationGateway can only be used by subscriptions which are registered for this feature.

Changes: Remove LoadDisctibutionPolicy and related resources from request body example. And also remove relevant resources from response example. Therefore, the example won't confuse customers.

Test: Tested with above modified request body and created appgw successfully. [Test template](https://microsoft-my.sharepoint.com/:o:/p/yuemingzhang/EqORiNmjo9BMj_DeqW_m0w0BaPKo8BnUEVFTlvi9YSQnmA?e=U5Hnua).

Related requests:
WorkItem: [WRR - API related document update](https://msazure.visualstudio.com/One/_workitems/edit/17456320)
Issues: https://github.com/Azure/azure-rest-api-specs/issues/19784
