### PR TITLE
databricks: Access Connector doesn't support `SystemAssigned,UserAssigned` (or `SystemAssigned, UserAssigned`)

### DIFF
--- a/specification/common-types/resource-management/v3/managedidentity.json
+++ b/specification/common-types/resource-management/v3/managedidentity.json
@@ -108,6 +108,47 @@
       "required": [
         "type"
       ]
+    },
+
+    "SystemAssignedOrUserAssignedServiceIdentityType": {
+      "description": "Type of managed service identity (either system assigned, or none).",
+      "enum": [
+        "None",
+        "SystemAssigned",
+        "UserAssigned"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "SystemAssignedOrUserAssignedServiceIdentityType",
+        "modelAsString": true
+      }
+    },
+    "SystemAssignedOrUserAssignedServiceIdentity": {
+      "description": "Type of managed service identity (system assigned or user assigned identities - but not system assigned and user assigned identities)",
+      "type": "object",
+      "properties": {
+        "principalId": {
+          "readOnly": true,
+          "format": "uuid",
+          "type": "string",
+          "description": "The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity."
+        },
+        "tenantId": {
+          "readOnly": true,
+          "format": "uuid",
+          "type": "string",
+          "description": "The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity."
+        },
+        "type": {
+          "$ref": "#/definitions/SystemAssignedOrUserAssignedServiceIdentityType"
+        },
+        "userAssignedIdentities": {
+          "$ref": "#/definitions/UserAssignedIdentities"
+        }
+      },
+      "required": [
+        "type"
+      ]
     }
   }
 }

--- a/specification/databricks/resource-manager/Microsoft.Databricks/preview/2022-10-01-preview/accessconnector.json
+++ b/specification/databricks/resource-manager/Microsoft.Databricks/preview/2022-10-01-preview/accessconnector.json
@@ -319,7 +319,7 @@
       "type": "object",
       "properties": {
         "identity": {
-          "$ref": "../../../../../common-types/resource-management/v3/managedidentity.json#/definitions/ManagedServiceIdentity"
+          "$ref": "../../../../../common-types/resource-management/v3/managedidentity.json#/definitions/SystemAssignedOrUserAssignedServiceIdentity"
         },
         "systemData": {
           "description": "The system metadata relating to this resource",


### PR DESCRIPTION
When specifying these values, the API returns:

> Only SystemAssigned or UserAssigned Identity is supported for an Access Connector resource, not both together.

Since there isn't a `common-type` for this setup, this PR adds one, which'll allow this API to be correctly described in the Swagger.

Whilst this fix is just for DataBricks, I've intentionally added this as ` common-type` since we've seen this combination used across a number of resources, thus I believe it can ultimately be reused across other resources too.