### PR TITLE
Rename operation

### DIFF
--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/stable/2023-03-01/costmanagement.benefits.json
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/stable/2023-03-01/costmanagement.benefits.json
@@ -320,7 +320,7 @@
         "tags": [
           "BenefitUtilizationSummariesAsync"
         ],
-        "operationId": "BillingAccountScope_GenerateBenefitUtilizationSummariesReport",
+        "operationId": "GenerateBenefitUtilizationSummariesReport_ByBillingAccount",
         "description": "Triggers generation of a benefit utilization summaries report for the provided billing account. This API supports only enrollment accounts.",
         "externalDocs": {
           "url": "https://docs.microsoft.com/rest/api/cost-management/"
@@ -386,7 +386,7 @@
         "tags": [
           "BenefitUtilizationSummariesAsync"
         ],
-        "operationId": "BillingProfileScope_GenerateBenefitUtilizationSummariesReport",
+        "operationId": "GenerateBenefitUtilizationSummariesReport_GenerateByBillingProfile",
         "description": "Triggers generation of a benefit utilization summaries report for the provided billing account and billing profile.",
         "externalDocs": {
           "url": "https://docs.microsoft.com/rest/api/cost-management/"
@@ -455,7 +455,7 @@
         "tags": [
           "BenefitUtilizationSummariesAsync"
         ],
-        "operationId": "ReservationOrderScope_GenerateBenefitUtilizationSummariesReport",
+        "operationId": "GenerateBenefitUtilizationSummariesReport_GenerateByReservationOrderId",
         "description": "Triggers generation of a benefit utilization summaries report for the provided reservation order.",
         "externalDocs": {
           "url": "https://docs.microsoft.com/rest/api/cost-management/"
@@ -521,7 +521,7 @@
         "tags": [
           "BenefitUtilizationSummariesAsync"
         ],
-        "operationId": "ReservationScope_GenerateBenefitUtilizationSummariesReport",
+        "operationId": "GenerateBenefitUtilizationSummariesReport_GenerateByReservationId",
         "description": "Triggers generation of a benefit utilization summaries report for the provided reservation.",
         "externalDocs": {
           "url": "https://docs.microsoft.com/rest/api/cost-management/"
@@ -590,7 +590,7 @@
         "tags": [
           "BenefitUtilizationSummariesAsync"
         ],
-        "operationId": "SavingsPlanOrderScope_GenerateBenefitUtilizationSummariesReport",
+        "operationId": "GenerateBenefitUtilizationSummariesReport_GenerateBySavingsPlanOrderId",
         "description": "Triggers generation of a benefit utilization summaries report for the provided savings plan order.",
         "externalDocs": {
           "url": "https://docs.microsoft.com/rest/api/cost-management/"
@@ -656,7 +656,7 @@
         "tags": [
           "BenefitUtilizationSummariesAsync"
         ],
-        "operationId": "SavingsPlanScope_GenerateBenefitUtilizationSummariesReportAsync",
+        "operationId": "GenerateBenefitUtilizationSummariesReportAsync_GenerateBySavingsPlanId",
         "description": "Triggers generation of a benefit utilization summaries report for the provided savings plan.",
         "externalDocs": {
           "url": "https://docs.microsoft.com/rest/api/cost-management/"

--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/stable/2023-03-01/costmanagement.benefits.json
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/stable/2023-03-01/costmanagement.benefits.json
@@ -320,7 +320,7 @@
         "tags": [
           "BenefitUtilizationSummariesAsync"
         ],
-        "operationId": "GenerateBenefitUtilizationSummariesReport_ByBillingAccount",
+        "operationId": "GenerateBenefitUtilizationSummariesReport_GenerateByBillingAccount",
         "description": "Triggers generation of a benefit utilization summaries report for the provided billing account. This API supports only enrollment accounts.",
         "externalDocs": {
           "url": "https://docs.microsoft.com/rest/api/cost-management/"


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

Selecting template is not working.

The issue is with operation ids as is, each scope appears in our documentation with the API as a drop down rather than a single API with multiple scopes in a drop down.

Screenshot below marks an existing API acting as expected in green and the new API to be changed in this PR in orange 
![image](https://github.com/Azure/azure-rest-api-specs/assets/107518095/860ea3ef-be86-465c-8575-4770d32f6c67)
