### PR TITLE
[network] generate with only path and body params positional

### DIFF
--- a/specification/network/resource-manager/readme.python.md
+++ b/specification/network/resource-manager/readme.python.md
@@ -9,6 +9,7 @@ package-name: azure-mgmt-network
 no-namespace-folders: true
 package-version: 1.0.0b1
 combine-operation-files: true
+only-path-and-body-params-positional: true
 ```
 
 ### Python multi-api


### PR DESCRIPTION
We want to move network over to be a combined multiapi sdk, with just one sdk keeping track of all of the api versions. As part of this, we need to generate with only path and body params positional, and query / header keyword only. Moving this into the python generation