### PR TITLE
New version 2023-05-01 for RP Microsoft.Consumption 

### DIFF
--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/consumption.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/consumption.json
@@ -1,0 +1,6002 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2023-05-01",
+    "title": "ConsumptionManagementClient",
+    "description": "Consumption management client provides access to consumption resources for Azure Enterprise Subscriptions."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/{scope}/providers/Microsoft.Consumption/usageDetails": {
+      "get": {
+        "tags": [
+          "UsageDetails"
+        ],
+        "operationId": "UsageDetails_List",
+        "description": "Lists the usage details for the defined scope. Usage details are available via this API only for May 1, 2014 or later.\n\n**Note:Microsoft will be retiring the Consumption Usage Details API at some point in the future. We do not recommend that you take a new dependency on this API. Please use the Cost Details API instead. We will notify customers once a date for retirement has been determined.For Learn more,see [Generate Cost Details Report - Create Operation](https://learn.microsoft.com/en-us/rest/api/cost-management/generate-cost-details-report/create-operation?tabs=HTTP)**",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "UsageDetailsList-Legacy": {
+            "$ref": "./examples/UsageDetailsList.json"
+          },
+          "UsageDetailsListFilterByTag-Legacy": {
+            "$ref": "./examples/UsageDetailsListFilterByTag.json"
+          },
+          "UsageDetailsListForBillingPeriod-Legacy": {
+            "$ref": "./examples/UsageDetailsListForBillingPeriod.json"
+          },
+          "UsageDetailsExpand-Legacy": {
+            "$ref": "./examples/UsageDetailsExpand.json"
+          },
+          "UsageDetailsListByMetricActualCost-Legacy": {
+            "$ref": "./examples/UsageDetailsListByMetricActualCost.json"
+          },
+          "UsageDetailsListByMetricAmortizedCost-Legacy": {
+            "$ref": "./examples/UsageDetailsListByMetricAmortizedCost.json"
+          },
+          "UsageDetailsListByMetricUsage-Legacy": {
+            "$ref": "./examples/UsageDetailsListByMetricUsage.json"
+          },
+          "BillingAccountUsageDetailsList-Legacy": {
+            "$ref": "./examples/UsageDetailsListByBillingAccount.json"
+          },
+          "BillingAccountUsageDetailsListForBillingPeriod-Legacy": {
+            "$ref": "./examples/UsageDetailsListForBillingPeriodByBillingAccount.json"
+          },
+          "DepartmentUsageDetailsList-Legacy": {
+            "$ref": "./examples/UsageDetailsListByDepartment.json"
+          },
+          "DepartmentUsageDetailsListForBillingPeriod-Legacy": {
+            "$ref": "./examples/UsageDetailsListForBillingPeriodByDepartment.json"
+          },
+          "EnrollmentAccountUsageDetailsList-Legacy": {
+            "$ref": "./examples/UsageDetailsListByEnrollmentAccount.json"
+          },
+          "EnrollmentAccountUsageDetailsListForBillingPeriod-Legacy": {
+            "$ref": "./examples/UsageDetailsListForBillingPeriodByEnrollmentAccount.json"
+          },
+          "ManagementGroupUsageDetailsList-Legacy": {
+            "$ref": "./examples/UsageDetailsListByManagementGroup.json"
+          },
+          "ManagementGroupUsageDetailsListForBillingPeriod-Legacy": {
+            "$ref": "./examples/UsageDetailsListForBillingPeriodByManagementGroup.json"
+          },
+          "BillingAccountUsageDetailsList-Modern": {
+            "$ref": "./examples/UsageDetailsListByMCABillingAccount.json"
+          },
+          "BillingProfileUsageDetailsList-Modern": {
+            "$ref": "./examples/UsageDetailsListByMCABillingProfile.json"
+          },
+          "InvoiceSectionUsageDetailsList-Modern": {
+            "$ref": "./examples/UsageDetailsListByMCAInvoiceSection.json"
+          },
+          "CustomerUsageDetailsList-Modern": {
+            "$ref": "./examples/UsageDetailsListByMCACustomer.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/scopeUsageDetailsParameter"
+          },
+          {
+            "name": "$expand",
+            "description": "May be used to expand the properties/additionalInfo or properties/meterDetails within a list of usage details. By default, these fields are not included when listing usage details.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "description": "May be used to filter usageDetails by properties/resourceGroup, properties/resourceName, properties/resourceId, properties/chargeType, properties/reservationId, properties/publisherType or tags. The filter supports 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne', 'or', or 'not'. Tag filter is a key value pair string where key and value is separated by a colon (:). PublisherType Filter accepts two values azure and marketplace and it is currently supported for Web Direct Offer Type",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skiptoken",
+            "description": "Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skiptoken parameter that specifies a starting point to use for subsequent calls.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "description": "May be used to limit the number of results to the most recent N usageDetails.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/metricParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/UsageDetailsListResult"
+            }
+          },
+          "204": {
+            "description": "No Content. The request has succeeded but returned no results."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Consumption/marketplaces": {
+      "get": {
+        "tags": [
+          "Marketplaces"
+        ],
+        "x-ms-odata": "#/definitions/Marketplace",
+        "operationId": "Marketplaces_List",
+        "description": "Lists the marketplaces for a scope at the defined scope. Marketplaces are available via this API only for May 1, 2014 or later.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "SubscriptionMarketplacesList": {
+            "$ref": "./examples/MarketplacesList.json"
+          },
+          "SubscriptionMarketplacesListForBillingPeriod": {
+            "$ref": "./examples/MarketplacesListForBillingPeriod.json"
+          },
+          "BillingAccountMarketplacesList": {
+            "$ref": "./examples/MarketplacesByBillingAccountList.json"
+          },
+          "BillingAccountMarketplacesListForBillingPeriod": {
+            "$ref": "./examples/MarketplacesByBillingAccountListForBillingPeriod.json"
+          },
+          "DepartmentMarketplacesList": {
+            "$ref": "./examples/MarketplacesByDepartmentList.json"
+          },
+          "DepartmentMarketplacesListForBillingPeriod": {
+            "$ref": "./examples/MarketplacesByDepartment_ListByBillingPeriod.json"
+          },
+          "EnrollmentAccountMarketplacesList": {
+            "$ref": "./examples/MarketplacesByEnrollmentAccountList.json"
+          },
+          "EnrollmentAccountMarketplacesListForBillingPeriod": {
+            "$ref": "./examples/MarketplacesByEnrollmentAccounts_ListByBillingPeriod.json"
+          },
+          "ManagementGroupMarketplacesList": {
+            "$ref": "./examples/MarketplacesByManagementGroupList.json"
+          },
+          "ManagementGroupMarketplacesListForBillingPeriod": {
+            "$ref": "./examples/MarketplacesByManagementGroup_ListForBillingPeriod.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "$filter",
+            "description": "May be used to filter marketplaces by properties/usageEnd (Utc time), properties/usageStart (Utc time), properties/resourceGroup, properties/instanceName or properties/instanceId. The filter supports 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne', 'or', or 'not'.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "description": "May be used to limit the number of results to the most recent N marketplaces.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          },
+          {
+            "name": "$skiptoken",
+            "description": "Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skiptoken parameter that specifies a starting point to use for subsequent calls.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/scopeMarketplaceParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/MarketplacesListResult"
+            }
+          },
+          "204": {
+            "description": "An empty response is sent when there is no information available within the selected scope."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Consumption/budgets": {
+      "get": {
+        "tags": [
+          "Budgets"
+        ],
+        "operationId": "Budgets_List",
+        "description": "Lists all budgets for the defined scope.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "BudgetsList": {
+            "$ref": "./examples/BudgetsList.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/scopeBudgetParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/BudgetsListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Consumption/budgets/{budgetName}": {
+      "get": {
+        "tags": [
+          "Budgets"
+        ],
+        "operationId": "Budgets_Get",
+        "description": "Gets the budget for the scope by budget name.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "Budget": {
+            "$ref": "./examples/Budget.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/scopeBudgetParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/budgetNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Budget"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Budgets"
+        ],
+        "operationId": "Budgets_CreateOrUpdate",
+        "description": "The operation to create or update a budget. You can optionally provide an eTag if desired as a form of concurrency control. To obtain the latest eTag for a given budget, perform a get operation prior to your put operation.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "CreateOrUpdateBudget": {
+            "$ref": "./examples/CreateOrUpdateBudget.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/scopeBudgetParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/budgetNameParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Budget"
+            },
+            "description": "Parameters supplied to the Create Budget operation."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Budget"
+            }
+          },
+          "201": {
+            "description": "Created.",
+            "schema": {
+              "$ref": "#/definitions/Budget"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Budgets"
+        ],
+        "operationId": "Budgets_Delete",
+        "description": "The operation to delete a budget.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "DeleteBudget": {
+            "$ref": "./examples/DeleteBudget.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/scopeBudgetParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/budgetNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Consumption/tags": {
+      "get": {
+        "tags": [
+          "Tags"
+        ],
+        "operationId": "Tags_Get",
+        "description": "Get all available tag keys for the defined scope",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "Tags_Get": {
+            "$ref": "./examples/Tags.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/scopeTagsParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/TagsResult"
+            }
+          },
+          "204": {
+            "description": "An empty response is sent when there is no information available within the selected scope."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Consumption/charges": {
+      "get": {
+        "tags": [
+          "Charges"
+        ],
+        "operationId": "Charges_List",
+        "description": "Lists the charges based for the defined scope.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ChargesListForEnrollmentAccount-Legacy": {
+            "$ref": "./examples/ChargesListForEnrollmentAccountFilterByStartEndDate.json"
+          },
+          "ChangesForBillingPeriodByEnrollmentAccount-Legacy": {
+            "$ref": "./examples/ChargesForBillingPeriodByEnrollmentAccount.json"
+          },
+          "ChargesListByDepartment-Legacy": {
+            "$ref": "./examples/ChargesListForDepartmentFilterByStartEndDate.json"
+          },
+          "ChangesForBillingPeriodByDepartment-Legacy": {
+            "$ref": "./examples/ChargesForBillingPeriodByDepartment.json"
+          },
+          "ChargesListByBillingAccount-Modern": {
+            "$ref": "./examples/ChargesListByModernBillingAccount.json"
+          },
+          "ChargesListByBillingAccountGroupByBillingProfileId-Modern": {
+            "$ref": "./examples/ChargesListByModernBillingAccountGroupByBillingProfileId.json"
+          },
+          "ChargesListByBillingAccountGroupByInvoiceSectionId-Modern": {
+            "$ref": "./examples/ChargesListByModernBillingAccountGroupByInvoiceSectionId.json"
+          },
+          "ChargesListByBillingAccountGroupByCustomerId-Modern": {
+            "$ref": "./examples/ChargesListByModernBillingAccountGroupByCustomerId.json"
+          },
+          "ChargesListByBillingProfile-Modern": {
+            "$ref": "./examples/ChargesListByModernBillingProfile.json"
+          },
+          "ChargesListByBillingProfileInvoiceSection-Modern": {
+            "$ref": "./examples/ChargesListByModernBillingProfileInvoiceSection.json"
+          },
+          "ChargesListByBillingProfileGroupByInvoiceSectionId-Modern": {
+            "$ref": "./examples/ChargesListByModernBillingProfileGroupByInvoiceSectionId.json"
+          },
+          "ChargesListByInvoiceSectionId-Modern": {
+            "$ref": "./examples/ChargesListByModernInvoiceSectionId.json"
+          },
+          "ChargesListByCustomer-Modern": {
+            "$ref": "./examples/ChargesListByModernCustomer.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/scopeChargesParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "description": "Start date",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "description": "End date",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "$filter",
+            "description": "May be used to filter charges by properties/usageEnd (Utc time), properties/usageStart (Utc time). The filter supports 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne', 'or', or 'not'. Tag filter is a key value pair string where key and value is separated by a colon (:).",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$apply",
+            "description": "May be used to group charges for billingAccount scope by properties/billingProfileId, properties/invoiceSectionId, properties/customerId (specific for Partner Led), or for billingProfile scope by properties/invoiceSectionId.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ChargesListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/providers/Microsoft.Consumption/balances": {
+      "get": {
+        "tags": [
+          "Balances"
+        ],
+        "operationId": "Balances_GetByBillingAccount",
+        "description": "Gets the balances for a scope by billingAccountId. Balances are available via this API only for May 1, 2014 or later.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "Balances": {
+            "$ref": "./examples/BalancesByBillingAccount.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Balance"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingPeriods/{billingPeriodName}/providers/Microsoft.Consumption/balances": {
+      "get": {
+        "tags": [
+          "Balances"
+        ],
+        "operationId": "Balances_GetForBillingPeriodByBillingAccount",
+        "description": "Gets the balances for a scope by billing period and billingAccountId. Balances are available via this API only for May 1, 2014 or later.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "Balances": {
+            "$ref": "./examples/BalancesByBillingAccountForBillingPeriod.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/billingPeriodNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Balance"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Capacity/reservationorders/{reservationOrderId}/providers/Microsoft.Consumption/reservationSummaries": {
+      "get": {
+        "tags": [
+          "ReservationSummaries"
+        ],
+        "operationId": "ReservationsSummaries_ListByReservationOrder",
+        "description": "Lists the reservations summaries for daily or monthly grain. Note: ARM has a payload size limit of 12MB, so currently callers get 400 when the response size exceeds the ARM limit. In such cases, API call should be made with smaller date ranges.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationSummariesDaily": {
+            "$ref": "./examples/ReservationSummariesDaily.json"
+          },
+          "ReservationSummariesMonthly": {
+            "$ref": "./examples/ReservationSummariesMonthly.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/reservationOrderIdParameter"
+          },
+          {
+            "$ref": "#/parameters/grainParameter"
+          },
+          {
+            "name": "$filter",
+            "description": "Required only for daily grain. The properties/UsageDate for start date and end date. The filter supports 'le' and  'ge'",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ReservationSummariesListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Capacity/reservationorders/{reservationOrderId}/reservations/{reservationId}/providers/Microsoft.Consumption/reservationSummaries": {
+      "get": {
+        "tags": [
+          "ReservationSummaries"
+        ],
+        "operationId": "ReservationsSummaries_ListByReservationOrderAndReservation",
+        "description": "Lists the reservations summaries for daily or monthly grain. Note: ARM has a payload size limit of 12MB, so currently callers get 400 when the response size exceeds the ARM limit. In such cases, API call should be made with smaller date ranges.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationSummariesDailyWithReservationId": {
+            "$ref": "./examples/ReservationSummariesDailyWithReservationId.json"
+          },
+          "ReservationSummariesMonthlyWithReservationId": {
+            "$ref": "./examples/ReservationSummariesMonthlyWithReservationId.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/reservationOrderIdParameter"
+          },
+          {
+            "$ref": "#/parameters/reservationIdParameter"
+          },
+          {
+            "$ref": "#/parameters/grainParameter"
+          },
+          {
+            "name": "$filter",
+            "description": "Required only for daily grain. The properties/UsageDate for start date and end date. The filter supports 'le' and  'ge'",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ReservationSummariesListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceScope}/providers/Microsoft.Consumption/reservationSummaries": {
+      "get": {
+        "tags": [
+          "ReservationSummaries"
+        ],
+        "operationId": "ReservationsSummaries_List",
+        "description": "Lists the reservations summaries for the defined scope daily or monthly grain. Note: ARM has a payload size limit of 12MB, so currently callers get 400 when the response size exceeds the ARM limit. In such cases, API call should be made with smaller date ranges.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationSummariesDailyWithBillingAccountId": {
+            "$ref": "./examples/ReservationSummariesDailyWithBillingAccountId.json"
+          },
+          "ReservationSummariesMonthlyWithBillingAccountId": {
+            "$ref": "./examples/ReservationSummariesMonthlyWithBillingAccountId.json"
+          },
+          "ReservationSummariesDailyWithBillingProfileId": {
+            "$ref": "./examples/ReservationSummariesDailyWithBillingProfileId.json"
+          },
+          "ReservationSummariesMonthlyWithBillingProfileId": {
+            "$ref": "./examples/ReservationSummariesMonthlyWithBillingProfileId.json"
+          },
+          "ReservationSummariesMonthlyWithBillingProfileIdReservationId": {
+            "$ref": "./examples/ReservationSummariesMonthlyWithBillingProfileIdReservationId.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/scopeReservationsSummariesParameter"
+          },
+          {
+            "$ref": "#/parameters/grainParameter"
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "description": "Start date. Only applicable when querying with billing profile",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "description": "End date. Only applicable when querying with billing profile",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "$filter",
+            "description": "Required only for daily grain. The properties/UsageDate for start date and end date. The filter supports 'le' and  'ge'. Not applicable when querying with billing profile",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "reservationId",
+            "in": "query",
+            "description": "Reservation Id GUID. Only valid if reservationOrderId is also provided. Filter to a specific reservation",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "reservationOrderId",
+            "in": "query",
+            "description": "Reservation Order Id GUID. Required if reservationId is provided. Filter to a specific reservation order",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ReservationSummariesListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Capacity/reservationorders/{reservationOrderId}/providers/Microsoft.Consumption/reservationDetails": {
+      "get": {
+        "tags": [
+          "ReservationDetails"
+        ],
+        "operationId": "ReservationsDetails_ListByReservationOrder",
+        "description": "Lists the reservations details for provided date range. Note: ARM has a payload size limit of 12MB, so currently callers get 400 when the response size exceeds the ARM limit. If the data size is too large, customers may also get 504 as the API timed out preparing the data. In such cases, API call should be made with smaller date ranges or a call to Generate Reservation Details Report API should be made as it is asynchronous and will not run into response size time outs.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationDetails": {
+            "$ref": "./examples/ReservationDetails.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/reservationOrderIdParameter"
+          },
+          {
+            "name": "$filter",
+            "description": "Filter reservation details by date range. The properties/UsageDate for start date and end date. The filter supports 'le' and  'ge'",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ReservationDetailsListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Capacity/reservationorders/{reservationOrderId}/reservations/{reservationId}/providers/Microsoft.Consumption/reservationDetails": {
+      "get": {
+        "tags": [
+          "ReservationDetails"
+        ],
+        "operationId": "ReservationsDetails_ListByReservationOrderAndReservation",
+        "description": "Lists the reservations details for provided date range. Note: ARM has a payload size limit of 12MB, so currently callers get 400 when the response size exceeds the ARM limit. If the data size is too large, customers may also get 504 as the API timed out preparing the data. In such cases, API call should be made with smaller date ranges or a call to Generate Reservation Details Report API should be made as it is asynchronous and will not run into response size time outs.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationDetailsWithReservationId": {
+            "$ref": "./examples/ReservationDetailsWithReservationId.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/reservationOrderIdParameter"
+          },
+          {
+            "$ref": "#/parameters/reservationIdParameter"
+          },
+          {
+            "name": "$filter",
+            "description": "Filter reservation details by date range. The properties/UsageDate for start date and end date. The filter supports 'le' and  'ge' ",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ReservationDetailsListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceScope}/providers/Microsoft.Consumption/reservationDetails": {
+      "get": {
+        "tags": [
+          "ReservationDetails"
+        ],
+        "operationId": "ReservationsDetails_List",
+        "description": "Lists the reservations details for provided date range. Note: ARM has a payload size limit of 12MB, so currently callers get 400 when the response size exceeds the ARM limit. If the data size is too large, customers may also get 504 as the API timed out preparing the data. In such cases, API call should be made with smaller date ranges or a call to Generate Reservation Details Report API should be made as it is asynchronous and will not run into response size time outs.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationDetailsByBillingAccountId": {
+            "$ref": "./examples/ReservationDetailsByBillingAccountId.json"
+          },
+          "ReservationDetailsByBillingProfileId": {
+            "$ref": "./examples/ReservationDetailsByBillingProfileId.json"
+          },
+          "ReservationDetailsByBillingProfileIdReservationId": {
+            "$ref": "./examples/ReservationDetailsByBillingProfileIdReservationId.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/scopeReservationDetailsParameter"
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "description": "Start date. Only applicable when querying with billing profile",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "description": "End date. Only applicable when querying with billing profile",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "$filter",
+            "description": "Filter reservation details by date range. The properties/UsageDate for start date and end date. The filter supports 'le' and  'ge'. Not applicable when querying with billing profile",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "reservationId",
+            "in": "query",
+            "description": "Reservation Id GUID. Only valid if reservationOrderId is also provided. Filter to a specific reservation",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "reservationOrderId",
+            "in": "query",
+            "description": "Reservation Order Id GUID. Required if reservationId is provided. Filter to a specific reservation order",
+            "required": false,
+            "type": "string",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ReservationDetailsListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceScope}/providers/Microsoft.Consumption/reservationRecommendations": {
+      "get": {
+        "tags": [
+          "ReservationRecommendations"
+        ],
+        "operationId": "ReservationRecommendations_List",
+        "description": "List of recommendations for purchasing reserved instances.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationRecommendationsBySubscription-Legacy": {
+            "$ref": "./examples/ReservationRecommendationsBySubscription.json"
+          },
+          "ReservationRecommendationsByResourceGroup-Legacy": {
+            "$ref": "./examples/ReservationRecommendationsByResourceGroup.json"
+          },
+          "ReservationRecommendationsFilterBySubscriptionForScopeLookBackPeriod-Legacy": {
+            "$ref": "./examples/ReservationRecommendationsFilterBySubscriptionForScopeLookBackPeriod.json"
+          },
+          "ReservationRecommendationsByBillingAccount-Legacy": {
+            "$ref": "./examples/ReservationRecommendationsByBillingAccount.json"
+          },
+          "ReservationRecommendationsByBillingProfile-Modern": {
+            "$ref": "./examples/ReservationRecommendationsByBillingProfile.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/filterParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/scopeReservationRecommendationsParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ReservationRecommendationsListResult"
+            }
+          },
+          "204": {
+            "description": "An empty response is sent when there are no recommendations."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceScope}/providers/Microsoft.Consumption/reservationRecommendationDetails": {
+      "get": {
+        "tags": [
+          "ReservationRecommendationDetails"
+        ],
+        "operationId": "ReservationRecommendationDetails_Get",
+        "description": "Details of a reservation recommendation for what-if analysis of reserved instances.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationRecommendationsBySubscription-Legacy": {
+            "$ref": "./examples/ReservationRecommendationDetailsBySubscription.json"
+          },
+          "ReservationRecommendationsByResourceGroup-Legacy": {
+            "$ref": "./examples/ReservationRecommendationDetailsByResourceGroup.json"
+          },
+          "ReservationRecommendationsByBillingAccount-Legacy": {
+            "$ref": "./examples/ReservationRecommendationDetailsByBillingAccount.json"
+          },
+          "ReservationRecommendationsByBillingProfile-Modern": {
+            "$ref": "./examples/ReservationRecommendationDetailsByBillingProfile.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/scopeReservationRecommendationDetailsParameter"
+          },
+          {
+            "$ref": "#/parameters/scopeParameter"
+          },
+          {
+            "$ref": "#/parameters/regionParameter"
+          },
+          {
+            "$ref": "#/parameters/termParameter"
+          },
+          {
+            "$ref": "#/parameters/lookBackPeriodParameter"
+          },
+          {
+            "$ref": "#/parameters/productParameter"
+          },
+          {
+            "$ref": "#/parameters/recommendationDetailsFilterParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ReservationRecommendationDetailsModel"
+            }
+          },
+          "204": {
+            "description": "An empty response is sent when there are no recommendation details."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/HighCasedErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/providers/Microsoft.Consumption/reservationTransactions": {
+      "get": {
+        "tags": [
+          "ReservationTransactions"
+        ],
+        "operationId": "ReservationTransactions_List",
+        "description": "List of transactions for reserved instances on billing account scope. Note: The refund transactions are posted along with its purchase transaction (i.e. in the purchase billing month). For example, The refund is requested in May 2021. This refund transaction will have event date as May 2021 but the billing month as April 2020 when the reservation purchase was made. Note: ARM has a payload size limit of 12MB, so currently callers get 400 when the response size exceeds the ARM limit. In such cases, API call should be made with smaller date ranges.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationTransactionsByEnrollmentNumber": {
+            "$ref": "./examples/ReservationTransactionsListByEnrollmentNumber.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "$filter",
+            "description": "Filter reservation transactions by date range. The properties/EventDate for start date and end date. The filter supports 'le' and  'ge'. Note: API returns data for the entire start date's and end date's billing month. For example, filter properties/eventDate+ge+2020-01-01+AND+properties/eventDate+le+2020-12-29 will include data for the entire December 2020 month (i.e. will contain records for dates December 30 and 31)",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/useMarkupIfPartnerParameter"
+          },
+          {
+            "$ref": "#/parameters/previewMarkupPercentage"
+          },
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ReservationTransactionsListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/providers/Microsoft.Consumption/reservationTransactions": {
+      "get": {
+        "tags": [
+          "ReservationTransactions"
+        ],
+        "operationId": "ReservationTransactions_ListByBillingProfile",
+        "description": "List of transactions for reserved instances on billing profile scope. The refund transactions are posted along with its purchase transaction (i.e. in the purchase billing month). For example, The refund is requested in May 2021. This refund transaction will have event date as May 2021 but the billing month as April 2020 when the reservation purchase was made. Note: ARM has a payload size limit of 12MB, so currently callers get 400 when the response size exceeds the ARM limit. In such cases, API call should be made with smaller date ranges.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "ReservationTransactionsByBillingProfileId": {
+            "$ref": "./examples/ReservationTransactionsListByBillingProfileId.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "$filter",
+            "description": "Filter reservation transactions by date range. The properties/EventDate for start date and end date. The filter supports 'le' and  'ge'. Note: API returns data for the entire start date's and end date's billing month. For example, filter properties/eventDate+ge+2020-01-01+AND+properties/eventDate+le+2020-12-29 will include data for entire December 2020 month (i.e. will contain records for dates December 30 and 31)",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/billingProfileIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ModernReservationTransactionsListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Consumption/pricesheets/default": {
+      "get": {
+        "tags": [
+          "PriceSheet"
+        ],
+        "operationId": "PriceSheet_Get",
+        "description": "Gets the price sheet for a subscription. Price sheet is available via this API only for May 1, 2014 or later.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "PriceSheet": {
+            "$ref": "./examples/PriceSheet.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "$expand",
+            "description": "May be used to expand the properties/meterDetails within a price sheet. By default, these fields are not included when returning price sheet.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skiptoken",
+            "description": "Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skiptoken parameter that specifies a starting point to use for subsequent calls.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "description": "May be used to limit the number of results to the top N results.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PriceSheetResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Billing/billingPeriods/{billingPeriodName}/providers/Microsoft.Consumption/pricesheets/default": {
+      "get": {
+        "tags": [
+          "PriceSheet"
+        ],
+        "operationId": "PriceSheet_GetByBillingPeriod",
+        "description": "Get the price sheet for a scope by subscriptionId and billing period. Price sheet is available via this API only for May 1, 2014 or later.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "PriceSheetForBillingPeriod": {
+            "$ref": "./examples/PriceSheetForBillingPeriod.json"
+          },
+          "PriceSheetExpand": {
+            "$ref": "./examples/PriceSheetExpand.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "$expand",
+            "description": "May be used to expand the properties/meterDetails within a price sheet. By default, these fields are not included when returning price sheet.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skiptoken",
+            "description": "Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skiptoken parameter that specifies a starting point to use for subsequent calls.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "description": "May be used to limit the number of results to the top N results.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 1000
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/billingPeriodNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PriceSheetResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Consumption/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "operationId": "Operations_List",
+        "description": "Lists all of the available consumption REST API operations.",
+        "x-ms-examples": {
+          "OperationList": {
+            "$ref": "./examples/OperationList.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Consumption/aggregatedcost": {
+      "get": {
+        "tags": [
+          "AggregatedCost"
+        ],
+        "operationId": "AggregatedCost_GetByManagementGroup",
+        "description": "Provides the aggregate cost of a management group and all child management groups by current billing period.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "AggregatedCostByManagementGroup": {
+            "$ref": "./examples/AggregatedCostByManagementGroup.json"
+          },
+          "AggregatedCostByManagementGroupFilterByDate": {
+            "$ref": "./examples/AggregatedCostByManagementGroupFilterByDate.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/managementGroupIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "name": "$filter",
+            "description": "May be used to filter aggregated cost by properties/usageStart (Utc time), properties/usageEnd (Utc time). The filter supports 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne', 'or', or 'not'. Tag filter is a key value pair string where key and value is separated by a colon (:).",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ManagementGroupAggregatedCostResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Billing/billingPeriods/{billingPeriodName}/providers/Microsoft.Consumption/aggregatedCost": {
+      "get": {
+        "tags": [
+          "AggregatedCost"
+        ],
+        "operationId": "AggregatedCost_GetForBillingPeriodByManagementGroup",
+        "description": "Provides the aggregate cost of a management group and all child management groups by specified billing period",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "AggregatedCostListForBillingPeriodByManagementGroup": {
+            "$ref": "./examples/AggregatedCostForBillingPeriodByManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/managementGroupIdParameter"
+          },
+          {
+            "$ref": "#/parameters/billingPeriodNameParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ManagementGroupAggregatedCostResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/providers/Microsoft.Consumption/events": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "operationId": "Events_ListByBillingProfile",
+        "description": "Lists the events that decrements Azure credits or Microsoft Azure consumption commitment for a billing account or a billing profile for a given start and end date.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "EventsListByBillingProfile": {
+            "$ref": "./examples/EventsListByBillingProfile.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/billingProfileIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/startDateParameter"
+          },
+          {
+            "$ref": "#/parameters/endDateParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Events"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/providers/Microsoft.Consumption/events": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "operationId": "Events_ListByBillingAccount",
+        "description": "Lists the events that decrements Azure credits or Microsoft Azure consumption commitment for a billing account or a billing profile for a given start and end date.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "EventsGetByBillingAccount": {
+            "$ref": "./examples/EventsGetByBillingAccount.json"
+          },
+          "EventsGetByBillingAccountWithFilters": {
+            "$ref": "./examples/EventsGetByBillingAccountWithFilters.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "name": "$filter",
+            "description": "May be used to filter the events by lotId, lotSource etc. The filter supports 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne', 'or', or 'not'. Tag filter is a key value pair string where key and value is separated by a colon (:).",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Events"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/providers/Microsoft.Consumption/lots": {
+      "get": {
+        "tags": [
+          "Lots"
+        ],
+        "operationId": "Lots_ListByBillingProfile",
+        "description": "Lists all Azure credits for a billing account or a billing profile. The API is only supported for Microsoft Customer Agreements (MCA) billing accounts.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "LotsListByBillingProfile": {
+            "$ref": "./examples/LotsListByBillingProfile.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/billingProfileIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Lots"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/providers/Microsoft.Consumption/lots": {
+      "get": {
+        "tags": [
+          "Lots"
+        ],
+        "operationId": "Lots_ListByBillingAccount",
+        "description": "Lists all Microsoft Azure consumption commitments for a billing account. The API is only supported for Microsoft Customer Agreements (MCA) and Direct Enterprise Agreement (EA)  billing accounts.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "LotsListByBillingAccount": {
+            "$ref": "./examples/LotsListByBillingAccount.json"
+          },
+          "LotsListByBillingAccountWithStatusFilter": {
+            "$ref": "./examples/LotsListByBillingAccountWithFilters.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "name": "$filter",
+            "description": "May be used to filter the lots by Status, Source etc. The filter supports 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne', 'or', or 'not'. Tag filter is a key value pair string where key and value is separated by a colon (:).",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Lots"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/customers/{customerId}/providers/Microsoft.Consumption/lots": {
+      "get": {
+        "tags": [
+          "Lots"
+        ],
+        "operationId": "Lots_ListByCustomer",
+        "description": "Lists all Azure credits for a customer. The API is only supported for Microsoft Partner  Agreements (MPA) billing accounts.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "LotsListByCustomer": {
+            "$ref": "./examples/LotsListByCustomer.json"
+          },
+          "LotsListByCustomerWithFilter": {
+            "$ref": "./examples/LotsListByCustomerWithFilters.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/customerIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "name": "$filter",
+            "description": "May be used to filter the lots by Status, Source etc. The filter supports 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. Tag filter is a key value pair string where key and value is separated by a colon (:).",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Lots"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/providers/Microsoft.Consumption/credits/balanceSummary": {
+      "get": {
+        "tags": [
+          "Credits"
+        ],
+        "operationId": "Credits_Get",
+        "description": "The credit summary by billingAccountId and billingProfileId.",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-examples": {
+          "CreditSummaryByBillingProfile": {
+            "$ref": "./examples/CreditSummaryByBillingProfile.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/billingProfileIdParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CreditSummary"
+            }
+          },
+          "204": {
+            "description": "No Content. The request has succeeded but returned no results."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "MeterDetails": {
+      "description": "The properties of the meter detail.",
+      "properties": {
+        "meterName": {
+          "description": "The name of the meter, within the given meter category",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterCategory": {
+          "description": "The category of the meter, for example, 'Cloud services', 'Networking', etc..",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterSubCategory": {
+          "description": "The subcategory of the meter, for example, 'A6 Cloud services', 'ExpressRoute (IXP)', etc..",
+          "type": "string",
+          "readOnly": true
+        },
+        "unit": {
+          "description": "The unit in which the meter consumption is charged, for example, 'Hours', 'GB', etc.",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterLocation": {
+          "description": "The location in which the Azure service is available.",
+          "type": "string",
+          "readOnly": true
+        },
+        "totalIncludedQuantity": {
+          "description": "The total included quantity associated with the offer.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "pretaxStandardRate": {
+          "description": "The pretax listing price.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "serviceName": {
+          "description": "The name of the service.",
+          "type": "string",
+          "readOnly": true
+        },
+        "serviceTier": {
+          "description": "The service tier.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "UsageDetail": {
+      "type": "object",
+      "discriminator": "kind",
+      "description": "An usage detail resource.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Specifies the kind of usage details.",
+          "enum": [
+            "legacy",
+            "modern"
+          ],
+          "x-ms-enum": {
+            "name": "UsageDetailsKind",
+            "modelAsString": true
+          }
+        }
+      },
+      "required": [
+        "kind"
+      ]
+    },
+    "UsageDetailsListResult": {
+      "description": "Result of listing usage details. It contains a list of available usage details in reverse chronological order by billing period.",
+      "properties": {
+        "value": {
+          "description": "The list of usage details.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/UsageDetail"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "LegacyUsageDetail": {
+      "description": "Legacy usage detail.",
+      "type": "object",
+      "x-ms-discriminator-value": "legacy",
+      "properties": {
+        "properties": {
+          "description": "Properties for legacy usage details",
+          "$ref": "#/definitions/LegacyUsageDetailProperties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/UsageDetail"
+        }
+      ],
+      "required": [
+        "properties"
+      ]
+    },
+    "LegacyUsageDetailProperties": {
+      "description": "The properties of the legacy usage detail.",
+      "properties": {
+        "billingAccountId": {
+          "description": "Billing Account identifier.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingAccountName": {
+          "description": "Billing Account Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingPeriodStartDate": {
+          "description": "The billing period start date.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "billingPeriodEndDate": {
+          "description": "The billing period end date.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "billingProfileId": {
+          "description": "Billing Profile identifier.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingProfileName": {
+          "description": "Billing Profile Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "accountOwnerId": {
+          "description": "Account Owner Id.",
+          "type": "string",
+          "readOnly": true
+        },
+        "accountName": {
+          "description": "Account Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "subscriptionId": {
+          "description": "Subscription guid.",
+          "type": "string",
+          "readOnly": true
+        },
+        "subscriptionName": {
+          "description": "Subscription name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "date": {
+          "description": "Date for the usage record.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "product": {
+          "description": "Product name for the consumed service or purchase. Not available for Marketplace.",
+          "type": "string",
+          "readOnly": true
+        },
+        "partNumber": {
+          "description": "Part Number of the service used. Can be used to join with the price sheet. Not available for marketplace.",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterId": {
+          "description": "The meter id (GUID). Not available for marketplace. For reserved instance this represents the primary meter for which the reservation was purchased. For the actual VM Size for which the reservation is purchased see productOrderName.",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        },
+        "meterDetails": {
+          "description": "The details about the meter. By default this is not populated, unless it's specified in $expand.",
+          "$ref": "#/definitions/MeterDetailsResponse",
+          "readOnly": true
+        },
+        "quantity": {
+          "description": "The usage quantity.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "effectivePrice": {
+          "description": "Effective Price that's charged for the usage.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "cost": {
+          "description": "The amount of cost before tax.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "unitPrice": {
+          "description": "Unit Price is the price applicable to you. (your EA or other contract price).",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "billingCurrency": {
+          "description": "Billing Currency.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceLocation": {
+          "description": "Resource Location.",
+          "type": "string",
+          "readOnly": true
+        },
+        "consumedService": {
+          "description": "Consumed service name. Name of the azure resource provider that emits the usage or was purchased. This value is not provided for marketplace usage.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceId": {
+          "description": "Unique identifier of the Azure Resource Manager usage detail resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceName": {
+          "description": "Resource Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "serviceInfo1": {
+          "description": "Service-specific metadata.",
+          "type": "string",
+          "readOnly": true
+        },
+        "serviceInfo2": {
+          "description": "Legacy field with optional service-specific metadata.",
+          "type": "string",
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "description": "Additional details of this usage item. By default this is not populated, unless it's specified in $expand. Use this field to get usage line item specific details such as the actual VM Size (ServiceType) or the ratio in which the reservation discount is applied.",
+          "type": "string",
+          "readOnly": true
+        },
+        "invoiceSection": {
+          "description": "Invoice Section Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "costCenter": {
+          "description": "The cost center of this department if it is a department and a cost center is provided.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceGroup": {
+          "description": "Resource Group Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationId": {
+          "description": "ARM resource id of the reservation. Only applies to records relevant to reservations.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationName": {
+          "description": "User provided display name of the reservation. Last known name for a particular day is populated in the daily data. Only applies to records relevant to reservations.",
+          "type": "string",
+          "readOnly": true
+        },
+        "productOrderId": {
+          "description": "Product Order Id. For reservations this is the Reservation Order ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "productOrderName": {
+          "description": "Product Order Name. For reservations this is the SKU that was purchased.",
+          "type": "string",
+          "readOnly": true
+        },
+        "offerId": {
+          "description": "Offer Id. Ex: MS-AZR-0017P, MS-AZR-0148P.",
+          "type": "string",
+          "readOnly": true
+        },
+        "isAzureCreditEligible": {
+          "description": "Is Azure Credit Eligible.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "term": {
+          "description": "Term (in months). 1 month for monthly recurring purchase. 12 months for a 1 year reservation. 36 months for a 3 year reservation.",
+          "type": "string",
+          "readOnly": true
+        },
+        "publisherName": {
+          "description": "Publisher Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "publisherType": {
+          "description": "Publisher Type.",
+          "type": "string",
+          "readOnly": true
+        },
+        "planName": {
+          "description": "Plan Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "chargeType": {
+          "description": "Indicates a charge represents credits, usage, a Marketplace purchase, a reservation fee, or a refund.",
+          "type": "string",
+          "readOnly": true
+        },
+        "frequency": {
+          "description": "Indicates how frequently this charge will occur. OneTime for purchases which only happen once, Monthly for fees which recur every month, and UsageBased for charges based on how much a service is used.",
+          "type": "string",
+          "readOnly": true
+        },
+        "payGPrice": {
+          "description": "Retail price for the resource.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "benefitId": {
+          "description": "Unique identifier for the applicable benefit.",
+          "type": "string",
+          "readOnly": true
+        },
+        "benefitName": {
+          "description": "Name of the applicable benefit.",
+          "type": "string",
+          "readOnly": true
+        },
+        "pricingModel": {
+          "description": "Identifier that indicates how the meter is priced.",
+          "type": "string",
+          "readOnly": true,
+          "enum": [
+            "On Demand",
+            "Reservation",
+            "Spot"
+          ],
+          "x-ms-enum": {
+            "name": "pricingModelType",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "ModernUsageDetail": {
+      "description": "Modern usage detail.",
+      "type": "object",
+      "x-ms-discriminator-value": "modern",
+      "properties": {
+        "properties": {
+          "description": "Properties for modern usage details",
+          "$ref": "#/definitions/ModernUsageDetailProperties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/UsageDetail"
+        }
+      ],
+      "required": [
+        "properties"
+      ]
+    },
+    "ModernUsageDetailProperties": {
+      "description": "The properties of the usage detail.",
+      "properties": {
+        "billingAccountId": {
+          "description": "Billing Account identifier.",
+          "type": "string",
+          "readOnly": true
+        },
+        "effectivePrice": {
+          "description": "Effective Price that's charged for the usage.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "pricingModel": {
+          "description": "Identifier that indicates how the meter is priced",
+          "type": "string",
+          "readOnly": true,
+          "enum": [
+            "On Demand",
+            "Reservation",
+            "Spot"
+          ],
+          "x-ms-enum": {
+            "name": "pricingModelType",
+            "modelAsString": true
+          }
+        },
+        "billingAccountName": {
+          "description": "Name of the Billing Account.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingPeriodStartDate": {
+          "description": "Billing Period Start Date as in the invoice.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "billingPeriodEndDate": {
+          "description": "Billing Period End Date as in the invoice.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "billingProfileId": {
+          "description": "Identifier for the billing profile that groups costs across invoices in the a singular billing currency across across the customers who have onboarded the Microsoft customer agreement and the customers in CSP who have made entitlement purchases like SaaS, Marketplace, RI, etc.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingProfileName": {
+          "description": "Name of the billing profile that groups costs across invoices in the a singular billing currency across across the customers who have onboarded the Microsoft customer agreement and the customers in CSP who have made entitlement purchases like SaaS, Marketplace, RI, etc.",
+          "type": "string",
+          "readOnly": true
+        },
+        "subscriptionGuid": {
+          "description": "Unique Microsoft generated identifier for the Azure Subscription.",
+          "type": "string",
+          "readOnly": true
+        },
+        "subscriptionName": {
+          "description": "Name of the Azure Subscription.",
+          "type": "string",
+          "readOnly": true
+        },
+        "date": {
+          "description": "Date for the usage record.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "product": {
+          "description": "Name of the product that has accrued charges by consumption or purchase as listed in the invoice. Not available for Marketplace.",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterId": {
+          "description": "The meter id (GUID). Not available for marketplace. For reserved instance this represents the primary meter for which the reservation was purchased. For the actual VM Size for which the reservation is purchased see productOrderName.",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        },
+        "meterName": {
+          "description": "Identifies the name of the meter against which consumption is measured.",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterRegion": {
+          "description": "Identifies the location of the datacenter for certain services that are priced based on datacenter location.",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterCategory": {
+          "description": "Identifies the top-level service for the usage.",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterSubCategory": {
+          "description": "Defines the type or sub-category of Azure service that can affect the rate.",
+          "type": "string",
+          "readOnly": true
+        },
+        "serviceFamily": {
+          "description": "List the service family for the product purchased or charged (Example: Storage ; Compute).",
+          "type": "string",
+          "readOnly": true
+        },
+        "quantity": {
+          "description": "Measure the quantity purchased or consumed.The amount of the meter used during the billing period.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "unitOfMeasure": {
+          "description": "Identifies the Unit that the service is charged in. For example, GB, hours, 10,000 s.",
+          "type": "string",
+          "readOnly": true
+        },
+        "instanceName": {
+          "description": "Instance Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "costInUSD": {
+          "description": "Estimated extendedCost or blended cost before tax in USD.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "unitPrice": {
+          "description": "Unit Price is the price applicable to you. (your EA or other contract price).",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "billingCurrencyCode": {
+          "description": "The currency defining the billed cost.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceLocation": {
+          "description": "Name of the resource location.",
+          "type": "string",
+          "readOnly": true
+        },
+        "consumedService": {
+          "description": "Consumed service name. Name of the azure resource provider that emits the usage or was purchased. This value is not provided for marketplace usage.",
+          "type": "string",
+          "readOnly": true
+        },
+        "serviceInfo1": {
+          "description": "Service-specific metadata.",
+          "type": "string",
+          "readOnly": true
+        },
+        "serviceInfo2": {
+          "description": "Legacy field with optional service-specific metadata.",
+          "type": "string",
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "description": "Additional details of this usage item. Use this field to get usage line item specific details such as the actual VM Size (ServiceType) or the ratio in which the reservation discount is applied.",
+          "type": "string",
+          "readOnly": true
+        },
+        "invoiceSectionId": {
+          "description": "Identifier of the project that is being charged in the invoice. Not applicable for Microsoft Customer Agreements onboarded by partners.",
+          "type": "string",
+          "readOnly": true
+        },
+        "invoiceSectionName": {
+          "description": "Name of the project that is being charged in the invoice. Not applicable for Microsoft Customer Agreements onboarded by partners.",
+          "type": "string",
+          "readOnly": true
+        },
+        "costCenter": {
+          "description": "The cost center of this department if it is a department and a cost center is provided.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceGroup": {
+          "description": "Name of the Azure resource group used for cohesive lifecycle management of resources.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationId": {
+          "description": "ARM resource id of the reservation. Only applies to records relevant to reservations.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationName": {
+          "description": "User provided display name of the reservation. Last known name for a particular day is populated in the daily data. Only applies to records relevant to reservations.",
+          "type": "string",
+          "readOnly": true
+        },
+        "productOrderId": {
+          "description": "The identifier for the asset or Azure plan name that the subscription belongs to. For example: Azure Plan. For reservations this is the Reservation Order ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "productOrderName": {
+          "description": "Product Order Name. For reservations this is the SKU that was purchased.",
+          "type": "string",
+          "readOnly": true
+        },
+        "isAzureCreditEligible": {
+          "description": "Determines if the cost is eligible to be paid for using Azure credits.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "term": {
+          "description": "Term (in months). Displays the term for the validity of the offer. For example. In case of reserved instances it displays 12 months for yearly term of reserved instance. For one time purchases or recurring purchases, the terms displays 1 month; This is not applicable for Azure consumption.",
+          "type": "string",
+          "readOnly": true
+        },
+        "publisherName": {
+          "description": "Name of the publisher of the service including Microsoft or Third Party publishers.",
+          "type": "string",
+          "readOnly": true
+        },
+        "publisherType": {
+          "description": "Type of publisher that identifies if the publisher is first party, third party reseller or third party agency.",
+          "type": "string",
+          "readOnly": true
+        },
+        "chargeType": {
+          "description": "Indicates a charge represents credits, usage, a Marketplace purchase, a reservation fee, or a refund.",
+          "type": "string",
+          "readOnly": true
+        },
+        "frequency": {
+          "description": "Indicates how frequently this charge will occur. OneTime for purchases which only happen once, Monthly for fees which recur every month, and UsageBased for charges based on how much a service is used.",
+          "type": "string",
+          "readOnly": true
+        },
+        "costInBillingCurrency": {
+          "description": "ExtendedCost or blended cost before tax in billed currency.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "costInPricingCurrency": {
+          "description": "ExtendedCost or blended cost before tax in pricing currency to correlate with prices.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "exchangeRate": {
+          "description": "Exchange rate used in conversion from pricing currency to billing currency.",
+          "type": "string",
+          "readOnly": true
+        },
+        "exchangeRateDate": {
+          "description": "Date on which exchange rate used in conversion from pricing currency to billing currency.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "invoiceId": {
+          "description": "Invoice ID as on the invoice where the specific transaction appears.",
+          "type": "string",
+          "readOnly": true
+        },
+        "previousInvoiceId": {
+          "description": "Reference to an original invoice there is a refund (negative cost). This is populated only when there is a refund.",
+          "type": "string",
+          "readOnly": true
+        },
+        "pricingCurrencyCode": {
+          "description": "Pricing Billing Currency.",
+          "type": "string",
+          "readOnly": true
+        },
+        "productIdentifier": {
+          "description": "Identifier for the product that has accrued charges by consumption or purchase . This is the concatenated key of productId and SkuId in partner center.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceLocationNormalized": {
+          "description": "Resource Location Normalized.",
+          "type": "string",
+          "readOnly": true
+        },
+        "servicePeriodStartDate": {
+          "description": "Start date for the rating period when the service usage was rated for charges. The prices for Azure services are determined for the rating period.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "servicePeriodEndDate": {
+          "description": "End date for the period when the service usage was rated for charges. The prices for Azure services are determined based on the rating period.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "customerTenantId": {
+          "description": "Identifier of the customer's AAD tenant.",
+          "type": "string",
+          "readOnly": true
+        },
+        "customerName": {
+          "description": "Name of the customer's AAD tenant.",
+          "type": "string",
+          "readOnly": true
+        },
+        "partnerTenantId": {
+          "description": "Identifier for the partner's AAD tenant.",
+          "type": "string",
+          "readOnly": true
+        },
+        "partnerName": {
+          "description": "Name of the partner' AAD tenant.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resellerMpnId": {
+          "description": "MPNId for the reseller associated with the subscription.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resellerName": {
+          "description": "Reseller Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "publisherId": {
+          "description": "Publisher Id.",
+          "type": "string",
+          "readOnly": true
+        },
+        "marketPrice": {
+          "description": "Market Price that's charged for the usage.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "exchangeRatePricingToBilling": {
+          "description": "Exchange Rate from pricing currency to billing currency.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "paygCostInBillingCurrency": {
+          "description": "The amount of PayG cost before tax in billing currency.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "paygCostInUSD": {
+          "description": "The amount of PayG cost before tax in US Dollar currency.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "partnerEarnedCreditRate": {
+          "description": "Rate of discount applied if there is a partner earned credit (PEC) based on partner admin link access.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "partnerEarnedCreditApplied": {
+          "description": "Flag to indicate if partner earned credit has been applied or not.",
+          "type": "string",
+          "readOnly": true
+        },
+        "payGPrice": {
+          "description": "Retail price for the resource.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "benefitId": {
+          "description": "Unique identifier for the applicable benefit.",
+          "type": "string",
+          "readOnly": true
+        },
+        "benefitName": {
+          "description": "Name of the applicable benefit.",
+          "type": "string",
+          "readOnly": true
+        },
+        "provider": {
+          "description": "Identifier for Product Category or Line Of Business, Ex - Azure, Microsoft 365, AWS e.t.c",
+          "type": "string",
+          "readOnly": true
+        },
+        "costAllocationRuleName": {
+          "description": "Name for Cost Allocation Rule.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "Marketplace": {
+      "description": "A marketplace resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/MarketplaceProperties",
+          "title": "Marketplace properties"
+        }
+      }
+    },
+    "MarketplacesListResult": {
+      "description": "Result of listing marketplaces. It contains a list of available marketplaces in reverse chronological order by billing period.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The list of marketplaces.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/Marketplace"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "MarketplaceProperties": {
+      "description": "The properties of the marketplace usage detail.",
+      "type": "object",
+      "properties": {
+        "billingPeriodId": {
+          "description": "The id of the billing period resource that the usage belongs to.",
+          "type": "string",
+          "readOnly": true
+        },
+        "usageStart": {
+          "description": "The start of the date time range covered by the usage detail.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "usageEnd": {
+          "description": "The end of the date time range covered by the usage detail.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "resourceRate": {
+          "description": "The marketplace resource rate.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "offerName": {
+          "description": "The type of offer.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceGroup": {
+          "description": "The name of resource group.",
+          "type": "string",
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "description": "Additional information.",
+          "type": "string",
+          "readOnly": true
+        },
+        "orderNumber": {
+          "description": "The order number.",
+          "type": "string",
+          "readOnly": true
+        },
+        "instanceName": {
+          "description": "The name of the resource instance that the usage is about.",
+          "type": "string",
+          "readOnly": true
+        },
+        "instanceId": {
+          "description": "The uri of the resource instance that the usage is about.",
+          "type": "string",
+          "readOnly": true
+        },
+        "currency": {
+          "description": "The ISO currency in which the meter is charged, for example, USD.",
+          "type": "string",
+          "readOnly": true
+        },
+        "consumedQuantity": {
+          "description": "The quantity of usage.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "unitOfMeasure": {
+          "description": "The unit of measure.",
+          "type": "string",
+          "readOnly": true
+        },
+        "pretaxCost": {
+          "description": "The amount of cost before tax.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "isEstimated": {
+          "description": "The estimated usage is subject to change.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "meterId": {
+          "description": "The meter id (GUID).",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        },
+        "subscriptionGuid": {
+          "description": "Subscription guid.",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        },
+        "subscriptionName": {
+          "description": "Subscription name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "accountName": {
+          "description": "Account name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "departmentName": {
+          "description": "Department name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "consumedService": {
+          "description": "Consumed service name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "costCenter": {
+          "description": "The cost center of this department if it is a department and a costcenter exists",
+          "type": "string",
+          "readOnly": true
+        },
+        "additionalProperties": {
+          "description": "Additional details of this usage item. By default this is not populated, unless it's specified in $expand.",
+          "type": "string",
+          "readOnly": true
+        },
+        "publisherName": {
+          "description": "The name of publisher.",
+          "type": "string",
+          "readOnly": true
+        },
+        "planName": {
+          "description": "The name of plan.",
+          "type": "string",
+          "readOnly": true
+        },
+        "isRecurringCharge": {
+          "description": "Flag indicating whether this is a recurring charge or not.",
+          "type": "boolean",
+          "readOnly": true
+        }
+      }
+    },
+    "Balance": {
+      "description": "A balance resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/BalanceProperties",
+          "title": "Balance properties"
+        }
+      }
+    },
+    "BalanceProperties": {
+      "description": "The properties of the balance.",
+      "type": "object",
+      "properties": {
+        "currency": {
+          "description": "The ISO currency in which the meter is charged, for example, USD.",
+          "type": "string",
+          "readOnly": true
+        },
+        "beginningBalance": {
+          "description": "The beginning balance for the billing period.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "endingBalance": {
+          "description": "The ending balance for the billing period (for open periods this will be updated daily).",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "newPurchases": {
+          "description": "Total new purchase amount.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "adjustments": {
+          "description": "Total adjustment amount.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "utilized": {
+          "description": "Total Commitment usage.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "serviceOverage": {
+          "description": "Overage for Azure services.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "chargesBilledSeparately": {
+          "description": "Charges Billed separately.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "totalOverage": {
+          "description": "serviceOverage + chargesBilledSeparately.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "totalUsage": {
+          "description": "Azure service commitment + total Overage.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "azureMarketplaceServiceCharges": {
+          "description": "Total charges for Azure Marketplace.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "billingFrequency": {
+          "description": "The billing frequency.",
+          "type": "string",
+          "enum": [
+            "Month",
+            "Quarter",
+            "Year"
+          ],
+          "x-ms-enum": {
+            "name": "BillingFrequency",
+            "modelAsString": true
+          }
+        },
+        "priceHidden": {
+          "description": "Price is hidden or not.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "overageRefund": {
+          "description": "Overage Refunds",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "newPurchasesDetails": {
+          "description": "List of new purchases.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "the name of new purchase.",
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "description": "the value of new purchase.",
+                "type": "number",
+                "format": "decimal",
+                "readOnly": true
+              }
+            }
+          },
+          "x-ms-identifiers": [
+            "name"
+          ],
+          "readOnly": true
+        },
+        "adjustmentDetails": {
+          "description": "List of Adjustments (Promo credit, SIE credit etc.).",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "the name of new adjustment.",
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "description": "the value of new adjustment.",
+                "type": "number",
+                "format": "decimal",
+                "readOnly": true
+              }
+            }
+          },
+          "x-ms-identifiers": [
+            "name"
+          ],
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationSummary": {
+      "description": "reservation summary resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ReservationSummaryProperties",
+          "title": "Reservation Summary properties"
+        }
+      }
+    },
+    "ReservationSummariesListResult": {
+      "description": "Result of listing reservation summaries.",
+      "properties": {
+        "value": {
+          "description": "The list of reservation summaries.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/ReservationSummary"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationSummaryProperties": {
+      "description": "The properties of the reservation summary.",
+      "properties": {
+        "reservationOrderId": {
+          "description": "The reservation order ID is the identifier for a reservation purchase. Each reservation order ID represents a single purchase transaction. A reservation order contains reservations. The reservation order specifies the VM size and region for the reservations.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationId": {
+          "description": "The reservation ID is the identifier of a reservation within a reservation order. Each reservation is the grouping for applying the benefit scope and also specifies the number of instances to which the reservation benefit can be applied to.",
+          "type": "string",
+          "readOnly": true
+        },
+        "skuName": {
+          "description": "This is the ARM Sku name. It can be used to join with the serviceType field in additional info in usage records.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservedHours": {
+          "description": "This is the total hours reserved. E.g. if reservation for 1 instance was made on 1 PM, this will be 11 hours for that day and 24 hours from subsequent days",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "usageDate": {
+          "description": "Data corresponding to the utilization record. If the grain of data is monthly, it will be first day of month.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "usedHours": {
+          "description": "Total used hours by the reservation",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "minUtilizationPercentage": {
+          "description": "This is the minimum hourly utilization in the usage time (day or month). E.g. if usage record corresponds to 12/10/2017 and on that for hour 4 and 5, utilization was 10%, this field will return 10% for that day",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "avgUtilizationPercentage": {
+          "description": "This is average utilization for the entire time range. (day or month depending on the grain)",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "maxUtilizationPercentage": {
+          "description": "This is the maximum hourly utilization in the usage time (day or month). E.g. if usage record corresponds to 12/10/2017 and on that for hour 4 and 5, utilization was 100%, this field will return 100% for that day.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "kind": {
+          "description": "The reservation kind.",
+          "type": "string",
+          "readOnly": true
+        },
+        "purchasedQuantity": {
+          "description": "This is the purchased quantity for the reservationId.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "remainingQuantity": {
+          "description": "This is the remaining quantity for the reservationId.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "totalReservedQuantity": {
+          "description": "This is the total count of instances that are reserved for the reservationId.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "usedQuantity": {
+          "description": "This is the used quantity for the reservationId.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "utilizedPercentage": {
+          "description": "This is the utilized percentage for the reservation Id.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationDetail": {
+      "description": "reservation detail resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ReservationDetailProperties",
+          "title": "Reservation Detail properties"
+        }
+      }
+    },
+    "ReservationDetailsListResult": {
+      "description": "Result of listing reservation details.",
+      "properties": {
+        "value": {
+          "description": "The list of reservation details.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/ReservationDetail"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationDetailProperties": {
+      "description": "The properties of the reservation detail.",
+      "properties": {
+        "reservationOrderId": {
+          "description": "The reservation order ID is the identifier for a reservation purchase. Each reservation order ID represents a single purchase transaction. A reservation order contains reservations. The reservation order specifies the VM size and region for the reservations.",
+          "type": "string",
+          "readOnly": true
+        },
+        "instanceFlexibilityRatio": {
+          "description": "The instance Flexibility Ratio.",
+          "type": "string",
+          "readOnly": true
+        },
+        "instanceFlexibilityGroup": {
+          "description": "The instance Flexibility Group.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationId": {
+          "description": "The reservation ID is the identifier of a reservation within a reservation order. Each reservation is the grouping for applying the benefit scope and also specifies the number of instances to which the reservation benefit can be applied to.",
+          "type": "string",
+          "readOnly": true
+        },
+        "skuName": {
+          "description": "This is the ARM Sku name. It can be used to join with the serviceType field in additional info in usage records.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservedHours": {
+          "description": "This is the total hours reserved for the day. E.g. if reservation for 1 instance was made on 1 PM, this will be 11 hours for that day and 24 hours from subsequent days.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "usageDate": {
+          "description": "The date on which consumption occurred.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "usedHours": {
+          "description": "This is the total hours used by the instance.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "instanceId": {
+          "description": "This identifier is the name of the resource or the fully qualified Resource ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "totalReservedQuantity": {
+          "description": "This is the total count of instances that are reserved for the reservationId.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "kind": {
+          "description": "The reservation kind.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationRecommendationDetailsModel": {
+      "description": "Reservation recommendation details.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Resource Location."
+        },
+        "sku": {
+          "type": "string",
+          "description": "Resource sku"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ReservationRecommendationDetailsProperties",
+          "title": "Reservation Recommendation details properties"
+        }
+      }
+    },
+    "ReservationRecommendationDetailsProperties": {
+      "description": "The properties of the reservation recommendation.",
+      "properties": {
+        "currency": {
+          "description": "An ISO 4217 currency code identifier for the costs and savings ",
+          "type": "string",
+          "readOnly": true
+        },
+        "resource": {
+          "description": "Resource specific properties.",
+          "$ref": "#/definitions/ReservationRecommendationDetailsResourceProperties",
+          "readOnly": true
+        },
+        "resourceGroup": {
+          "description": "Resource Group.",
+          "type": "string",
+          "readOnly": true
+        },
+        "savings": {
+          "description": "Savings information for the recommendation.",
+          "$ref": "#/definitions/ReservationRecommendationDetailsSavingsProperties",
+          "readOnly": true
+        },
+        "scope": {
+          "description": "Scope of the reservation, ex: Single or Shared.",
+          "type": "string",
+          "readOnly": true
+        },
+        "usage": {
+          "description": "Historical usage details used to calculate the estimated savings.",
+          "$ref": "#/definitions/ReservationRecommendationDetailsUsageProperties",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationRecommendationDetailsCalculatedSavingsProperties": {
+      "description": "Details of estimated savings. The costs and savings are estimated for the term.",
+      "properties": {
+        "onDemandCost": {
+          "description": "The cost without reservation. Includes hardware and software cost.",
+          "type": "number",
+          "readOnly": true
+        },
+        "overageCost": {
+          "description": "Hardware and software cost of the resources not covered by the reservation.",
+          "type": "number",
+          "readOnly": true
+        },
+        "quantity": {
+          "description": "The quantity for calculated savings.",
+          "type": "number",
+          "readOnly": true
+        },
+        "reservationCost": {
+          "description": "Hardware cost of the resources covered by the reservation.",
+          "type": "number",
+          "readOnly": true
+        },
+        "totalReservationCost": {
+          "description": "Reservation cost + software cost of the resources covered by the reservation + overage cost.",
+          "type": "number",
+          "readOnly": true
+        },
+        "reservedUnitCount": {
+          "description": "The number of reserved units used to calculate savings. Always 1 for virtual machines.",
+          "type": "number"
+        },
+        "savings": {
+          "description": "The amount saved by purchasing the recommended quantity of reservation. This is equal to onDemandCost - totalReservationCost.",
+          "type": "number",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationRecommendationDetailsResourceProperties": {
+      "description": "Details of the resource.",
+      "properties": {
+        "appliedScopes": {
+          "description": "List of subscriptions for which the reservation is applied.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "onDemandRate": {
+          "description": "Hourly on-demand rate of the resource. Includes only hardware rate i.e, software rate is not included.",
+          "type": "number",
+          "readOnly": true
+        },
+        "product": {
+          "description": "Azure product ex: Standard_E8s_v3 etc.",
+          "type": "string",
+          "readOnly": true
+        },
+        "region": {
+          "description": "Azure resource region ex:EastUS, WestUS etc.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationRate": {
+          "description": "Hourly reservation rate of the resource. Varies based on the term.",
+          "type": "number",
+          "readOnly": true
+        },
+        "resourceType": {
+          "description": "The azure resource type.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationRecommendationDetailsSavingsProperties": {
+      "description": "Details of the estimated savings.",
+      "properties": {
+        "calculatedSavings": {
+          "description": "List of calculated savings.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReservationRecommendationDetailsCalculatedSavingsProperties"
+          },
+          "x-ms-identifiers": []
+        },
+        "lookBackPeriod": {
+          "description": "Number of days of usage to look back used for computing the recommendation.",
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true
+        },
+        "recommendedQuantity": {
+          "description": "Number of recommended units of the resource.",
+          "type": "number",
+          "readOnly": true
+        },
+        "reservationOrderTerm": {
+          "description": "Term period of the reservation, ex: P1Y or P3Y.",
+          "type": "string",
+          "readOnly": true
+        },
+        "savingsType": {
+          "description": "Type of savings, ex: instance.",
+          "type": "string",
+          "readOnly": true
+        },
+        "unitOfMeasure": {
+          "description": "Measurement unit ex: hour etc.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationRecommendationDetailsUsageProperties": {
+      "description": "Details about historical usage data that has been used for computing the recommendation.",
+      "properties": {
+        "firstConsumptionDate": {
+          "description": "The first usage date used for looking back for computing the recommendation.",
+          "type": "string",
+          "readOnly": true
+        },
+        "lastConsumptionDate": {
+          "description": "The last usage date used for looking back for computing the recommendation.",
+          "type": "string",
+          "readOnly": true
+        },
+        "lookBackUnitType": {
+          "description": "What the usage data values represent ex: virtual machine instance.",
+          "type": "string",
+          "readOnly": true
+        },
+        "usageData": {
+          "description": "The breakdown of historical resource usage.  The values are in the order of usage between the firstConsumptionDate and the lastConsumptionDate.",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "readOnly": true
+        },
+        "usageGrain": {
+          "description": "The grain of the values represented in the usage data ex: hourly.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationRecommendationsListResult": {
+      "description": "Result of listing reservation recommendations.",
+      "properties": {
+        "value": {
+          "description": "The list of reservation recommendations.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/ReservationRecommendation"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        },
+        "previousLink": {
+          "description": "The link (url) to the previous page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationRecommendation": {
+      "description": "A reservation recommendation resource.",
+      "type": "object",
+      "discriminator": "kind",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        },
+        {
+          "$ref": "#/definitions/ResourceAttributes"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Specifies the kind of reservation recommendation.",
+          "enum": [
+            "legacy",
+            "modern"
+          ],
+          "x-ms-enum": {
+            "name": "ReservationRecommendationKind",
+            "modelAsString": true
+          }
+        }
+      },
+      "required": [
+        "kind"
+      ]
+    },
+    "LegacyReservationRecommendation": {
+      "description": "Legacy reservation recommendation.",
+      "type": "object",
+      "x-ms-discriminator-value": "legacy",
+      "properties": {
+        "properties": {
+          "description": "Properties for legacy reservation recommendation",
+          "$ref": "#/definitions/LegacyReservationRecommendationProperties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ReservationRecommendation"
+        }
+      ],
+      "required": [
+        "properties"
+      ]
+    },
+    "LegacyReservationRecommendationProperties": {
+      "description": "The properties of the reservation recommendation.",
+      "type": "object",
+      "discriminator": "scope",
+      "properties": {
+        "lookBackPeriod": {
+          "description": "The number of days of usage to look back for recommendation.",
+          "type": "string",
+          "readOnly": true
+        },
+        "instanceFlexibilityRatio": {
+          "description": "The instance Flexibility Ratio.",
+          "type": "number",
+          "readOnly": true
+        },
+        "instanceFlexibilityGroup": {
+          "description": "The instance Flexibility Group.",
+          "type": "string",
+          "readOnly": true
+        },
+        "normalizedSize": {
+          "description": "The normalized Size.",
+          "type": "string",
+          "readOnly": true
+        },
+        "recommendedQuantityNormalized": {
+          "description": "The recommended Quantity Normalized.",
+          "type": "number",
+          "readOnly": true
+        },
+        "meterId": {
+          "description": "The meter id (GUID)",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        },
+        "resourceType": {
+          "description": "The azure resource type.",
+          "type": "string",
+          "readOnly": true
+        },
+        "term": {
+          "description": "RI recommendations in one or three year terms.",
+          "type": "string",
+          "readOnly": true
+        },
+        "costWithNoReservedInstances": {
+          "description": "The total amount of cost without reserved instances.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "recommendedQuantity": {
+          "description": "Recommended quality for reserved instances.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "totalCostWithReservedInstances": {
+          "description": "The total amount of cost with reserved instances.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "netSavings": {
+          "description": "Total estimated savings with reserved instances.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "firstUsageDate": {
+          "description": "The usage date for looking back.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "scope": {
+          "description": "Shared or single recommendation.",
+          "type": "string"
+        },
+        "skuProperties": {
+          "description": "List of sku properties",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SkuProperty"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "scope"
+      ]
+    },
+    "LegacySingleScopeReservationRecommendationProperties": {
+      "description": "The properties of the legacy reservation recommendation for single scope.",
+      "type": "object",
+      "x-ms-discriminator-value": "Single",
+      "properties": {
+        "subscriptionId": {
+          "description": "Subscription id associated with single scoped recommendation.",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/LegacyReservationRecommendationProperties"
+        }
+      ]
+    },
+    "LegacySharedScopeReservationRecommendationProperties": {
+      "description": "The properties of the legacy reservation recommendation for shared scope.",
+      "type": "object",
+      "x-ms-discriminator-value": "Shared",
+      "allOf": [
+        {
+          "$ref": "#/definitions/LegacyReservationRecommendationProperties"
+        }
+      ]
+    },
+    "SkuProperty": {
+      "description": "The Sku property",
+      "properties": {
+        "name": {
+          "description": "The name of sku property.",
+          "type": "string",
+          "readOnly": true
+        },
+        "value": {
+          "description": "The value of sku property.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ModernReservationRecommendation": {
+      "description": "Modern reservation recommendation.",
+      "type": "object",
+      "x-ms-discriminator-value": "modern",
+      "properties": {
+        "properties": {
+          "description": "Properties for modern reservation recommendation",
+          "$ref": "#/definitions/ModernReservationRecommendationProperties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ReservationRecommendation"
+        }
+      ],
+      "required": [
+        "properties"
+      ]
+    },
+    "ModernReservationRecommendationProperties": {
+      "description": "The properties of the reservation recommendation.",
+      "type": "object",
+      "discriminator": "scope",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Resource Location.",
+          "readOnly": true
+        },
+        "lookBackPeriod": {
+          "description": "The number of days of usage to look back for recommendation.",
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true
+        },
+        "instanceFlexibilityRatio": {
+          "description": "The instance Flexibility Ratio.",
+          "type": "number",
+          "readOnly": true
+        },
+        "instanceFlexibilityGroup": {
+          "description": "The instance Flexibility Group.",
+          "type": "string",
+          "readOnly": true
+        },
+        "normalizedSize": {
+          "description": "The normalized Size.",
+          "type": "string",
+          "readOnly": true
+        },
+        "recommendedQuantityNormalized": {
+          "description": "The recommended Quantity Normalized.",
+          "type": "number",
+          "readOnly": true
+        },
+        "meterId": {
+          "description": "The meter id (GUID)",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        },
+        "term": {
+          "description": "RI recommendations in one or three year terms.",
+          "type": "string",
+          "readOnly": true
+        },
+        "costWithNoReservedInstances": {
+          "description": "The total amount of cost without reserved instances.",
+          "$ref": "#/definitions/amount",
+          "readOnly": true
+        },
+        "recommendedQuantity": {
+          "description": "Recommended quality for reserved instances.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "resourceType": {
+          "description": "Resource type.",
+          "type": "string",
+          "readOnly": true
+        },
+        "totalCostWithReservedInstances": {
+          "description": "The total amount of cost with reserved instances.",
+          "$ref": "#/definitions/amount",
+          "readOnly": true
+        },
+        "netSavings": {
+          "description": "Total estimated savings with reserved instances.",
+          "$ref": "#/definitions/amount",
+          "readOnly": true
+        },
+        "firstUsageDate": {
+          "description": "The usage date for looking back.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "scope": {
+          "description": "Shared or single recommendation.",
+          "type": "string"
+        },
+        "skuProperties": {
+          "description": "List of sku properties",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SkuProperty"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ],
+          "readOnly": true
+        },
+        "skuName": {
+          "description": "This is the ARM Sku name.",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "scope"
+      ]
+    },
+    "ModernSingleScopeReservationRecommendationProperties": {
+      "description": "The properties of the modern reservation recommendation for single scope.",
+      "type": "object",
+      "x-ms-discriminator-value": "Single",
+      "properties": {
+        "subscriptionId": {
+          "description": "Subscription ID associated with single scoped recommendation.",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ModernReservationRecommendationProperties"
+        }
+      ]
+    },
+    "ModernSharedScopeReservationRecommendationProperties": {
+      "description": "The properties of the modern reservation recommendation for shared scope.",
+      "type": "object",
+      "x-ms-discriminator-value": "Shared",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ModernReservationRecommendationProperties"
+        }
+      ]
+    },
+    "ModernReservationTransactionProperties": {
+      "description": "The properties of a modern reservation transaction.",
+      "properties": {
+        "amount": {
+          "description": "The charge of the transaction.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "armSkuName": {
+          "description": "This is the ARM Sku name. It can be used to join with the serviceType field in additional info in usage records.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingFrequency": {
+          "description": "The billing frequency, which can be either one-time or recurring.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingProfileId": {
+          "description": "Billing profile Id.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingProfileName": {
+          "description": "Billing profile name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "currency": {
+          "description": "The ISO currency in which the transaction is charged, for example, USD.",
+          "type": "string",
+          "readOnly": true
+        },
+        "description": {
+          "description": "The description of the transaction.",
+          "type": "string",
+          "readOnly": true
+        },
+        "eventDate": {
+          "description": "The date of the transaction",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "eventType": {
+          "description": "The type of the transaction (Purchase, Cancel or Refund).",
+          "type": "string",
+          "readOnly": true
+        },
+        "invoice": {
+          "description": "Invoice Number",
+          "type": "string",
+          "readOnly": true
+        },
+        "invoiceId": {
+          "description": "Invoice Id as on the invoice where the specific transaction appears.",
+          "type": "string",
+          "readOnly": true
+        },
+        "invoiceSectionId": {
+          "description": "Invoice Section Id",
+          "type": "string",
+          "readOnly": true
+        },
+        "invoiceSectionName": {
+          "description": "Invoice Section Name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "purchasingSubscriptionGuid": {
+          "description": "The subscription guid that makes the transaction.",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        },
+        "purchasingSubscriptionName": {
+          "description": "The subscription name that makes the transaction.",
+          "type": "string",
+          "readOnly": true
+        },
+        "quantity": {
+          "description": "The quantity of the transaction.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "region": {
+          "description": "The region of the transaction.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationOrderId": {
+          "description": "The reservation order ID is the identifier for a reservation purchase. Each reservation order ID represents a single purchase transaction. A reservation order contains reservations. The reservation order specifies the VM size and region for the reservations.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationOrderName": {
+          "description": "The name of the reservation order.",
+          "type": "string",
+          "readOnly": true
+        },
+        "term": {
+          "description": "This is the term of the transaction.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ModernReservationTransaction": {
+      "description": "Modern Reservation transaction resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ReservationTransactionResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ModernReservationTransactionProperties",
+          "title": "Reservation Transaction properties"
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "LegacyReservationTransaction": {
+      "description": "Legacy Reservation transaction resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ReservationTransaction"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/LegacyReservationTransactionProperties",
+          "title": "Reservation Transaction properties"
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "LegacyReservationTransactionProperties": {
+      "description": "The properties of a legacy reservation transaction.",
+      "properties": {
+        "eventDate": {
+          "description": "The date of the transaction",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "reservationOrderId": {
+          "description": "The reservation order ID is the identifier for a reservation purchase. Each reservation order ID represents a single purchase transaction. A reservation order contains reservations. The reservation order specifies the VM size and region for the reservations.",
+          "type": "string",
+          "readOnly": true
+        },
+        "description": {
+          "description": "The description of the transaction.",
+          "type": "string",
+          "readOnly": true
+        },
+        "eventType": {
+          "description": "The type of the transaction (Purchase, Cancel or Refund).",
+          "type": "string",
+          "readOnly": true
+        },
+        "quantity": {
+          "description": "The quantity of the transaction.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "amount": {
+          "description": "The charge of the transaction.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "currency": {
+          "description": "The ISO currency in which the transaction is charged, for example, USD.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reservationOrderName": {
+          "description": "The name of the reservation order.",
+          "type": "string",
+          "readOnly": true
+        },
+        "purchasingEnrollment": {
+          "description": "The purchasing enrollment.",
+          "type": "string",
+          "readOnly": true
+        },
+        "purchasingSubscriptionGuid": {
+          "description": "The subscription guid that makes the transaction.",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        },
+        "purchasingSubscriptionName": {
+          "description": "The subscription name that makes the transaction.",
+          "type": "string",
+          "readOnly": true
+        },
+        "armSkuName": {
+          "description": "This is the ARM Sku name. It can be used to join with the serviceType field in additional info in usage records.",
+          "type": "string",
+          "readOnly": true
+        },
+        "term": {
+          "description": "This is the term of the transaction.",
+          "type": "string",
+          "readOnly": true
+        },
+        "region": {
+          "description": "The region of the transaction.",
+          "type": "string",
+          "readOnly": true
+        },
+        "accountName": {
+          "description": "The name of the account that makes the transaction.",
+          "type": "string",
+          "readOnly": true
+        },
+        "accountOwnerEmail": {
+          "description": "The email of the account owner that makes the transaction.",
+          "type": "string",
+          "readOnly": true
+        },
+        "departmentName": {
+          "description": "The department name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "costCenter": {
+          "description": "The cost center of this department if it is a department and a cost center is provided.",
+          "type": "string",
+          "readOnly": true
+        },
+        "currentEnrollment": {
+          "description": "The current enrollment.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingFrequency": {
+          "description": "The billing frequency, which can be either one-time or recurring.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingMonth": {
+          "description": "The billing month(yyyyMMdd), on which the event initiated.",
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true
+        },
+        "monetaryCommitment": {
+          "description": "The monetary commitment amount at the enrollment scope.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "overage": {
+          "description": "The overage amount at the enrollment scope.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        }
+      }
+    },
+    "ReservationTransaction": {
+      "description": "Reservation transaction resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ReservationTransactionResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/LegacyReservationTransactionProperties",
+          "title": "Reservation Transaction properties"
+        }
+      }
+    },
+    "ReservationTransactionsListResult": {
+      "description": "Result of listing reservation recommendations.",
+      "properties": {
+        "value": {
+          "description": "The list of reservation recommendations.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/ReservationTransaction"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ModernReservationTransactionsListResult": {
+      "description": "Result of listing reservation recommendations.",
+      "properties": {
+        "value": {
+          "description": "The list of reservation recommendations.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/ModernReservationTransaction"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "TagsResult": {
+      "description": "A resource listing all tags.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/TagProperties",
+          "title": "Tag properties"
+        }
+      }
+    },
+    "TagProperties": {
+      "description": "The properties of the tag.",
+      "properties": {
+        "tags": {
+          "description": "A list of Tag.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        },
+        "previousLink": {
+          "description": "The link (url) to the previous page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "Tag": {
+      "description": "The tag resource.",
+      "properties": {
+        "key": {
+          "description": "Tag key.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Tag values.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "BudgetsListResult": {
+      "description": "Result of listing budgets. It contains a list of available budgets in the scope provided.",
+      "properties": {
+        "value": {
+          "description": "The list of budgets.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/Budget"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "Budget": {
+      "description": "A budget resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/BudgetProperties",
+          "title": "Budget properties"
+        }
+      }
+    },
+    "BudgetProperties": {
+      "description": "The properties of the budget.",
+      "properties": {
+        "category": {
+          "description": "The category of the budget, whether the budget tracks cost or usage.",
+          "type": "string",
+          "enum": [
+            "Cost"
+          ],
+          "x-ms-enum": {
+            "name": "CategoryType",
+            "modelAsString": true
+          }
+        },
+        "amount": {
+          "description": "The total amount of cost to track with the budget",
+          "type": "number",
+          "format": "decimal"
+        },
+        "timeGrain": {
+          "description": "The time covered by a budget. Tracking of the amount will be reset based on the time grain. BillingMonth, BillingQuarter, and BillingAnnual are only supported by WD customers",
+          "type": "string",
+          "enum": [
+            "Monthly",
+            "Quarterly",
+            "Annually",
+            "BillingMonth",
+            "BillingQuarter",
+            "BillingAnnual"
+          ],
+          "x-ms-enum": {
+            "name": "TimeGrainType",
+            "modelAsString": true
+          }
+        },
+        "timePeriod": {
+          "description": "Has start and end date of the budget. The start date must be first of the month and should be less than the end date. Budget start date must be on or after June 1, 2017. Future start date should not be more than twelve months. Past start date should  be selected within the timegrain period. There are no restrictions on the end date.",
+          "$ref": "#/definitions/BudgetTimePeriod"
+        },
+        "filter": {
+          "description": "May be used to filter budgets by user-specified dimensions and/or tags.",
+          "type": "object",
+          "$ref": "#/definitions/BudgetFilter"
+        },
+        "currentSpend": {
+          "description": "The current amount of cost which is being tracked for a budget.",
+          "$ref": "#/definitions/CurrentSpend",
+          "readOnly": true
+        },
+        "notifications": {
+          "type": "object",
+          "description": "Dictionary of notifications associated with the budget. Budget can have up to five notifications.",
+          "additionalProperties": {
+            "type": "object",
+            "$ref": "#/definitions/Notification"
+          },
+          "maxItems": 5
+        },
+        "forecastSpend": {
+          "description": "The forecasted cost which is being tracked for a budget.",
+          "$ref": "#/definitions/ForecastSpend",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "category",
+        "amount",
+        "timeGrain",
+        "timePeriod"
+      ]
+    },
+    "BudgetTimePeriod": {
+      "description": "The start and end date for a budget.",
+      "properties": {
+        "startDate": {
+          "description": "The start date for the budget.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "endDate": {
+          "description": "The end date for the budget. If not provided, we default this to 10 years from the start date.",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "startDate"
+      ]
+    },
+    "BudgetFilter": {
+      "description": "May be used to filter budgets by resource group, resource, or meter.",
+      "properties": {
+        "and": {
+          "description": "The logical \"AND\" expression. Must have at least 2 items.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BudgetFilterProperties"
+          },
+          "x-ms-identifiers": [],
+          "minItems": 0
+        },
+        "dimensions": {
+          "description": "Has comparison expression for a dimension",
+          "$ref": "#/definitions/BudgetComparisonExpression"
+        },
+        "tags": {
+          "description": "Has comparison expression for a tag",
+          "$ref": "#/definitions/BudgetComparisonExpression"
+        }
+      }
+    },
+    "BudgetFilterProperties": {
+      "description": "The Dimensions or Tags to filter a budget by.",
+      "properties": {
+        "dimensions": {
+          "description": "Has comparison expression for a dimension",
+          "$ref": "#/definitions/BudgetComparisonExpression"
+        },
+        "tags": {
+          "description": "Has comparison expression for a tag",
+          "$ref": "#/definitions/BudgetComparisonExpression"
+        }
+      }
+    },
+    "BudgetComparisonExpression": {
+      "description": "The comparison expression to be used in the budgets.",
+      "properties": {
+        "name": {
+          "description": "The name of the column to use in comparison.",
+          "type": "string"
+        },
+        "operator": {
+          "description": "The operator to use for comparison.",
+          "type": "string",
+          "enum": [
+            "In"
+          ],
+          "x-ms-enum": {
+            "name": "BudgetOperatorType",
+            "modelAsString": true
+          }
+        },
+        "values": {
+          "description": "Array of values to use for comparison",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0
+        }
+      },
+      "required": [
+        "name",
+        "operator",
+        "values"
+      ]
+    },
+    "CurrentSpend": {
+      "description": "The current amount of cost which is being tracked for a budget.",
+      "properties": {
+        "amount": {
+          "description": "The total amount of cost which is being tracked by the budget.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "unit": {
+          "description": "The unit of measure for the budget amount.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ForecastSpend": {
+      "description": "The forecasted cost which is being tracked for a budget.",
+      "properties": {
+        "amount": {
+          "description": "The forecasted cost for the total time period which is being tracked by the budget. This value is only provided if the budget contains a forecast alert type.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "unit": {
+          "description": "The unit of measure for the budget amount.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "Notification": {
+      "description": "The notification associated with a budget.",
+      "properties": {
+        "enabled": {
+          "description": "The notification is enabled or not.",
+          "type": "boolean"
+        },
+        "operator": {
+          "description": "The comparison operator.",
+          "type": "string",
+          "enum": [
+            "EqualTo",
+            "GreaterThan",
+            "GreaterThanOrEqualTo"
+          ],
+          "x-ms-enum": {
+            "name": "OperatorType",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "EqualTo",
+                "description": "Alert will be triggered if the evaluated cost is the same as threshold value. Note: It’s not recommended to use this OperatorType as there’s low chance of cost being exactly the same as threshold value, leading to missing of your alert. This OperatorType will be deprecated in future. ",
+                "name": "EqualTo"
+              },
+              {
+                "value": "GreaterThan",
+                "description": "Alert will be triggered if the evaluated cost is greater than the threshold value. Note: This is the recommended OperatorType while configuring Budget Alert.",
+                "name": "GreaterThan"
+              },
+              {
+                "value": "GreaterThanOrEqualTo",
+                "description": "Alert will be triggered if the evaluated cost is greater than or equal to the threshold value.",
+                "name": "GreaterThanOrEqualTo"
+              }
+            ]
+          }
+        },
+        "threshold": {
+          "description": "Threshold value associated with a notification. Notification is sent when the cost exceeded the threshold. It is always percent and has to be between 0 and 1000.",
+          "type": "number",
+          "format": "decimal"
+        },
+        "contactEmails": {
+          "description": "Email addresses to send the budget notification to when the threshold is exceeded. Must have at least one contact email or contact group specified at the Subscription or Resource Group scopes. All other scopes must have at least one contact email specified.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "maxItems": 50
+        },
+        "contactRoles": {
+          "description": "Contact roles to send the budget notification to when the threshold is exceeded.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "contactGroups": {
+          "description": "Action groups to send the budget notification to when the threshold is exceeded. Must be provided as a fully qualified Azure resource id. Only supported at Subscription or Resource Group scopes.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "maxItems": 50
+        },
+        "thresholdType": {
+          "description": "The type of threshold",
+          "type": "string",
+          "enum": [
+            "Actual",
+            "Forecasted"
+          ],
+          "x-ms-enum": {
+            "name": "ThresholdType",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "Actual",
+                "description": "Actual costs budget alerts notify when the actual accrued cost exceeds the allocated budget .",
+                "name": "Actual"
+              },
+              {
+                "value": "Forecasted",
+                "description": "Forecasted costs budget alerts provide advanced notification that your spending trends are likely to exceed your allocated budget, as it relies on forecasted cost predictions.",
+                "name": "Forecasted"
+              }
+            ]
+          },
+          "default": "Actual"
+        },
+        "locale": {
+          "description": "Language in which the recipient will receive the notification",
+          "type": "string",
+          "enum": [
+            "en-us",
+            "ja-jp",
+            "zh-cn",
+            "de-de",
+            "es-es",
+            "fr-fr",
+            "it-it",
+            "ko-kr",
+            "pt-br",
+            "ru-ru",
+            "zh-tw",
+            "cs-cz",
+            "pl-pl",
+            "tr-tr",
+            "da-dk",
+            "en-gb",
+            "hu-hu",
+            "nb-no",
+            "nl-nl",
+            "pt-pt",
+            "sv-se"
+          ],
+          "x-ms-enum": {
+            "name": "CultureCode",
+            "modelAsString": true
+          }
+        }
+      },
+      "required": [
+        "enabled",
+        "operator",
+        "threshold",
+        "contactEmails"
+      ]
+    },
+    "PriceSheetResult": {
+      "description": "An pricesheet resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PriceSheetModel",
+          "title": "Price sheet properties"
+        }
+      }
+    },
+    "PriceSheetModel": {
+      "description": "price sheet result. It contains the pricesheet associated with billing period",
+      "properties": {
+        "pricesheets": {
+          "description": "Price sheet",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/PriceSheetProperties"
+          },
+          "x-ms-identifiers": [
+            "meterId"
+          ]
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        },
+        "download": {
+          "description": "Pricesheet download details.",
+          "$ref": "#/definitions/MeterDetails",
+          "readOnly": true
+        }
+      }
+    },
+    "DownloadProperties": {
+      "description": "The properties of the price sheet download.",
+      "properties": {
+        "downloadUrl": {
+          "description": "The link (url) to download the pricesheet.",
+          "type": "string",
+          "readOnly": true
+        },
+        "validTill": {
+          "description": "Download link validity.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "PriceSheetProperties": {
+      "description": "The properties of the price sheet.",
+      "properties": {
+        "billingPeriodId": {
+          "description": "The id of the billing period resource that the usage belongs to.",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterId": {
+          "description": "The meter id (GUID)",
+          "type": "string",
+          "format": "uuid",
+          "readOnly": true
+        },
+        "meterDetails": {
+          "description": "The details about the meter. By default this is not populated, unless it's specified in $expand.",
+          "$ref": "#/definitions/MeterDetails",
+          "readOnly": true
+        },
+        "unitOfMeasure": {
+          "description": "Unit of measure",
+          "type": "string",
+          "readOnly": true
+        },
+        "includedQuantity": {
+          "description": "Included quality for an offer",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "partNumber": {
+          "description": "Part Number",
+          "type": "string",
+          "readOnly": true
+        },
+        "unitPrice": {
+          "description": "Unit Price",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "currencyCode": {
+          "description": "Currency Code",
+          "type": "string",
+          "readOnly": true
+        },
+        "offerId": {
+          "description": "Offer Id",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ManagementGroupAggregatedCostResult": {
+      "description": "A management group aggregated cost resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ManagementGroupAggregatedCostProperties",
+          "title": "Management Group Aggregated Cost properties"
+        }
+      }
+    },
+    "ManagementGroupAggregatedCostProperties": {
+      "description": "The properties of the Management Group Aggregated Cost.",
+      "type": "object",
+      "properties": {
+        "billingPeriodId": {
+          "description": "The id of the billing period resource that the aggregated cost belongs to.",
+          "type": "string",
+          "readOnly": true
+        },
+        "usageStart": {
+          "description": "The start of the date time range covered by aggregated cost.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "usageEnd": {
+          "description": "The end of the date time range covered by the aggregated cost.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "azureCharges": {
+          "description": "Azure Charges.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "marketplaceCharges": {
+          "description": "Marketplace Charges.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "chargesBilledSeparately": {
+          "description": "Charges Billed Separately.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "currency": {
+          "description": "The ISO currency in which the meter is charged, for example, USD.",
+          "type": "string",
+          "readOnly": true
+        },
+        "children": {
+          "description": "Children of a management group",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ManagementGroupAggregatedCostResult"
+          }
+        },
+        "includedSubscriptions": {
+          "description": "List of subscription Guids included in the calculation of aggregated cost",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludedSubscriptions": {
+          "description": "List of subscription Guids excluded from the calculation of aggregated cost",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ChargesListResult": {
+      "description": "Result of listing charge summary.",
+      "properties": {
+        "value": {
+          "description": "The list of charge summary",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/ChargeSummary"
+          }
+        }
+      }
+    },
+    "ChargeSummary": {
+      "description": "A charge summary resource.",
+      "type": "object",
+      "discriminator": "kind",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Specifies the kind of charge summary.",
+          "enum": [
+            "legacy",
+            "modern"
+          ],
+          "x-ms-enum": {
+            "name": "ChargeSummaryKind",
+            "modelAsString": true
+          }
+        }
+      },
+      "required": [
+        "kind"
+      ]
+    },
+    "LegacyChargeSummary": {
+      "description": "Legacy charge summary.",
+      "type": "object",
+      "x-ms-discriminator-value": "legacy",
+      "properties": {
+        "properties": {
+          "description": "Properties for legacy charge summary",
+          "$ref": "#/definitions/LegacyChargeSummaryProperties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChargeSummary"
+        }
+      ],
+      "required": [
+        "properties"
+      ]
+    },
+    "LegacyChargeSummaryProperties": {
+      "description": "The properties of legacy charge summary.",
+      "type": "object",
+      "properties": {
+        "billingPeriodId": {
+          "description": "The id of the billing period resource that the charge belongs to.",
+          "type": "string",
+          "readOnly": true
+        },
+        "usageStart": {
+          "description": "Usage start date.",
+          "type": "string",
+          "readOnly": true
+        },
+        "usageEnd": {
+          "description": "Usage end date.",
+          "type": "string",
+          "readOnly": true
+        },
+        "azureCharges": {
+          "description": "Azure Charges.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "chargesBilledSeparately": {
+          "description": "Charges Billed separately.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "azureMarketplaceCharges": {
+          "description": "Marketplace Charges.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "currency": {
+          "description": "Currency Code",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ModernChargeSummary": {
+      "description": "Modern charge summary.",
+      "type": "object",
+      "x-ms-discriminator-value": "modern",
+      "properties": {
+        "properties": {
+          "description": "Properties for modern charge summary",
+          "$ref": "#/definitions/ModernChargeSummaryProperties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChargeSummary"
+        }
+      ],
+      "required": [
+        "properties"
+      ]
+    },
+    "ModernChargeSummaryProperties": {
+      "description": "The properties of modern charge summary.",
+      "type": "object",
+      "properties": {
+        "billingPeriodId": {
+          "description": "The id of the billing period resource that the charge belongs to.",
+          "type": "string",
+          "readOnly": true
+        },
+        "usageStart": {
+          "description": "Usage start date.",
+          "type": "string",
+          "readOnly": true
+        },
+        "usageEnd": {
+          "description": "Usage end date.",
+          "type": "string",
+          "readOnly": true
+        },
+        "azureCharges": {
+          "description": "Azure Charges.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "chargesBilledSeparately": {
+          "description": "Charges Billed separately.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "marketplaceCharges": {
+          "description": "Marketplace Charges.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "billingAccountId": {
+          "description": "Billing Account Id",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingProfileId": {
+          "description": "Billing Profile Id",
+          "type": "string",
+          "readOnly": true
+        },
+        "invoiceSectionId": {
+          "description": "Invoice Section Id",
+          "type": "string",
+          "readOnly": true
+        },
+        "customerId": {
+          "description": "Customer Id",
+          "type": "string",
+          "readOnly": true
+        },
+        "isInvoiced": {
+          "description": "Is charge Invoiced",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "subscriptionId": {
+          "description": "Subscription guid.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "MeterDetailsResponse": {
+      "description": "The properties of the meter detail.",
+      "properties": {
+        "meterName": {
+          "description": "The name of the meter, within the given meter category",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterCategory": {
+          "description": "The category of the meter, for example, 'Cloud services', 'Networking', etc..",
+          "type": "string",
+          "readOnly": true
+        },
+        "meterSubCategory": {
+          "description": "The subcategory of the meter, for example, 'A6 Cloud services', 'ExpressRoute (IXP)', etc..",
+          "type": "string",
+          "readOnly": true
+        },
+        "unitOfMeasure": {
+          "description": "The unit in which the meter consumption is charged, for example, 'Hours', 'GB', etc.",
+          "type": "string",
+          "readOnly": true
+        },
+        "serviceFamily": {
+          "description": "The service family.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ErrorDetails": {
+      "description": "The details of the error.",
+      "properties": {
+        "code": {
+          "description": "Error code.",
+          "type": "string",
+          "readOnly": true
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "HighCasedErrorDetails": {
+      "description": "The details of the error.",
+      "properties": {
+        "code": {
+          "description": "Error code.",
+          "type": "string",
+          "readOnly": true
+        },
+        "message": {
+          "description": "Error message indicating why the operation failed.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "HighCasedErrorResponse": {
+      "description": "Error response indicates that the service is not able to process the incoming request. The reason is provided in the error message. \n\nSome Error responses: \n\n * 429 TooManyRequests - Request is throttled. Retry after waiting for the time specified in the \"x-ms-ratelimit-microsoft.consumption-retry-after\" header. \n\n * 503 ServiceUnavailable - Service is temporarily unavailable. Retry after waiting for the time specified in the \"Retry-After\" header.",
+      "type": "object",
+      "properties": {
+        "error": {
+          "description": "The details of the error.",
+          "$ref": "#/definitions/HighCasedErrorDetails"
+        }
+      }
+    },
+    "ErrorResponse": {
+      "description": "Error response indicates that the service is not able to process the incoming request. The reason is provided in the error message. \n\nSome Error responses: \n\n * 429 TooManyRequests - Request is throttled. Retry after waiting for the time specified in the \"x-ms-ratelimit-microsoft.consumption-retry-after\" header. \n\n * 503 ServiceUnavailable - Service is temporarily unavailable. Retry after waiting for the time specified in the \"Retry-After\" header.",
+      "type": "object",
+      "properties": {
+        "error": {
+          "description": "The details of the error.",
+          "$ref": "#/definitions/ErrorDetails"
+        }
+      }
+    },
+    "Operation": {
+      "description": "A Consumption REST API operation.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Operation Id."
+        },
+        "name": {
+          "description": "Operation name: {provider}/{resource}/{operation}.",
+          "type": "string",
+          "readOnly": true
+        },
+        "display": {
+          "description": "The object that represents the operation.",
+          "properties": {
+            "provider": {
+              "description": "Service provider: Microsoft.Consumption.",
+              "type": "string",
+              "readOnly": true
+            },
+            "resource": {
+              "description": "Resource on which the operation is performed: UsageDetail, etc.",
+              "type": "string",
+              "readOnly": true
+            },
+            "operation": {
+              "description": "Operation type: Read, write, delete, etc.",
+              "type": "string",
+              "readOnly": true
+            },
+            "description": {
+              "description": "Description of the operation.",
+              "type": "string",
+              "readOnly": true
+            }
+          }
+        }
+      }
+    },
+    "OperationListResult": {
+      "description": "Result of listing consumption operations. It contains a list of operations and a URL link to get the next set of results.",
+      "properties": {
+        "value": {
+          "description": "List of consumption operations supported by the Microsoft.Consumption resource provider.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "nextLink": {
+          "description": "URL to get the next set of operation list results if there are any.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "Events": {
+      "description": "Result of listing event summary.",
+      "properties": {
+        "value": {
+          "description": "The list of event summary.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/EventSummary"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "EventSummary": {
+      "description": "An event summary resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/EventProperties",
+          "title": "Event summary properties"
+        }
+      }
+    },
+    "EventProperties": {
+      "description": "The event properties.",
+      "properties": {
+        "transactionDate": {
+          "description": "The date of the event.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "description": {
+          "description": "The description of the event.",
+          "type": "string",
+          "readOnly": true
+        },
+        "newCredit": {
+          "description": "The amount of new credit or commitment for NewCredit or SettleCharges event.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "adjustments": {
+          "description": "The amount of balance adjustment. The property is not available for ConsumptionCommitment lots.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "creditExpired": {
+          "description": "The amount of expired credit or commitment for NewCredit or SettleCharges event.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "charges": {
+          "description": "The amount of charges for events of type SettleCharges and PendingEligibleCharges. ",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "closedBalance": {
+          "description": "The balance after the event. ",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "eventType": {
+          "description": "Identifies the type of the event.",
+          "type": "string",
+          "enum": [
+            "SettledCharges",
+            "PendingCharges",
+            "PendingAdjustments",
+            "PendingNewCredit",
+            "PendingExpiredCredit",
+            "UnKnown",
+            "NewCredit",
+            "CreditExpired"
+          ],
+          "x-ms-enum": {
+            "name": "EventType",
+            "modelAsString": true
+          }
+        },
+        "invoiceNumber": {
+          "description": "The number which uniquely identifies the invoice on which the event was billed. This will be empty for unbilled events.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingProfileId": {
+          "description": "The ID that uniquely identifies the billing profile for which the event happened. The property is only available for billing account of type MicrosoftCustomerAgreement. ",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingProfileDisplayName": {
+          "description": "The display name of the billing profile for which the event happened. The property is only available for billing account of type MicrosoftCustomerAgreement.",
+          "type": "string",
+          "readOnly": true
+        },
+        "lotId": {
+          "description": "The ID that uniquely identifies the lot for which the event happened.",
+          "type": "string",
+          "readOnly": true
+        },
+        "lotSource": {
+          "description": "Identifies the source of the lot for which the event happened. ",
+          "type": "string",
+          "readOnly": true
+        },
+        "canceledCredit": {
+          "description": "Amount of canceled credit.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "creditCurrency": {
+          "description": "The credit currency of the event.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingCurrency": {
+          "description": "The billing currency of the event.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reseller": {
+          "description": "The reseller of the event.",
+          "readOnly": true,
+          "$ref": "#/definitions/Reseller"
+        },
+        "creditExpiredInBillingCurrency": {
+          "description": "The amount of expired credit or commitment for NewCredit or SettleCharges event in billing currency.",
+          "readOnly": true,
+          "$ref": "#/definitions/AmountWithExchangeRate"
+        },
+        "newCreditInBillingCurrency": {
+          "description": "The amount of new credit or commitment for NewCredit or SettleCharges event in billing currency.",
+          "readOnly": true,
+          "$ref": "#/definitions/AmountWithExchangeRate"
+        },
+        "adjustmentsInBillingCurrency": {
+          "description": "The amount of balance adjustment in billing currency.",
+          "readOnly": true,
+          "$ref": "#/definitions/AmountWithExchangeRate"
+        },
+        "chargesInBillingCurrency": {
+          "description": "The amount of charges for events of type SettleCharges and PendingEligibleCharges in billing currency.",
+          "readOnly": true,
+          "$ref": "#/definitions/AmountWithExchangeRate"
+        },
+        "closedBalanceInBillingCurrency": {
+          "description": "The balance in billing currency after the event.",
+          "readOnly": true,
+          "$ref": "#/definitions/AmountWithExchangeRate"
+        },
+        "isEstimatedBalance": {
+          "description": "If true, the listed details are based on an estimation and it will be subjected to change.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "eTag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The eTag for the resource."
+        }
+      }
+    },
+    "Lots": {
+      "description": "Result of listing lot summary.",
+      "properties": {
+        "value": {
+          "description": "The list of lot summary.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/LotSummary"
+          }
+        },
+        "nextLink": {
+          "description": "The link (url) to the next page of results.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "LotSummary": {
+      "description": "A lot summary resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/LotProperties",
+          "title": "Lot summary properties"
+        }
+      }
+    },
+    "LotProperties": {
+      "description": "The lot properties.",
+      "properties": {
+        "originalAmount": {
+          "description": "The original amount of a lot.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "closedBalance": {
+          "description": "The balance as of the last invoice.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "source": {
+          "description": "The source of the lot.",
+          "type": "string",
+          "enum": [
+            "PurchasedCredit",
+            "PromotionalCredit",
+            "ConsumptionCommitment"
+          ],
+          "x-ms-enum": {
+            "name": "LotSource",
+            "modelAsString": true
+          },
+          "readOnly": true
+        },
+        "startDate": {
+          "description": "The date when the lot became effective.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "expirationDate": {
+          "description": "The expiration date of a lot.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "poNumber": {
+          "description": "The po number of the invoice on which the lot was added. This property is not available for ConsumptionCommitment lots.",
+          "type": "string",
+          "readOnly": true
+        },
+        "purchasedDate": {
+          "description": "The date when the lot was added.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "status": {
+          "description": "The status of the lot.",
+          "type": "string",
+          "enum": [
+            "None",
+            "Active",
+            "Inactive",
+            "Expired",
+            "Complete",
+            "Canceled"
+          ],
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "Status",
+            "modelAsString": true
+          }
+        },
+        "creditCurrency": {
+          "description": "The currency of the lot.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingCurrency": {
+          "description": "The billing currency of the lot.",
+          "type": "string",
+          "readOnly": true
+        },
+        "originalAmountInBillingCurrency": {
+          "description": "The original amount of a lot in billing currency.",
+          "readOnly": true,
+          "$ref": "#/definitions/AmountWithExchangeRate"
+        },
+        "closedBalanceInBillingCurrency": {
+          "description": "The balance as of the last invoice in billing currency.",
+          "readOnly": true,
+          "$ref": "#/definitions/AmountWithExchangeRate"
+        },
+        "reseller": {
+          "description": "The reseller of the lot.",
+          "readOnly": true,
+          "$ref": "#/definitions/Reseller"
+        },
+        "isEstimatedBalance": {
+          "description": "If true, the listed details are based on an estimation and it will be subjected to change.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "eTag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The eTag for the resource."
+        }
+      }
+    },
+    "CreditSummary": {
+      "description": "A credit summary resource.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/CreditSummaryProperties",
+          "title": "Credit summary properties"
+        }
+      }
+    },
+    "CreditSummaryProperties": {
+      "description": "The properties of the credit summary.",
+      "type": "object",
+      "properties": {
+        "balanceSummary": {
+          "description": "Summary of balances associated with this credit summary.",
+          "readOnly": true,
+          "$ref": "#/definitions/CreditBalanceSummary"
+        },
+        "pendingCreditAdjustments": {
+          "description": "Pending credit adjustments.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "expiredCredit": {
+          "description": "Expired credit.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "pendingEligibleCharges": {
+          "description": "Pending eligible charges.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "creditCurrency": {
+          "description": "The credit currency.",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingCurrency": {
+          "description": "The billing currency.",
+          "type": "string",
+          "readOnly": true
+        },
+        "reseller": {
+          "description": "Credit's reseller.",
+          "readOnly": true,
+          "$ref": "#/definitions/Reseller"
+        },
+        "isEstimatedBalance": {
+          "description": "If true, the listed details are based on an estimation and it will be subjected to change.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "eTag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The eTag for the resource."
+        }
+      }
+    },
+    "CreditBalanceSummary": {
+      "description": "Summary of credit balances.",
+      "properties": {
+        "estimatedBalance": {
+          "description": "Estimated balance.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "currentBalance": {
+          "description": "Current balance.",
+          "readOnly": true,
+          "$ref": "#/definitions/amount"
+        },
+        "estimatedBalanceInBillingCurrency": {
+          "description": "Estimated balance in billing currency.",
+          "readOnly": true,
+          "$ref": "#/definitions/AmountWithExchangeRate"
+        }
+      }
+    },
+    "amount": {
+      "description": "The amount plus currency .",
+      "properties": {
+        "currency": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Amount currency."
+        },
+        "value": {
+          "readOnly": true,
+          "type": "number",
+          "format": "decimal",
+          "description": "Amount."
+        }
+      }
+    },
+    "Resource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The full qualified ARM ID of an event."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The ID that uniquely identifies an event. "
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type."
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The etag for the resource."
+        },
+        "tags": {
+          "readOnly": true,
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ReservationTransactionResource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type."
+        },
+        "tags": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Resource tags."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ResourceAttributes": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "location": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource location"
+        },
+        "sku": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource sku"
+        }
+      }
+    },
+    "ProxyResource": {
+      "description": "The Resource model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type."
+        },
+        "eTag": {
+          "type": "string",
+          "description": "eTag of the resource. To handle concurrent update scenario, this field will be used to determine whether the user is updating the latest version or not."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "AmountWithExchangeRate": {
+      "description": "The amount with exchange rate.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/amount"
+        }
+      ],
+      "properties": {
+        "exchangeRate": {
+          "description": "The exchange rate.",
+          "type": "number",
+          "format": "decimal",
+          "readOnly": true
+        },
+        "exchangeRateMonth": {
+          "description": "The exchange rate month.",
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true
+        }
+      }
+    },
+    "Reseller": {
+      "description": "The reseller properties.",
+      "type": "object",
+      "properties": {
+        "resellerId": {
+          "description": "The reseller property ID.",
+          "type": "string",
+          "readOnly": true
+        },
+        "resellerDescription": {
+          "description": "The reseller property description.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "scopeChargesParameter": {
+      "name": "scope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with charges operations. This includes '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/departments/{departmentId}' for Department scope, and '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/enrollmentAccounts/{enrollmentAccountId}' for EnrollmentAccount scope. For department and enrollment accounts, you can also add billing period to the scope using '/providers/Microsoft.Billing/billingPeriods/{billingPeriodName}'. For e.g. to specify billing period at department scope use '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/departments/{departmentId}/providers/Microsoft.Billing/billingPeriods/{billingPeriodName}'. Also, Modern Commerce Account scopes are '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for billingAccount scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for billingProfile scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/invoiceSections/{invoiceSectionId}' for invoiceSection scope, and '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/customers/{customerId}' specific for partners.",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "scopeUsageDetailsParameter": {
+      "name": "scope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with usage details operations. This includes '/subscriptions/{subscriptionId}/' for subscription scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for Billing Account scope, '/providers/Microsoft.Billing/departments/{departmentId}' for Department scope, '/providers/Microsoft.Billing/enrollmentAccounts/{enrollmentAccountId}' for EnrollmentAccount scope and '/providers/Microsoft.Management/managementGroups/{managementGroupId}' for Management Group scope. For subscription, billing account, department, enrollment account and management group, you can also add billing period to the scope using '/providers/Microsoft.Billing/billingPeriods/{billingPeriodName}'. For e.g. to specify billing period at department scope use '/providers/Microsoft.Billing/departments/{departmentId}/providers/Microsoft.Billing/billingPeriods/{billingPeriodName}'. Also, Modern Commerce Account scopes are '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for billingAccount scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for billingProfile scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/invoiceSections/{invoiceSectionId}' for invoiceSection scope, and '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/customers/{customerId}' specific for partners.",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "scopeMarketplaceParameter": {
+      "name": "scope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with marketplace operations. This includes '/subscriptions/{subscriptionId}/' for subscription scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for Billing Account scope, '/providers/Microsoft.Billing/departments/{departmentId}' for Department scope, '/providers/Microsoft.Billing/enrollmentAccounts/{enrollmentAccountId}' for EnrollmentAccount scope and '/providers/Microsoft.Management/managementGroups/{managementGroupId}' for Management Group scope. For subscription, billing account, department, enrollment account and ManagementGroup, you can also add billing period to the scope using '/providers/Microsoft.Billing/billingPeriods/{billingPeriodName}'. For e.g. to specify billing period at department scope use '/providers/Microsoft.Billing/departments/{departmentId}/providers/Microsoft.Billing/billingPeriods/{billingPeriodName}'",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "scopeBudgetParameter": {
+      "name": "scope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with budget operations. This includes '/subscriptions/{subscriptionId}/' for subscription scope, '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for resourceGroup scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for Billing Account scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/departments/{departmentId}' for Department scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/enrollmentAccounts/{enrollmentAccountId}' for EnrollmentAccount scope, '/providers/Microsoft.Management/managementGroups/{managementGroupId}' for Management Group scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for billingProfile scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/invoiceSections/{invoiceSectionId}' for invoiceSection scope.",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "scopeTagsParameter": {
+      "name": "scope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with tags operations. This includes '/subscriptions/{subscriptionId}/' for subscription scope, '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for resourceGroup scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for Billing Account scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/departments/{departmentId}' for Department scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/enrollmentAccounts/{enrollmentAccountId}' for EnrollmentAccount scope and '/providers/Microsoft.Management/managementGroups/{managementGroupId}' for Management Group scope..",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "scopeReservationsSummariesParameter": {
+      "name": "resourceScope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with reservations summaries operations. This includes '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for BillingAccount scope (legacy), and '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for BillingProfile scope (modern). ",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "scopeReservationDetailsParameter": {
+      "name": "resourceScope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with reservations details operations. This includes '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for BillingAccount scope (legacy), and '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for BillingProfile scope (modern). ",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "scopeReservationRecommendationsParameter": {
+      "name": "resourceScope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with reservation recommendations operations. This includes '/subscriptions/{subscriptionId}/' for subscription scope, '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for resource group scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for BillingAccount scope, and '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for billingProfile scope",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "scopeReservationRecommendationDetailsParameter": {
+      "name": "resourceScope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with reservation recommendation details operations. This includes '/subscriptions/{subscriptionId}/' for subscription scope, '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for resource group scope, /providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for BillingAccount scope, and '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for billingProfile scope",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "scopeReservationTransactionsParameter": {
+      "name": "resourceScope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The scope associated with reservation transactions operations. This includes '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for BillingAccount/Enrollment scope, and '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for billingProfile scope",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "apiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Version of the API to be used with the client request. The current version is 2023-03-01."
+    },
+    "billingAccountIdParameter": {
+      "name": "billingAccountId",
+      "in": "path",
+      "description": "BillingAccount ID",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "customerIdParameter": {
+      "name": "customerId",
+      "in": "path",
+      "description": "Customer ID",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "departmentIdParameter": {
+      "name": "departmentId",
+      "in": "path",
+      "description": "Department ID",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "enrollmentAccountIdParameter": {
+      "name": "enrollmentAccountId",
+      "in": "path",
+      "description": "EnrollmentAccount ID",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "subscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Azure Subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "resourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "Azure Resource Group Name.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "budgetNameParameter": {
+      "name": "budgetName",
+      "in": "path",
+      "description": "Budget Name.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "billingPeriodNameParameter": {
+      "name": "billingPeriodName",
+      "in": "path",
+      "description": "Billing Period Name.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "reservationOrderIdParameter": {
+      "name": "reservationOrderId",
+      "in": "path",
+      "description": "Order Id of the reservation",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "reservationIdParameter": {
+      "name": "reservationId",
+      "in": "path",
+      "description": "Id of the reservation",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "grainParameter": {
+      "name": "grain",
+      "description": "Can be daily or monthly",
+      "x-ms-parameter-location": "method",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "daily",
+        "monthly"
+      ],
+      "x-ms-enum": {
+        "name": "datagrain",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "daily",
+            "description": "Daily grain of data",
+            "name": "DailyGrain"
+          },
+          {
+            "value": "monthly",
+            "description": "Monthly grain of data",
+            "name": "MonthlyGrain"
+          }
+        ]
+      }
+    },
+    "managementGroupIdParameter": {
+      "name": "managementGroupId",
+      "in": "path",
+      "description": "Azure Management Group ID.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "billingProfileIdParameter": {
+      "name": "billingProfileId",
+      "in": "path",
+      "description": "Azure Billing Profile ID.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "invoiceSectionIdParameter": {
+      "name": "invoiceSectionId",
+      "in": "path",
+      "description": "Azure Invoice Section ID.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "startDateParameter": {
+      "name": "startDate",
+      "in": "query",
+      "description": "Start date",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "endDateParameter": {
+      "name": "endDate",
+      "in": "query",
+      "description": "End date",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "metricParameter": {
+      "name": "metric",
+      "in": "query",
+      "description": "Allows to select different type of cost/usage records.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "enum": [
+        "actualcost",
+        "amortizedcost",
+        "usage"
+      ],
+      "x-ms-enum": {
+        "name": "metrictype",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "actualcost",
+            "description": "Actual cost data.",
+            "name": "ActualCostMetricType"
+          },
+          {
+            "value": "amortizedcost",
+            "description": "Amortized cost data.",
+            "name": "AmortizedCostMetricType"
+          },
+          {
+            "value": "usage",
+            "description": "Usage data.",
+            "name": "UsageMetricType"
+          }
+        ]
+      }
+    },
+    "filterParameter": {
+      "name": "$filter",
+      "in": "query",
+      "description": "May be used to filter reservationRecommendations by: properties/scope with allowed values ['Single', 'Shared'] and default value 'Single'; properties/resourceType with allowed values ['VirtualMachines', 'SQLDatabases', 'PostgreSQL', 'ManagedDisk', 'MySQL', 'RedHat', 'MariaDB', 'RedisCache', 'CosmosDB', 'SqlDataWarehouse', 'SUSELinux', 'AppService', 'BlockBlob', 'AzureDataExplorer', 'VMwareCloudSimple'] and default value 'VirtualMachines'; and properties/lookBackPeriod with allowed values ['Last7Days', 'Last30Days', 'Last60Days'] and default value 'Last7Days'.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "recommendationDetailsFilterParameter": {
+      "name": "$filter",
+      "in": "query",
+      "description": "Used to filter reservation recommendation details by: properties/subscriptionId can be specified for billing account and billing profile paths.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "termParameter": {
+      "description": "Specify length of reservation recommendation term.",
+      "type": "string",
+      "in": "query",
+      "required": true,
+      "name": "term",
+      "x-ms-parameter-location": "method",
+      "enum": [
+        "P1Y",
+        "P3Y"
+      ],
+      "x-ms-enum": {
+        "name": "term",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "P1Y",
+            "description": "1 year reservation term",
+            "name": "P1Y"
+          },
+          {
+            "value": "P3Y",
+            "description": "3 year reservation term",
+            "name": "P3Y"
+          }
+        ]
+      }
+    },
+    "regionParameter": {
+      "name": "region",
+      "in": "query",
+      "description": "Used to select the region the recommendation should be generated for.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "lookBackPeriodParameter": {
+      "name": "lookBackPeriod",
+      "in": "query",
+      "description": "Filter the time period on which reservation recommendation results are based.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "enum": [
+        "Last7Days",
+        "Last30Days",
+        "Last60Days"
+      ],
+      "x-ms-enum": {
+        "name": "lookBackPeriod",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Last7Days",
+            "description": "Use 7 days of data for recommendations",
+            "name": "Last07Days"
+          },
+          {
+            "value": "Last30Days",
+            "description": "Use 30 days of data for recommendations",
+            "name": "Last30Days"
+          },
+          {
+            "value": "Last60Days",
+            "description": "Use 60 days of data for recommendations",
+            "name": "Last60Days"
+          }
+        ]
+      }
+    },
+    "productParameter": {
+      "name": "product",
+      "in": "query",
+      "description": "Filter the products for which reservation recommendation results are generated. Examples: Standard_DS1_v2 (for VM), Premium_SSD_Managed_Disks_P30 (for Managed Disks)",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "scopeParameter": {
+      "description": "Scope of the reservation.",
+      "type": "string",
+      "name": "scope",
+      "in": "query",
+      "required": true,
+      "x-ms-parameter-location": "method",
+      "enum": [
+        "Single",
+        "Shared"
+      ],
+      "x-ms-enum": {
+        "name": "scope",
+        "modelAsString": true
+      }
+    },
+    "useMarkupIfPartnerParameter": {
+      "name": "useMarkupIfPartner",
+      "in": "query",
+      "description": "Applies mark up to the transactions if the caller is a partner.",
+      "required": false,
+      "type": "boolean",
+      "x-ms-parameter-location": "method"
+    },
+    "previewMarkupPercentage": {
+      "name": "previewMarkupPercentage",
+      "in": "query",
+      "description": "Preview markup percentage to be applied.",
+      "required": false,
+      "type": "number",
+      "format": "decimal",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/consumption_pricesheet.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/consumption_pricesheet.json
@@ -1,0 +1,158 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2023-03-01",
+    "title": "ConsumptionManagementClient",
+    "description": "Consumption management client provides access to consumption resources for Azure Enterprise Subscriptions."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingPeriods/{billingPeriodName}/providers/Microsoft.Consumption/pricesheets/download": {
+      "post": {
+        "tags": [
+          "PriceSheet"
+        ],
+        "operationId": "PriceSheet_DownloadByBillingAccountPeriod",
+        "description": "Generates the pricesheet for the provided billing period asynchronously based on the enrollment id",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/en-us/rest/api/consumption/"
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-examples": {
+          "EAPriceSheetForBillingPeriod": {
+            "$ref": "./examples/EAPriceSheetForBillingPeriod.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/billingAccountIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/billingPeriodNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request processing completed.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatus"
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "Location": {
+                "type": "string"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "OperationStatus": {
+      "description": "The status of the long running operation.",
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "The status of the long running operation.",
+          "type": "string",
+          "enum": [
+            "Running",
+            "Completed",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "OperationStatusType",
+            "modelAsString": true
+          }
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "description": "The properties of the resource generated.",
+          "$ref": "#/definitions/PricesheetDownloadProperties"
+        }
+      }
+    },
+    "PricesheetDownloadProperties": {
+      "description": "The properties of the price sheet download.",
+      "type": "object",
+      "properties": {
+        "downloadUrl": {
+          "description": "The link (url) to download the pricesheet.",
+          "type": "string",
+          "readOnly": true
+        },
+        "validTill": {
+          "description": "Download link validity.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "billingAccountIdParameter": {
+      "name": "billingAccountId",
+      "in": "path",
+      "description": "BillingAccount ID",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "billingPeriodNameParameter": {
+      "name": "billingPeriodName",
+      "in": "path",
+      "description": "Billing Period Name.",
+      "required": true,
+      "type": "string",
+      "pattern": "^[0-9]*$",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/consumption_pricesheet.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/consumption_pricesheet.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2023-03-01",
+    "version": "2023-05-01",
     "title": "ConsumptionManagementClient",
     "description": "Consumption management client provides access to consumption resources for Azure Enterprise Subscriptions."
   },

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/AggregatedCostByManagementGroup.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/AggregatedCostByManagementGroup.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "managementGroupId": "managementGroupForTest"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Management/managementGroups/managementGroupForTest/providers/Microsoft.Consumption/aggregatedcostId1",
+        "name": "aggregatedcostId1",
+        "type": "Microsoft.Consumption/aggregatedcost",
+        "properties": {
+          "includedSubscriptions": [
+            "1caaa5a3-2b66-438e-8ab4-bce37d518c5d"
+          ],
+          "excludedSubscriptions": [],
+          "usageStart": "2023-03-01T00:00:00.0000000Z",
+          "usageEnd": "2023-05-01T00:00:00.0000000Z",
+          "azureCharges": 250.9876,
+          "marketplaceCharges": 150.786,
+          "chargesBilledSeparately": 120.345,
+          "currency": "USD",
+          "children": [
+            {
+              "id": "/providers/Microsoft.Management/managementGroups/managementGroupChildForTest/providers/Microsoft.Consumption/aggregatedcostId2",
+              "name": "aggregatedcostId2",
+              "type": "Microsoft.Consumption/aggregatedcost",
+              "properties": {
+                "includedSubscriptions": [
+                  "c349567d-c83a-48c9-ab0e-578c69dc97a4"
+                ],
+                "excludedSubscriptions": [],
+                "usageStart": "2023-03-01T00:00:00.0000000Z",
+                "usageEnd": "2023-05-01T00:00:00.0000000Z",
+                "azureCharges": 150.0,
+                "marketplaceCharges": 50.786,
+                "chargesBilledSeparately": 30.345,
+                "currency": "USD",
+                "children": []
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/AggregatedCostByManagementGroupFilterByDate.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/AggregatedCostByManagementGroupFilterByDate.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "managementGroupId": "managementGroupForTest",
+    "$filter": "usageStart ge '2018-08-15' and properties/usageStart le '2018-08-31'"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Management/managementGroups/managementGroupForTest/providers/Microsoft.Consumption/aggregatedcostId1",
+        "name": "aggregatedcostId1",
+        "type": "Microsoft.Consumption/aggregatedcost",
+        "properties": {
+          "includedSubscriptions": [
+            "1caaa5a3-2b66-438e-8ab4-bce37d518c5d"
+          ],
+          "excludedSubscriptions": [],
+          "usageStart": "2018-08-15T00:00:00.0000000Z",
+          "usageEnd": "2018-08-31T00:00:00.0000000Z",
+          "azureCharges": 150.9876,
+          "marketplaceCharges": 80.786,
+          "chargesBilledSeparately": 90.345,
+          "currency": "USD",
+          "children": [
+            {
+              "id": "/providers/Microsoft.Management/managementGroups/managementGroupChildForTest/providers/Microsoft.Consumption/aggregatedcostId2",
+              "name": "aggregatedcostId2",
+              "type": "Microsoft.Consumption/aggregatedcost",
+              "properties": {
+                "includedSubscriptions": [
+                  "c349567d-c83a-48c9-ab0e-578c69dc97a4"
+                ],
+                "excludedSubscriptions": [],
+                "usageStart": "2018-08-15T00:00:00.0000000Z",
+                "usageEnd": "2018-08-31T00:00:00.0000000Z",
+                "azureCharges": 50.0,
+                "marketplaceCharges": 10.786,
+                "chargesBilledSeparately": 30.345,
+                "currency": "USD",
+                "children": []
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/AggregatedCostForBillingPeriodByManagementGroup.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/AggregatedCostForBillingPeriodByManagementGroup.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "managementGroupId": "managementGroupForTest",
+    "billingPeriodName": "201807"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Management/managementGroups/managementGroupForTest/providers/Microsoft.Consumption/aggregatedcostId1",
+        "name": "aggregatedcostId1",
+        "type": "Microsoft.Consumption/aggregatedcost",
+        "properties": {
+          "usageStart": "2018-07-01T00:00:00.0000000Z",
+          "usageEnd": "2018-07-31T00:00:00.0000000Z",
+          "azureCharges": 250.9876,
+          "marketplaceCharges": 150.786,
+          "chargesBilledSeparately": 120.345,
+          "currency": "USD",
+          "children": [
+            {
+              "id": "/providers/Microsoft.Management/managementGroups/managementGroupChildForTest/providers/Microsoft.Consumption/aggregatedcostId2",
+              "name": "aggregatedcostId2",
+              "type": "Microsoft.Consumption/aggregatedcost",
+              "properties": {
+                "usageStart": "2018-07-01T00:00:00.0000000Z",
+                "usageEnd": "2018-07-31T00:00:00.0000000Z",
+                "azureCharges": 150.0,
+                "marketplaceCharges": 50.786,
+                "chargesBilledSeparately": 30.345,
+                "currency": "USD",
+                "children": []
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/BalancesByBillingAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/BalancesByBillingAccount.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "123456"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Billing/billingAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/balances/balanceId1",
+        "name": "balanceId1",
+        "type": "Microsoft.Consumption/balances",
+        "properties": {
+          "currency": "USD  ",
+          "beginningBalance": 3396469.19,
+          "endingBalance": 2922371.02,
+          "newPurchases": 0,
+          "adjustments": 0,
+          "utilized": 474098.17,
+          "serviceOverage": 0,
+          "chargesBilledSeparately": 0,
+          "totalOverage": 0,
+          "totalUsage": 474098.17,
+          "azureMarketplaceServiceCharges": 609.82,
+          "billingFrequency": "Month",
+          "priceHidden": false,
+          "overageRefund": 2012.61,
+          "newPurchasesDetails": [
+            {
+              "name": "Promo Purchase",
+              "value": 1
+            }
+          ],
+          "adjustmentDetails": [
+            {
+              "name": "Promo Credit",
+              "value": 1.1
+            },
+            {
+              "name": "SIE Credit",
+              "value": 1.0
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/BalancesByBillingAccountForBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/BalancesByBillingAccountForBillingPeriod.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "123456",
+    "billingPeriodName": "201702"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "providers/Microsoft.Billing/billingAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/balances/balanceId1",
+        "name": "balanceId1",
+        "type": "Microsoft.Consumption/balances",
+        "properties": {
+          "currency": "USD  ",
+          "beginningBalance": 3396469.19,
+          "endingBalance": 2922371.02,
+          "newPurchases": 0,
+          "adjustments": 0,
+          "utilized": 474098.17,
+          "serviceOverage": 0,
+          "chargesBilledSeparately": 0,
+          "totalOverage": 0,
+          "totalUsage": 474098.17,
+          "azureMarketplaceServiceCharges": 609.82,
+          "billingFrequency": "Month",
+          "priceHidden": false,
+          "overageRefund": 2012.61,
+          "newPurchasesDetails": [
+            {
+              "name": "Promo Purchase",
+              "value": 1
+            }
+          ],
+          "adjustmentDetails": [
+            {
+              "name": "Promo Credit",
+              "value": 1.1
+            },
+            {
+              "name": "SIE Credit",
+              "value": 1.0
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/Budget.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/Budget.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "MYDEVTESTRG",
+    "budgetName": "TestBudget",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Consumption/budgets/TestBudget",
+        "name": "TestBudget",
+        "type": "Microsoft.Consumption/budgets",
+        "eTag": "\"1d34d012214157f\"",
+        "properties": {
+          "category": "Cost",
+          "amount": 100.65,
+          "timeGrain": "Monthly",
+          "timePeriod": {
+            "startDate": "2017-10-01T00:00:00Z",
+            "endDate": "2018-10-31T00:00:00Z"
+          },
+          "filter": {
+            "and": [
+              {
+                "dimensions": {
+                  "name": "ResourceId",
+                  "operator": "In",
+                  "values": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/MSVM2",
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/platformcloudplatformGeneric1"
+                  ]
+                }
+              },
+              {
+                "tags": {
+                  "name": "category",
+                  "operator": "In",
+                  "values": [
+                    "Dev",
+                    "Prod"
+                  ]
+                }
+              },
+              {
+                "tags": {
+                  "name": "department",
+                  "operator": "In",
+                  "values": [
+                    "engineering",
+                    "sales"
+                  ]
+                }
+              }
+            ]
+          },
+          "currentSpend": {
+            "amount": 80.89,
+            "unit": "USD"
+          },
+          "notifications": {
+            "Actual_GreaterThan_80_Percent": {
+              "enabled": true,
+              "operator": "GreaterThan",
+              "threshold": 80,
+              "contactEmails": [
+                "johndoe@contoso.com",
+                "janesmith@contoso.com"
+              ],
+              "contactRoles": [
+                "Contributor",
+                "Reader"
+              ],
+              "contactGroups": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/microsoft.insights/actionGroups/SampleActionGroup"
+              ],
+              "thresholdType": "Actual"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/BudgetsList.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/BudgetsList.json
@@ -1,0 +1,186 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "MYDEVTESTRG"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Consumption/budgets/TestBudget",
+            "name": "TestBudget",
+            "type": "Microsoft.Consumption/budgets",
+            "eTag": "\"1d34d012214157f\"",
+            "properties": {
+              "category": "Cost",
+              "amount": 100.65,
+              "timeGrain": "Monthly",
+              "timePeriod": {
+                "startDate": "2017-10-01T00:00:00Z",
+                "endDate": "2018-10-31T00:00:00Z"
+              },
+              "filter": {
+                "and": [
+                  {
+                    "dimensions": {
+                      "name": "ResourceId",
+                      "operator": "In",
+                      "values": [
+                        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/MSVM2",
+                        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/platformcloudplatformGeneric1"
+                      ]
+                    }
+                  },
+                  {
+                    "tags": {
+                      "name": "category",
+                      "operator": "In",
+                      "values": [
+                        "Dev",
+                        "Prod"
+                      ]
+                    }
+                  },
+                  {
+                    "tags": {
+                      "name": "department",
+                      "operator": "In",
+                      "values": [
+                        "engineering",
+                        "sales"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "currentSpend": {
+                "amount": 80.89,
+                "unit": "USD"
+              },
+              "notifications": {
+                "Actual_GreaterThan_80_Percent": {
+                  "enabled": true,
+                  "operator": "GreaterThan",
+                  "threshold": 80,
+                  "contactEmails": [
+                    "johndoe@contoso.com",
+                    "janesmith@contoso.com"
+                  ],
+                  "contactRoles": [
+                    "Contributor",
+                    "Reader"
+                  ]
+                },
+                "Actual_GreaterThanOrEqualTo_90_Percent": {
+                  "enabled": true,
+                  "operator": "GreaterThanOrEqualTo",
+                  "threshold": 90,
+                  "contactEmails": [
+                    "johndoe@contoso.com",
+                    "janesmith@contoso.com"
+                  ],
+                  "contactRoles": [
+                    "Contributor",
+                    "Reader"
+                  ],
+                  "contactGroups": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/microsoft.insights/actionGroups/SampleActionGroup"
+                  ]
+                },
+                "thresholdType": "Actual"
+              }
+            }
+          },
+          {
+            "id": "subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/budgets/TestBudget",
+            "name": "TestBudget",
+            "type": "Microsoft.Consumption/budgets",
+            "eTag": "\"1d34d012214157f\"",
+            "properties": {
+              "category": "Cost",
+              "amount": 600.65,
+              "timeGrain": "Monthly",
+              "timePeriod": {
+                "startDate": "2017-10-01T00:00:00Z",
+                "endDate": "2018-10-31T00:00:00Z"
+              },
+              "filter": {
+                "and": [
+                  {
+                    "dimensions": {
+                      "name": "ResourceId",
+                      "operator": "In",
+                      "values": [
+                        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/MSVM2",
+                        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/platformcloudplatformGeneric1"
+                      ]
+                    }
+                  },
+                  {
+                    "tags": {
+                      "name": "category",
+                      "operator": "In",
+                      "values": [
+                        "Dev",
+                        "Prod"
+                      ]
+                    }
+                  },
+                  {
+                    "tags": {
+                      "name": "department",
+                      "operator": "In",
+                      "values": [
+                        "engineering",
+                        "sales"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "currentSpend": {
+                "amount": 120.89,
+                "unit": "USD"
+              },
+              "notifications": {
+                "Actual_GreaterThan_40_Percent": {
+                  "enabled": true,
+                  "operator": "GreaterThan",
+                  "threshold": 40,
+                  "contactEmails": [
+                    "johndoe@contoso.com",
+                    "janesmith@contoso.com"
+                  ],
+                  "contactRoles": [
+                    "Contributor",
+                    "Reader"
+                  ]
+                },
+                "Actual_GreaterThanOrEqualTo_60_Percent": {
+                  "enabled": true,
+                  "operator": "GreaterThanOrEqualTo",
+                  "threshold": 60,
+                  "contactEmails": [
+                    "johndoe@contoso.com",
+                    "janesmith@contoso.com"
+                  ],
+                  "contactRoles": [
+                    "Contributor",
+                    "Reader"
+                  ],
+                  "contactGroups": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/microsoft.insights/actionGroups/SampleActionGroup"
+                  ],
+                  "thresholdType": "Actual"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesForBillingPeriodByDepartment.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesForBillingPeriodByDepartment.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingPeriodName": "201804",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234/departments/42425"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234/departments/42425/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "legacy",
+            "properties": {
+              "billingPeriodId": "/providers/Microsoft.Billing/BillingAccounts/1234/providers/Microsoft.Billing/billingPeriods/201804",
+              "usageStart": "2018-04-01",
+              "usageEnd": "2018-04-30",
+              "azureCharges": 5000.00,
+              "chargesBilledSeparately": 60.90,
+              "azureMarketplaceCharges": 100.00,
+              "currency": "USD"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesForBillingPeriodByEnrollmentAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesForBillingPeriodByEnrollmentAccount.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingPeriodName": "201804",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234/enrollmentAccounts/42425"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234/enrollmentAccounts/42425/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "legacy",
+            "properties": {
+              "billingPeriodId": "/providers/Microsoft.Billing/BillingAccounts/1234/providers/Microsoft.Billing/billingPeriods/201804",
+              "usageStart": "2018-04-01",
+              "usageEnd": "2018-04-30",
+              "azureCharges": 5000.00,
+              "chargesBilledSeparately": 60.90,
+              "azureMarketplaceCharges": 100.00,
+              "currency": "USD"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingAccount.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "startDate": "2019-09-01",
+    "endDate": "2019-10-31",
+    "scope": "providers/Microsoft.Billing/billingAccounts/1234:56789"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201910",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-10-31",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 0.0
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 265.09
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 0.0
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": null,
+              "invoiceSectionId": null
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingAccountGroupByBillingProfileId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingAccountGroupByBillingProfileId.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/billingAccounts/1234:56789",
+    "startDate": "2019-09-01",
+    "endDate": "2019-09-30",
+    "$apply": "groupby((properties/billingProfileId))"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/123456/providers/Microsoft.Billing/billingPeriods/201909",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-09-30",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/123456"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234:56789/billingProfiles/42425/providers/Microsoft.Consumption/charges/chargeSummaryId2",
+            "name": "chargeSummaryId2",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201909",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-09-30",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingAccountGroupByCustomerId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingAccountGroupByCustomerId.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/billingAccounts/1234:56789",
+    "startDate": "2019-09-01",
+    "endDate": "2019-09-30",
+    "$apply": "groupby((properties/customerId))"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/customers/67890/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "customerId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/customers/67890",
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201909",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-09-30",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/invoiceSections/67890"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234:56789/customers/123456/providers/Microsoft.Consumption/charges/chargeSummaryId2",
+            "name": "chargeSummaryId2",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "customerId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/customers/123456",
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201909",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-09-30",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/invoiceSections/67890"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingAccountGroupByInvoiceSectionId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingAccountGroupByInvoiceSectionId.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+    "startDate": "2019-09-01",
+    "endDate": "2019-09-30",
+    "$apply": "groupby((properties/invoiceSectionId))"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425/invoiceSections/4567/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201909",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-09-30",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/invoiceSections/4567"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234:56789//billingProfiles/42425/invoiceSections/67890/providers/Microsoft.Consumption/charges/chargeSummaryId2",
+            "name": "chargeSummaryId2",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201909",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-09-30",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/invoiceSections/67890"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingProfile.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingProfile.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234:56789/billingProfiles/2460"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/2460/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201910",
+              "usageStart": "2023-03-01",
+              "usageEnd": "2023-05-31",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 0.0
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 265.09
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 0.0
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/2460",
+              "invoiceSectionId": null
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingProfileGroupByInvoiceSectionId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingProfileGroupByInvoiceSectionId.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+    "startDate": "2019-09-01",
+    "endDate": "2019-09-30",
+    "$apply": "groupby((properties/invoiceSectionId))"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425/invoiceSections/4567/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201909",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-09-30",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/invoiceSections/4567"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234:56789//billingProfiles/42425/invoiceSections/67890/providers/Microsoft.Consumption/charges/chargeSummaryId2",
+            "name": "chargeSummaryId2",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201909",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-09-30",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/invoiceSections/67890"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingProfileInvoiceSection.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernBillingProfileInvoiceSection.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "startDate": "2019-09-01",
+    "endDate": "2019-10-31",
+    "scope": "providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425/invoiceSections/67890"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425/invoiceSections/67890/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201909",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-09-30",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425/invoiceSections/4567"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425/invoiceSections/67890/providers/Microsoft.Consumption/charges/chargeSummaryId2",
+            "name": "chargeSummaryId2",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201910",
+              "usageStart": "2019-09-01",
+              "usageEnd": "2019-10-31",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/42425/invoiceSections/4567"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernCustomer.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernCustomer.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234:56789/customers/67890"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/customers/67890/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201910",
+              "usageStart": "2023-03-01",
+              "usageEnd": "2023-05-31",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 0.0
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 265.09
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 0.0
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": null,
+              "invoiceSectionId": null
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernInvoiceSectionId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListByModernInvoiceSectionId.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234:56789/invoiceSections/97531"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/2460/invoiceSections/97531/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "modern",
+            "properties": {
+              "isInvoiced": false,
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Billing/billingPeriods/201910",
+              "usageStart": "2023-03-01",
+              "usageEnd": "2023-05-31",
+              "azureCharges": {
+                "currency": "USD",
+                "value": 12.0
+              },
+              "chargesBilledSeparately": {
+                "currency": "USD",
+                "value": 0.0
+              },
+              "marketplaceCharges": {
+                "currency": "USD",
+                "value": 0.0
+              },
+              "billingAccountId": "/providers/Microsoft.Billing/billingAccounts/1234:56789",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/2460",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/1234:56789/billingProfiles/2460/invoiceSections/97531"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListForDepartmentFilterByStartEndDate.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListForDepartmentFilterByStartEndDate.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234/departments/42425",
+    "$filter": "usageStart eq '2018-04-01' AND usageEnd eq '2018-05-30'"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234/departments/42425/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "legacy",
+            "properties": {
+              "billingPeriodId": "/providers/Microsoft.Billing/BillingAccounts/1234/providers/Microsoft.Billing/billingPeriods/201804",
+              "usageStart": "2018-04-01",
+              "usageEnd": "2018-04-30",
+              "azureCharges": 5000.00,
+              "chargesBilledSeparately": 60.90,
+              "azureMarketplaceCharges": 100.00,
+              "currency": "USD"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListForEnrollmentAccountFilterByStartEndDate.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ChargesListForEnrollmentAccountFilterByStartEndDate.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234/enrollmentAccounts/42425"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234/enrollmentAccounts/42425/providers/Microsoft.Consumption/charges/chargeSummaryId1",
+            "name": "chargeSummaryId1",
+            "type": "Microsoft.Consumption/charges",
+            "kind": "legacy",
+            "properties": {
+              "billingPeriodId": "/providers/Microsoft.Billing/BillingAccounts/1234/providers/Microsoft.Billing/billingPeriods/201804",
+              "usageStart": "2018-04-01",
+              "usageEnd": "2018-04-30",
+              "azureCharges": 5000.00,
+              "chargesBilledSeparately": 60.90,
+              "azureMarketplaceCharges": 100.00,
+              "currency": "USD"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/CreateOrUpdateBudget.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/CreateOrUpdateBudget.json
@@ -1,0 +1,227 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "MYDEVTESTRG",
+    "budgetName": "TestBudget",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "parameters": {
+      "eTag": "\"1d34d016a593709\"",
+      "properties": {
+        "category": "Cost",
+        "amount": 100.65,
+        "timeGrain": "Monthly",
+        "timePeriod": {
+          "startDate": "2017-10-01T00:00:00Z",
+          "endDate": "2018-10-31T00:00:00Z"
+        },
+        "filter": {
+          "and": [
+            {
+              "dimensions": {
+                "name": "ResourceId",
+                "operator": "In",
+                "values": [
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/MSVM2",
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/platformcloudplatformGeneric1"
+                ]
+              }
+            },
+            {
+              "tags": {
+                "name": "category",
+                "operator": "In",
+                "values": [
+                  "Dev",
+                  "Prod"
+                ]
+              }
+            },
+            {
+              "tags": {
+                "name": "department",
+                "operator": "In",
+                "values": [
+                  "engineering",
+                  "sales"
+                ]
+              }
+            }
+          ]
+        },
+        "notifications": {
+          "Actual_GreaterThan_80_Percent": {
+            "enabled": true,
+            "operator": "GreaterThan",
+            "threshold": 80,
+            "locale": "en-us",
+            "contactEmails": [
+              "johndoe@contoso.com",
+              "janesmith@contoso.com"
+            ],
+            "contactRoles": [
+              "Contributor",
+              "Reader"
+            ],
+            "contactGroups": [
+              "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/microsoft.insights/actionGroups/SampleActionGroup"
+            ],
+            "thresholdType": "Actual"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Consumption/budgets/TestBudget",
+        "name": "TestBudget",
+        "type": "Microsoft.Consumption/budgets",
+        "eTag": "\"1d34d012214157f\"",
+        "properties": {
+          "category": "Cost",
+          "amount": 100.65,
+          "timeGrain": "Monthly",
+          "timePeriod": {
+            "startDate": "2017-10-01T00:00:00Z",
+            "endDate": "2018-10-31T00:00:00Z"
+          },
+          "filter": {
+            "and": [
+              {
+                "dimensions": {
+                  "name": "ResourceId",
+                  "operator": "In",
+                  "values": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/MSVM2",
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/platformcloudplatformGeneric1"
+                  ]
+                }
+              },
+              {
+                "tags": {
+                  "name": "category",
+                  "operator": "In",
+                  "values": [
+                    "Dev",
+                    "Prod"
+                  ]
+                }
+              },
+              {
+                "tags": {
+                  "name": "department",
+                  "operator": "In",
+                  "values": [
+                    "engineering",
+                    "sales"
+                  ]
+                }
+              }
+            ]
+          },
+          "currentSpend": {
+            "amount": 80.89,
+            "unit": "USD"
+          },
+          "notifications": {
+            "Actual_GreaterThan_80_Percent": {
+              "enabled": true,
+              "operator": "GreaterThan",
+              "threshold": 80,
+              "locale": "en-us",
+              "contactEmails": [
+                "johndoe@contoso.com",
+                "janesmith@contoso.com"
+              ],
+              "contactRoles": [
+                "Contributor",
+                "Reader"
+              ],
+              "contactGroups": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/microsoft.insights/actionGroups/SampleActionGroup"
+              ],
+              "thresholdType": "Actual"
+            }
+          }
+        }
+      }
+    },
+    "200": {
+      "body": {
+        "id": "subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/budgets/TestBudget",
+        "name": "TestBudget",
+        "type": "Microsoft.Consumption/budgets",
+        "eTag": "\"1d34d012214157f\"",
+        "properties": {
+          "category": "Cost",
+          "amount": 100.65,
+          "timeGrain": "Monthly",
+          "timePeriod": {
+            "startDate": "2017-10-01T00:00:00Z",
+            "endDate": "2018-10-31T00:00:00Z"
+          },
+          "filter": {
+            "and": [
+              {
+                "dimensions": {
+                  "name": "ResourceId",
+                  "operator": "In",
+                  "values": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/MSVM2",
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/Microsoft.Compute/virtualMachines/platformcloudplatformGeneric1"
+                  ]
+                }
+              },
+              {
+                "tags": {
+                  "name": "category",
+                  "operator": "In",
+                  "values": [
+                    "Dev",
+                    "Prod"
+                  ]
+                }
+              },
+              {
+                "tags": {
+                  "name": "department",
+                  "operator": "In",
+                  "values": [
+                    "engineering",
+                    "sales"
+                  ]
+                }
+              }
+            ]
+          },
+          "currentSpend": {
+            "amount": 80.89,
+            "unit": "USD"
+          },
+          "notifications": {
+            "Actual_GreaterThan_80_Percent": {
+              "enabled": true,
+              "operator": "GreaterThan",
+              "threshold": 80,
+              "locale": "en-us",
+              "contactEmails": [
+                "johndoe@contoso.com",
+                "janesmith@contoso.com"
+              ],
+              "contactRoles": [
+                "Contributor",
+                "Reader"
+              ],
+              "contactGroups": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MYDEVTESTRG/providers/microsoft.insights/actionGroups/SampleActionGroup"
+              ],
+              "thresholdType": "Actual"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/CreditSummaryByBillingProfile.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/CreditSummaryByBillingProfile.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "1234:5678",
+    "billingProfileId": "2468"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/credits/balanceSummary1",
+        "name": "balanceSummary1",
+        "type": "Microsoft.Consumption/credits/balanceSummary",
+        "properties": {
+          "creditCurrency": "USD",
+          "billingCurrency": "USD",
+          "balanceSummary": {
+            "estimatedBalance": {
+              "currency": "USD",
+              "value": 600.00
+            },
+            "currentBalance": {
+              "currency": "USD",
+              "value": 100.00
+            }
+          },
+          "pendingCreditAdjustments": {
+            "currency": "USD",
+            "value": 500.00
+          },
+          "expiredCredit": {
+            "currency": "USD",
+            "value": 0.00
+          },
+          "pendingEligibleCharges": {
+            "currency": "USD",
+            "value": 0.00
+          },
+          "reseller": {
+            "resellerId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/reseller/reseller1",
+            "resellerDescription": "Reseller information."
+          },
+          "isEstimatedBalance": false
+        }
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/DeleteBudget.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/DeleteBudget.json
@@ -1,0 +1,12 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "MYDEVTESTRG",
+    "budgetName": "TestBudget",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EAPriceSheetForBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EAPriceSheetForBillingPeriod.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2023-03-01",
+    "billingAccountId": "0000000",
+    "billingPeriodName": "202305"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/providers/Microsoft.Billing/billingAccounts/0000000/providers/Microsoft.Consumption/operationResults/00000000-0000-0000-0000-000000000000?api-version=2023-03-01",
+        "Retry-After": 10
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Completed",
+        "properties": {
+          "downloadUrl": "https://xxxxxx.blob.core.windows.net/armpricesheetreportdownloadcontainer/20230510/00000000-0000-0000-0000-000000000000",
+          "validTill": "2023-05-11T05:12:50.4266333Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EAPriceSheetForBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EAPriceSheetForBillingPeriod.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2023-03-01",
+    "api-version": "2023-05-01",
     "billingAccountId": "0000000",
     "billingPeriodName": "202305"
   },

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EventsGetByBillingAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EventsGetByBillingAccount.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "1234:5678"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Consumption/events/eventId1",
+            "name": "eventId1",
+            "type": "Microsoft.Consumption/events",
+            "properties": {
+              "lotSource": "ConsumptionCommitment",
+              "lotId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/Microsoft.Consumption/lots/G202001083926600XXXXX",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/X3TD-KVTT-BG7-TGB",
+              "billingProfileDisplayName": "Contoso Operations Billing",
+              "transactionDate": "2019-07-01T00:00:00Z",
+              "description": "New MACC Added",
+              "charges": {
+                "currency": "USD",
+                "value": 500
+              },
+              "newCredit": {
+                "currency": "USD",
+                "value": 500
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 500
+              },
+              "invoiceNumber": "3304",
+              "eventType": "NewCredit"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Consumption/events/eventId2",
+            "name": "eventId2",
+            "type": "Microsoft.Consumption/events",
+            "properties": {
+              "lotSource": "AzurePrepayment",
+              "lotId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/Microsoft.Consumption/lots/7004bc39-974d-482e-8e45-caf91dba0870",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/X3TD-KVTT-BG7-TGB",
+              "billingProfileDisplayName": "Contoso Operations Billing",
+              "transactionDate": "2019-07-01T00:00:00Z",
+              "description": "Balance after invoice 3304",
+              "charges": {
+                "currency": "USD",
+                "value": 500
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 500
+              },
+              "invoiceNumber": "3304",
+              "eventType": "SettledCharges"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EventsGetByBillingAccountWithFilters.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EventsGetByBillingAccountWithFilters.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "1234:5678",
+    "$filter": "lotid eq 'G202001083926600XXXXX' AND lotsource eq 'consumptioncommitment'"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:56789/providers/Microsoft.Consumption/events/eventId1",
+            "name": "eventId1",
+            "type": "Microsoft.Consumption/events",
+            "properties": {
+              "lotSource": "ConsumptionCommitment",
+              "lotId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/Microsoft.Consumption/lots/G202001083926600XXXXX",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/X3TD-KVTT-BG7-TGB",
+              "billingProfileDisplayName": "Contoso Operations Billing",
+              "transactionDate": "2019-07-01T00:00:00Z",
+              "description": "MACC Canceled",
+              "canceledCredit": {
+                "currency": "USD",
+                "value": 200
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 500
+              },
+              "invoiceNumber": "3304",
+              "eventType": "CanceledCredit"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EventsListByBillingProfile.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/EventsListByBillingProfile.json
@@ -1,0 +1,261 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "1234:5678",
+    "billingProfileId": "4268",
+    "startDate": "2019-09-01",
+    "endDate": "2019-10-31"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/4268/providers/Microsoft.Consumption/events/event1",
+            "name": "event1",
+            "type": "Microsoft.Consumption/events",
+            "properties": {
+              "transactionDate": "2019-07-01T00:00:00Z",
+              "description": "Settled invoice #312033",
+              "creditCurrency": "USD",
+              "reseller": {
+                "resellerId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/reseller/reseller1",
+                "resellerDescription": "Reseller information"
+              },
+              "billingCurrency": "USD",
+              "newCredit": {
+                "currency": "USD",
+                "value": 0.00
+              },
+              "newCreditInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "adjustments": {
+                "currency": "USD",
+                "value": 0.00
+              },
+              "adjustmentsInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "creditExpired": {
+                "currency": "USD",
+                "value": 0.00
+              },
+              "creditExpiredInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "charges": {
+                "currency": "USD",
+                "value": 500.00
+              },
+              "chargesInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 500.00
+              },
+              "closedBalanceInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "eventType": "SettledCharges",
+              "invoiceNumber": "3301",
+              "isEstimatedBalance": false
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/4268/providers/Microsoft.Consumption/events/event2",
+            "name": "event2",
+            "type": "Microsoft.Consumption/events",
+            "properties": {
+              "transactionDate": "2019-08-01T00:00:00Z",
+              "description": "New credits added",
+              "creditCurrency": "USD",
+              "reseller": {
+                "resellerId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/reseller/reseller1",
+                "resellerDescription": "Reseller information"
+              },
+              "billingCurrency": "USD",
+              "newCredit": {
+                "currency": "USD",
+                "value": 400.00
+              },
+              "newCreditInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "canceledCredit": {
+                "currency": "USD",
+                "value": 5000
+              },
+              "adjustments": {
+                "currency": "USD",
+                "value": 0.00
+              },
+              "adjustmentsInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "creditExpired": {
+                "currency": "USD",
+                "value": 0.00
+              },
+              "creditExpiredInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "charges": {
+                "currency": "USD",
+                "value": 0.00
+              },
+              "chargesInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 900.00
+              },
+              "closedBalanceInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "eventType": "NewCredit",
+              "invoiceNumber": "3302",
+              "isEstimatedBalance": false
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/4268/providers/Microsoft.Consumption/events/event3",
+            "name": "event3",
+            "type": "Microsoft.Consumption/events",
+            "properties": {
+              "transactionDate": "2019-09-01T00:00:00Z",
+              "description": "Credits Expired",
+              "creditCurrency": "USD",
+              "reseller": {
+                "resellerId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/reseller/reseller1",
+                "resellerDescription": "Reseller information"
+              },
+              "billingCurrency": "USD",
+              "newCredit": {
+                "currency": "USD",
+                "value": 0.00
+              },
+              "newCreditInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "canceledCredit": {
+                "currency": "USD",
+                "value": 5000
+              },
+              "adjustments": {
+                "currency": "USD",
+                "value": 0.00
+              },
+              "adjustmentsInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "creditExpired": {
+                "currency": "USD",
+                "value": 300.00
+              },
+              "creditExpiredInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "charges": {
+                "currency": "USD",
+                "value": 0.00
+              },
+              "chargesInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 600.00
+              },
+              "closedBalanceInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "eventType": "ExpiredCredit",
+              "invoiceNumber": "",
+              "isEstimatedBalance": false
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/4268/providers/Microsoft.Consumption/events/event4",
+            "name": "event4",
+            "type": "Microsoft.Consumption/events",
+            "properties": {
+              "transactionDate": "2019-10-01T00:00:00Z",
+              "description": "Settled invoice #212033",
+              "creditCurrency": "USD",
+              "reseller": {
+                "resellerId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/reseller/reseller1",
+                "resellerDescription": "Reseller information"
+              },
+              "billingCurrency": "USD",
+              "newCredit": {
+                "currency": "USD",
+                "value": 300.00
+              },
+              "newCreditInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "canceledCredit": {
+                "currency": "USD",
+                "value": 5000
+              },
+              "adjustments": {
+                "currency": "USD",
+                "value": -200.00
+              },
+              "adjustmentsInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "creditExpired": {
+                "currency": "USD",
+                "value": 100.00
+              },
+              "creditExpiredInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "charges": {
+                "currency": "USD",
+                "value": 300.00
+              },
+              "chargesInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 700.00
+              },
+              "closedBalanceInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "eventType": "SettledCharges",
+              "invoiceNumber": "3303",
+              "isEstimatedBalance": false
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByBillingAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByBillingAccount.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "1234:5678"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/lots/lot1",
+            "name": "lot1",
+            "type": "Microsoft.Consumption/lots",
+            "properties": {
+              "originalAmount": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "source": "ConsumptionCommitment",
+              "startDate": "2019-10-01T00:00:00Z",
+              "expirationDate": "2019-11-01T00:00:00Z",
+              "purchasedDate": "2019-09-01T00:00:00Z",
+              "status": "Active"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/lots/lot2",
+            "name": "lot2",
+            "type": "Microsoft.Consumption/lots",
+            "properties": {
+              "originalAmount": {
+                "currency": "USD",
+                "value": 6000.00
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 80.90
+              },
+              "source": "ConsumptionCommitment",
+              "startDate": "2019-11-01T00:00:00Z",
+              "expirationDate": "2019-12-31T00:00:00Z",
+              "purchasedDate": "2019-09-01T00:00:00Z",
+              "status": "Expired"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByBillingAccountWithFilters.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByBillingAccountWithFilters.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "1234:5678",
+    "$filter": "status eq 'active' AND source eq 'consumptioncommitment'"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/lots/lot1",
+            "name": "lot1",
+            "type": "Microsoft.Consumption/lots",
+            "properties": {
+              "originalAmount": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "source": "ConsumptionCommitment",
+              "startDate": "2019-10-01T00:00:00Z",
+              "expirationDate": "2019-11-01T00:00:00Z",
+              "purchasedDate": "2019-09-01T00:00:00Z",
+              "status": "Active"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByBillingProfile.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByBillingProfile.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "1234:5678",
+    "billingProfileId": "2468"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/lots/lot1",
+            "name": "lot1",
+            "type": "Microsoft.Consumption/lots",
+            "properties": {
+              "creditCurrency": "USD",
+              "billingCurrency": "USD",
+              "originalAmount": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "originalAmountInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "closedBalanceInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "reseller": {
+                "resellerId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/reseller/reseller1",
+                "resellerDescription": "Reseller information."
+              },
+              "source": "PurchasedCredit",
+              "startDate": "2023-05-01T00:00:00Z",
+              "expirationDate": "2023-05-01T00:00:00Z",
+              "poNumber": "3524",
+              "isEstimatedBalance": false
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/lots/lot2",
+            "name": "lot2",
+            "type": "Microsoft.Consumption/lots",
+            "properties": {
+              "creditCurrency": "USD",
+              "billingCurrency": "USD",
+              "originalAmount": {
+                "currency": "USD",
+                "value": 6000.00
+              },
+              "originalAmountInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 80.90
+              },
+              "closedBalanceInBillingCurrency": {
+                "exchangeRate": 5000.00,
+                "exchangeRateMonth": 1
+              },
+              "reseller": {
+                "resellerId": "/providers/Microsoft.Billing/billingAccounts/1234:5678/billingProfiles/2468/providers/Microsoft.Consumption/reseller/reseller2",
+                "resellerDescription": "Reseller information."
+              },
+              "source": "PurchasedCredit",
+              "startDate": "2023-05-01T00:00:00Z",
+              "expirationDate": "2023-05-31T00:00:00Z",
+              "poNumber": "31224",
+              "isEstimatedBalance": false
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByCustomer.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByCustomer.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "1234:5678",
+    "customerId": "1234:5678"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234/customers/456/providers/Microsoft.Consumption/lots/lot1",
+            "name": "lot1",
+            "type": "Microsoft.Consumption/lots",
+            "properties": {
+              "originalAmount": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "source": "PurchasedCredit",
+              "startDate": "2021-05-01T00:00:00Z",
+              "expirationDate": "2021-05-01T00:00:00Z",
+              "poNumber": "3524",
+              "isEstimatedBalance": false
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234/customers/456/providers/Microsoft.Consumption/lots/lot2",
+            "name": "lot2",
+            "type": "Microsoft.Consumption/lots",
+            "properties": {
+              "originalAmount": {
+                "currency": "USD",
+                "value": 6000.00
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 80.90
+              },
+              "source": "PurchasedCredit",
+              "startDate": "2021-05-01T00:00:00Z",
+              "expirationDate": "2019-12-31T00:00:00Z",
+              "poNumber": "31224",
+              "isEstimatedBalance": false
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByCustomerWithFilters.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/LotsListByCustomerWithFilters.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "1234:5678",
+    "customerId": "1234:5678",
+    "$filter": "status eq 'active' AND source eq 'consumptioncommitment'"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/1234/customers/456/providers/Microsoft.Consumption/lots/lot1",
+            "name": "lot1",
+            "type": "Microsoft.Consumption/lots",
+            "properties": {
+              "originalAmount": {
+                "currency": "USD",
+                "value": 5000.00
+              },
+              "closedBalance": {
+                "currency": "USD",
+                "value": 60.90
+              },
+              "source": "PurchasedCredit",
+              "startDate": "2021-05-01T00:00:00Z",
+              "expirationDate": "2021-05-01T00:00:00Z",
+              "poNumber": "3524",
+              "isEstimatedBalance": false
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByBillingAccountList.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByBillingAccountList.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/billingAccounts/123456",
+    "billingAccountId": "123456"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/marketplaces/marketplaceId1",
+            "name": "marketplaceId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702",
+              "usageStart": "2017-02-13T00:00:00Z",
+              "usageEnd": "2017-02-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/subid/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan1",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByBillingAccountListForBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByBillingAccountListForBillingPeriod.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "123456",
+    "scope": "providers/Microsoft.Billing/billingAccounts/123456",
+    "billingPeriodName": "201702"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "providers/Microsoft.Billing/billingAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/marketplaces/marketplaceId1",
+            "name": "marketplacesId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/providers/Microsoft.Billing/billingAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702",
+              "usageStart": "2017-02-13T00:00:00Z",
+              "usageEnd": "2017-02-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/subid/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByDepartmentList.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByDepartmentList.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "departmentId": "123456",
+    "billingPeriodName": "201702",
+    "scope": "providers/Microsoft.Billing/departments/123456"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/departments/123456/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/marketplaces/marketplaceId1",
+            "name": "marketplacesId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/providers/Microsoft.Billing/departments/123456/providers/Microsoft.Billing/billingPeriods/201702",
+              "usageStart": "2017-02-13T00:00:00Z",
+              "usageEnd": "2017-02-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/subid/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByDepartment_ListByBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByDepartment_ListByBillingPeriod.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "departmentId": "123456",
+    "billingPeriodName": "201702",
+    "scope": "providers/Microsoft.Billing/departments/123456"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/departments/123456/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/marketplaces/marketplaceId1",
+            "name": "marketplacesId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/providers/Microsoft.Billing/departments/123456/providers/Microsoft.Billing/billingPeriods/201702",
+              "usageStart": "2017-02-13T00:00:00Z",
+              "usageEnd": "2017-02-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/subid/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByEnrollmentAccountList.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByEnrollmentAccountList.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "enrollmentAccountId": "123456",
+    "billingPeriodName": "201702",
+    "scope": "providers/Microsoft.Billing/enrollmentAccounts/123456"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/enrollmentAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/marketplaces/marketplaceId1",
+            "name": "marketplacesId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/providers/Microsoft.Billing/enrollmentAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702",
+              "usageStart": "2017-02-13T00:00:00Z",
+              "usageEnd": "2017-02-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/subid/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByEnrollmentAccounts_ListByBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByEnrollmentAccounts_ListByBillingPeriod.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "enrollmentAccountId": "123456",
+    "billingPeriodName": "201702",
+    "scope": "providers/Microsoft.Billing/enrollmentAccounts/123456"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/enrollmentAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/marketplaces/marketplaceId1",
+            "name": "marketplacesId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/providers/Microsoft.Billing/enrollmentAccounts/123456/providers/Microsoft.Billing/billingPeriods/201702",
+              "usageStart": "2017-02-13T00:00:00Z",
+              "usageEnd": "2017-02-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/subid/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByManagementGroupList.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByManagementGroupList.json
@@ -1,0 +1,86 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "managementGroupId": "managementGroupForTest",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201810/providers/Microsoft.Consumption/marketplaces/marketplaceId1",
+            "name": "marketplacesId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201810",
+              "usageStart": "2018-10-13T00:00:00Z",
+              "usageEnd": "2018-10-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          },
+          {
+            "id": "/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Billing/billingPeriods/201810/providers/Microsoft.Consumption/marketplaces/marketplaceId2",
+            "name": "marketplacesId2",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account2",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center2",
+              "departmentName": "Department2",
+              "billingPeriodId": "/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Billing/billingPeriods/201810",
+              "usageStart": "2018-10-13T00:00:00Z",
+              "usageEnd": "2018-10-13T23:59:59Z",
+              "instanceName": "shared2",
+              "instanceId": "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared2",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "11111111-1111-1111-1111-111111111111",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "11111111-1111-1111-1111-111111111111",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "11111111-1111-1111-1111-111111111111",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByManagementGroup_ListForBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesByManagementGroup_ListForBillingPeriod.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "managementGroupId": "managementGroupForTest",
+    "billingPeriodName": "201808",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201808/providers/Microsoft.Consumption/marketplaces/marketplaceId1",
+            "name": "marketplacesId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201808",
+              "usageStart": "2018-08-13T00:00:00Z",
+              "usageEnd": "2018-08-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          },
+          {
+            "id": "/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Billing/billingPeriods/201808/providers/Microsoft.Consumption/marketplaces/marketplaceId2",
+            "name": "marketplacesId2",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account2",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center2",
+              "departmentName": "Department2",
+              "billingPeriodId": "/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Billing/billingPeriods/201810",
+              "usageStart": "2018-08-13T00:00:00Z",
+              "usageEnd": "2018-08-13T23:59:59Z",
+              "instanceName": "shared2",
+              "instanceId": "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared2",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "11111111-1111-1111-1111-111111111111",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "11111111-1111-1111-1111-111111111111",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "11111111-1111-1111-1111-111111111111",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesList.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesList.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/marketPlaces/marketplaceId1",
+            "name": "marketplaceId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/subscriptions/subid/providers/Microsoft.Billing/billingPeriods/201702",
+              "usageStart": "2017-02-13T00:00:00Z",
+              "usageEnd": "2017-02-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/subid/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan1",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesListForBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/MarketplacesListForBillingPeriod.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "billingPeriodName": "201801"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/subid/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/marketPlaces/marketplacesId1",
+            "name": "marketplacesId1",
+            "type": "Microsoft.Consumption/marketPlaces",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "accountName": "Account1",
+              "additionalProperties": "additionalProperties",
+              "costCenter": "Center1",
+              "departmentName": "Department1",
+              "billingPeriodId": "/subscriptions/subid/providers/Microsoft.Billing/billingPeriods/201702",
+              "usageStart": "2017-02-13T00:00:00Z",
+              "usageEnd": "2017-02-13T23:59:59Z",
+              "instanceName": "shared1",
+              "instanceId": "/subscriptions/subid/resourceGroups/Default-Web-eastasia/providers/Microsoft.Web/sites/shared1",
+              "currency": "USD",
+              "consumedQuantity": 0.00328,
+              "pretaxCost": 0.67,
+              "isEstimated": false,
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "offerName": "offer1",
+              "resourceGroup": "TEST",
+              "orderNumber": "00000000-0000-0000-0000-000000000000",
+              "publisherName": "xyz",
+              "planName": "plan2",
+              "resourceRate": 0.24,
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "azure subscription",
+              "unitOfMeasure": "10 Hours",
+              "isRecurringCharge": false
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/OperationList.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/OperationList.json
@@ -1,0 +1,293 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "Microsoft.Consumption/usageDetails/read",
+            "name": "Microsoft.Consumption/usageDetails/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "UsageDetails",
+              "operation": "List Usage Details",
+              "description": "List the usage details for a scope for EA and WebDirect subscriptions."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/reservationSummaries/read",
+            "name": "Microsoft.Consumption/reservationSummaries/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "ReservationSummaries",
+              "operation": "List Reservation Utilization Summaries",
+              "description": "List the utilization summary for reserved instances by reservation order or managment groups. The summary data is either at monthly or daily level."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/reservationDetails/read",
+            "name": "Microsoft.Consumption/reservationDetails/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "ReservationDetails",
+              "operation": "List Reservation Utilization Details",
+              "description": "List the utilization details for reserved instances by reservation order or managment groups. The details data is per instance per day level."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/reservationTransactions/read",
+            "name": "Microsoft.Consumption/reservationTransactions/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "ReservationTransactions",
+              "operation": "List Reservation Transactions history",
+              "description": "List the transaction history for reserved instances by management groups."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/balances/read",
+            "name": "Microsoft.Consumption/balances/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Balances",
+              "operation": "List utlization summary",
+              "description": "List the utilization summary for a billing period for a management group."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/pricesheets/read",
+            "name": "Microsoft.Consumption/pricesheets/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Pricesheets",
+              "operation": "List Price sheets",
+              "description": "List the Pricesheets data for a subscription or a management group."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/marketplaces/read",
+            "name": "Microsoft.Consumption/marketplaces/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Marketplaces",
+              "operation": "List Marketplace resource usage",
+              "description": "List the marketplace resource usage details for a scope for EA and WebDirect subscriptions."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/budgets/read",
+            "name": "Microsoft.Consumption/budgets/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Budgets",
+              "operation": "List budgets",
+              "description": "List the budgets by a subscription or a management group."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/budgets/write",
+            "name": "Microsoft.Consumption/budgets/write",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Budgets",
+              "operation": "Create and update budgets",
+              "description": "Creates and update the budgets by a subscription or a management group."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/budgets/delete",
+            "name": "Microsoft.Consumption/budgets/delete",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Budgets",
+              "operation": "Delete budgets",
+              "description": "Delete the budgets by a subscription or a management group."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/charges/read",
+            "name": "Microsoft.Consumption/charges/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Charges",
+              "operation": "List charges",
+              "description": "List charges"
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/credits/read",
+            "name": "Microsoft.Consumption/credits/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Credits",
+              "operation": "List credits",
+              "description": "List credits"
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/events/read",
+            "name": "Microsoft.Consumption/events/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Events",
+              "operation": "List events",
+              "description": "List events"
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/forecasts/read",
+            "name": "Microsoft.Consumption/forecasts/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Forecasts",
+              "operation": "List forecasts",
+              "description": "List forecasts"
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/lots/read",
+            "name": "Microsoft.Consumption/lots/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Lots",
+              "operation": "List lots",
+              "description": "List lots"
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/operationstatus/read",
+            "name": "Microsoft.Consumption/operationstatus/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Operationstatus",
+              "operation": "List operationstatus",
+              "description": "List operationstatus"
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/operationresults/read",
+            "name": "Microsoft.Consumption/operationresults/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Operationresults",
+              "operation": "List operationresults",
+              "description": "List operationresults"
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/register/action",
+            "name": "Microsoft.Consumption/register/action",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Register",
+              "operation": "Register to Consumption RP",
+              "description": "Register to Consumption RP"
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/tags/read",
+            "name": "Microsoft.Consumption/tags/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Tags",
+              "operation": "List tags",
+              "description": "List tags for EA and subscriptions."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/tenants/register/action",
+            "name": "Microsoft.Consumption/tenants/register/action",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "tenants/register",
+              "operation": "register tenants",
+              "description": "Register action for scope of Microsoft.Consumption by a tenant."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/terms/read",
+            "name": "Microsoft.Consumption/terms/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Terms",
+              "operation": "List Terms",
+              "description": "List the terms for a subscription or a management group."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/reservationRecommendations/read",
+            "name": "Microsoft.Consumption/reservationRecommendations/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "ReservationRecommendations",
+              "operation": "List reserved instances recommendations",
+              "description": "List single or shared recommendations for Reserved instances for a subscription."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/operations/read",
+            "name": "Microsoft.Consumption/operations/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Operations",
+              "operation": "List supported operations",
+              "description": "List all supported operations by Microsoft.Consumption resource provider."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/tenants/read",
+            "name": "Microsoft.Consumption/tenants/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "Tenants",
+              "operation": "List tenants",
+              "description": "List tenants"
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/externalBillingAccounts/tags/read",
+            "name": "Microsoft.Consumption/externalBillingAccounts/tags/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "externalBillingAccounts/Tags",
+              "operation": "List tags",
+              "description": "List tags for EA and subscriptions."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/externalSubscriptions/tags/read",
+            "name": "Microsoft.Consumption/externalSubscriptions/tags/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "externalSubscriptions/Tags",
+              "operation": "List tags",
+              "description": "List tags for EA and subscriptions."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/aggregatedcost/read",
+            "name": "Microsoft.Consumption/aggregatedcost/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "AggregatedCost",
+              "operation": "List AggregatedCost",
+              "description": "List AggregatedCost for management group."
+            }
+          },
+          {
+            "id": "Microsoft.Consumption/reservationRecommendationDetails/read",
+            "name": "Microsoft.Consumption/reservationRecommendationDetails/read",
+            "display": {
+              "provider": "Microsoft.Consumption",
+              "resource": "ReservationRecommendationDetails",
+              "operation": "List Reservation Recommendation Details",
+              "description": "List Reservation Recommendation Details"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/PriceSheet.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/PriceSheet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/pricesheets/default",
+        "name": "default",
+        "type": "Microsoft.Consumption/pricesheets",
+        "properties": {
+          "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.consumption/pricesheets/default?api-version=2018-01-31&$skiptoken=AQAAAA%3D%3D",
+          "pricesheets": [
+            {
+              "billingPeriodId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201702",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "unitOfMeasure": "100 Hours",
+              "includedQuantity": 100,
+              "partNumber": "XX-11110",
+              "unitPrice": 0.00328,
+              "currencyCode": "EUR",
+              "offerId": "OfferId 1"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/PriceSheetExpand.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/PriceSheetExpand.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "billingPeriodName": "201801",
+    "$expand": "meterDetails"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/pricesheets/default",
+        "name": "default",
+        "type": "Microsoft.Consumption/pricesheets",
+        "properties": {
+          "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.consumption/pricesheets/default?api-version=2018-01-31&$skiptoken=AQAAAA%3D%3D&$expand=properties/pricesheets/meterDetails",
+          "pricesheets": [
+            {
+              "billingPeriodId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201702",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "unitOfMeasure": "100 Hours",
+              "includedQuantity": 100,
+              "partNumber": "XX-11110",
+              "unitPrice": 0.00328,
+              "currencyCode": "EUR",
+              "offerId": "OfferId 1",
+              "meterDetails": {
+                "meterName": "Data Transfer Out (GB)",
+                "meterCategory": "Networking",
+                "unit": "GB",
+                "meterLocation": "Zone 2",
+                "totalIncludedQuantity": 0,
+                "pretaxStandardRate": 0.138
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/PriceSheetForBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/PriceSheetForBillingPeriod.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "billingPeriodName": "201801"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201702/providers/Microsoft.Consumption/pricesheets/default",
+        "name": "default",
+        "type": "Microsoft.Consumption/pricesheets",
+        "properties": {
+          "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201702/providers/microsoft.consumption/pricesheets/default?api-version=2018-01-31",
+          "pricesheets": [
+            {
+              "billingPeriodId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201702",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "unitOfMeasure": "100 Hours",
+              "includedQuantity": 100,
+              "partNumber": "XX-11110",
+              "unitPrice": 0.00328,
+              "currencyCode": "EUR",
+              "offerId": "OfferId 1"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetails.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetails.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+    "$filter": "properties/usageDate ge 2017-10-01 AND properties/usageDate le 2017-12-05"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "providers/Microsoft.Capacity/reservationOrders/00000000-0000-0000-0000-000000000000/reservations/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationDetails/20171129",
+            "name": "00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000_20171129",
+            "type": "Microsoft.Consumption/reservationDetails",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "usageDate": "2017-11-29T00:00:00Z",
+              "skuName": "Standard_D2_v2",
+              "instanceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/wvn-sql/providers/microsoft.compute/virtualmachines/abc-sql2014sp33",
+              "totalReservedQuantity": 1.000000000000000,
+              "reservedHours": 24.000000000000000,
+              "usedHours": 24.000000000000000,
+              "instanceFlexibilityGroup": "DSv2 Series",
+              "instanceFlexibilityRatio": "0.25"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetailsByBillingAccountId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetailsByBillingAccountId.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/12345",
+    "$filter": "properties/usageDate ge 2017-10-01 AND properties/usageDate le 2017-12-05"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/12345/providers/Microsoft.Consumption/reservationDetails/reservationDetails_Id1",
+            "name": "reservationDetails_Id1",
+            "type": "Microsoft.Consumption/reservationDetails",
+            "tags": null,
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "usageDate": "2017-11-30T00:00:00-08:00",
+              "skuName": "Standard_D2s_v3",
+              "instanceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sqlh1/providers/microsoft.compute/virtualmachines/sqlh1",
+              "totalReservedQuantity": 0,
+              "reservedHours": 48,
+              "usedHours": 0.6,
+              "instanceFlexibilityGroup": "DSv3 Series",
+              "instanceFlexibilityRatio": "1"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetailsByBillingProfileId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetailsByBillingProfileId.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579",
+    "startDate": "2019-09-01",
+    "endDate": "2019-10-31"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579/providers/Microsoft.Consumption/reservationDetails/reservationDetails_Id1",
+            "name": "reservationDetails_Id1",
+            "type": "Microsoft.Consumption/reservationDetails",
+            "tags": null,
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "usageDate": "2019-09-30T00:00:00-08:00",
+              "skuName": "Standard_D2s_v3",
+              "instanceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sqlh1/providers/microsoft.compute/virtualmachines/sqlh1",
+              "totalReservedQuantity": 0,
+              "reservedHours": 48,
+              "usedHours": 0.6,
+              "instanceFlexibilityGroup": "DSv3 Series",
+              "instanceFlexibilityRatio": "1"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetailsByBillingProfileIdReservationId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetailsByBillingProfileIdReservationId.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579",
+    "startDate": "2019-09-01",
+    "endDate": "2019-10-31",
+    "reservationId": "1c6b6358-709f-484c-85f1-72e862a0cf3b",
+    "reservationOrderId": "9f39ba10-794f-4dcb-8f4b-8d0cb47c27dc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579/providers/Microsoft.Consumption/reservationDetails/reservationDetails_Id1",
+            "name": "reservationDetails_Id1",
+            "type": "Microsoft.Consumption/reservationDetails",
+            "tags": null,
+            "properties": {
+              "reservationOrderId": "9f39ba10-794f-4dcb-8f4b-8d0cb47c27dc",
+              "reservationId": "1c6b6358-709f-484c-85f1-72e862a0cf3b",
+              "usageDate": "2019-09-30T00:00:00-08:00",
+              "skuName": "Standard_D2s_v3",
+              "instanceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/sqlh1/providers/microsoft.compute/virtualmachines/sqlh1",
+              "totalReservedQuantity": 0,
+              "reservedHours": 48,
+              "usedHours": 0.6,
+              "instanceFlexibilityGroup": "DSv3 Series",
+              "instanceFlexibilityRatio": "1"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetailsWithReservationId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationDetailsWithReservationId.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+    "reservationId": "00000000-0000-0000-0000-000000000000",
+    "$filter": "properties/usageDate ge 2017-10-01 AND properties/usageDate le 2017-12-05"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "providers/Microsoft.Capacity/reservationOrders/00000000-0000-0000-0000-000000000000/reservations/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationDetails/20171129",
+            "name": "00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000_20171129",
+            "type": "Microsoft.Consumption/reservationDetails",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "usageDate": "2017-11-29T00:00:00Z",
+              "skuName": "Standard_D2_v2",
+              "instanceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/wvn-sql/providers/microsoft.compute/virtualmachines/wvn-sql2014sp33",
+              "totalReservedQuantity": 1.000000000000000,
+              "reservedHours": 24.000000000000000,
+              "usedHours": 24.000000000000000,
+              "kind": "Reservation",
+              "instanceFlexibilityGroup": "D2v2 Series",
+              "instanceFlexibilityRatio": "1"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationDetailsByBillingAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationDetailsByBillingAccount.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/00000000",
+    "lookBackPeriod": "Last60Days",
+    "product": "Standard_DS14_v2",
+    "region": "eastus",
+    "scope": "Shared",
+    "term": "P1Y",
+    "$filter": "properties/subscriptionId eq 00000000-0000-0000-0000-00000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "providers/Microsoft.Billing/billingAccounts/00000000/providers/microsoft.consumption/reservationrecommendationdetails",
+        "name": "reservationRecommendationDetails",
+        "type": "Microsoft.Consumption/ReservationRecommendationDetails",
+        "properties": {
+          "currency": "USD",
+          "resource": {
+            "appliedScopes": [
+              "00000000-0000-0000-0000-00000000",
+              "00000000-0000-0000-0000-00000000"
+            ],
+            "onDemandRate": 1.482,
+            "product": "Standard_DS14_v2",
+            "region": "eastus",
+            "reservationRate": 0.70570776255707,
+            "resourceType": "virtualmachines"
+          },
+          "resourceGroup": null,
+          "savings": {
+            "calculatedSavings": [
+              {
+                "onDemandCost": 529550.326618951,
+                "overageCost": 63253.5935111345,
+                "quantity": 220,
+                "reservationCost": 223102.452054792,
+                "totalReservationCost": 286356.045565927,
+                "savings": 243194.281053024
+              },
+              {
+                "onDemandCost": 529550.326618950,
+                "overageCost": 149335.025050147,
+                "quantity": 179,
+                "reservationCost": 181524.267808217,
+                "totalReservationCost": 330859.292858364,
+                "savings": 198691.033760586
+              },
+              {
+                "onDemandCost": 529550.326618950,
+                "overageCost": 195942.319606957,
+                "quantity": 157,
+                "reservationCost": 159214.022602738,
+                "totalReservationCost": 355156.342209695,
+                "savings": 174393.984409255
+              },
+              {
+                "onDemandCost": 529550.326618950,
+                "overageCost": 30975.2311896299,
+                "quantity": 241,
+                "reservationCost": 244398.595205477,
+                "totalReservationCost": 275373.826395107,
+                "savings": 254176.500223843
+              }
+            ],
+            "lookBackPeriod": 60,
+            "recommendedQuantity": 253.0,
+            "reservationOrderTerm": "P1Y",
+            "savingsType": "instance",
+            "unitOfMeasure": "hour"
+          },
+          "scope": "Shared",
+          "usage": {
+            "firstConsumptionDate": "2019-11-27T00:00:00",
+            "lastConsumptionDate": "2020-01-25T21:00:00",
+            "lookBackUnitType": "virtualMachine quantity",
+            "usageData": [
+              275.95003899999995,
+              275.916705,
+              276.0,
+              276.0,
+              275.916725,
+              275.916705,
+              275.98335299999997,
+              276.0,
+              276.0,
+              276.0,
+              276.0,
+              276.0,
+              275.98335299999997,
+              276.0,
+              276.0,
+              276.0,
+              276.0,
+              275.933352
+            ],
+            "usageGrain": "hourly"
+          }
+        }
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationDetailsByBillingProfile.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationDetailsByBillingProfile.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/00000000-0000-0000-0000-00000000:00000000-0000-0000-0000-00000000/billingProfiles/00000000-0000-0000-0000-00000000",
+    "lookBackPeriod": "Last7Days",
+    "product": "Standard_B2s",
+    "region": "australiaeast",
+    "scope": "Shared",
+    "term": "P1Y",
+    "$filter": "properties/subscriptionId eq 00000000-0000-0000-0000-00000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "providers/Microsoft.Billing/billingAccounts/00000000-0000-0000-0000-00000000:00000000-0000-0000-0000-00000000/billingProfiles/00000000-0000-0000-0000-00000000/providers/microsoft.consumption/reservationrecommendationdetails",
+        "name": "reservationRecommendationDetails",
+        "type": "Microsoft.Consumption/ReservationRecommendationDetails",
+        "properties": {
+          "currency": "AUD",
+          "resource": {
+            "appliedScopes": [
+              "00000000-0000-0000-0000-00000000"
+            ],
+            "onDemandRate": 0.0725,
+            "product": "Standard_B2s",
+            "region": "australiaeast",
+            "reservationRate": 0.044141665317880413,
+            "resourceType": "virtualmachines"
+          },
+          "resourceGroup": null,
+          "savings": {
+            "calculatedSavings": [
+              {
+                "onDemandCost": 632.884472049689441,
+                "overageCost": 0.0,
+                "quantity": 1,
+                "reservationCost": 387.740388152261739,
+                "totalReservationCost": 387.740388152261739,
+                "savings": 245.144083897427702
+              }
+            ],
+            "lookBackPeriod": 7,
+            "recommendedQuantity": 1.0,
+            "reservationOrderTerm": "P1Y",
+            "savingsType": "instance",
+            "unitOfMeasure": "hour"
+          },
+          "scope": "Shared",
+          "usage": {
+            "firstConsumptionDate": "2020-01-19T00:00:00",
+            "lastConsumptionDate": "2020-01-25T17:00:00",
+            "lookBackUnitType": "virtualMachine quantity",
+            "usageData": [
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              0.0
+            ],
+            "usageGrain": "hourly"
+          }
+        }
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationDetailsByResourceGroup.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationDetailsByResourceGroup.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "subscriptions/00000000-0000-0000-0000-00000000/resourceGroups/testGroup",
+    "lookBackPeriod": "Last30Days",
+    "product": "Standard_DS13_v2",
+    "region": "westus",
+    "scope": "Single",
+    "term": "P3Y"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "subscriptions/00000000-0000-0000-0000-00000000/resourceGroups/testGroup/providers/microsoft.consumption/reservationrecommendationdetails",
+        "name": "reservationRecommendationDetails",
+        "type": "Microsoft.Consumption/ReservationRecommendationDetails",
+        "properties": {
+          "currency": "USD",
+          "resource": {
+            "appliedScopes": [
+              "00000000-0000-0000-0000-00000000",
+              "testGroup"
+            ],
+            "onDemandRate": 0.519,
+            "product": "Standard_DS13_v2",
+            "region": "westus",
+            "reservationRate": 0.302549467275493,
+            "resourceType": "virtualmachines"
+          },
+          "resourceGroup": "testGroup",
+          "savings": {
+            "calculatedSavings": [
+              {
+                "onDemandCost": 368.4813602070006,
+                "overageCost": 0.0,
+                "quantity": 2,
+                "reservationCost": 429.01514459665,
+                "totalReservationCost": 429.01514459665,
+                "savings": -60.5337843896494
+              },
+              {
+                "onDemandCost": 368.481360207000,
+                "overageCost": 1.557,
+                "quantity": 1,
+                "reservationCost": 214.507572298325,
+                "totalReservationCost": 216.064572298325,
+                "savings": 152.416787908675
+              }
+            ],
+            "lookBackPeriod": 30,
+            "recommendedQuantity": 1.0,
+            "reservationOrderTerm": "P3Y",
+            "savingsType": "instance",
+            "unitOfMeasure": "hour"
+          },
+          "scope": "Single",
+          "usage": {
+            "firstConsumptionDate": "2020-02-03T00:00:00",
+            "lastConsumptionDate": "2020-03-03T13:00:00",
+            "lookBackUnitType": "virtualMachine quantity",
+            "usageData": [
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ],
+            "usageGrain": "hourly"
+          }
+        }
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationDetailsBySubscription.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationDetailsBySubscription.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "subscriptions/00000000-0000-0000-0000-00000000",
+    "lookBackPeriod": "Last30Days",
+    "product": "Standard_DS13_v2",
+    "region": "westus",
+    "scope": "Single",
+    "term": "P3Y"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "subscriptions/00000000-0000-0000-0000-00000000/providers/microsoft.consumption/reservationrecommendationdetails",
+        "name": "reservationRecommendationDetails",
+        "type": "Microsoft.Consumption/ReservationRecommendationDetails",
+        "properties": {
+          "currency": "USD",
+          "resource": {
+            "appliedScopes": [
+              "00000000-0000-0000-0000-00000000"
+            ],
+            "onDemandRate": 0.519,
+            "product": "Standard_DS13_v2",
+            "region": "westus",
+            "reservationRate": 0.302549467275493,
+            "resourceType": "virtualmachines"
+          },
+          "resourceGroup": null,
+          "savings": {
+            "calculatedSavings": [
+              {
+                "onDemandCost": 368.4813602070006,
+                "overageCost": 0.0,
+                "quantity": 2,
+                "reservationCost": 429.01514459665,
+                "totalReservationCost": 429.01514459665,
+                "savings": -60.5337843896494
+              },
+              {
+                "onDemandCost": 368.481360207000,
+                "overageCost": 1.557,
+                "quantity": 1,
+                "reservationCost": 214.507572298325,
+                "totalReservationCost": 216.064572298325,
+                "savings": 152.416787908675
+              }
+            ],
+            "lookBackPeriod": 30,
+            "recommendedQuantity": 1.0,
+            "reservationOrderTerm": "P3Y",
+            "savingsType": "instance",
+            "unitOfMeasure": "hour"
+          },
+          "scope": "Single",
+          "usage": {
+            "firstConsumptionDate": "2020-02-03T00:00:00",
+            "lastConsumptionDate": "2020-03-03T13:00:00",
+            "lookBackUnitType": "virtualMachine quantity",
+            "usageData": [
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ],
+            "usageGrain": "hourly"
+          }
+        }
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsByBillingAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsByBillingAccount.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/123456"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "billingAccount/123456/providers/Microsoft.Consumption/reservationRecommendations/00000000-0000-0000-0000-000000000000",
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "location": "westus",
+            "sku": "Standard_DS1_v2",
+            "kind": "legacy",
+            "properties": {
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "term": "P1Y",
+              "costWithNoReservedInstances": 12.0785105,
+              "recommendedQuantity": 1,
+              "totalCostWithReservedInstances": 11.4899644807748,
+              "netSavings": 0.588546019225182,
+              "firstUsageDate": "2019-07-07T00:00:00-07:00",
+              "scope": "Shared",
+              "lookBackPeriod": "Last7Days",
+              "instanceFlexibilityRatio": 1,
+              "instanceFlexibilityGroup": "DSv2 Series",
+              "normalizedSize": "Standard_DS1_v2",
+              "recommendedQuantityNormalized": 1,
+              "skuProperties": [
+                {
+                  "name": "Cores",
+                  "value": "1"
+                },
+                {
+                  "name": "Ram",
+                  "value": "1"
+                }
+              ]
+            }
+          },
+          {
+            "id": "billingAccount/123456/providers/Microsoft.Consumption/reservationRecommendations/00000000-0000-0000-0000-000000000000",
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "location": "westus",
+            "sku": "Standard_DS1_v2",
+            "kind": "legacy",
+            "properties": {
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "term": "P1Y",
+              "costWithNoReservedInstances": 10.0785105,
+              "recommendedQuantity": 1,
+              "totalCostWithReservedInstances": 13.48,
+              "netSavings": 0.68,
+              "firstUsageDate": "2019-07-07T00:00:00-07:00",
+              "scope": "Shared",
+              "lookBackPeriod": "Last7Days",
+              "instanceFlexibilityRatio": 1,
+              "instanceFlexibilityGroup": "DSv2 Series",
+              "normalizedSize": "Standard_DS1",
+              "recommendedQuantityNormalized": 1.2,
+              "skuProperties": [
+                {
+                  "name": "SkuDisplayName",
+                  "value": "B"
+                },
+                {
+                  "name": "CPU",
+                  "value": "1"
+                }
+              ]
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationRecommendations?api-version=2023-05-01&$skiptoken=AQAAAA%3D%3D&"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsByBillingProfile.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsByBillingProfile.json
@@ -1,0 +1,86 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/123456/billingProfiles/6420"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/123456/billingProfiles/6420/providers/Microsoft.Consumption/reservationRecommendations/00000000-0000-0000-0000-000000000000",
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "kind": "modern",
+            "properties": {
+              "costWithNoReservedInstances": {
+                "currency": "USD",
+                "value": 279881.9457795231
+              },
+              "firstUsageDate": "2022-08-22T00:00:00Z",
+              "instanceFlexibilityGroup": "NA",
+              "instanceFlexibilityRatio": 1,
+              "location": "westus2",
+              "lookBackPeriod": 60,
+              "meterId": "30f7049a-b092-42f4-9173-9ec31ab945ad",
+              "netSavings": {
+                "currency": "USD",
+                "value": 153766.87728637524
+              },
+              "normalizedSize": "SQLDB_BC_Compute_Gen5",
+              "recommendedQuantity": 35,
+              "recommendedQuantityNormalized": 35,
+              "resourceType": "sqldatabases",
+              "scope": "Single",
+              "skuName": "SQLDB_BC_Compute_Gen5",
+              "skuProperties": null,
+              "subscriptionId": "c6aa8a01-a744-44a7-a4f1-caad17512f27",
+              "term": "P3Y",
+              "totalCostWithReservedInstances": {
+                "currency": "USD",
+                "value": 126115.06849314792
+              }
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/123456/billingProfiles/6420/providers/Microsoft.Consumption/reservationRecommendations/00000000-0000-0000-0000-000000000000",
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "kind": "modern",
+            "properties": {
+              "costWithNoReservedInstances": {
+                "currency": "USD",
+                "value": 93208.8596802244
+              },
+              "firstUsageDate": "2022-08-22T00:00:00Z",
+              "instanceFlexibilityGroup": "NA",
+              "instanceFlexibilityRatio": 1,
+              "location": "westus2",
+              "lookBackPeriod": 60,
+              "meterId": "30f7049a-b092-42f4-9173-9ec31ab945ad",
+              "netSavings": {
+                "currency": "USD",
+                "value": 32553.85968022456
+              },
+              "normalizedSize": "SQLDB_BC_Compute_Gen5",
+              "recommendedQuantity": 35,
+              "recommendedQuantityNormalized": 35,
+              "resourceType": "sqldatabases",
+              "scope": "Single",
+              "skuName": "SQLDB_BC_Compute_Gen5",
+              "skuProperties": null,
+              "subscriptionId": "c6aa8a01-a744-44a7-a4f1-caad17512f27",
+              "term": "P1Y",
+              "totalCostWithReservedInstances": {
+                "currency": "USD",
+                "value": 60654.99999999984
+              }
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationRecommendations?api-version=2023-05-01&$skiptoken=AQAAAA%3D%3D&"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsByResourceGroup.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsByResourceGroup.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGrouups/testGroup/providers/Microsoft.Consumption/reservationRecommendations/reservationRecommendations1",
+            "name": "reservationRecommendations1",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "sku": "Standard_DS1_v2",
+            "location": "northeurope",
+            "kind": "legacy",
+            "properties": {
+              "lookBackPeriod": "Last7Days",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "term": "P1Y",
+              "costWithNoReservedInstances": 0.0,
+              "recommendedQuantity": 1,
+              "totalCostWithReservedInstances": 0.0,
+              "netSavings": 4.634521202630137,
+              "firstUsageDate": "2018-03-06T00:00:00Z",
+              "scope": "Single",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "id": "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Consumption/reservationRecommendations/reservationRecommendations2",
+            "name": "reservationRecommendations2",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "sku": "Standard_DS1_v2",
+            "location": "northeurope",
+            "kind": "legacy",
+            "properties": {
+              "lookBackPeriod": "Last7Days",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "term": "P3Y",
+              "costWithNoReservedInstances": 0.0,
+              "recommendedQuantity": 1,
+              "totalCostWithReservedInstances": 0.0,
+              "netSavings": 7.2893157231780812,
+              "firstUsageDate": "2018-03-06T00:00:00Z",
+              "scope": "Single",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Consumption/reservationRecommendations?api-version=2023-05-01&$skiptoken=AQAAAA%3D%3D&"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsBySubscription.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "subscriptions/00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationRecommendations/reservationRecommendations1",
+            "name": "reservationRecommendations1",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "sku": "Standard_DS1_v2",
+            "location": "northeurope",
+            "kind": "legacy",
+            "properties": {
+              "lookBackPeriod": "Last7Days",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "term": "P1Y",
+              "costWithNoReservedInstances": 0.0,
+              "recommendedQuantity": 1,
+              "totalCostWithReservedInstances": 0.0,
+              "netSavings": 4.634521202630137,
+              "firstUsageDate": "2018-03-06T00:00:00Z",
+              "scope": "Single",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "id": "subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationRecommendations/reservationRecommendations2",
+            "name": "reservationRecommendations2",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "sku": "Standard_DS1_v2",
+            "location": "northeurope",
+            "kind": "legacy",
+            "properties": {
+              "lookBackPeriod": "Last7Days",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "term": "P3Y",
+              "costWithNoReservedInstances": 0.0,
+              "recommendedQuantity": 1,
+              "totalCostWithReservedInstances": 0.0,
+              "netSavings": 7.2893157231780812,
+              "firstUsageDate": "2018-03-06T00:00:00Z",
+              "scope": "Single",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationRecommendations?api-version=2023-05-01&$skiptoken=AQAAAA%3D%3D&"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsFilterBySubscriptionForScopeLookBackPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationRecommendationsFilterBySubscriptionForScopeLookBackPeriod.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "$filter": "properties/scope eq 'Single' AND properties/lookBackPeriod eq 'Last7Days'"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationRecommendations/reservationRecommendations1",
+            "name": "reservationRecommendations1",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "sku": "Standard_DS1_v2",
+            "location": "northeurope",
+            "kind": "legacy",
+            "properties": {
+              "lookBackPeriod": "Last7Days",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "term": "P1Y",
+              "costWithNoReservedInstances": 0.0,
+              "recommendedQuantity": 1,
+              "totalCostWithReservedInstances": 0.0,
+              "netSavings": 4.634521202630137,
+              "firstUsageDate": "2018-03-06T00:00:00Z",
+              "scope": "Single",
+              "skuProperties": [
+                {
+                  "name": "Cores",
+                  "value": "1"
+                },
+                {
+                  "name": "Ram",
+                  "value": "1"
+                }
+              ],
+              "subscriptionId": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "id": "subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationRecommendations/reservationRecommendations2",
+            "name": "reservationRecommendations2",
+            "type": "Microsoft.Consumption/reservationRecommendations",
+            "sku": "Standard_DS1_v2",
+            "location": "northeurope",
+            "kind": "legacy",
+            "properties": {
+              "lookBackPeriod": "Last7Days",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "term": "P3Y",
+              "costWithNoReservedInstances": 0.0,
+              "recommendedQuantity": 1,
+              "totalCostWithReservedInstances": 0.0,
+              "netSavings": 7.2893157231780812,
+              "firstUsageDate": "2018-03-06T00:00:00Z",
+              "scope": "Single",
+              "skuProperties": [
+                {
+                  "name": "SkuDisplayName",
+                  "value": "B"
+                },
+                {
+                  "name": "CPU",
+                  "value": "1"
+                }
+              ],
+              "subscriptionId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        ],
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationRecommendations?api-version=2023-05-01&$filter=properties/scope+eq+'Single'+AND+properties/lookBackPeriod+eq+'Last7Days'&$skiptoken=AQAAAA%3D%3D&"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesDaily.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesDaily.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+    "grain": "daily",
+    "$filter": "properties/usageDate ge 2017-10-01 AND properties/usageDate le 2017-11-20"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "providers/Microsoft.Capacity/reservationOrders/00000000-0000-0000-0000-000000000000/reservations/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationSummaries/20171001",
+            "name": "00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000_20171001",
+            "type": "Microsoft.Consumption/reservationSummaries",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "skuName": "Standard_D8s_v3",
+              "kind": "Reservation",
+              "reservedHours": 0.0,
+              "usageDate": "2017-10-01T00:00:00Z",
+              "usedHours": 0.0,
+              "minUtilizationPercentage": 0.0,
+              "avgUtilizationPercentage": 0.0,
+              "maxUtilizationPercentage": 0.0,
+              "purchasedQuantity": 0,
+              "remainingQuantity": 0,
+              "totalReservedQuantity": 155,
+              "usedQuantity": 0,
+              "utilizedPercentage": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesDailyWithBillingAccountId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesDailyWithBillingAccountId.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/12345",
+    "grain": "daily",
+    "$filter": "properties/usageDate ge 2017-10-01 AND properties/usageDate le 2017-11-20"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/12345/providers/Microsoft.Consumption/reservationSummaries/reservationSummaries_Id1",
+            "name": "reservationSummaries_Id1",
+            "type": "Microsoft.Consumption/reservationSummaries",
+            "tags": null,
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "skuName": "Standard_B1s",
+              "reservedHours": 720,
+              "usageDate": "2018-09-01T00:00:00-07:00",
+              "usedHours": 0,
+              "minUtilizationPercentage": 0,
+              "avgUtilizationPercentage": 0,
+              "maxUtilizationPercentage": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesDailyWithBillingProfileId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesDailyWithBillingProfileId.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579",
+    "grain": "daily",
+    "startDate": "2017-10-01",
+    "endDate": "2017-11-20"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579/providers/Microsoft.Consumption/reservationSummaries/reservationSummaries_Id1",
+            "name": "reservationSummaries_Id1",
+            "type": "Microsoft.Consumption/reservationSummaries",
+            "tags": null,
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "skuName": "Standard_B1s",
+              "reservedHours": 720,
+              "usageDate": "2018-09-01T00:00:00-07:00",
+              "usedHours": 0,
+              "minUtilizationPercentage": 0,
+              "avgUtilizationPercentage": 0,
+              "maxUtilizationPercentage": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesDailyWithReservationId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesDailyWithReservationId.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+    "reservationId": "00000000-0000-0000-0000-000000000000",
+    "grain": "daily",
+    "$filter": "properties/usageDate ge 2017-10-01 AND properties/usageDate le 2017-11-20"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "providers/Microsoft.Capacity/reservationOrders/00000000-0000-0000-0000-000000000000/reservations/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationSummaries/20171001",
+            "name": "00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000_20171001",
+            "type": "Microsoft.Consumption/reservationSummaries",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "skuName": "Standard_D8s_v3",
+              "kind": "Reservation",
+              "reservedHours": 0.0,
+              "usageDate": "2017-10-01T00:00:00Z",
+              "usedHours": 0.0,
+              "minUtilizationPercentage": 0.0,
+              "avgUtilizationPercentage": 0.0,
+              "maxUtilizationPercentage": 0.0,
+              "purchasedQuantity": 0,
+              "remainingQuantity": 0,
+              "totalReservedQuantity": 155,
+              "usedQuantity": 0,
+              "utilizedPercentage": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthly.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthly.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+    "grain": "monthly"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "providers/Microsoft.Capacity/reservationOrders/00000000-0000-0000-0000-000000000000/reservations/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationSummaries/20171001",
+            "name": "00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000_20171001",
+            "type": "Microsoft.Consumption/reservationSummaries",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "skuName": "Standard_D8s_v3",
+              "kind": "Reservation",
+              "reservedHours": 0.0,
+              "usageDate": "2017-10-01T00:00:00Z",
+              "usedHours": 0.0,
+              "minUtilizationPercentage": 0.0,
+              "avgUtilizationPercentage": 0.0,
+              "maxUtilizationPercentage": 0.0,
+              "purchasedQuantity": 0,
+              "remainingQuantity": 0,
+              "totalReservedQuantity": 155,
+              "usedQuantity": 0,
+              "utilizedPercentage": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthlyWithBillingAccountId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthlyWithBillingAccountId.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/12345",
+    "grain": "monthly"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/12345/providers/Microsoft.Consumption/reservationSummaries/reservationSummaries_Id1",
+            "name": "reservationSummaries_Id1",
+            "type": "Microsoft.Consumption/reservationSummaries",
+            "tags": null,
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "skuName": "Standard_B1s",
+              "reservedHours": 720,
+              "usageDate": "2018-09-01T00:00:00-07:00",
+              "usedHours": 0,
+              "minUtilizationPercentage": 0,
+              "avgUtilizationPercentage": 0,
+              "maxUtilizationPercentage": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthlyWithBillingProfileId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthlyWithBillingProfileId.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579",
+    "grain": "monthly"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579/providers/Microsoft.Consumption/reservationSummaries/reservationSummaries_Id1",
+            "name": "reservationSummaries_Id1",
+            "type": "Microsoft.Consumption/reservationSummaries",
+            "tags": null,
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "skuName": "Standard_B1s",
+              "reservedHours": 720,
+              "usageDate": "2018-09-01T00:00:00-07:00",
+              "usedHours": 0,
+              "minUtilizationPercentage": 0,
+              "avgUtilizationPercentage": 0,
+              "maxUtilizationPercentage": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthlyWithBillingProfileIdReservationId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthlyWithBillingProfileIdReservationId.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "resourceScope": "providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579",
+    "grain": "monthly",
+    "reservationId": "1c6b6358-709f-484c-85f1-72e862a0cf3b",
+    "reservationOrderId": "9f39ba10-794f-4dcb-8f4b-8d0cb47c27dc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/12345:2468/billingProfiles/13579/providers/Microsoft.Consumption/reservationSummaries/reservationSummaries_Id1",
+            "name": "reservationSummaries_Id1",
+            "type": "Microsoft.Consumption/reservationSummaries",
+            "tags": null,
+            "properties": {
+              "reservationOrderId": "9f39ba10-794f-4dcb-8f4b-8d0cb47c27dc",
+              "reservationId": "1c6b6358-709f-484c-85f1-72e862a0cf3b",
+              "skuName": "Standard_B1s",
+              "reservedHours": 720,
+              "usageDate": "2018-09-01T00:00:00-07:00",
+              "usedHours": 0,
+              "minUtilizationPercentage": 0,
+              "avgUtilizationPercentage": 0,
+              "maxUtilizationPercentage": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthlyWithReservationId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationSummariesMonthlyWithReservationId.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+    "reservationId": "00000000-0000-0000-0000-000000000000",
+    "grain": "monthly"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "providers/Microsoft.Capacity/reservationOrders/00000000-0000-0000-0000-000000000000/reservations/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/reservationSummaries/20171001",
+            "name": "00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000_20171001",
+            "type": "Microsoft.Consumption/reservationSummaries",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "reservationId": "00000000-0000-0000-0000-000000000000",
+              "skuName": "Standard_D8s_v3",
+              "kind": "Reservation",
+              "reservedHours": 0.0,
+              "usageDate": "2017-10-01T00:00:00Z",
+              "usedHours": 0.0,
+              "minUtilizationPercentage": 0.0,
+              "avgUtilizationPercentage": 0.0,
+              "maxUtilizationPercentage": 0.0,
+              "purchasedQuantity": 0,
+              "remainingQuantity": 0,
+              "totalReservedQuantity": 155,
+              "usedQuantity": 0,
+              "utilizedPercentage": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationTransactionsListByBillingProfileId.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationTransactionsListByBillingProfileId.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "$filter": "properties/eventDate+ge+2020-05-20+AND+properties/eventDate+le+2020-05-30",
+    "billingAccountId": "fcebaabc-fced-4284-a83d-79f83dee183c:45796ba8-988f-45ad-bea9-7b71fc6c7513_2018-09-30",
+    "billingProfileId": "Z76D-SGAF-BG7-TGB"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/billingAccounts/fcebaabc-fced-4284-a83d-79f83dee183c:45796ba8-988f-45ad-bea9-7b71fc6c7513_2018-09-30/billingProfiles/Z76D-SGAF-BG7-TGB/providers/Microsoft.Consumption/reservationTransactions",
+            "name": "a838a8c3-a408-49e1-ac90-42cb95bff9b2",
+            "type": "Microsoft.Consumption/reservationTransactions",
+            "properties": {
+              "eventDate": "2020-04-25T21:21:38Z",
+              "reservationOrderId": "a838a8c3-a408-49e1-ac90-42cb95bff9b2",
+              "description": "Reserved VM Instance, Standard_B1ls, US East, 3 Years",
+              "eventType": "Purchase",
+              "quantity": 1,
+              "amount": 1.44,
+              "currency": "USD",
+              "reservationOrderName": "VM_RI_03-25-2020_14-18",
+              "armSkuName": "Standard_B1ls",
+              "billingFrequency": "Recurring",
+              "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/fcebaabc-fced-4284-a83d-79f83dee183c:45796ba8-988f-45ad-bea9-7b71fc6c7513_2018-09-30/billingProfiles/Z76D-SGAF-BG7-TGB",
+              "billingProfileName": "IT Department*",
+              "invoice": "T000456437",
+              "invoiceId": "/providers/Microsoft.Billing/billingAccounts/fcebaabc-fced-4284-a83d-79f83dee183c:45796ba8-988f-45ad-bea9-7b71fc6c7513_2018-09-30/billingProfiles/Z76D-SGAF-BG7-TGB/invoices/T000456437",
+              "invoiceSectionId": "/providers/Microsoft.Billing/billingAccounts/fcebaabc-fced-4284-a83d-79f83dee183c:45796ba8-988f-45ad-bea9-7b71fc6c7513_2018-09-30/invoiceSections/QBTB-EYAK-PJA-TGB",
+              "invoiceSectionName": "IT Department",
+              "purchasingSubscriptionGuid": "d924ad15-4a3d-4047-971d-c8b1b300a97b",
+              "purchasingSubscriptionName": "contoso",
+              "region": "eastus",
+              "term": "P3Y"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationTransactionsListByEnrollmentNumber.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/ReservationTransactionsListByEnrollmentNumber.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "$filter": "properties/eventDate+ge+2020-05-20+AND+properties/eventDate+le+2020-05-30",
+    "useMarkupIfPartner": true,
+    "previewMarkupPercentage": 15.5,
+    "billingAccountId": "123456"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/billingAccounts/123456/providers/Microsoft.Consumption/reservationtransactions/201909091919",
+            "name": "201909091919",
+            "type": "Microsoft.Consumption/reservationTransactions",
+            "tags": [],
+            "properties": {
+              "eventDate": "2019-09-09T19:19:04Z",
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "description": "Standard_DS1_v2 westus 1 Year",
+              "eventType": "Refund",
+              "quantity": 1,
+              "amount": -21.000000000000000,
+              "currency": "USD",
+              "reservationOrderName": "Transaction-DS1_v2",
+              "purchasingEnrollment": "123456",
+              "armSkuName": "Standard_DS1_v2",
+              "term": "P1Y",
+              "region": "westus",
+              "purchasingSubscriptionGuid": "a838a8c3-a408-49e1-ac90-42cb95bff9b2",
+              "purchasingSubscriptionName": "Infrastructure Subscription",
+              "accountName": "Microsoft Infrastructure",
+              "accountOwnerEmail": "admin@microsoft.com",
+              "departmentName": "Unassigned",
+              "costCenter": "",
+              "currentEnrollment": "123456",
+              "billingFrequency": "recurring",
+              "billingMonth": 20190901,
+              "monetaryCommitment": 523123.90,
+              "overage": 23234.49
+            }
+          },
+          {
+            "id": "/billingAccounts/123456/providers/Microsoft.Consumption/reservationtransactions/201909091919",
+            "name": "201909091919",
+            "type": "Microsoft.Consumption/reservationTransactions",
+            "tags": [],
+            "properties": {
+              "eventDate": "2019-09-09T19:19:04Z",
+              "reservationOrderId": "00000000-0000-0000-0000-000000000000",
+              "description": "Standard_DS1_v2 westus 1 Year",
+              "eventType": "Purchase",
+              "quantity": 1,
+              "amount": 21.000000000000000,
+              "currency": "USD",
+              "reservationOrderName": "Transaction-DS1_v2",
+              "purchasingEnrollment": "123456",
+              "armSkuName": "Standard_DS1_v2",
+              "term": "P1Y",
+              "region": "westus",
+              "purchasingSubscriptionGuid": "a838a8c3-a408-49e1-ac90-42cb95bff9b2",
+              "purchasingSubscriptionName": "Infrastructure Subscription",
+              "accountName": "Microsoft Infrastructure",
+              "accountOwnerEmail": "admin@microsoft.com",
+              "departmentName": "Unassigned",
+              "costCenter": "",
+              "currentEnrollment": "123456",
+              "billingFrequency": "recurring",
+              "billingMonth": 20190901,
+              "monetaryCommitment": 523123.90,
+              "overage": 23234.49
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/Tags.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/Tags.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "billingAccountId": "12345",
+    "scope": "providers/Microsoft.CostManagement/billingAccounts/1234"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "providers/Microsoft.CostManagement/billingAccounts/{billingaccount-id}/providers/Microsoft.Consumption/tags/tags1",
+        "name": "tags1",
+        "type": "Microsoft.Consumption/tags",
+        "eTag": "\"1d34d012214157f\"",
+        "properties": {
+          "tags": [
+            {
+              "key": "Department"
+            },
+            {
+              "key": "CostCenter"
+            },
+            {
+              "key": "Portal"
+            },
+            {
+              "key": "OrgName"
+            },
+            {
+              "key": "Namespace"
+            },
+            {
+              "key": "resourceType"
+            },
+            {
+              "key": "Subsystem"
+            },
+            {
+              "key": "Environment"
+            },
+            {
+              "key": "clusterName"
+            }
+          ],
+          "nextLink": "https://management.azure.com/providers/Microsoft.Billing/billingAccounts/{billingaccount-id}/providers/Microsoft.Consumption/tags/?$expand=properties/tags/value&api-version=2023-05-01&startDate=2020-12-01&endDate=2020-12-31&$top=1000&$skiptoken=AwAAAA%3D%3D",
+          "previousLink": "https://management.azure.com/providers/Microsoft.Billing/billingAccounts/{billingaccount-id}/providers/Microsoft.Consumption/tags/?$expand=properties/tags/value&api-version=2023-05-01&startDate=2020-12-01&endDate=2020-12-31&$top=1000&$skiptoken=AQAAAA%3D%3D"
+        }
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsExpand.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsExpand.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "billingPeriodName": "201903",
+    "$expand": "meterDetails,additionalInfo",
+    "$filter": "tags eq 'dev:tools'",
+    "$top": 1
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": {
+                "meterName": "Data Transfer Out (GB)",
+                "meterCategory": "Networking",
+                "meterSubCategory": "ExpressRoute",
+                "unitOfMeasure": "GB",
+                "serviceFamily": "Compute"
+              },
+              "quantity": 0.8234,
+              "effectivePrice": 0.010464556322455,
+              "cost": 0.000342194841184,
+              "unitPrice": 3.54,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "frequency": "UsageBased",
+              "additionalInfo": "{\"MyType\":\"\",\"ServiceType\":\"\",\"VMName\":\"\",\"UsageType\":\"MyUsage\"}",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsList.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsList.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Customer Name 1",
+              "billingPeriodStartDate": "2019-04-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-04-30T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Customer Name 1",
+              "accountName": "AccountName",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "SubscriptionName 1",
+              "date": "2019-04-09T00:00:00.0000000Z",
+              "product": "Product1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.000036,
+              "effectivePrice": 0.054693034210767,
+              "cost": 0.000001980949998,
+              "unitPrice": 5.47,
+              "billingCurrency": "CAD",
+              "resourceLocation": "uswest",
+              "consumedService": "Microsoft.ClassicStorage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource-Group-westus/providers/Microsoft.ClassicStorage/storageAccounts/ResourceName1",
+              "resourceName": "ResourceName1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "BAS",
+              "resourceGroup": "Resource-Group-westus",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "frequency": "UsageBased",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByBillingAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByBillingAccount.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.7329,
+              "effectivePrice": 0.000402776395232,
+              "cost": 0.000295194820065,
+              "unitPrice": 4.38,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByDepartment.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByDepartment.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/Departments/1234",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/Departments/1234/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.7329,
+              "effectivePrice": 0.000402776395232,
+              "cost": 0.000295194820065,
+              "unitPrice": 4.38,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByEnrollmentAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByEnrollmentAccount.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/EnrollmentAccounts/1234",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/EnrollmentAccounts/1234/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.7329,
+              "effectivePrice": 0.000402776395232,
+              "cost": 0.000295194820065,
+              "unitPrice": 4.38,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMCABillingAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMCABillingAccount.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234:56789"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234:56789/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "modern",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "1234:56789",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-09-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-10-31T00:00:00.0000000Z",
+              "billingProfileId": "2468",
+              "billingProfileName": "Account Name 1",
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-10-30T00:00:00.0000000Z",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "quantity": 0.7329,
+              "unitPrice": 4.38,
+              "billingCurrencyCode": "USD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "instanceName": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "invoiceSectionId": "98765",
+              "invoiceSectionName": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "additionalInfo": "{  \"UsageType\": \"ComputeHR\",  \"ImageType\": \"Windows Client BYOL\",  \"ServiceType\": \"Standard_D1\",  \"VMName\": null,  \"VMProperties\": null,  \"VCPUs\": 1,  \"CPUs\": 0}",
+              "costInBillingCurrency": 1.84763819095477,
+              "costInPricingCurrency": 1.84763819095477,
+              "exchangeRate": "1",
+              "exchangeRateDate": "2019-09-30T00:00:00Z",
+              "invoiceId": "",
+              "previousInvoiceId": "",
+              "pricingCurrencyCode": "USD",
+              "product": "Virtual Machines D Series - D1 - US East",
+              "productIdentifier": "DZH318Z0BQ4B00FV",
+              "productOrderId": "a3db7880-70eb-4b4c-6a79-1425a058df5a",
+              "productOrderName": "Azure plan",
+              "publisherName": "Microsoft",
+              "publisherType": "Microsoft",
+              "resourceLocationNormalized": "US East",
+              "serviceInfo1": "",
+              "serviceInfo2": "Windows Client BYOL",
+              "servicePeriodEndDate": "2019-12-01T00:00:00Z",
+              "servicePeriodStartDate": "2019-09-01T00:00:00Z",
+              "customerTenantId": "00000000-0000-0000-0000-000000000000",
+              "customerName": "Modern Azure Customer 1",
+              "partnerTenantId": "00000000-0000-0000-0000-000000000000",
+              "partnerName": "Partner Name 1",
+              "resellerMpnId": "",
+              "resellerName": "Reseller Name 1",
+              "publisherId": "",
+              "reservationId": "",
+              "reservationName": "",
+              "frequency": "UsageBased",
+              "term": "",
+              "marketPrice": 0.077,
+              "costInUSD": 1.84763819095477,
+              "paygCostInBillingCurrency": 1.848,
+              "paygCostInUSD": 1.848,
+              "exchangeRatePricingToBilling": 0.077,
+              "partnerEarnedCreditRate": 0.077,
+              "partnerEarnedCreditApplied": "0",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMCABillingProfile.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMCABillingProfile.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234:56789/billingProfiles/2468"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234:56789/billingProfiles/2468/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "modern",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "1234:56789",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-09-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-10-31T00:00:00.0000000Z",
+              "billingProfileId": "2468",
+              "billingProfileName": "Account Name 1",
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-10-30T00:00:00.0000000Z",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "quantity": 0.7329,
+              "unitPrice": 4.38,
+              "billingCurrencyCode": "USD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "instanceName": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "invoiceSectionId": "98765",
+              "invoiceSectionName": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "additionalInfo": "{  \"UsageType\": \"ComputeHR\",  \"ImageType\": \"Windows Client BYOL\",  \"ServiceType\": \"Standard_D1\",  \"VMName\": null,  \"VMProperties\": null,  \"VCPUs\": 1,  \"CPUs\": 0}",
+              "costInBillingCurrency": 1.84763819095477,
+              "costInPricingCurrency": 1.84763819095477,
+              "exchangeRate": "1",
+              "exchangeRateDate": "2019-09-30T00:00:00Z",
+              "invoiceId": "",
+              "previousInvoiceId": "",
+              "pricingCurrencyCode": "USD",
+              "product": "Virtual Machines D Series - D1 - US East",
+              "productIdentifier": "DZH318Z0BQ4B00FV",
+              "productOrderId": "a3db7880-70eb-4b4c-6a79-1425a058df5a",
+              "productOrderName": "Azure plan",
+              "publisherName": "Microsoft",
+              "publisherType": "Microsoft",
+              "resourceLocationNormalized": "US East",
+              "serviceInfo1": "",
+              "serviceInfo2": "Windows Client BYOL",
+              "servicePeriodEndDate": "2019-12-01T00:00:00Z",
+              "servicePeriodStartDate": "2019-09-01T00:00:00Z",
+              "customerTenantId": "00000000-0000-0000-0000-000000000000",
+              "customerName": "Modern Azure Customer 1",
+              "partnerTenantId": "00000000-0000-0000-0000-000000000000",
+              "partnerName": "Partner Name 1",
+              "resellerMpnId": "",
+              "resellerName": "Reseller Name 1",
+              "publisherId": "",
+              "reservationId": "",
+              "reservationName": "",
+              "frequency": "UsageBased",
+              "term": "",
+              "marketPrice": 0.077,
+              "costInUSD": 1.84763819095477,
+              "paygCostInBillingCurrency": 1.848,
+              "paygCostInUSD": 1.848,
+              "exchangeRatePricingToBilling": 0.077,
+              "partnerEarnedCreditRate": 0.077,
+              "partnerEarnedCreditApplied": "0",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMCACustomer.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMCACustomer.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234:56789/customers/00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234:56789/customers/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "modern",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "1234:56789",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-09-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-10-31T00:00:00.0000000Z",
+              "billingProfileId": "2468",
+              "billingProfileName": "Account Name 1",
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-10-30T00:00:00.0000000Z",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "quantity": 0.7329,
+              "unitPrice": 4.38,
+              "billingCurrencyCode": "USD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "instanceName": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "invoiceSectionId": "98765",
+              "invoiceSectionName": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "additionalInfo": "{  \"UsageType\": \"ComputeHR\",  \"ImageType\": \"Windows Client BYOL\",  \"ServiceType\": \"Standard_D1\",  \"VMName\": null,  \"VMProperties\": null,  \"VCPUs\": 1,  \"CPUs\": 0}",
+              "costInBillingCurrency": 1.84763819095477,
+              "costInPricingCurrency": 1.84763819095477,
+              "exchangeRate": "1",
+              "exchangeRateDate": "2019-09-30T00:00:00Z",
+              "invoiceId": "",
+              "previousInvoiceId": "",
+              "pricingCurrencyCode": "USD",
+              "product": "Virtual Machines D Series - D1 - US East",
+              "productIdentifier": "DZH318Z0BQ4B00FV",
+              "productOrderId": "a3db7880-70eb-4b4c-6a79-1425a058df5a",
+              "productOrderName": "Azure plan",
+              "publisherName": "Microsoft",
+              "publisherType": "Microsoft",
+              "resourceLocationNormalized": "US East",
+              "serviceInfo1": "",
+              "serviceInfo2": "Windows Client BYOL",
+              "servicePeriodEndDate": "2019-12-01T00:00:00Z",
+              "servicePeriodStartDate": "2019-09-01T00:00:00Z",
+              "customerTenantId": "00000000-0000-0000-0000-000000000000",
+              "customerName": "Modern Azure Customer 1",
+              "partnerTenantId": "00000000-0000-0000-0000-000000000000",
+              "partnerName": "Partner Name 1",
+              "resellerMpnId": "",
+              "resellerName": "Reseller Name 1",
+              "publisherId": "",
+              "reservationId": "",
+              "reservationName": "",
+              "frequency": "UsageBased",
+              "term": "",
+              "marketPrice": 0.077,
+              "costInUSD": 1.84763819095477,
+              "paygCostInBillingCurrency": 1.848,
+              "paygCostInUSD": 1.848,
+              "exchangeRatePricingToBilling": 0.077,
+              "partnerEarnedCreditRate": 0.077,
+              "partnerEarnedCreditApplied": "0",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMCAInvoiceSection.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMCAInvoiceSection.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234:56789/invoiceSections/98765"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234:56789/invoiceSections/98765/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "modern",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "1234:56789",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-09-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-10-31T00:00:00.0000000Z",
+              "billingProfileId": "2468",
+              "billingProfileName": "Account Name 1",
+              "subscriptionGuid": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-10-30T00:00:00.0000000Z",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "quantity": 0.7329,
+              "unitPrice": 4.38,
+              "billingCurrencyCode": "USD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "instanceName": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "invoiceSectionId": "98765",
+              "invoiceSectionName": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "additionalInfo": "{  \"UsageType\": \"ComputeHR\",  \"ImageType\": \"Windows Client BYOL\",  \"ServiceType\": \"Standard_D1\",  \"VMName\": null,  \"VMProperties\": null,  \"VCPUs\": 1,  \"CPUs\": 0}",
+              "costInBillingCurrency": 1.84763819095477,
+              "costInPricingCurrency": 1.84763819095477,
+              "exchangeRate": "1",
+              "exchangeRateDate": "2019-09-30T00:00:00Z",
+              "invoiceId": "",
+              "previousInvoiceId": "",
+              "pricingCurrencyCode": "USD",
+              "product": "Virtual Machines D Series - D1 - US East",
+              "productIdentifier": "DZH318Z0BQ4B00FV",
+              "productOrderId": "a3db7880-70eb-4b4c-6a79-1425a058df5a",
+              "productOrderName": "Azure plan",
+              "publisherName": "Microsoft",
+              "publisherType": "Microsoft",
+              "resourceLocationNormalized": "US East",
+              "serviceInfo1": "",
+              "serviceInfo2": "Windows Client BYOL",
+              "servicePeriodEndDate": "2019-12-01T00:00:00Z",
+              "servicePeriodStartDate": "2019-09-01T00:00:00Z",
+              "customerTenantId": "00000000-0000-0000-0000-000000000000",
+              "customerName": "Modern Azure Customer 1",
+              "partnerTenantId": "00000000-0000-0000-0000-000000000000",
+              "partnerName": "Partner Name 1",
+              "resellerMpnId": "",
+              "resellerName": "Reseller Name 1",
+              "publisherId": "",
+              "reservationId": "",
+              "reservationName": "",
+              "frequency": "UsageBased",
+              "term": "",
+              "marketPrice": 0.077,
+              "costInUSD": 1.84763819095477,
+              "paygCostInBillingCurrency": 1.848,
+              "paygCostInUSD": 1.848,
+              "exchangeRatePricingToBilling": 0.077,
+              "partnerEarnedCreditRate": 0.077,
+              "partnerEarnedCreditApplied": "0",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByManagementGroup.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByManagementGroup.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "managementGroupId": "managementGroupForTest",
+    "billingPeriodName": "201903",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.8234,
+              "effectivePrice": 0.010534556373432,
+              "cost": 0.000342194841184,
+              "unitPrice": 3.74,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          },
+          {
+            "id": "/scope/providers/Microsoft.Billing/billingPeriods/20180801/providers/Microsoft.Consumption/usageDetails/usageDetails_Id2",
+            "name": "usageDetails_Id2",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 2",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 2",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 2",
+              "partNumber": "Part Number 2",
+              "meterId": "11111111-1111-1111-1111-111111111111",
+              "meterDetails": null,
+              "quantity": 0.7329,
+              "effectivePrice": 0.000402776395232,
+              "cost": 0.000295194820065,
+              "unitPrice": 4.38,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 2/providers/Microsoft.Storage/storageAccounts/Resource Name 2",
+              "resourceName": "Resource Name 2",
+              "invoiceSection": "Invoice Section 2",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 2",
+              "offerId": "Offer Id 2",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMetricActualCost.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMetricActualCost.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "metric": "actualcost",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Customer Name 1",
+              "billingPeriodStartDate": "2019-04-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-04-30T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Customer Name 1",
+              "accountName": "AccountName",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "SubscriptionName 1",
+              "date": "2019-04-09T00:00:00.0000000Z",
+              "product": "Product1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.000036,
+              "effectivePrice": 0.054693055510767,
+              "cost": 0.000001968949998,
+              "unitPrice": 5.47,
+              "billingCurrency": "CAD",
+              "resourceLocation": "uswest",
+              "consumedService": "Microsoft.ClassicStorage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource-Group-westus/providers/Microsoft.ClassicStorage/storageAccounts/ResourceName1",
+              "resourceName": "ResourceName1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "BAS",
+              "resourceGroup": "Resource-Group-westus",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMetricAmortizedCost.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMetricAmortizedCost.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "metric": "amortizedcost",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Customer Name 1",
+              "billingPeriodStartDate": "2019-04-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-04-30T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Customer Name 1",
+              "accountName": "AccountName",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "SubscriptionName 1",
+              "date": "2019-04-09T00:00:00.0000000Z",
+              "product": "Product1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.000036,
+              "effectivePrice": 0.054693055510767,
+              "cost": 0.000001968949998,
+              "unitPrice": 5.47,
+              "billingCurrency": "CAD",
+              "resourceLocation": "uswest",
+              "consumedService": "Microsoft.ClassicStorage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource-Group-westus/providers/Microsoft.ClassicStorage/storageAccounts/ResourceName1",
+              "resourceName": "ResourceName1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "BAS",
+              "resourceGroup": "Resource-Group-westus",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "frequency": "UsageBased",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMetricUsage.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListByMetricUsage.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "metric": "usage",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Customer Name 1",
+              "billingPeriodStartDate": "2019-04-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-04-30T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Customer Name 1",
+              "accountName": "AccountName",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "SubscriptionName 1",
+              "date": "2019-04-09T00:00:00.0000000Z",
+              "product": "Product1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.000036,
+              "effectivePrice": 0.054693055510767,
+              "cost": 0.000001968949998,
+              "unitPrice": 5.47,
+              "billingCurrency": "CAD",
+              "resourceLocation": "uswest",
+              "consumedService": "Microsoft.ClassicStorage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource-Group-westus/providers/Microsoft.ClassicStorage/storageAccounts/ResourceName1",
+              "resourceName": "ResourceName1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "BAS",
+              "resourceGroup": "Resource-Group-westus",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListFilterByTag.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListFilterByTag.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "$filter": "tags eq 'dev:tools'",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.8234,
+              "effectivePrice": 0.010534556373432,
+              "cost": 0.000342194841184,
+              "unitPrice": 3.74,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriod.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriod.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.8234,
+              "effectivePrice": 0.010534556373432,
+              "cost": 0.000342194841184,
+              "unitPrice": 3.74,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriodByBillingAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriodByBillingAccount.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/BillingAccounts/1234",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/BillingAccounts/1234/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.8234,
+              "effectivePrice": 0.010534556373432,
+              "cost": 0.000342194841184,
+              "unitPrice": 3.74,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriodByDepartment.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriodByDepartment.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/Departments/1234",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/Departments/1234/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.8234,
+              "effectivePrice": 0.010534556373432,
+              "cost": 0.000342194841184,
+              "unitPrice": 3.74,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriodByEnrollmentAccount.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriodByEnrollmentAccount.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "scope": "providers/Microsoft.Billing/EnrollmentAccounts/1234",
+    "billingPeriodName": "201903"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Billing/EnrollmentAccounts/1234/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.8234,
+              "effectivePrice": 0.010534556373432,
+              "cost": 0.000342194841184,
+              "unitPrice": 3.74,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriodByManagementGroup.json
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-05-01/examples/UsageDetailsListForBillingPeriodByManagementGroup.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2023-05-01",
+    "managementGroupId": "managementGroupForTest",
+    "billingPeriodName": "201903",
+    "scope": "subscriptions/00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Billing/billingPeriods/201903/providers/Microsoft.Consumption/usageDetails/usageDetails_Id1",
+            "name": "usageDetails_Id1",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 1",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 1",
+              "accountName": "Account Name 1",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 1",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 1",
+              "partNumber": "Part Number 1",
+              "meterId": "00000000-0000-0000-0000-000000000000",
+              "meterDetails": null,
+              "quantity": 0.8234,
+              "effectivePrice": 0.010534556373432,
+              "cost": 0.000342194841184,
+              "unitPrice": 3.74,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 1/providers/Microsoft.Storage/storageAccounts/Resource Name 1",
+              "resourceName": "Resource Name 1",
+              "invoiceSection": "Invoice Section 1",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 1",
+              "offerId": "Offer Id 1",
+              "isAzureCreditEligible": false,
+              "chargeType": "Usage",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          },
+          {
+            "id": "/scope/providers/Microsoft.Billing/billingPeriods/billingPeriodName/providers/Microsoft.Consumption/usageDetails/usageDetails_Id2",
+            "name": "usageDetails_Id2",
+            "type": "Microsoft.Consumption/usageDetails",
+            "kind": "legacy",
+            "tags": {
+              "env": "newcrp",
+              "dev": "tools"
+            },
+            "properties": {
+              "billingAccountId": "xxxxxxxx",
+              "billingAccountName": "Account Name 2",
+              "billingPeriodStartDate": "2019-03-01T00:00:00.0000000Z",
+              "billingPeriodEndDate": "2019-03-31T00:00:00.0000000Z",
+              "billingProfileId": "xxxxxxxx",
+              "billingProfileName": "Account Name 2",
+              "accountName": "Account Name 2",
+              "subscriptionId": "00000000-0000-0000-0000-000000000000",
+              "subscriptionName": "Subscription Name 2",
+              "date": "2019-03-30T00:00:00.0000000Z",
+              "product": "Product Name 2",
+              "partNumber": "Part Number 2",
+              "meterId": "11111111-1111-1111-1111-111111111111",
+              "meterDetails": null,
+              "quantity": 0.4759,
+              "effectivePrice": 0.073488920944598,
+              "cost": 0.000821821271948,
+              "unitPrice": 5.74,
+              "billingCurrency": "CAD",
+              "resourceLocation": "USEast",
+              "consumedService": "Microsoft.Storage",
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Resource Group 2/providers/Microsoft.Storage/storageAccounts/Resource Name 2",
+              "resourceName": "Resource Name 2",
+              "invoiceSection": "Invoice Section 2",
+              "costCenter": "DEV",
+              "resourceGroup": "Resource Group 2",
+              "offerId": "Offer Id 2",
+              "isAzureCreditEligible": false,
+              "chargeType": "UnusedReservation",
+              "benefitId": "00000000-0000-0000-0000-000000000000",
+              "benefitName": "Reservation_purchase_03-09-2018_10-59"
+            }
+          }
+        ]
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/consumption/resource-manager/readme.md
+++ b/specification/consumption/resource-manager/readme.md
@@ -26,19 +26,29 @@ These are the global settings for the Consumption API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2023-03
+tag: package-2023-05
 ```
 
 
+### Tag: package-2023-05
+
+These settings apply only when `--tag=package-2023-05` is specified on the command line.
+
+```yaml $(tag) == 'package-2023-05'
+input-file:
+  - Microsoft.Consumption/stable/2023-05-01/consumption.json
+  - Microsoft.Consumption/stable/2023-05-01/consumption_pricesheet.json
+```
 ### Tag: package-2023-03
 
 These settings apply only when `--tag=package-2023-03` is specified on the command line.
 
-```yaml $(tag) == 'package-2023-03'
+``` yaml $(tag) == 'package-2023-03'
 input-file:
   - Microsoft.Consumption/stable/2023-03-01/consumption.json
   - Microsoft.Consumption/stable/2023-03-01/consumption_pricesheet.json
 ```
+
 ### Tag: package-2022-09
 
 These settings apply only when `--tag=package-2022-09` is specified on the command line.

--- a/specification/consumption/resource-manager/readme.md
+++ b/specification/consumption/resource-manager/readme.md
@@ -43,7 +43,7 @@ input-file:
 
 These settings apply only when `--tag=package-2023-03` is specified on the command line.
 
-``` yaml $(tag) == 'package-2023-03'
+```yaml $(tag) == 'package-2023-03'
 input-file:
   - Microsoft.Consumption/stable/2023-03-01/consumption.json
   - Microsoft.Consumption/stable/2023-03-01/consumption_pricesheet.json


### PR DESCRIPTION
In this PR, I am creating a new version 2023-05-01 for Consumption RP.
I am making minor change in the reservation recommendation details API in this PR. Swagger documentation for other APIs in this RP remains same as current public stable version 2023-03-01.

Explanation: In the latest version 2023-05-01, subscriptionId will be accepted via oData filter for billing account and billing profile paths.
