### PR TITLE
Remove the minimum number for the option field requestBodyInspectLimitInKB

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/webapplicationfirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/webapplicationfirewall.json
@@ -456,7 +456,6 @@
         "requestBodyInspectLimitInKB": {
           "type": "integer",
           "format": "int32",
-          "exclusiveMinimum": false,
           "description": "Max inspection limit in KB for request body inspection for WAF."
         },
         "requestBodyEnforcement": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/webapplicationfirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2022-11-01/webapplicationfirewall.json
@@ -456,7 +456,6 @@
         "requestBodyInspectLimitInKB": {
           "type": "integer",
           "format": "int32",
-          "minimum": 8,
           "exclusiveMinimum": false,
           "description": "Max inspection limit in KB for request body inspection for WAF."
         },


### PR DESCRIPTION
Remove the minimum value for optional field "requestBodyInspectLimitInKB". There is no breaking change introduced.