### PR TITLE
[TypeSpec-Clean]: Updating HealthInsights

### DIFF
--- a/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.response.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.response.tsp
@@ -5,6 +5,7 @@ using TypeSpec.Rest;
 namespace AzureHealthInsights;
 
 alias Response = {
+  #suppress "@azure-tools/typespec-azure-core/no-format" "This is an old spec"
   @doc("A processing job identifier.")
   @visibility("read")
   @key
@@ -31,7 +32,6 @@ alias Response = {
   @visibility("read")
   errors?: Azure.Core.Foundations.Error[];
 };
-
 
 @doc("An inference made by the model regarding a patient.")
 model Inference {

--- a/specification/cognitiveservices/HealthInsights/healthinsights.common/primitives.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.common/primitives.tsp
@@ -2,16 +2,16 @@ using Azure.Core;
 using TypeSpec.Http;
 namespace AzureHealthInsights;
 
+#suppress "@azure-tools/typespec-azure-core/long-running-polling-operation-required" "This is a template"
 @doc("Long running RPC operation template")
 op LongRunningRpcOperation<
-    TParams extends object,
-    TResponse extends object,
-    Traits extends object = {}
-  > is RpcOperation<
-    TParams & Traits,
-    Foundations.AcceptedResponse<Traits &
-                                 Foundations.LongRunningStatusLocation &
-                                 Foundations.RetryAfterHeader &
-                                 RepeatabilityResponseHeaders> | TResponse,
-    Traits
-  >;
+  TParams,
+  TResponse
+> is Azure.Core.Foundations.Operation<
+  TParams & RepeatabilityRequestHeaders,
+  (Foundations.AcceptedResponse<Foundations.LongRunningStatusLocation &
+    Foundations.RetryAfterHeader> &
+    RepeatabilityResponseHeaders) | TResponse,
+  RepeatabilityRequestHeaders & RepeatabilityResponseHeaders,
+  Azure.Core.Foundations.ErrorResponse
+>;

--- a/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/route.oncophenotype.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/route.oncophenotype.tsp
@@ -17,14 +17,21 @@ interface OncoPhenotype {
   @summary("Get Onco Phenotype job details")
   @tag("OncoPhenotype")
   @doc("Gets the status and details of the Onco Phenotype job.")
-  @example("./examples/SuccessfulOncoPhenotypeResponse.json", "SuccessfulOncoPhenotypeGetAnalyzeStatus")
+  @example(
+    "./examples/SuccessfulOncoPhenotypeResponse.json",
+    "SuccessfulOncoPhenotypeGetAnalyzeStatus"
+  )
   GetJob is Azure.Core.ResourceRead<OncoPhenotypeResult>;
 
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "There is no long-runnign RPC template in Azure.Core"
   @summary("Create Onco Phenotype job")
   @tag("OncoPhenotype")
   @doc("Creates an Onco Phenotype job with the given request body.")
   @pollingOperation(OncoPhenotype.GetJob)
   @route("/oncophenotype/jobs")
-  @example("./examples/SuccessfulOncoPhenotypeRequest.json", "SuccessfulOncoPhenotypeAnalyzeRequest")
-  CreateJob is LongRunningRpcOperation<OncoPhenotypeData, OncoPhenotypeResult, RepeatabilityRequestHeaders>;
+  @example(
+    "./examples/SuccessfulOncoPhenotypeRequest.json",
+    "SuccessfulOncoPhenotypeAnalyzeRequest"
+  )
+  CreateJob is LongRunningRpcOperation<OncoPhenotypeData, OncoPhenotypeResult>;
 }

--- a/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/route.oncophenotype.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/route.oncophenotype.tsp
@@ -23,7 +23,7 @@ interface OncoPhenotype {
   )
   GetJob is Azure.Core.ResourceRead<OncoPhenotypeResult>;
 
-  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "There is no long-runnign RPC template in Azure.Core"
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "There is no long-running RPC template in Azure.Core"
   @summary("Create Onco Phenotype job")
   @tag("OncoPhenotype")
   @doc("Creates an Onco Phenotype job with the given request body.")

--- a/specification/cognitiveservices/HealthInsights/healthinsights.openapi/tspconfig.yaml
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.openapi/tspconfig.yaml
@@ -6,5 +6,7 @@ emit: [
 
 options:
   "@azure-tools/typespec-autorest":
-     output-file: "openapi.json"
+     azure-resource-provider-folder: "HealthInsights"
+     emitter-output-dir: "{project-root}/../../data-plane"
+     output-file: "{azure-resource-provider-folder}/{version-status}/{version}/openapi.json"
      examples-directory: "./examples"

--- a/specification/cognitiveservices/HealthInsights/healthinsights.openapi/tspconfig.yaml
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.openapi/tspconfig.yaml
@@ -6,7 +6,7 @@ emit: [
 
 options:
   "@azure-tools/typespec-autorest":
-     azure-resource-provider-folder: "HealthInsights"
-     emitter-output-dir: "{project-root}/../../data-plane"
-     output-file: "{azure-resource-provider-folder}/{version-status}/{version}/openapi.json"
+     azure-resource-provider-folder: "./data-plane"
+     emitter-output-dir: "{project-root}/../.."
+     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
      examples-directory: "./examples"

--- a/specification/cognitiveservices/HealthInsights/healthinsights.openapi/tspconfig.yaml
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.openapi/tspconfig.yaml
@@ -6,7 +6,7 @@ emit: [
 
 options:
   "@azure-tools/typespec-autorest":
-     azure-resource-provider-folder: "HealthInsights"
-     emitter-output-dir: "{project-root}/../../data-plane"
-     output-file: "{azure-resource-provider-folder}/{version-status}/{version}/openapi.json"
+     azure-resource-provider-folder: "./data-plane"
+     emitter-output-dir: "{project-root}/../.."
+     output-file: "{azure-resource-provider-folder}/HealthInsights/{version-status}/{version}/openapi.json"
      examples-directory: "./examples"

--- a/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/route.trialmatcher.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/route.trialmatcher.tsp
@@ -17,15 +17,21 @@ interface TrialMatcher {
   @summary("Get Trial Matcher job details")
   @tag("TrialMatcher")
   @doc("Gets the status and details of the Trial Matcher job.")
-  @example("./examples/SuccessfulTrialMatcherResponse.json", "SuccessfulTrialMatcherGetAnalyzeStatus")
+  @example(
+    "./examples/SuccessfulTrialMatcherResponse.json",
+    "SuccessfulTrialMatcherGetAnalyzeStatus"
+  )
   GetJob is Azure.Core.ResourceRead<TrialMatcherResult>;
 
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "There is no long-runnign RPC template in Azure.Core"
   @summary("Create Trial Matcher job")
   @tag("TrialMatcher")
   @doc("Creates a Trial Matcher job with the given request body.")
   @pollingOperation(TrialMatcher.GetJob)
   @route("/trialmatcher/jobs")
-  @example("./examples/SuccessfulTrialMatcherRequest.json", "SuccessfulTrialMatcherAnalyzeRequest")
-  CreateJob is LongRunningRpcOperation<TrialMatcherData, TrialMatcherResult, RepeatabilityRequestHeaders>;
+  @example(
+    "./examples/SuccessfulTrialMatcherRequest.json",
+    "SuccessfulTrialMatcherAnalyzeRequest"
+  )
+  CreateJob is LongRunningRpcOperation<TrialMatcherData, TrialMatcherResult>;
 }
-

--- a/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/route.trialmatcher.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/route.trialmatcher.tsp
@@ -23,7 +23,7 @@ interface TrialMatcher {
   )
   GetJob is Azure.Core.ResourceRead<TrialMatcherResult>;
 
-  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "There is no long-runnign RPC template in Azure.Core"
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "There is no long-running RPC template in Azure.Core"
   @summary("Create Trial Matcher job")
   @tag("TrialMatcher")
   @doc("Creates a Trial Matcher job with the given request body.")


### PR DESCRIPTION
- TypeSpecValidation is failing due to a bug in the tool (validates all folders under `cognitiveservices`).
- TypeSpecApiView is failing because it tries to generate swagger from folders like `healthinsights.oncophenotype` that are not configured to generate Swagger.
- Passing CI: https://dev.azure.com/azure-sdk/public/_build/results?buildId=2772654&view=logs&j=9cd39ef8-47c1-5b58-08db-8c3708712f1b&t=467c1474-02d7-5bdd-89c6-4f3a05c439d0