### PR TITLE
Change size properties from int32 to long.

### DIFF
--- a/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
+++ b/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
@@ -606,7 +606,7 @@
         "maxSizeInMegabytes": {
           "description": "The maximum size of the queue in megabytes, which is the size of memory allocated for the queue.",
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "xml": {
             "name": "MaxSizeInMegabytes",
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
@@ -805,7 +805,7 @@
         "maxMessageSizeInKilobytes": {
           "description": "The maximum size in kilobytes of message payload that can be accepted by the queue.",
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "xml": {
             "name": "MaxMessageSizeInKilobytes",
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
@@ -1019,7 +1019,7 @@
         "maxSizeInMegabytes": {
           "description": "The maximum size of the topic in megabytes, which is the size of memory allocated for the topic.",
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "xml": {
             "name": "MaxSizeInMegabytes",
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
@@ -1184,7 +1184,7 @@
         "maxMessageSizeInKilobytes": {
           "description": "The maximum size in kilobytes of message payload that can be accepted by the topic.",
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "xml": {
             "name": "MaxMessageSizeInKilobytes",
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"


### PR DESCRIPTION
# Data Plane API - Pull Request

Update size of queue and topics from integer to long. Aligns with the previous version of sb swagger in: https://github.com/Azure/azure-sdk-for-java/issues/32064

## API Info: The Basics
Most of the information about your service should be captured in the issue that serves as your [*engagement record*](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/271/Azure-REST-API-Stewardship?anchor=rest-api-stewardship-process).

* Link to engagement record issue:

Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [x] GA release

### Change Scope
<sup>This section will help us focus on the specific parts of your API that are new or have been modified. <br/>Please share a link to the design document for the new APIs, a link to the previous Open API document (swagger) if applicable, and the root paths that have been updated. </sup>
* Design Document:
* Previous Open API Doc:
* Updated paths: definitions of QueueDescription and SubscriptionDescription.
