### PR TITLE
Change Scope field from Enum to string

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/preview/2023-02-01-preview/healthReports.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2023-02-01-preview/healthReports.json
@@ -267,17 +267,7 @@
         },
         "scope": {
           "type": "string",
-          "description": "The resource scope of the health report",
-          "enum": [
-            "Connectors",
-            "Clusters",
-            "VirtualMachines",
-            "Unknown"
-          ],
-          "x-ms-enum": {
-            "name": "scopeName",
-            "modelAsString": true
-          }
+          "description": "The resource scope of the health report"
         }
       }
     },


### PR DESCRIPTION
We decided to change this field to string, instead of Enum.
We are aware that this is a breaking change.
But
We still don't have customers that are using this resource.
We still didn't publish this new resource to Microsoft documentation.

We can change it as no one still using this SDKs