### PR TITLE
[TypeSpec CI] Remove folder OpenAI.Authoring

### DIFF
--- a/eng/pipelines/typespec-ci.yml
+++ b/eng/pipelines/typespec-ci.yml
@@ -46,11 +46,6 @@ jobs:
 
   - template: templates/steps/typespec-ci.yml
     parameters:
-      Folder: specification/cognitiveservices/OpenAI.Authoring
-      DisplayName: OpenAI.Authoring
-
-  - template: templates/steps/typespec-ci.yml
-    parameters:
       Folder: specification/cognitiveservices/OpenAI.Inference
       DisplayName: OpenAI.Inference
 


### PR DESCRIPTION
- Spec removed from repo in #23969
