### PR TITLE
[AnomalyDetector] Fix for SDK clients due to associative arrays 

### DIFF
--- a/specification/cognitiveservices/AnomalyDetector/client.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/client.tsp
@@ -3,14 +3,4 @@ import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
 
-@@convenientAPI(AnomalyDetector.Multivariate.GetMultivariateBatchDetectionResult, true)
-@@convenientAPI(AnomalyDetector.Multivariate.TrainMultivariateModel, true)
-@@convenientAPI(AnomalyDetector.Multivariate.ListMultivariateModels, true)
-@@convenientAPI(AnomalyDetector.Multivariate.DeleteMultivariateModel, true)
-@@convenientAPI(AnomalyDetector.Multivariate.GetMultivariateModel, true)
-@@convenientAPI(AnomalyDetector.Multivariate.DetectMultivariateBatchAnomaly, true)
-@@convenientAPI(AnomalyDetector.Multivariate.DetectMultivariateLastAnomaly, true)
-
 @@convenientAPI(AnomalyDetector.Univariate.DetectUnivariateEntireSeries, false)
-@@convenientAPI(AnomalyDetector.Univariate.DetectUnivariateLastPoint, true)
-@@convenientAPI(AnomalyDetector.Univariate.DetectUnivariateChangePoint, true)

--- a/specification/cognitiveservices/AnomalyDetector/client.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/client.tsp
@@ -11,6 +11,6 @@ using Azure.ClientGenerator.Core;
 @@convenientAPI(AnomalyDetector.Multivariate.DetectMultivariateBatchAnomaly, true)
 @@convenientAPI(AnomalyDetector.Multivariate.DetectMultivariateLastAnomaly, true)
 
-@@convenientAPI(AnomalyDetector.Univariate.DetectUnivariateEntireSeries, true)
+@@convenientAPI(AnomalyDetector.Univariate.DetectUnivariateEntireSeries, false)
 @@convenientAPI(AnomalyDetector.Univariate.DetectUnivariateLastPoint, true)
 @@convenientAPI(AnomalyDetector.Univariate.DetectUnivariateChangePoint, true)

--- a/specification/cognitiveservices/AnomalyDetector/tspconfig.yaml
+++ b/specification/cognitiveservices/AnomalyDetector/tspconfig.yaml
@@ -1,6 +1,12 @@
 parameters:
   "python-sdk-folder":
     default: "{project-root}/azure-sdk-for-python/"
+  "java-sdk-folder":
+    default: "{project-root}/azure-sdk-for-java/"
+  "js-sdk-folder":
+    default: "{project-root}/azure-sdk-for-js/"
+  "csharp-sdk-folder":
+    default: "{project-root}/azure-sdk-for-net/"
   "service-directory-name":
     default: "anomalydetector"
 emit: [
@@ -22,9 +28,16 @@ options:
   "@azure-tools/typespec-java":
     namespace: com.azure.ai.anomalydetector
     partial-update: true
+    emitter-output-dir: "{java-sdk-folder}/sdk/{service-directory-name}/azure-ai-anomalydetector"
   # Uncomment this line and add "@azure-tools/typespec-csharp" to your package.json to generate C# code
   "@azure-tools/typespec-csharp":
     save-inputs: false
     clear-output-folder: true
     namespace: Azure.AI.AnomalyDetector
     model-namespace: false
+  "@azure-tools/typespec-ts":
+    emitter-output-dir: "{js-sdk-folder}/sdk/{service-directory-name}/ai-anomaly-detector-rest"
+    generateMetadata: true
+    generateTest: true
+    packageDetails:
+      name: "@azure-rest/ai-anomaly-detector"


### PR DESCRIPTION
Turn off @convenientAPI generation for `DetectUnivariateEntireSeries`. 
Also, cleaned up client.tsp, using @convenientAPI with a `true` value is redundant since the convenience methods are now generated by default.

NOTE: The change to `DetectUnivariateEntireSeries` affects .NET and Java, this method should be handwritten