### PR TITLE
Sync ADF changes into Synapse: Add state and onInactiveMarkAs to Synapse activities

### DIFF
--- a/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/entityTypes/Pipeline.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/entityTypes/Pipeline.json
@@ -78,6 +78,31 @@
           "description": "Activity description.",
           "type": "string"
         },
+        "state": {
+          "description": "Activity state. This is an optional property and if not provided, the state will be Active by default.",
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ],
+          "x-ms-enum": {
+            "name": "ActivityState",
+            "modelAsString": true
+          }
+        },
+        "onInactiveMarkAs": {
+          "description": "Status result of the activity when the state is set to Inactive. This is an optional property and if not provided when the activity is inactive, the status will be Succeeded by default.",
+          "type": "string",
+          "enum": [
+            "Succeeded",
+            "Failed",
+            "Skipped"
+          ],
+          "x-ms-enum": {
+            "name": "ActivityOnInactiveMarkAs",
+            "modelAsString": true
+          }
+        },
         "dependsOn": {
           "type": "array",
           "description": "Activity depends on condition.",


### PR DESCRIPTION
Sync ADF changes (https://github.com/Azure/azure-rest-api-specs/pull/23910) to Synapse

The changes being replicated originate from these PRs:
Private PR: https://github.com/Azure/azure-rest-api-specs-pr/pull/12375
Public PR: https://github.com/Azure/azure-rest-api-specs/pull/23910

Following the same approach of a similar PR: https://github.com/Azure/azure-rest-api-specs/pull/23619

