### PR TITLE
Changing modelAsString = true

### DIFF
--- a/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
+++ b/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
@@ -104,7 +104,7 @@
       ],
       "x-ms-enum": {
         "name": "AccessRights",
-        "modelAsString": false
+        "modelAsString": true
       }
     },
     "AuthorizationRule": {
@@ -341,7 +341,7 @@
       ],
       "x-ms-enum": {
         "name": "EntityAvailabilityStatus",
-        "modelAsString": false
+        "modelAsString": true
       }
     },
     "EntityStatus": {
@@ -364,7 +364,7 @@
       ],
       "x-ms-enum": {
         "name": "EntityStatus",
-        "modelAsString": false
+        "modelAsString": true
       }
     },
     "MessageCountDetails": {
@@ -441,7 +441,7 @@
       ],
       "x-ms-enum": {
         "name": "MessagingSku",
-        "modelAsString": false
+        "modelAsString": true
       }
     },
     "NamespaceProperties": {


### PR DESCRIPTION
## Description

AccessRights, NamespaceType, EntityAvailabilityStatus, EntityStatus, MessagingSku, and NamespaceType should be generated as `ExtensibleStringEnum<T>` rather than just enums.  Fixing by setting `modelAsString=true`