### PR TITLE
Recovery Services Backup: Marking the LROs as LROs

### DIFF
--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2023-06-01/bms.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2023-06-01/bms.json
@@ -1440,6 +1440,10 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
         "x-ms-examples": {
           "Enable Protection on Azure IaasVm": {
             "$ref": "./examples/AzureIaasVm/ConfigureProtection.json"
@@ -1509,6 +1513,10 @@
               "$ref": "#/definitions/CloudError"
             }
           }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
         },
         "x-ms-examples": {
           "Delete Protection from Azure Virtual Machine": {
@@ -3143,6 +3151,9 @@
           }
         },
         "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
         "x-ms-examples": {
           "RegisterAzure Storage ProtectionContainers": {
             "$ref": "./examples/AzureStorage/ProtectionContainers_Register.json"
@@ -3202,6 +3213,10 @@
               "$ref": "#/definitions/CloudError"
             }
           }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
         },
         "x-ms-examples": {
           "Unregister Protection Container": {


### PR DESCRIPTION
This API returns a 202 with a Location header and is thus a Long Running Operation and so should be defined as such

Fixes https://github.com/hashicorp/pandora/issues/2345

This means that users don't need to manually parse and poll on the LRO: https://github.com/hashicorp/terraform-provider-azurerm/commit/dd3769186e61e14b196b6ef56fde3c63fe4d7ead#diff-3a615b62819b696f833f32c65c05e033eeeb4e66a8657931eb9e62a24b63f46bR114-R130