### PR TITLE
Set "name" in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "azure-rest-api-specs",
       "dependencies": {
         "@azure-tools/cadl-apiview": "0.3.5",
         "@azure-tools/cadl-autorest": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "azure-rest-api-specs",
   "dependencies": {
     "@azure-tools/cadl-autorest": "0.26.0",
     "@azure-tools/cadl-azure-core": "0.26.0",


### PR DESCRIPTION
- If not set, package-lock.json uses name of directory where repo is cloned
- Directory name may be different on every dev machine, causing unintended diffs in package-lock.json
