### PR TITLE
Update `package.json` to do `npx tsc` in `postinstall` to fix `npx prettier`

### DIFF
--- a/documentation/ci-fix.md
+++ b/documentation/ci-fix.md
@@ -34,7 +34,7 @@ If upon running running `prettier` in any of the ways described above you encoun
 [error] Cannot find module '/home/<username>/tmp/azure-rest-api-specs/scripts/prettier-swagger-plugin'
 ```
 
-then please first run `npx tsc`. Even if it outputs errors, try running `prettier` againl it should work.
+then please first run `npx tsc`. Even if it outputs errors, try running `prettier` again. It should work.
 
 ## Model Validation
 

--- a/documentation/ci-fix.md
+++ b/documentation/ci-fix.md
@@ -21,7 +21,7 @@ Or if you want to fix specified service, use the complete path, not relative:
 
 ```
 npm install
-npm run prettier -- --write "<path to repo>/azure-rest-api-specs/specification/**/*.json"
+npm run prettier-fix --write "<path to repo>/azure-rest-api-specs/specification/**/*.json"
 ```
 
 Then please commit and push changes made by prettier.

--- a/documentation/ci-fix.md
+++ b/documentation/ci-fix.md
@@ -21,23 +21,20 @@ Or if you want to fix specified service, use the complete path, not relative:
 
 ```
 npm install
-npm run prettier --write "<path to repo clone>/azure-rest-api-specs/specification/**/*.json"
+npx prettier --write "<path to repo clone>/azure-rest-api-specs/specification/**/*.json"
 ```
 
 Then please commit and push changes made by prettier.
 
 ### Troublshooting prettier
 
-If upon running `npm run prettier-fix` or `npm run prettier` you encounter error similar to this one:
+If upon running running `prettier` in any of the ways described above you encounter error similar to this one:
+
 ```
 [error] Cannot find module '/home/<username>/tmp/azure-rest-api-specs/scripts/prettier-swagger-plugin'
 ```
 
-then please first run
-
-```
-npx tsc
-```
+then please first run `npx tsc`. Even if it outputs errors, try running `prettier` againl it should work.
 
 ## Model Validation
 

--- a/documentation/ci-fix.md
+++ b/documentation/ci-fix.md
@@ -21,10 +21,23 @@ Or if you want to fix specified service, use the complete path, not relative:
 
 ```
 npm install
-npm run prettier-fix --write "<path to repo>/azure-rest-api-specs/specification/**/*.json"
+npm run prettier --write "<path to repo clone>/azure-rest-api-specs/specification/**/*.json"
 ```
 
 Then please commit and push changes made by prettier.
+
+### Troublshooting prettier
+
+If upon running `npm run prettier-fix` or `npm run prettier` you encounter error similar to this one:
+```
+[error] Cannot find module '/home/<username>/tmp/azure-rest-api-specs/scripts/prettier-swagger-plugin'
+```
+
+then please first run
+
+```
+npx tsc
+```
 
 ## Model Validation
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@azure-tools/typespec-autorest": "0.29.0",
     "@azure-tools/typespec-azure-core": "0.29.0",
     "@azure-tools/typespec-azure-resource-manager": "0.29.0",
-    "@azure-tools/typespec-client-generator-core": "0.29.0,
+    "@azure-tools/typespec-client-generator-core": "0.29.0",
     "@azure-tools/typespec-providerhub": "0.29.0",
     "@azure-tools/typespec-apiview": "0.4.4",    
     "@typespec/compiler": "0.43.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "prettier-check": "ts-node ./scripts/prettier-check.ts",
     "prettier-fix": "prettier --write specification/**/*.json"
+    "postinstall": "tsc"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "@azure-tools/typespec-autorest": "0.29.0",
     "@azure-tools/typespec-azure-core": "0.29.0",
     "@azure-tools/typespec-azure-resource-manager": "0.29.0",
+    "@azure-tools/typespec-client-generator-core": "0.29.0,
     "@azure-tools/typespec-providerhub": "0.29.0",
-    "@azure-tools/typespec-apiview": "0.4.4",
+    "@azure-tools/typespec-apiview": "0.4.4",    
     "@typespec/compiler": "0.43.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@azure-tools/typespec-autorest": "0.29.0",
     "@azure-tools/typespec-azure-core": "0.29.0",
     "@azure-tools/typespec-azure-resource-manager": "0.29.0",
-    "@azure-tools/typespec-client-generator-core": "0.29.0",
     "@azure-tools/typespec-providerhub": "0.29.0",
     "@azure-tools/typespec-apiview": "0.4.4",    
     "@typespec/compiler": "0.43.0"


### PR DESCRIPTION
@weshaggard , some users reported the issue (e.g. [azure/azure-sdk-tools #6017](https://github.com/Azure/azure-sdk-tools/issues/6017))
```
npm run prettier -- --write specification/**/*.json

> prettier
> prettier --write specification/**/*.json

[error] Cannot find module '/home/raychen/tmp/azure-rest-api-specs/scripts/prettier-swagger-plugin'
[error] Require stack:
[error] - /home/raychen/tmp/azure-rest-api-specs/node_modules/prettier/index.js
[error] - /home/raychen/tmp/azure-rest-api-specs/node_modules/prettier/cli.js
[error] - /home/raychen/tmp/azure-rest-api-specs/node_modules/prettier/bin-prettier.js
```
It needs to run tsc after run `npm install`. So I added back the build step of post npm install.

~~The aka.ms/ci-fix also needs to be updated to remove the `npm run prettier` part as `prettier` script was removed from `package.json`.~~
- Fixed by kojamroz by additional commits pushed to this PR.