### PR TITLE
update servicebus swagger required/types

### DIFF
--- a/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
+++ b/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
@@ -516,7 +516,7 @@
         },
         "title": {
           "description": "The name of the namespace.",
-          "type": "object",
+          "type": "string",
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           }
@@ -538,6 +538,10 @@
         "content": {
           "description": "Information about the namespace.",
           "type": "object",
+          "required": [
+            "type",
+            "NamespaceProperties"
+          ],
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           },
@@ -828,7 +832,7 @@
         },
         "title": {
           "description": "The name of the queue",
-          "type": "object",
+          "type": "string",
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           }
@@ -858,6 +862,10 @@
         "content": {
           "description": "The QueueDescription",
           "type": "object",
+          "required": [
+            "type",
+            "QueueDescription"
+          ],
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           },
@@ -1203,7 +1211,7 @@
         },
         "title": {
           "description": "The name of the topic",
-          "type": "object",
+          "type": "string",
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           }
@@ -1233,6 +1241,10 @@
         "content": {
           "description": "The TopicDescription",
           "type": "object",
+          "required": [
+            "type",
+            "TopicDescription"
+          ],
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           },
@@ -1461,7 +1473,7 @@
         },
         "title": {
           "description": "The name of the subscription",
-          "type": "object",
+          "type": "string",
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           }
@@ -1488,6 +1500,10 @@
         "content": {
           "description": "The SubscriptionDescription.",
           "type": "object",
+          "required": [
+            "type",
+            "SubscriptionDescription"
+          ],
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           },
@@ -1864,7 +1880,7 @@
         },
         "title": {
           "description": "The name of the rule",
-          "type": "object",
+          "type": "string",
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           }
@@ -1891,6 +1907,10 @@
         "content": {
           "description": "The RuleDescription",
           "type": "object",
+          "required": [
+            "type",
+            "RuleDescription"
+          ],
           "xml": {
             "namespace": "http://www.w3.org/2005/Atom"
           },

--- a/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
+++ b/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
@@ -1366,6 +1366,14 @@
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
         },
+        "defaultRuleDescription": {
+          "description": "The default rule description.",
+          "$ref": "#/definitions/RuleDescription",
+          "xml": {
+            "name": "DefaultRuleDescription",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
         "messageCount": {
           "description": "The number of messages in the subscription.",
           "type": "integer",

--- a/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
+++ b/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
@@ -506,6 +506,9 @@
     "NamespacePropertiesEntry": {
       "description": "Represents an entry in the feed when querying namespace info",
       "type": "object",
+      "required": [
+        "title"
+      ],
       "properties": {
         "id": {
           "description": "The URL of the GET request",


### PR DESCRIPTION
updating the Servicebus swagger:
* If entities exist, entity descriptions should exist/be required.
* Names of entities should be type string.