### PR TITLE
remove 'selector' and 'selectorMatchOperator' from ApplicationGatewayFirewallExclutions

### DIFF
--- a/specification/network/resource-manager/readme.java.md
+++ b/specification/network/resource-manager/readme.java.md
@@ -31,6 +31,10 @@ directive:
     where: '$.info'
     transform: >
       $["version"] = "2018-10-01";
+  - from: applicationGateway.json
+    where: '$.definitions.ApplicationGatewayFirewallExclusion'
+    transform: >
+      $["required"] = ["matchVariable"]
 ```
 
 ### Java multi-api


### PR DESCRIPTION
They fixed it in new [WafPolicy](https://github.com/Azure/azure-rest-api-specs/pull/23184), but will not change existing WafConfiguration since it's scheduled deprecated in 2024.

They'll probably not updating old WafConfiguration any more, so replacing required array should be fine.

Tested locally.