### PR TITLE
Update tspconfig.yaml

### DIFF
--- a/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
@@ -9,26 +9,23 @@ emit:
   - "@azure-tools/typespec-autorest"
 options:
   "@azure-tools/typespec-autorest":
-    azure-resource-provider-folder: "./data-plane"
+    azure-resource-provider-folder: "data-plane"
     emitter-output-dir: "{project-root}/.."
-    examples-directory: "./examples"
+    examples-directory: "examples"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/widgets.json"
-  "@azure-tools/typespec-python":    
+  "@azure-tools/typespec-python":
     package-dir: "azure-contoso-widgetmanager"
     package-mode: "dataplane"
-    package-name: "{package-dir}"    
+    package-name: "{package-dir}"
   "@azure-tools/typespec-csharp":
     package-dir: "Azure.Contoso.WidgetManager"
     clear-output-folder: true
     model-namespace: false
-    namespace: "{package-dir}"    
+    namespace: "{package-dir}"
   "@azure-tools/typespec-ts":
     package-dir: "contosowidgetmanager-rest"
-    generateMetadata: true
-    generateTest: true
     packageDetails:
       name: "@azure-rest/contoso-widgetmanager-rest"
-      description: "Contoso WidgetManager Service"
   "@azure-tools/typespec-java":
     package-dir: "azure-contoso-widgetmanager"
     namespace: com.azure.contoso.widgetmanager

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
@@ -1,7 +1,7 @@
 parameters:  
   "service-dir":
     default: "sdk/contosowidgetmanager"
-   "dependencies":
+  "dependencies":
     "additionalDirectories":
       - "specification/contosowidgetmanager/Contoso.WidgetManager.Shared/"
     default: ""

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
@@ -1,6 +1,10 @@
 parameters:  
   "service-dir":
     default: "sdk/contosowidgetmanager"
+   "dependencies":
+    "additionalDirectories":
+      - "specification/contosowidgetmanager/Contoso.WidgetManager.Shared/"
+    default: ""
 emit:
   - "@azure-tools/typespec-autorest"
 options:

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
@@ -1,14 +1,6 @@
-parameters:
-  "python-sdk-folder":
-    default: "{project-root}/azure-sdk-for-python/"
-  "java-sdk-folder":
-    default: "{project-root}/azure-sdk-for-java/"
-  "js-sdk-folder":
-    default: "{project-root}/azure-sdk-for-js/"
-  "csharp-sdk-folder":
-    default: "{project-root}/azure-sdk-for-csharp/"
-  "service-directory-name":
-    default: "contosowidgetmanager"
+parameters:  
+  "service-dir":
+    default: "sdk/contosowidgetmanager"
 emit:
   - "@azure-tools/typespec-autorest"
 options:
@@ -17,22 +9,22 @@ options:
     emitter-output-dir: "{project-root}/.."
     examples-directory: "./examples"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/widgets.json"
-  "@azure-tools/typespec-python":
-    emitter-output-dir: "{python-sdk-folder}/sdk/{service-directory-name}/{package-name}"
+  "@azure-tools/typespec-python":    
+    package-dir: "azure-contoso-widgetmanager"
     package-mode: "dataplane"
-    package-name: "azure-contoso-widgetmanager"
+    package-name: "{package-dir}"    
   "@azure-tools/typespec-csharp":
+    package-dir: "Azure.Contoso.WidgetManager"
     clear-output-folder: true
-    emitter-output-dir: "{csharp-sdk-folder}/sdk/{service-directory-name}/{namespace}/src"
     model-namespace: false
-    namespace: Azure.Contoso.WidgetManager
+    namespace: "{package-dir}"    
   "@azure-tools/typespec-ts":
-    emitter-output-dir: "{js-sdk-folder}/sdk/{service-directory-name}/contosowidgetmanager-rest"
+    package-dir: "contosowidgetmanager-rest"
     generateMetadata: true
     generateTest: true
     packageDetails:
       name: "@azure-rest/contoso-widgetmanager-rest"
       description: "Contoso WidgetManager Service"
   "@azure-tools/typespec-java":
-    emitter-output-dir: "{java-sdk-folder}/sdk/{service-directory-name}/azure-contoso-widgetmanager"
+    package-dir: "azure-contoso-widgetmanager"
     namespace: com.azure.contoso.widgetmanager


### PR DESCRIPTION
The purpose is to have each language emitter to use the same config value in this file for code generation. Language emitters have the knowledge of the code generation path under sdk project directory base on the sdk project template.
 - clean up parameters section
 - get rid of `emitter-out-dir`
 - introduce `service-dir` and `package-dir` to be used by emitter and tools to compute the sdk project directory
 - add `additionalDirectories` to parameters section

