### PR TITLE
Remove "postinstall: tsc" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,5 @@
     "prettier": "^2.8.8",
     "typescript": "~5.0.4"
   },
-  "scripts": {
-    "postinstall": "tsc"
-  },
   "private": true
 }


### PR DESCRIPTION
- Causing pipeline failures due to build errors from scripts in openapi-alps repo
- Added in #23763 to improve the experience on local dev machines
