### PR TITLE
Improve how `workflow-bot` is handling `NewApiVersionRequired` and `WaitForARMFeedback` labels.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
@@ -1,6 +1,7 @@
 ## ARM API Information (Control Plane)
 
 ### Changelog
+
 Add a changelog entry for this PR by answering the following questions:
   1. What's the purpose of the update?
       - [ ] new service onboarding
@@ -13,6 +14,7 @@ Add a changelog entry for this PR by answering the following questions:
   4. By default, Azure SDKs of all languages (.NET/Python/Java/JavaScript for both management-plane SDK and data-plane SDK, Go for management-plane SDK only ) MUST be refreshed with/after swagger of new version is published. If you prefer NOT to refresh any specific SDK language upon swagger updates in the current PR, please leave details with justification here.
 
 ### Contribution checklist (MS Employees Only):
+
 - [ ] I commit to follow the [Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy) of "no breaking changes"
 - [ ] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
 - [ ] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)
@@ -28,22 +30,27 @@ If any further question about AME onboarding or validation tools, please view th
 > - Adding new properties
 > - All removals
 
-Otherwise your PR may be subject to ARM review requirements. Complete the following:
-- [ ] Check this box if any of the following apply to the PR so that the label "ARMReview" and "WaitForARMFeedback" will be added by bot to kick off ARM API Review.  Missing to check this box in the following scenario may result in delays to the ARM manifest review and deployment.
-  - Adding a new service
-  - Adding new API(s)
-  - Adding a new API version
-    -[ ] To review changes efficiently, ensure you copy the existing version into the new directory structure for first commit and then push new changes, including version updates, in separate commits. You can use OpenAPIHub to initialize the PR for adding a new version. For more details refer to the [wiki](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/208/OpenAPI-Hub-Adding-new-API-version). Note that this doesn't apply if you are trying to merge a PR that was previously in the private repository.
+Complete the following questionnaire to determine if the mandatory ARM review is applicable and if so, automatically schedule it:
 
-- [ ] Ensure you've reviewed following [guidelines](https://aka.ms/rpguidelines) including [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md). Estimated time (4 hours). This is required before you can request review from ARM API Review board.
+- [ ] Check this box if any of the following apply to this PR. This will label your PR with `ARMReview`.
+  - This PR is adding a new service
+  - This PR is adding new API(s)
+  - This PR is adding a new API version
 
-- [ ] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM oncall for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them.
+- [ ] If this PR is adding a new API version, you have ensured that you copied an existing API version into a new directory structure for first commit and then pushed new changes, including version updates, in separate commits. 
+    - You can use OpenAPIHub to initialize the PR for adding a new version. For more details refer to the [wiki](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/208/OpenAPI-Hub-Adding-new-API-version).
+  - Note that this doesn't apply if you are trying to merge a PR that was previously in the private repository.
+
+- [ ] Ensure you've reviewed following [guidelines](https://aka.ms/rpguidelines) including [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md). Estimated time: 4 hours.
+
+- [ ] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM on-call for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them.
 
 ### Breaking Change Review Checklist
+
 If you have any breaking changes as defined in the [Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy/), request approval from the Breaking Change Review Board.
 
 **Action**: to initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate). Additional details on the process and office hours are on the [Breaking Change Wiki](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-core-pm-and-design/trusted-platform-pm-karimb/service-lifecycle-and-actions-team/service-lifecycle-actions-team/apex/media/overview_breakingchanges).
 
 NOTE: To update API(s) in public preview for over 1 year (refer to [Retirement of Previews](http://aka.ms/aprwiki))
 
-Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).
+Please follow the link to find more details on [PR review process](https://aka.ms/specprreview).

--- a/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
@@ -38,7 +38,7 @@ Complete the following questionnaire to determine if the mandatory ARM review is
   - This PR is adding a new API version
 
 - [ ] If this PR is adding a new API version, you have ensured that you copied an existing API version into a new directory structure for first commit and then pushed new changes, including version updates, in separate commits. 
-    - You can use OpenAPIHub to initialize the PR for adding a new version. For more details refer to the [wiki](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/208/OpenAPI-Hub-Adding-new-API-version).
+  - You can use OpenAPIHub to initialize the PR for adding a new version. For more details refer to the [wiki](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/208/OpenAPI-Hub-Adding-new-API-version).
   - Note that this doesn't apply if you are trying to merge a PR that was previously in the private repository.
 
 - [ ] Ensure you've reviewed following [guidelines](https://aka.ms/rpguidelines) including [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md). Estimated time: 4 hours.

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -17,7 +17,7 @@
 - rule:
     type: checkbox
     keywords:
-      - "WaitForARMFeedback"
+      - "ARMReview"
     booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit||BreakingChangeReviewRequired)&&NewApiVersionRequired"
     onCheckedLabels:
       - ARMChangesRequested

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -3,11 +3,37 @@
     type: checkbox
     keywords:
       - "WaitForARMFeedback"
-    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit||BreakingChangeReviewRequired)"
+    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit||BreakingChangeReviewRequired||NewApiVersionRequired)"
     onCheckedLabels:
       - WaitForARMFeedback
       - ARMReview
-    onCheckedComments: "Hi, @${PRAuthor} your PR are labelled with <b> WaitForARMFeedback</b>. A notification email will be sent out shortly afterwards to notify ARM review board(armapireview@microsoft.com)."
+    onCheckedComments: >-
+      Hi @${PRAuthor}!<br/>
+      <br/>
+      The automation detected that in the `ARM API Review Checklist` you denoted that this PR requires an ARM review. As a result, the automation labelled your PR with `ARMReview` and `WaitForARMFeedback` labels. A notification email will be sent out shortly to notify ARM review board (armapireview@microsoft.com) to review your PR.
+      <br/><br/>
+      **ACTION ITEM** for you: wait until either `ARMChangesRequested` or `ARMSignedOff` labels are added to your PR by an ARM review board member.
+      <br/><br/>
+      For more information, please refer to https://aka.ms/specprreview
+
+- rule:
+    type: checkbox
+    keywords:
+      - "WaitForARMFeedback"
+    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit||BreakingChangeReviewRequired)&&NewApiVersionRequired"
+    onCheckedLabels:
+      - ARMChangesRequested
+      - ARMReview
+    onCheckedComments: >-
+      Hi @${PRAuthor}!<br/>
+      <br/>
+      The automation detected that in the `ARM API Review Checklist` you denoted that this PR requires an ARM review. As a result, the automation has added the `ARMReview` label to this PR. The automation has also detected this PR has the label `NewApiVersionRequired`, which you must address before any ARM review can take place. To denote this, the automation added the `ARMChangesRequested` label.
+      <br/><br/>
+      **ACTION ITEMS** for you:<br/>
+      - Follow the guidance provided in the comment explaining why `NewApiVersionRequired` label was added.<br/>
+      - Manually remove the `ARMChangesRequested` label once the `NewApiVersionRequired` has been removed by automation.
+      <br/><br/>
+      For more information, please refer to https://aka.ms/specprreview
 
 - rule:
     type: label
@@ -39,7 +65,19 @@
 - rule:
     type: label
     label: NewApiVersionRequired
-    onLabeledComments: "The automation detected this Pull Request introduces breaking changes to an existing API version and hence it added the <code>NewApiVersionRequired</code> label. This means you cannot proceed with merging this PR until you complete one of the following action items:<br/><br/>- A) Submit a new PR instead of this one, or modify this PR, so that it introduces a new API version instead of introducing breaking changes to an existing API version. The automation will remove the label once it detects there are no more breaking changes.<br/>- B) OR you can request an approval of the breaking changes, get it reviewed, and approved. The reviewer will add <code>Approved-BreakingChange</code> label if they approve.<br/><br/>For additional guidance, please see https://aka.ms/NewApiVersionRequired<br/>  "
+    onLabeledComments: >-
+      The automation detected that this PR introduces breaking changes to an existing API version and hence it added the `NewApiVersionRequired` label. This means you cannot proceed with merging this PR until you complete one of the following action items:
+      <br/><br/>
+      **ACTION ITEM** for you:
+      <br/><br/>
+      - A) Submit a new PR instead of this one, or modify this PR, so that it introduces a new API version instead of introducing breaking changes to an existing API version. The automation will remove the label once it detects there are no more breaking changes.<br/>
+      - B) OR you can request an approval of the breaking changes, get it reviewed, and approved. The reviewer will add `Approved-BreakingChange` label if they approve.
+      <br/><br/>
+      For more information, please refer to https://aka.ms/specprreview
+    onLabeledRemoveLabels:
+        - WaitForARMFeedback
+    onLabeledAddLabels:
+        - ARMChangesRequested
 
 - rule:
     type: label
@@ -105,7 +143,7 @@
 - rule:
     type: label
     label: ARMChangesRequested
-    onLabeledComments: "Please ensure to respond feedbacks from the ARM API reviewer. When you are ready to continue the ARM API review, please remove `ARMChangesRequested`"
+    onLabeledComments: "Please ensure to respond to feedback from the ARM API reviewer. When you are ready to continue the ARM API review, please remove the `ARMChangesRequested` label. This will notify the reviewer to have another look."
     onLabeledRemoveLabels:
         - WaitForARMFeedback
 
@@ -116,7 +154,6 @@
     onLabeledAddLabels:
         - WaitForARMFeedback
       
-        
 - rule:
     type: unlabeled
     label: ARMChangesRequested

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -2,15 +2,13 @@
 - rule:
     type: checkbox
     keywords:
-      - "WaitForARMFeedback"
+      - "ARMReview"
     booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit||BreakingChangeReviewRequired||NewApiVersionRequired)"
     onCheckedLabels:
       - WaitForARMFeedback
       - ARMReview
     onCheckedComments: >-
-      Hi @${PRAuthor}!<br/>
-      <br/>
-      The automation detected that in the `ARM API Review Checklist` you denoted that this PR requires an ARM review. As a result, the automation labelled your PR with `ARMReview` and `WaitForARMFeedback` labels. A notification email will be sent out shortly to notify ARM review board (armapireview@microsoft.com) to review your PR.
+      Hi @${PRAuthor}! The automation detected that in the `ARM API Review Checklist` you denoted that this PR requires an ARM review. As a result, the automation labelled your PR with `ARMReview` and `WaitForARMFeedback` labels. The ARM review board will review your PR in first-come, first-served manner. Your PR is going to be added to one of the ARM PR review queues. You can see the queues here: [US + China](https://github.com/Azure/azure-rest-api-specs/pulls?q=is%3Aopen+is%3Apr+label%3AWaitForARMFeedback+-label%3AIDCDevDiv+draft%3Afalse) and [IDC DevDiv](https://github.com/Azure/azure-rest-api-specs/pulls?q=is%3Aopen+is%3Apr+label%3AWaitForARMFeedback+label%3AIDCDevDiv+draft%3Afalse). If you are not getting a review in a timely manner, you can [mailto: ARM review board](mailto:armapireview@microsoft.com).
       <br/><br/>
       **ACTION ITEM** for you: wait until either `ARMChangesRequested` or `ARMSignedOff` labels are added to your PR by an ARM review board member.
       <br/><br/>

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -72,6 +72,11 @@
       - B) OR you can request an approval of the breaking changes, get it reviewed, and approved. The reviewer will add `Approved-BreakingChange` label if they approve.
       <br/><br/>
       For more information, please refer to https://aka.ms/specprreview
+
+- rule:
+    type: label
+    label: NewApiVersionRequired
+    booleanFilterExpression: "ARMReview"
     onLabeledRemoveLabels:
         - WaitForARMFeedback
     onLabeledAddLabels:


### PR DESCRIPTION
This is a PR made by the Azure SDK Engineering System team.

This PR improves the `workflow-bot` behavior when handling `NewApiVersionRequired` label.

This PR contributes to:
- https://github.com/Azure/azure-sdk-tools/issues/6076

and is a follow-up to:
- https://github.com/Azure/azure-rest-api-specs/pull/24058

## Changes made

- Now when somebody checkmarks the PR requires an ARM review, different set of labels will be added depending on if the `NewApiVersionRequired` label is present.
- Now when the `NewApiVersionRequired` label is added, appropriate other labels are added or removed.
- Improved the GitHub comments added by the `workflow-bot`.
- Improved the initial comment added to PRs touching ARM APIs.
- Updated the information about ARM review queue; now mentioning the PR review queues instead of email notifications, which have since been disabled. See [this comment thread](https://github.com/Azure/azure-rest-api-specs/pull/24083#discussion_r1200832979) for details.

## Future work

- Currently there is no easy way to remove the `ARMChangesRequested` label when `NewApiVersionRequired` label is removed, because there is only [`onUnlabeledAddLabels`](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps?path=private/openapi-kebab/src/bots/workflow/workflowBot.ts&version=GC9df1258de7cdcbd322cfc2ff15f4ef4f96998f9d&line=92&lineStartColumn=3&lineEndColumn=23&_a=contents) operation, but not `onUnlabeledRemoveLabels`.
- The label `BreakingChangeReviewRequired` may require similar treatment as the `NewApiVersionRequired` label, because these labels appear to be mutually exclusive, based on the [BreakingChangeRules.yml](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps?path=private/azure-rest-api-specs-pipeline/config/BreakingChangeRules.yml&version=GC0a9aa5e599c77ebca04b230ccc0933ae68dab3fa&_a=contents) and based on [their handling by the Summary task](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps?path=public/rest-api-specs-scripts/src/prSummary.ts&version=GC02e956adcdd563ab5e0f43e60cf1cd259669cb85&line=744&lineEnd=747&lineStartColumn=1&lineEndColumn=6&_a=contents).
- We might want to enforce rule execution order at some point. See [this comment](https://github.com/Azure/azure-rest-api-specs/pull/24083/files#r1199574602) for details.

## Testing done

Before deploying to production, I will test these changes on preproduction, per [these instructions](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/891/openapi-alps?anchor=testing-changes). I will report the result of testing here.
