### PR TITLE
[TypeSpec-Clean]: Content-safety changes

### DIFF
--- a/specification/cognitiveservices/ContentSafety/routes.tsp
+++ b/specification/cognitiveservices/ContentSafety/routes.tsp
@@ -1,5 +1,4 @@
 import "@azure-tools/typespec-azure-core";
-//import "@azure-tools/typespec-client-generator-core";
 import "@typespec/http";
 import "@typespec/rest";
 import "./models.tsp";
@@ -9,7 +8,6 @@ using TypeSpec.Rest;
 using TypeSpec.Versioning;
 using Azure.Core;
 using Azure.Core.Traits;
-//using Azure.ClientGenerator.Core;
 
 namespace ContentSafety;
 

--- a/specification/cognitiveservices/ContentSafety/routes.tsp
+++ b/specification/cognitiveservices/ContentSafety/routes.tsp
@@ -1,5 +1,5 @@
 import "@azure-tools/typespec-azure-core";
-import "@azure-tools/typespec-client-generator-core";
+//import "@azure-tools/typespec-client-generator-core";
 import "@typespec/http";
 import "@typespec/rest";
 import "./models.tsp";
@@ -9,7 +9,7 @@ using TypeSpec.Rest;
 using TypeSpec.Versioning;
 using Azure.Core;
 using Azure.Core.Traits;
-using Azure.ClientGenerator.Core;
+//using Azure.ClientGenerator.Core;
 
 namespace ContentSafety;
 
@@ -43,26 +43,30 @@ interface ImageOperations {
   >;
 }
 
+interface BlockOps
+  extends Azure.Core.ResourceOperations<NoRepeatableRequests &
+      NoConditionalRequests &
+      NoClientRequestId> {}
 interface TextBlocklists {
   @summary("Get Text Blocklist By blocklistName")
   @doc("Returns text blocklist details.")
-  getTextBlocklist is Azure.Core.ResourceRead<TextBlocklist>;
+  getTextBlocklist is BlockOps.ResourceRead<TextBlocklist>;
 
   @summary("Create Or Update Text Blocklist")
   @doc("Updates a text blocklist, if blocklistName does not exist, create a new blocklist.")
-  createOrUpdateTextBlocklist is Azure.Core.ResourceCreateOrUpdate<TextBlocklist>;
+  createOrUpdateTextBlocklist is BlockOps.ResourceCreateOrUpdate<TextBlocklist>;
 
   @summary("Delete Text Blocklist By blocklistName")
   @doc("Deletes a text blocklist.")
-  deleteTextBlocklist is Azure.Core.ResourceDelete<TextBlocklist>;
+  deleteTextBlocklist is BlockOps.ResourceDelete<TextBlocklist>;
 
   @summary("Get All Text Blocklists")
   @doc("Get all text blocklists details.")
-  listTextBlocklists is Azure.Core.ResourceList<TextBlocklist>;
+  listTextBlocklists is BlockOps.ResourceList<TextBlocklist>;
 
   @summary("Add BlockItems To Text Blocklist")
   @doc("Add blockItems to a text blocklist. You can add at most 100 BlockItems in one request.")
-  addBlockItems is ResourceAction<
+  addBlockItems is BlockOps.ResourceAction<
     TextBlocklist,
     AddBlockItemsOptions,
     AddBlockItemsResult
@@ -70,7 +74,7 @@ interface TextBlocklists {
 
   @summary("Remove BlockItems From Text Blocklist")
   @doc("Remove blockItems from a text blocklist. You can remove at most 100 BlockItems in one request.")
-  removeBlockItems is ResourceAction<
+  removeBlockItems is BlockOps.ResourceAction<
     TextBlocklist,
     RemoveBlockItemsOptions,
     NoContentResponse
@@ -78,11 +82,11 @@ interface TextBlocklists {
 
   @summary("Get BlockItem By blocklistName And blockItemId")
   @doc("Get blockItem By blockItemId from a text blocklist.")
-  getTextBlocklistItem is Azure.Core.ResourceRead<TextBlockItem>;
+  getTextBlocklistItem is BlockOps.ResourceRead<TextBlockItem>;
 
   @summary("Get All BlockItems By blocklistName")
   @doc("Get all blockItems in a text blocklist")
-  listTextBlocklistItems is Azure.Core.ResourceList<
+  listTextBlocklistItems is BlockOps.ResourceList<
     TextBlockItem,
     ListQueryParametersTrait<StandardListQueryParameters>
   >;

--- a/specification/cognitiveservices/ContentSafety/tspconfig.yaml
+++ b/specification/cognitiveservices/ContentSafety/tspconfig.yaml
@@ -13,8 +13,9 @@ emit:
   - "@azure-tools/typespec-autorest"
 options:
   "@azure-tools/typespec-autorest":
-    output-file: "contentsafety.json"
-    azure-resource-provider-folder: ../../../../data-plane
+    emitter-output-dir: "{project-root}/../"
+    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/contentsafety.json"
+    azure-resource-provider-folder: "data-plane"
     examples-directory: ./examples
   "@azure-tools/typespec-python":
     package-name: "azure-ai-contentsafety"

--- a/specification/cognitiveservices/data-plane/ContentSafety/preview/2023-04-30-preview/contentsafety.json
+++ b/specification/cognitiveservices/data-plane/ContentSafety/preview/2023-04-30-preview/contentsafety.json
@@ -121,7 +121,7 @@
                   "type": "string",
                   "format": "uri",
                   "description": "The link to the next page of items",
-                  "x-typespec-name": "Rest.ResourceLocation"
+                  "x-typespec-name": "TypeSpec.Rest.ResourceLocation"
                 }
               },
               "description": "Paged collection of TextBlocklist items",
@@ -453,7 +453,7 @@
                   "type": "string",
                   "format": "uri",
                   "description": "The link to the next page of items",
-                  "x-typespec-name": "Rest.ResourceLocation"
+                  "x-typespec-name": "TypeSpec.Rest.ResourceLocation"
                 }
               },
               "description": "Paged collection of TextBlockItem items",


### PR DESCRIPTION
- TypeSpecValidation is failing due to a bug in the tool (validates all folders under `cognitiveservices`).  Validation of `ContentSafety` folder passed.
- Passing CI: https://dev.azure.com/azure-sdk/public/_build/results?buildId=2772573&view=logs&j=9cd39ef8-47c1-5b58-08db-8c3708712f1b&t=b0666886-a1bc-5f0b-4c5c-3e4f20acee0f