### PR TITLE
Update minimum snapshot retention period.

### DIFF
--- a/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
@@ -1645,7 +1645,7 @@
         "retention_period": {
           "description": "The amount of time, in seconds, that a snapshot will remain in the archived state before expiring. This property is only writable during the creation of a snapshot. If not specified, the default lifetime of key-value revisions will be used.",
           "type": "integer",
-          "minimum": 0,
+          "minimum": 3600,
           "maximum": 7776000,
           "format": "int64"
         },


### PR DESCRIPTION
The minimum retention period of App Configuration snapshots should be 3600 (one hour). This is needed to give a minimum viable time for recovery of a snapshot if necessary. If the minimum retention period is '0', then there could be a possibility of 0% chance of recovery.