### PR TITLE
Fix Python misspelling

### DIFF
--- a/specification/containerregistry/resource-manager/readme.md
+++ b/specification/containerregistry/resource-manager/readme.md
@@ -395,7 +395,7 @@ csharp:
   clear-output-folder: true
 ```
 
-## Pyhton
+## Python
 
 See configuration in [readme.python.md](./readme.python.md)
 

--- a/specification/mixedreality/resource-manager/readme.md
+++ b/specification/mixedreality/resource-manager/readme.md
@@ -187,7 +187,7 @@ csharp:
 
 ## Python
 
-See configuration in [readme.pyhton.md](./readme.python.md)
+See configuration in [readme.Python.md](./readme.python.md)
 
 ## Go
 

--- a/specification/msi/resource-manager/readme.md
+++ b/specification/msi/resource-manager/readme.md
@@ -110,7 +110,7 @@ swagger-to-sdk:
   - repo: azure-powershell
 ```
 
-## Pyhton
+## Python
 
 See configuration in [readme.python.md](./readme.python.md)
 

--- a/specification/subscription/resource-manager/readme.md
+++ b/specification/subscription/resource-manager/readme.md
@@ -149,9 +149,9 @@ swagger-to-sdk:
   - repo: azure-powershell
 ```
 
-## Pyhton
+## Python
 
-See configuration in [readme.pyhton.md](./readme.python.md)
+See configuration in [readme.Python.md](./readme.python.md)
 
 ## Go
 


### PR DESCRIPTION
Hi! 

I was reading through some of these specs and caught this small misspelling present in 4 files. 