### PR TITLE
Mvad update

### DIFF
--- a/specification/cognitiveservices/AnomalyDetector/examples/v1.1/ChangePointDetect.json
+++ b/specification/cognitiveservices/AnomalyDetector/examples/v1.1/ChangePointDetect.json
@@ -6,7 +6,7 @@
     "ApiVersion": "v1.1",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "body": {
+    "options": {
       "series": [
         {
           "timestamp": "2017-01-01T06:45:00Z",

--- a/specification/cognitiveservices/AnomalyDetector/examples/v1.1/DetectAnomaly.json
+++ b/specification/cognitiveservices/AnomalyDetector/examples/v1.1/DetectAnomaly.json
@@ -7,7 +7,7 @@
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
     "modelId": "45aad126-aafd-11ea-b8fb-d89ef3400c5f",
-    "body": {
+    "options": {
       "dataSource": "https://multiadsample.blob.core.windows.net/data/sample_data_2_1000.csv",
       "topContributorCount": 10,
       "startTime": "2019-04-01T00:15:00Z",

--- a/specification/cognitiveservices/AnomalyDetector/examples/v1.1/EntireDetect.json
+++ b/specification/cognitiveservices/AnomalyDetector/examples/v1.1/EntireDetect.json
@@ -6,7 +6,7 @@
     "ApiVersion": "v1.1",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "body": {
+    "options": {
       "series": [
         {
           "timestamp": "1972-01-01T00:00:00Z",

--- a/specification/cognitiveservices/AnomalyDetector/examples/v1.1/LastDetect.json
+++ b/specification/cognitiveservices/AnomalyDetector/examples/v1.1/LastDetect.json
@@ -6,7 +6,7 @@
     "ApiVersion": "v1.1",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "body": {
+    "options": {
       "series": [
         {
           "timestamp": "1972-01-01T00:00:00Z",

--- a/specification/cognitiveservices/AnomalyDetector/examples/v1.1/LastDetectAnomaly.json
+++ b/specification/cognitiveservices/AnomalyDetector/examples/v1.1/LastDetectAnomaly.json
@@ -7,7 +7,7 @@
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
     "modelId": "45aad126-aafd-11ea-b8fb-d89ef3400c5f",
-    "body": {
+    "options": {
       "variables": [
         {
           "variable": "Variable_1",

--- a/specification/cognitiveservices/AnomalyDetector/examples/v1.1/TrainModel.json
+++ b/specification/cognitiveservices/AnomalyDetector/examples/v1.1/TrainModel.json
@@ -6,7 +6,7 @@
     "ApiVersion": "v1.1",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "body": {
+    "modelInfo": {
       "slidingWindow": 20,
       "alignPolicy": {
         "alignMode": "Outer",

--- a/specification/cognitiveservices/AnomalyDetector/main.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/main.tsp
@@ -10,7 +10,7 @@ using TypeSpec.Versioning;
 
 @versioned(APIVersion)
 @service({title: "Anomaly Detector"})
-@useAuth(ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">)
+@useAuth(AnomalyDetectoryApiKeyAuth)
 @server(
   "{Endpoint}/anomalydetector/{ApiVersion}",
   "The Anomaly Detector API detects anomalies automatically in time series data. It supports two kinds of mode, one is for stateless using, another is for stateful using. In stateless mode, there are three functionalities. Entire Detect is for detecting the whole series with model trained by the time series, Last Detect is detecting last point with model trained by points before. ChangePoint Detect is for detecting trend changes in time series. In stateful mode, user can store time series, the stored time series will be used for detection anomalies. Under this mode, user can still use the above three functionalities by only giving a time range without preparing time series in client side. Besides the above three functionalities, stateful model also provide group based detection and labeling service. By leveraging labeling service user can provide labels for each detection result, these labels will be used for retuning or regenerating detection models. Inconsistency detection is a kind of group based detection, this detection will find inconsistency ones in a set of time series. By using anomaly detector service, business customers can discover incidents and establish a logic flow for root cause analysis.",
@@ -45,6 +45,9 @@ a set of time series. By using the anomaly detector service, business customers 
 discover incidents and establish a logic flow for root cause analysis.
 """)
 namespace AnomalyDetector;
+
+@doc("The secret key for your Azure Cognitive Services subscription.")
+model AnomalyDetectoryApiKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">;
 
 enum APIVersion {
   v1_1: "v1.1",

--- a/specification/cognitiveservices/AnomalyDetector/main.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/main.tsp
@@ -10,7 +10,7 @@ using TypeSpec.Versioning;
 
 @versioned(APIVersion)
 @service({title: "Anomaly Detector"})
-@useAuth(AnomalyDetectoryApiKeyAuth)
+@useAuth(AnomalyDetectorApiKeyAuth)
 @server(
   "{Endpoint}/anomalydetector/{ApiVersion}",
   "The Anomaly Detector API detects anomalies automatically in time series data. It supports two kinds of mode, one is for stateless using, another is for stateful using. In stateless mode, there are three functionalities. Entire Detect is for detecting the whole series with model trained by the time series, Last Detect is detecting last point with model trained by points before. ChangePoint Detect is for detecting trend changes in time series. In stateful mode, user can store time series, the stored time series will be used for detection anomalies. Under this mode, user can still use the above three functionalities by only giving a time range without preparing time series in client side. Besides the above three functionalities, stateful model also provide group based detection and labeling service. By leveraging labeling service user can provide labels for each detection result, these labels will be used for retuning or regenerating detection models. Inconsistency detection is a kind of group based detection, this detection will find inconsistency ones in a set of time series. By using anomaly detector service, business customers can discover incidents and establish a logic flow for root cause analysis.",
@@ -47,7 +47,7 @@ discover incidents and establish a logic flow for root cause analysis.
 namespace AnomalyDetector;
 
 @doc("The secret key for your Azure Cognitive Services subscription.")
-model AnomalyDetectoryApiKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">;
+model AnomalyDetectorApiKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">;
 
 enum APIVersion {
   v1_1: "v1.1",

--- a/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
@@ -357,7 +357,7 @@ Number of top contributed
 variables for one anomalous time stamp in the response. The default is
 10.
 """)
-  topContributorCount: int32;
+  topContributorCount?: int32 = 10;
 }
 
 @doc("Variable values.")

--- a/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
@@ -17,7 +17,6 @@ enum FillNAMethod {
   "Fixed",
 }
 
-@fixed
 enum MultivariateBatchDetectionStatus {
   Created: "CREATED",
   Running: "RUNNING",
@@ -33,13 +32,11 @@ enum DataSchema {
   "MultiTable",
 }
 
-@fixed
 enum AlignMode {
   "Inner",
   "Outer",
 }
 
-@fixed
 enum ModelStatus {
   Created: "CREATED",
   Running: "RUNNING",
@@ -50,8 +47,8 @@ enum ModelStatus {
 @doc("Detection results for the resultId value.")
 @resource("multivariate/detect-batch")
 model MultivariateDetectionResult {
+  #suppress "@azure-tools/typespec-azure-core/key-visibility-required" "Properties in response-only schemas should not be marked readOnly"
   @doc("Result identifier that's used to fetch the results of an inference call.")
-  @visibility("read")
   @key
   @format("uuid")
   resultId: string;
@@ -96,6 +93,7 @@ model VariableState {
   @doc("Variable name in variable states.")
   variable?: string;
 
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Service uppercases common acronyms like NA."
   @doc("Proportion of missing values that need to be filled by fillNAMethod.")
   @minValue(0.0)
   @maxValue(1.0)
@@ -245,13 +243,15 @@ detect whether the time stamp is an anomaly or not.
   alignPolicy?: AlignPolicy;
 
   @doc("Model status.")
+  @visibility("read")
   status?: ModelStatus;
 
-  @visibility("read")
   @doc("Error messages after failure to create a model.")
+  @visibility("read")
   errors?: ErrorResponse[];
 
   @doc("Diagnostics information to help inspect the states of a model or variable.")
+  @visibility("read")
   diagnosticsInfo?: DiagnosticsInfo;
 }
 
@@ -263,6 +263,7 @@ time range.
 """)
   alignMode?: AlignMode;
 
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Service uppercases common acronyms like NA."
   @doc("""
 Field that indicates how missing values will be filled.
 """)
@@ -307,8 +308,8 @@ epoch.
 @doc("Response of getting a model.")
 @resource("multivariate/models")
 model AnomalyDetectionModel {
+  #suppress "@azure-tools/typespec-azure-core/key-visibility-required" "Properties in response-only schemas should not be marked readOnly"
   @doc("Model identifier.")
-  @visibility("read")
   @key
   @format("uuid")
   modelId: string;
@@ -384,8 +385,8 @@ model MultivariateLastDetectionResult {
 @doc("Error response.")
 @error
 model ResponseError {
-  @header
+  @header("x-ms-error-code")
   @doc("Error code.")
-  "x-ms-error-code"?: string,
+  msErrorCode?: string,
   ...ErrorResponse
 }

--- a/specification/cognitiveservices/AnomalyDetector/multivariate/routes.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/multivariate/routes.tsp
@@ -9,6 +9,21 @@ using Azure.Core;
 
 namespace AnomalyDetector.Multivariate;
 
+// Operation templates
+
+@post
+@doc("Operation template for multivariate anomaly detection service action.")
+op MultivariateServiceAction<TParams, TResponse>(
+  ...TParams
+): TResponse | ResponseError;
+
+// Operations
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Does not fit any standard operation pattern"
+// This operation does not fit any standard operation pattern.
+// The closest match is probably GetResourceOperationStatus, but that can't be used because
+// it does not support an api-version in the path defined in the @server decorator.
+// https://github.com/Azure/typespec-azure/issues/2798
 @get
 @route("/multivariate/detect-batch/{resultId}")
 @summary("Get Multivariate Anomaly Detection Result")
@@ -16,15 +31,14 @@ namespace AnomalyDetector.Multivariate;
 For asynchronous inference, get a multivariate anomaly detection result based on the
 resultId value that the BatchDetectAnomaly API returns.
 """)
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
 op GetMultivariateBatchDetectionResult(
   @format("uuid")
   @doc("ID of a batch detection result.")
   @path resultId: string,
 ): MultivariateDetectionResult | ResponseError;
 
-
-@post
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Azure core RpcOperation does not support custom error response"
+// https://github.com/Azure/typespec-azure/issues/2795
 @route("/multivariate/models")
 @summary("Train a Multivariate Anomaly Detection Model")
 @doc("""
@@ -35,38 +49,44 @@ Storage folder that contains multiple CSV files, where each CSV file has
 two columns, time stamp and variable. Or the Blob Storage URI can point to a single blob that contains a CSV file that has all the variables and a
 time stamp column.
 """)
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
-op TrainMultivariateModel(
-  @doc("Model information.")
-  @body modelInfo: ModelInfo,
-): {
-  @statusCode statusCode: 201,
-  @doc("Location and ID of the model.")
-  @header Location: string,
-  @body result: AnomalyDetectionModel
-  } | ResponseError;
+op TrainMultivariateModel is MultivariateServiceAction<
+  // TParams
+  {
+    @doc("Model information.")
+    @body modelInfo: ModelInfo,
+  },
+  // TResponse
+  {
+    @statusCode statusCode: 201,
+    @doc("Location and ID of the model.")
+    @header location: string,
+    @body result: AnomalyDetectionModel
+  }>;
 
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Does not fit any standard operation pattern"
+// This operation does not fit any standard operation pattern.
+// The closest match is probably ResourceList, but that can't be used because
+// it does not support an api-version in the path defined in the @server decorator.
+// https://github.com/Azure/typespec-azure/issues/2798
+// and because the response uses "models" instead of "value" as the array property name.
 @get
 @route("/multivariate/models")
 @summary("List Multivariate Models")
 @doc("List models of a resource.")
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
 op ListMultivariateModels(
-  @doc("Skip indicates how many models will be skipped.")
-  @query
-  skip?: int32 = 0;
-
-  @doc("Top indicates how many models will be fetched.")
-  @query
-  top?: int32;
+  ...SkipQueryParameter,
+  ...TopQueryParameter,
 ): ModelList | ResponseError;
 
 
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Does not fit any standard operation pattern"
+// This operation does not fit any standard operation pattern.
+// The closest match is probably ResourceDelete, but that can't be used because
+// it does not support an api-version in the path defined in the @server decorator.
 @summary("Delete Multivariate Model")
 @doc("Delete an existing multivariate model according to the modelId value.")
 @delete
 @route("/multivariate/models/{modelId}")
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
 op DeleteMultivariateModel(
   @doc("Model identifier.")
   @path
@@ -77,6 +97,11 @@ op DeleteMultivariateModel(
   statusCode: 204
   } | ResponseError;
 
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Does not fit any standard operation pattern"
+// This operation does not fit any standard operation pattern.
+// The closest match is probably ResourceGet, but that can't be used because
+// it does not support an api-version in the path defined in the @server decorator.
 @summary("Get Multivariate Model")
 @doc("""
 Get detailed information about the multivariate model, including the training status
@@ -84,13 +109,17 @@ and variables used in the model.
 """)
 @get
 @route("/multivariate/models/{modelId}")
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
 op GetMultivariateModel(
   @doc("Model identifier.")
   @path
   modelId: string,
 ): AnomalyDetectionModel | ResponseError;
 
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Does not fit any standard operation pattern"
+// This operation does not fit any standard operation pattern.
+// The closest match is probably LongRunningResourceAction, but that can't be used because
+// it does not support an api-version in the path defined in the @server decorator.
+@post
 @route("/multivariate/models/{modelId}:detect-batch")
 @summary("Detect Multivariate Anomaly")
 @doc("""
@@ -101,7 +130,6 @@ query the detection result. The request should be a source link to indicate an
 externally accessible Azure Storage URI that either points to an Azure Blob
 Storage folder or points to a CSV file in Azure Blob Storage.
 """)
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
 op DetectMultivariateBatchAnomaly(
   @doc("Model identifier.")
   @path
@@ -111,12 +139,17 @@ op DetectMultivariateBatchAnomaly(
 ): {
   @statusCode statusCode: 202,
   @doc("ID of the detection result.")
-  @header "Operation-Id": string,
+  @header("Operation-Id") operationId: string,
   @doc("Location of the detection result.")
-  @header "Operation-Location": string,
+  @header("Operation-Location") operationLocation: string,
   @body result: MultivariateDetectionResult,
 } | ResponseError;
 
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Does not fit any standard operation pattern"
+// This operation does not fit any standard operation pattern.
+// The closest match is probably ResourceAction, but that can't be used because
+// it does not support an api-version in the path defined in the @server decorator.
 @route("/multivariate/models/{modelId}:detect-last")
 @summary("Detect anomalies in the last point of the request body")
 @doc("""
@@ -125,7 +158,6 @@ and inference data. The inference data should be put into the request body in
 JSON format. The request will finish synchronously and return the detection
 immediately in the response body.
 """)
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
 op DetectMultivariateLastAnomaly(
   @doc("Model identifier.")
   @path

--- a/specification/cognitiveservices/AnomalyDetector/tspconfig.yaml
+++ b/specification/cognitiveservices/AnomalyDetector/tspconfig.yaml
@@ -3,5 +3,7 @@ emit: [
 ]
 options:
   "@azure-tools/typespec-autorest":
-    "output-file": "openapi.json"
-    "examples-directory": ./examples
+    examples-directory: ./examples
+    omit-unreachable-types: true
+    output-file: openapi.json
+    emitter-output-dir: "{project-root}/../data-plane/AnomalyDetector/stable"

--- a/specification/cognitiveservices/AnomalyDetector/tspconfig.yaml
+++ b/specification/cognitiveservices/AnomalyDetector/tspconfig.yaml
@@ -7,3 +7,18 @@ options:
     omit-unreachable-types: true
     output-file: openapi.json
     emitter-output-dir: "{project-root}/../data-plane/AnomalyDetector/stable"
+  "@azure-tools/typespec-python":
+    "basic-setup-py": true
+    "package-version": 3.0.0b6
+    "package-name": azure-ai-anomalydetector
+  #   "output-path":
+  # Uncomment this line and add "@azure-tools/typespec-java" to your package.json to generate Java code
+  "@azure-tools/typespec-java":
+    namespace: com.azure.ai.anomalydetector
+    partial-update: true
+  # Uncomment this line and add "@azure-tools/typespec-csharp" to your package.json to generate C# code
+  "@azure-tools/typespec-csharp":
+    save-inputs: false
+    clear-output-folder: true
+    namespace: Azure.AI.AnomalyDetector
+    model-namespace: false

--- a/specification/cognitiveservices/AnomalyDetector/tspconfig.yaml
+++ b/specification/cognitiveservices/AnomalyDetector/tspconfig.yaml
@@ -1,26 +1,7 @@
 emit: [
   "@azure-tools/typespec-autorest",
-  "@azure-tools/typespec-python",
-  "@azure-tools/typespec-csharp",
 ]
 options:
   "@azure-tools/typespec-autorest":
     "output-file": "openapi.json"
     "examples-directory": ./examples
-  "@azure-tools/typespec-python":
-    "basic-setup-py": true
-    "package-version": 3.0.0b6
-    "package-name": azure-ai-anomalydetector
-  #   "output-path":
-  # Uncomment this line and add "@azure-tools/typespec-java" to your package.json to generate Java code
-  "@azure-tools/typespec-java":
-    namespace: com.azure.ai.anomalydetector
-    partial-update: true
-  # Uncomment this line and add "@azure-tools/typespec-csharp" to your package.json to generate C# code
-  "@azure-tools/typespec-csharp":
-    save-inputs: false
-    clear-output-folder: true
-    namespace: Azure.AI.AnomalyDetector
-    model-namespace: false
-  # Uncomment this line and add "@azure-tools/typespec-typescript" to your package.json to generate Typescript code
-  # "@azure-tools/cadl-typescript": true

--- a/specification/cognitiveservices/AnomalyDetector/univariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/univariate/models.tsp
@@ -31,7 +31,6 @@ enum AnomalyDetectorErrorCodes {
   "InvalidImputeFixedValue",
 }
 
-@fixed
 enum TimeGranularity {
   Yearly: "yearly",
   Monthly: "monthly",
@@ -172,15 +171,15 @@ severe the anomaly is. For normal points, the severity is always 0.
 @doc("Error information that the API returned.")
 @error
 model AnomalyDetectorError {
-  @header
+  @header("x-ms-error-code")
   @doc("Error code.")
-  "x-ms-error-code"?: string,
+  msErrorCode: string,
 
   @doc("Error code.")
-  code?: AnomalyDetectorErrorCodes;
+  code: AnomalyDetectorErrorCodes;
 
   @doc("Message that explains the error that the service reported.")
-  message?: string;
+  message: string;
 }
 
 @doc("Response of the last anomaly detection.")

--- a/specification/cognitiveservices/AnomalyDetector/univariate/routes.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/univariate/routes.tsp
@@ -5,10 +5,18 @@ import "./models.tsp";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;
+using Azure.Core;
 
 namespace AnomalyDetector.Univariate;
 
 @post
+@doc("Operation template for univariate anomaly detection service action.")
+op UnivariateServiceAction<TParams, TResponse>(
+  ...TParams
+): TResponse | AnomalyDetectorError;
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Azure core RpcOperation does not support custom error response"
+// https://github.com/Azure/typespec-azure/issues/2795
 @route("timeseries/entire/detect")
 @summary("Detect anomalies for the entire series in batch.")
 @doc("""
@@ -17,31 +25,42 @@ with the same model. With this method, points before and after a certain point
 are used to determine whether it's an anomaly. The entire detection can give the
 user an overall status of the time series.
 """)
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
-op DetectUnivariateEntireSeries(
-  @doc("Method of univariate anomaly detection.")
-  @body options: UnivariateDetectionOptions,
-): UnivariateEntireDetectionResult | AnomalyDetectorError;
+op DetectUnivariateEntireSeries is UnivariateServiceAction<
+  // TParams
+  {
+    @doc("Method of univariate anomaly detection.")
+    @body options: UnivariateDetectionOptions,
+  },
+  // TResponse
+  UnivariateEntireDetectionResult>;
 
-@post
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Azure core RpcOperation does not support custom error response"
+// https://github.com/Azure/typespec-azure/issues/2795
 @route("timeseries/last/detect")
 @summary("Detect anomaly status of the latest point in time series.")
 @doc("""
 This operation generates a model by using the points that you sent in to the API
 and based on all data to determine whether the last point is anomalous.
 """)
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
-op DetectUnivariateLastPoint(
-  @doc("Method of univariate anomaly detection.")
-  @body options: UnivariateDetectionOptions,
-): UnivariateLastDetectionResult | AnomalyDetectorError;
+op DetectUnivariateLastPoint is UnivariateServiceAction<
+  // TParams
+  {
+    @doc("Method of univariate anomaly detection.")
+    @body options: UnivariateDetectionOptions,
+  },
+  // TResponse
+  UnivariateLastDetectionResult>;
 
-@post
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Azure core RpcOperation does not support custom error response"
+// https://github.com/Azure/typespec-azure/issues/2795
 @route("timeseries/changepoint/detect")
 @summary("Detect change point for the entire series")
 @doc("Evaluate the change point score of every series point.")
-// To improve CADL implementation apply: https://github.com/Azure/azure-rest-api-specs/issues/21527
-op DetectUnivariateChangePoint(
-  @doc("Method of univariate anomaly detection.")
-  @body options: UnivariateChangePointDetectionOptions,
-): UnivariateChangePointDetectionResult | AnomalyDetectorError;
+op DetectUnivariateChangePoint is UnivariateServiceAction<
+  // TParams
+  {
+    @doc("Method of univariate anomaly detection.")
+    @body options: UnivariateChangePointDetectionOptions,
+  },
+  // TResponse
+  UnivariateChangePointDetectionResult>;

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/ChangePointDetect.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/ChangePointDetect.json
@@ -6,7 +6,7 @@
     "ApiVersion": "v1.1",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "body": {
+    "options": {
       "series": [
         {
           "timestamp": "2017-01-01T06:45:00Z",

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/DetectAnomaly.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/DetectAnomaly.json
@@ -7,7 +7,7 @@
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
     "modelId": "45aad126-aafd-11ea-b8fb-d89ef3400c5f",
-    "body": {
+    "options": {
       "dataSource": "https://multiadsample.blob.core.windows.net/data/sample_data_2_1000.csv",
       "topContributorCount": 10,
       "startTime": "2019-04-01T00:15:00Z",

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/EntireDetect.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/EntireDetect.json
@@ -6,7 +6,7 @@
     "ApiVersion": "v1.1",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "body": {
+    "options": {
       "series": [
         {
           "timestamp": "1972-01-01T00:00:00Z",

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/LastDetect.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/LastDetect.json
@@ -6,7 +6,7 @@
     "ApiVersion": "v1.1",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "body": {
+    "options": {
       "series": [
         {
           "timestamp": "1972-01-01T00:00:00Z",

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/LastDetectAnomaly.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/LastDetectAnomaly.json
@@ -7,7 +7,7 @@
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
     "modelId": "45aad126-aafd-11ea-b8fb-d89ef3400c5f",
-    "body": {
+    "options": {
       "variables": [
         {
           "variable": "Variable_1",

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/TrainModel.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/examples/TrainModel.json
@@ -6,7 +6,7 @@
     "ApiVersion": "v1.1",
     "Content-Type": "application/json",
     "Ocp-Apim-Subscription-Key": "{API key}",
-    "body": {
+    "modelInfo": {
       "slidingWindow": 20,
       "alignPolicy": {
         "alignMode": "Outer",

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/openapi.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/openapi.json
@@ -516,57 +516,6 @@
     }
   },
   "definitions": {
-    "APIVersion": {
-      "type": "string",
-      "enum": [
-        "v1.1"
-      ],
-      "x-ms-enum": {
-        "name": "APIVersion",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "v1_1",
-            "value": "v1.1"
-          }
-        ]
-      }
-    },
-    "AnomalyDetectoryApiKeyAuth": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "apiKey"
-          ],
-          "description": "API key authentication"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "header"
-          ],
-          "description": "location of the API key"
-        },
-        "name": {
-          "type": "string",
-          "enum": [
-            "Ocp-Apim-Subscription-Key"
-          ],
-          "x-ms-enum": {
-            "modelAsString": false
-          },
-          "description": "name of the API key"
-        }
-      },
-      "description": "The secret key for your Azure Cognitive Services subscription.",
-      "required": [
-        "type",
-        "in",
-        "name"
-      ]
-    },
     "Multivariate.AlignMode": {
       "type": "string",
       "enum": [

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/openapi.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/openapi.json
@@ -53,12 +53,13 @@
   ],
   "security": [
     {
-      "ApiKeyAuth": []
+      "AnomalyDetectoryApiKeyAuth": []
     }
   ],
   "securityDefinitions": {
-    "ApiKeyAuth": {
+    "AnomalyDetectoryApiKeyAuth": {
       "type": "apiKey",
+      "description": "The secret key for your Azure Cognitive Services subscription.",
       "in": "header",
       "name": "Ocp-Apim-Subscription-Key"
     }
@@ -161,21 +162,10 @@
         "description": "List models of a resource.",
         "parameters": [
           {
-            "name": "skip",
-            "in": "query",
-            "required": false,
-            "description": "Skip indicates how many models will be skipped.",
-            "default": 0,
-            "type": "integer",
-            "format": "int32"
+            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
           },
           {
-            "name": "top",
-            "in": "query",
-            "required": false,
-            "description": "Top indicates how many models will be fetched.",
-            "type": "integer",
-            "format": "int32"
+            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
           }
         ],
         "responses": {
@@ -312,11 +302,11 @@
           "202": {
             "description": "The request has been accepted for processing, but processing has not yet completed.",
             "headers": {
-              "operation-id": {
+              "Operation-Id": {
                 "description": "ID of the detection result.",
                 "type": "string"
               },
-              "operation-location": {
+              "Operation-Location": {
                 "description": "Location of the detection result.",
                 "type": "string"
               }
@@ -542,6 +532,41 @@
         ]
       }
     },
+    "AnomalyDetectoryApiKeyAuth": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ],
+          "description": "API key authentication"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header"
+          ],
+          "description": "location of the API key"
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "Ocp-Apim-Subscription-Key"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          },
+          "description": "name of the API key"
+        }
+      },
+      "description": "The secret key for your Azure Cognitive Services subscription.",
+      "required": [
+        "type",
+        "in",
+        "name"
+      ]
+    },
     "Multivariate.AlignMode": {
       "type": "string",
       "enum": [
@@ -550,7 +575,7 @@
       ],
       "x-ms-enum": {
         "name": "AlignMode",
-        "modelAsString": false
+        "modelAsString": true
       }
     },
     "Multivariate.AlignPolicy": {
@@ -578,8 +603,7 @@
         "modelId": {
           "type": "string",
           "description": "Model identifier.",
-          "format": "uuid",
-          "readOnly": true
+          "format": "uuid"
         },
         "createdTime": {
           "type": "string",
@@ -814,7 +838,8 @@
         },
         "status": {
           "$ref": "#/definitions/Multivariate.ModelStatus",
-          "description": "Model status."
+          "description": "Model status.",
+          "readOnly": true
         },
         "errors": {
           "type": "array",
@@ -828,7 +853,8 @@
         },
         "diagnosticsInfo": {
           "$ref": "#/definitions/Multivariate.DiagnosticsInfo",
-          "description": "Diagnostics information to help inspect the states of a model or variable."
+          "description": "Diagnostics information to help inspect the states of a model or variable.",
+          "readOnly": true
         }
       },
       "description": "Training result of a model, including its status, errors, and diagnostics\ninformation.",
@@ -924,7 +950,7 @@
       ],
       "x-ms-enum": {
         "name": "ModelStatus",
-        "modelAsString": false,
+        "modelAsString": true,
         "values": [
           {
             "name": "Created",
@@ -1022,7 +1048,7 @@
       ],
       "x-ms-enum": {
         "name": "MultivariateBatchDetectionStatus",
-        "modelAsString": false,
+        "modelAsString": true,
         "values": [
           {
             "name": "Created",
@@ -1049,8 +1075,7 @@
         "resultId": {
           "type": "string",
           "description": "Result identifier that's used to fetch the results of an inference call.",
-          "format": "uuid",
-          "readOnly": true
+          "format": "uuid"
         },
         "summary": {
           "$ref": "#/definitions/Multivariate.MultivariateBatchDetectionResultSummary",
@@ -1088,13 +1113,13 @@
         "topContributorCount": {
           "type": "integer",
           "format": "int32",
-          "description": "Number of top contributed\nvariables for one anomalous time stamp in the response. The default is\n10."
+          "description": "Number of top contributed\nvariables for one anomalous time stamp in the response. The default is\n10.",
+          "default": 10
         }
       },
       "description": "Request of the last detection.",
       "required": [
-        "variables",
-        "topContributorCount"
+        "variables"
       ]
     },
     "Multivariate.MultivariateLastDetectionResult": {
@@ -1215,7 +1240,11 @@
           "description": "Message that explains the error that the service reported."
         }
       },
-      "description": "Error information that the API returned."
+      "description": "Error information that the API returned.",
+      "required": [
+        "code",
+        "message"
+      ]
     },
     "Univariate.AnomalyDetectorErrorCodes": {
       "type": "string",
@@ -1293,7 +1322,7 @@
       ],
       "x-ms-enum": {
         "name": "TimeGranularity",
-        "modelAsString": false,
+        "modelAsString": true,
         "values": [
           {
             "name": "Yearly",
@@ -1615,5 +1644,24 @@
       ]
     }
   },
-  "parameters": {}
+  "parameters": {
+    "Azure.Core.SkipQueryParameter": {
+      "name": "skip",
+      "in": "query",
+      "required": false,
+      "description": "The number of result items to skip.",
+      "type": "integer",
+      "format": "int32",
+      "x-ms-parameter-location": "method"
+    },
+    "Azure.Core.TopQueryParameter": {
+      "name": "top",
+      "in": "query",
+      "required": false,
+      "description": "The number of result items to return.",
+      "type": "integer",
+      "format": "int32",
+      "x-ms-parameter-location": "method"
+    }
+  }
 }

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/openapi.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/openapi.json
@@ -53,11 +53,11 @@
   ],
   "security": [
     {
-      "AnomalyDetectoryApiKeyAuth": []
+      "AnomalyDetectorApiKeyAuth": []
     }
   ],
   "securityDefinitions": {
-    "AnomalyDetectoryApiKeyAuth": {
+    "AnomalyDetectorApiKeyAuth": {
       "type": "apiKey",
       "description": "The secret key for your Azure Cognitive Services subscription.",
       "in": "header",


### PR DESCRIPTION
This PR updates the TypeSpec for AnomalyDetector to the latest TypeSpec and Azure.Core versions. It also fixes some minor issues in the API definition.  Some details:

Fixes:
- topContributorCount is optional with default of 10
- Fix x-ms-error-code header
- Suppress camel case warnings on some properties
- remove @fixed from enums
- removed language emitters from tspconfig.yaml
- Marked status and diagnosticsInfo as readOnly in ModelInfo
- removed readOnly from resultId in response-only models
- Added documentation string to auth model
- Added suppressions and comments on operations that don't use Azure core operation templates
- Replaced skip and top parameters with Azure.Core definitions.

