### PR TITLE
`sql` @ `2022-11-01-preview` - fixing a data consistency issue

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2022-11-01-preview/ManagedDatabaseSensitivityLabels.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2022-11-01-preview/ManagedDatabaseSensitivityLabels.json
@@ -280,19 +280,7 @@
             "type": "string"
           },
           {
-            "name": "sensitivityLabelSource",
-            "in": "path",
-            "description": "The source of the sensitivity label.",
-            "required": true,
-            "type": "string",
-            "enum": [
-              "current",
-              "recommended"
-            ],
-            "x-ms-enum": {
-              "name": "SensitivityLabelSource",
-              "modelAsString": false
-            }
+            "$ref": "#/parameters/SensitivityLabelSourceParameter"
           },
           {
             "$ref": "../../../common/v1/types.json#/parameters/SubscriptionIdParameter"
@@ -360,18 +348,7 @@
             "type": "string"
           },
           {
-            "name": "sensitivityLabelSource",
-            "in": "path",
-            "description": "The source of the sensitivity label.",
-            "required": true,
-            "type": "string",
-            "enum": [
-              "current"
-            ],
-            "x-ms-enum": {
-              "name": "WritableSensitivityLabelSource",
-              "modelAsString": false
-            }
+            "$ref": "#/parameters/SensitivityLabelSourceParameter"
           },
           {
             "name": "parameters",
@@ -454,18 +431,7 @@
             "type": "string"
           },
           {
-            "name": "sensitivityLabelSource",
-            "in": "path",
-            "description": "The source of the sensitivity label.",
-            "required": true,
-            "type": "string",
-            "enum": [
-              "current"
-            ],
-            "x-ms-enum": {
-              "name": "WritableSensitivityLabelSource",
-              "modelAsString": false
-            }
+            "$ref": "#/parameters/SensitivityLabelSourceParameter"
           },
           {
             "$ref": "../../../common/v1/types.json#/parameters/SubscriptionIdParameter"
@@ -485,6 +451,73 @@
         "x-ms-examples": {
           "Deletes the sensitivity label of a given column in a managed database": {
             "$ref": "./examples/ManagedDatabaseColumnSensitivityLabelDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/columns/{columnName}/sensitivityLabels/recommended": {
+      "get": {
+        "tags": [
+          "ManagedDatabaseSensitivityLabels"
+        ],
+        "description": "Gets the sensitivity label recommendations for a given column",
+        "operationId": "ManagedDatabaseSensitivityLabels_GetRecommended",
+        "parameters": [
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/ResourceGroupParameter"
+          },
+          {
+            "name": "managedInstanceName",
+            "in": "path",
+            "description": "The name of the managed instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/DatabaseNameParameter"
+          },
+          {
+            "name": "schemaName",
+            "in": "path",
+            "description": "The name of the schema.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tableName",
+            "in": "path",
+            "description": "The name of the table.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "columnName",
+            "in": "path",
+            "description": "The name of the column.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the sensitivity label.",
+            "schema": {
+              "$ref": "#/definitions/SensitivityLabel"
+            }
+          },
+          "default": {
+            "description": "*** Error Responses: ***\n\n * 400 DatawarehouseDatabaseIsDeactivated - Could not execute Data Classification operation because the database is paused. Please resume it.\n\n * 400 SensitivityLabelSourceNameNotSupported - The specified sensitivity label source is not valid\n\n * 404 SubscriptionDoesNotHaveServer - The requested server was not found\n\n * 404 DatabaseDoesNotExist - User has specified a database name that does not exist on this server instance.\n\n * 404 SensitivityLabelsLabelNotFound - The specified sensitivity label could not be found\n\n * 404 SensitivityLabelsSchemaNotFound - The schema {0} could not be found\n\n * 404 SensitivityLabelsTableNotFound - The table {0} could not be found in schema {1}\n\n * 404 SensitivityLabelsColumnNotFound - The column {0} could not be found in table {2}.{1}\n\n * 501 SensitivityLabelRecommendedSourceNameNotSupported - 'Recommended' sensitivity label source is not supported yet\n\n * 501 SensitivityLabelRecommendedSourceNameNotSupported - 'Recommended' sensitivity label source is not supported yet"
+          }
+        },
+        "x-ms-examples": {
+          "Gets the sensitivity label of a given column in a managed database": {
+            "$ref": "./examples/ManagedDatabaseColumnSensitivityLabelGetRecommended.json"
           }
         }
       }
@@ -941,6 +974,20 @@
       "required": true,
       "type": "string",
       "x-ms-parameter-location": "method"
+    },
+    "SensitivityLabelSourceParameter": {
+      "name": "sensitivityLabelSource",
+      "in": "path",
+      "description": "The source of the sensitivity label.",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "current"
+      ],
+      "x-ms-enum": {
+        "name": "SensitivityLabelSource",
+        "modelAsString": false
+      }
     }
   },
   "securityDefinitions": {

--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2022-11-01-preview/examples/ManagedDatabaseColumnSensitivityLabelGetRecommended.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2022-11-01-preview/examples/ManagedDatabaseColumnSensitivityLabelGetRecommended.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "myRG",
+    "managedInstanceName": "myManagedInstanceName",
+    "databaseName": "myDatabase",
+    "schemaName": "dbo",
+    "tableName": "myTable",
+    "columnName": "myColumn",
+    "api-version": "2022-11-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myRG/providers/Microsoft.Sql/managedInstances/myManagedInstanceName/databases/myDatabase/schemas/dbo/tables/myTable/columns/myColumn/sensitivityLabels/recommended",
+        "name": "recommended",
+        "type": "Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels",
+        "properties": {
+          "schemaName": "dbo",
+          "tableName": "myTable",
+          "columnName": "myColumn",
+          "informationType": "PhoneNumber",
+          "informationTypeId": "d22fa6e9-5ee4-3bde-4c2b-a409604c4646",
+          "labelId": "bf91e08c-f4f0-478a-b016-25164b2a65ff",
+          "labelName": "PII",
+          "rank": "Low"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The Enums for this parameter having conflicting values (`current` in 2 of 3 operations, and `current` and `recommended` in the other) mean that these conflict in downstream operations.

Since it appears that `recommended` is folded into this method to keep this DRY - I've opened this PR intentionally opted to split this out into a `GetRecommended` method which matches the pattern seen in similar APIs.

Fixes https://github.com/hashicorp/pandora/pull/2557/files#diff-c6309cb7c86d8a927d172057baa8ccc0a5381600b6228e4960994d642895a055L17-R22