### PR TITLE
[TypeSpec-Clean] Updates for OpenAi.Inference

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/chat.completions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/chat.completions.tsp
@@ -139,8 +139,8 @@ model ChatCompletionsOptions {
     """)
     @projectedName("json", "model")
     @projectedName("csharp", "InternalNonAzureModelName")
-    "model"?: string;
-};
+    `model`?: string;
+}
 
 @doc("""
 The representation of a single prompt completion as part of an overall chat completions request.
@@ -158,7 +158,7 @@ model ChatChoice {
 
     @doc("The reason that this chat completions choice completed its generated.")
     @projectedName("json", "finish_reason")
-    finishReason: CompletionsFinishReason | null;
+    finishReason?: CompletionsFinishReason;
 
     @doc("The delta message content for a streaming response.")
     @projectedName("json", "delta")

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions.create.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions.create.tsp
@@ -136,8 +136,8 @@ model CompletionsOptions {
     """)
     @projectedName("json", "model")
     @projectedName("csharp", "InternalNonAzureModelName")
-    "model"?: string;
-};
+    `model`?: string;
+}
 
 @doc("""
 Representation of the response data from a completions request.
@@ -189,11 +189,11 @@ model Choice {
     @doc("The log probabilities model for tokens associated with this completions choice.")
     @projectedName("json", "logprobs")
     @projectedName("csharp", "LogProbabilityModel")
-    logprobs: CompletionsLogProbabilityModel | null;
+    logprobs?: CompletionsLogProbabilityModel;
 
     @doc("Reason for finishing")
     @projectedName("json", "finish_reason")
-    finishReason: CompletionsFinishReason | null;
+    finishReason?: CompletionsFinishReason;
 }
 
 alias NullableFloat = float32 | null;

--- a/specification/cognitiveservices/OpenAI.Inference/routes.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/routes.tsp
@@ -1,7 +1,7 @@
 import "@azure-tools/typespec-azure-core";
 import "@typespec/rest";
 import "@typespec/http";
-import "@azure-tools/typespec-client-generator-core";
+//import "@azure-tools/typespec-client-generator-core";
 
 import "./models/completions.create.tsp";
 import "./models/chat.completions.tsp";
@@ -10,16 +10,18 @@ import "./models/embeddings.create.tsp";
 using TypeSpec.Rest;
 using TypeSpec.Http;
 using Azure.Core;
-using Azure.ClientGenerator.Core;
+//using Azure.ClientGenerator.Core;
 
 namespace Azure.OpenAI;
 
 @doc("Return the embeddings for a given prompt.")
 @TypeSpec.Rest.actionSeparator("/")
-@action("embeddings")
-@convenientAPI(true)
-op getEmbeddings is Azure.Core.ResourceAction<Deployment, EmbeddingsOptions, Embeddings>;
-
+@action("embeddings") //@convenientAPI(true)
+op getEmbeddings is Azure.Core.ResourceAction<
+    Deployment,
+    EmbeddingsOptions,
+    Embeddings
+>;
 
 @doc("""
 Gets completions for the provided input prompts.
@@ -27,10 +29,12 @@ Completions support a wide variety of tasks and generate text that continues fro
 provided prompt data.
 """)
 @TypeSpec.Rest.actionSeparator("/")
-@action("completions")
-@convenientAPI(true)
-op getCompletions is Azure.Core.ResourceAction<Deployment, CompletionsOptions, Completions>;
-
+@action("completions") //@convenientAPI(true)
+op getCompletions is Azure.Core.ResourceAction<
+    Deployment,
+    CompletionsOptions,
+    Completions
+>;
 
 @doc("""
 Gets chat completions for the provided chat messages.
@@ -38,6 +42,9 @@ Completions support a wide variety of tasks and generate text that continues fro
 provided prompt data.
 """)
 @TypeSpec.Rest.actionSeparator("/")
-@action("chat/completions")
-@convenientAPI(true)
-op getChatCompletions is Azure.Core.ResourceAction<Deployment, ChatCompletionsOptions, ChatCompletions>;
+@action("chat/completions") //@convenientAPI(true)
+op getChatCompletions is Azure.Core.ResourceAction<
+    Deployment,
+    ChatCompletionsOptions,
+    ChatCompletions
+>;

--- a/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
+++ b/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
@@ -1,6 +1,6 @@
 emit:
-  - "@azure-tools/typespec-autorest"
-  - "@azure-tools/cadl-apiview"
+#  - "@azure-tools/typespec-autorest"
+#  - "@azure-tools/cadl-apiview"
 options:
   # Uncomment this line and add "@azure-tools/cadl-python" to your package.json to generate Python code
   # "@azure-tools/cadl-python":


### PR DESCRIPTION
- TypeSpecValidation is failing due to a bug in the tool (validates all folders under cognitiveservices).
- CI Passing (but no emitter is configured): https://dev.azure.com/azure-sdk/public/_build/results?buildId=2772886&view=logs&j=9cd39ef8-47c1-5b58-08db-8c3708712f1b&t=462145f3-d740-50de-51e9-126e7c0a29e2