### PR TITLE
Fix topContributorCount to be optional with default of 10

### DIFF
--- a/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
@@ -129,11 +129,9 @@ to be detected.
   dataSource: url;
 
   @doc("""
-Number of top contributed
-variables for one anomalous time stamp in the response. The default is
-10.
+Number of top contributed variables for one anomalous time stamp in the response.
 """)
-  topContributorCount: int32;
+  topContributorCount?: int32 = 10;
 
   @doc("""
 Start date/time of data for detection, which should

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/openapi.json
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/stable/v1.1/openapi.json
@@ -936,7 +936,8 @@
         "topContributorCount": {
           "type": "integer",
           "format": "int32",
-          "description": "Number of top contributed\nvariables for one anomalous time stamp in the response. The default is\n10."
+          "description": "Number of top contributed variables for one anomalous time stamp in the response.",
+          "default": 10
         },
         "startTime": {
           "type": "string",
@@ -952,7 +953,6 @@
       "description": "Detection request for batch inference. This is an asynchronous inference that\nwill need another API to get detection results.",
       "required": [
         "dataSource",
-        "topContributorCount",
         "startTime",
         "endTime"
       ]


### PR DESCRIPTION
This PR fixes the `topContributorCount` field of `MultivariateBatchDetectionOptions` to be optional with a default of 10.

#23434 made a similar fix in `MultivariateLastDetectionOptions` but missed it in `MultivariateBatchDetectionOptions`.
