### PR TITLE
[AppConfiguration][Unreleased] Update snapshot composition_type enum values.

### DIFF
--- a/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
@@ -1620,8 +1620,8 @@
           "description": "The composition type describes how the key-values within the snapshot are composed. The 'key' composition type ensures there are no two key-values containing the same key. The 'key_label' composition type ensures there are no two key-values containing the same key and label.",
           "type": "string",
           "enum": [
-            "key_label",
-            "key"
+            "key",
+            "key_label"
           ],
           "x-nullable": false,
           "x-ms-enum": {

--- a/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/data-plane/Microsoft.AppConfiguration/preview/2022-11-01-preview/appconfiguration.json
@@ -1617,11 +1617,11 @@
           }
         },
         "composition_type": {
-          "description": "The composition type describes how the key-values within the snapshot are composed. The 'all' composition type includes all key-values. The 'group_by_key' composition type ensures there are no two key-values containing the same key.",
+          "description": "The composition type describes how the key-values within the snapshot are composed. The 'key' composition type ensures there are no two key-values containing the same key. The 'key_label' composition type ensures there are no two key-values containing the same key and label.",
           "type": "string",
           "enum": [
-            "all",
-            "group_by_key"
+            "key_label",
+            "key"
           ],
           "x-nullable": false,
           "x-ms-enum": {


### PR DESCRIPTION
This PR updates the enum values of a snapshot's composition_type property.

Renames the values of the composition_type enum from

`'group_by_key' | 'all'`

to

`'key' | 'key_label'`

The new description of the property:

"The composition type describes how the key-values within the snapshot are composed. The 'key' composition type ensures there are no two key-values containing the same key. The 'key_label' composition type ensures there are no two key-values containing the same key and label."