### PR TITLE
Simplify PR GH ARM comment template `control_plane_template.md`; simplify workflow bot rules `comment.yml`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
@@ -1,49 +1,41 @@
-## ARM API Information (Control Plane)
+# ARM (Control Plane) API Specification Update Pull Request 
 
-### Changelog
-Add a changelog entry for this PR by answering the following questions:
-  1. What's the purpose of the update?
-      - [ ] new service onboarding
-      - [ ] new API version
-      - [ ] update existing version for new feature
-      - [ ] update existing version to fix swagger quality issue in s360
-      - [ ] Other, please clarify
-  2. When are you targeting to deploy the new service/feature to public regions? Please provide the date or, if the date is not yet available, the month.
-  3. When do you expect to publish the swagger? Please provide date or, the the date is not yet available, the month.
-  4. By default, Azure SDKs of all languages (.NET/Python/Java/JavaScript for both management-plane SDK and data-plane SDK, Go for management-plane SDK only ) MUST be refreshed with/after swagger of new version is published. If you prefer NOT to refresh any specific SDK language upon swagger updates in the current PR, please leave details with justification here.
+## Purpose of this PR
 
-### Contribution checklist (MS Employees Only):
-- [ ] I commit to follow the [Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy) of "no breaking changes"
-- [ ] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
-- [ ] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)
+What's the purpose of this PR? Check all that apply. This is **mandatory**!
 
-If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).
+  - [ ] New API version. (Such PR should have been generated with [OpenAPI Hub](https://aka.ms/openapihub), per [this wiki doc](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/208/OpenAPI-Hub-Adding-new-API-version).)
+  - [ ] Update existing version for new feature. (This is applicable only when you are revising a private preview API version.)
+  - [ ] Update existing version to fix swagger quality issues in S360.
+  - [ ] Other, please clarify:
+    - _edit this with your clarification_
 
-### ARM API Review Checklist
+## Due diligence checklist
 
-> **Applicability**: :warning:
->
-> If your changes encompass only the following scenarios, you should SKIP this section, as these scenarios do not require ARM review.
-> - Change to data plane APIs
-> - Adding new properties
-> - All removals
+To merge this PR, you **must** go through the following checklist and confirm you understood 
+and followed the instructions by checking all the boxes:
 
-Otherwise your PR may be subject to ARM review requirements. Complete the following:
-- [ ] Check this box if any of the following apply to the PR so that the label "ARMReview" and "WaitForARMFeedback" will be added by bot to kick off ARM API Review.  Missing to check this box in the following scenario may result in delays to the ARM manifest review and deployment.
-  - Adding a new service
-  - Adding new API(s)
-  - Adding a new API version
-    -[ ] To review changes efficiently, ensure you copy the existing version into the new directory structure for first commit and then push new changes, including version updates, in separate commits. You can use OpenAPIHub to initialize the PR for adding a new version. For more details refer to the [wiki](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/208/OpenAPI-Hub-Adding-new-API-version). Note that this doesn't apply if you are trying to merge a PR that was previously in the private repository.
+- [ ] I have reviewed the general guidance on the spec PR review process: https://aka.ms/specprreview.
+- [ ] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data-plane related specifications.
+- [ ] I commit to follow the [Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy).
+- [ ] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including
+  [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and
+  [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md) (estimated time: 4 hours).  
+  I understand this is required before I can request review from an ARM API Review board.
 
-- [ ] Ensure you've reviewed following [guidelines](https://aka.ms/rpguidelines) including [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md). Estimated time (4 hours). This is required before you can request review from ARM API Review board.
+### ARM API changes review
 
-- [ ] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM oncall for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them.
+- If you want for the ARM team to review this PR, you must add the `ARMReview` label. 
+- The automation may automatically add the `ARMReview` label, if appropriate.  
+  If this happens, proceed according to guidance given in GitHub comments also added by the automation.
 
-### Breaking Change Review Checklist
-If you have any breaking changes as defined in the [Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy/), request approval from the Breaking Change Review Board.
+### Breaking change review
 
-**Action**: to initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate). Additional details on the process and office hours are on the [Breaking Change Wiki](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-core-pm-and-design/trusted-platform-pm-karimb/service-lifecycle-and-actions-team/service-lifecycle-actions-team/apex/media/overview_breakingchanges).
+If you have any breaking changes as defined in the [Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy/), 
+follow the process outlined in the [High-level Breaking Change Process doc](https://aka.ms/breakingchangesprocess#high-level-breaking-change-process).
+      
+## Getting help
 
-NOTE: To update API(s) in public preview for over 1 year (refer to [Retirement of Previews](http://aka.ms/aprwiki))
-
-Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).
+- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
+  and https://aka.ms/ci-fix.
+- For additional help, see https://aka.ms/azsdk/support/spectools.

--- a/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
@@ -5,7 +5,7 @@
 What's the purpose of this PR? Check all that apply. This is **mandatory**!
 
   - [ ] New API version. (Such PR should have been generated with [OpenAPI Hub](https://aka.ms/openapihub), per [this wiki doc](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/208/OpenAPI-Hub-Adding-new-API-version).)
-  - [ ] Update existing version for new feature. (This is applicable only when you are revising a private preview API version.)
+  - [ ] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
   - [ ] Update existing version to fix swagger quality issues in S360.
   - [ ] Other, please clarify:
     - _edit this with your clarification_

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -1,20 +1,55 @@
 ---
 - rule:
-    type: checkbox
-    keywords:
-      - "WaitForARMFeedback"
-    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit||BreakingChangeReviewRequired)"
-    onCheckedLabels:
-      - WaitForARMFeedback
-      - ARMReview
-    onCheckedComments: "Hi, @${PRAuthor} your PR are labelled with <b> WaitForARMFeedback</b>. A notification email will be sent out shortly afterwards to notify ARM review board(armapireview@microsoft.com)."
+    type: label
+    label: BreakingChangeReviewRequired
+    booleanFilterExpression: "!(Approved-OkToMerge)"
+    onLabeledComments: >-
+      Hi @${PRAuthor}! The automation detected breaking changes in this pull request.
+      As a result, it added the `BreakingChangeReviewRequired` label.
+      <br/><br/>
+      You cannot proceed with merging this PR until you complete one of the following action items:
+      <br/><br/>
+      **ACTION ITEM ALTERNATIVE A**: Fix the breaking change. <br/>
+      Please consult the documentation provided in the relevant validation failures.
+      <br/><br/>
+      **ACTION ITEM ALTERNATIVE B**: Request approval. <br/>
+      Alternatively, if you cannot fix the breaking changes, then you can request an approval for them.
+      Please follow the process described in the
+      [High-level Breaking Change Process doc](https://aka.ms/breakingchangesprocess#high-level-breaking-change-process).
+      <br/><br/>
+      **ACTION ITEM ALTERNATIVE C**: Report false positive. <br/>
+      If you think there are no breaking changes, 
+      i.e. the validation should pass yet it fails, 
+      then please explain why in a PR comment and @ the PR assignee.
 
 - rule:
     type: label
-    label: BreakingChangeReviewRequired
-    variables:
-        openapiHub: https://portal.azure-devex-tools.com
-    onLabeledComments: "Hi @${PRAuthor}, one or multiple breaking change(s) is detected in your PR. Please check out the breaking change(s), and provide business justification in the PR comment and @ PR assignee why you must have these change(s), and how external customer impact can be mitigated. Please ensure to follow [breaking change policy](https://aka.ms/AzBreakingChangesPolicy) to request breaking change review and approval before proceeding swagger PR review. </br>**Action**: To initiate an evaluation of the breaking change, create a new intake using the [template for breaking changes](https://aka.ms/Breakingchangetemplate). Addition details on the process and office hours are on the [Breaking change Wiki](https://dev.azure.com/msazure/AzureWiki/_wiki/wikis/AzureWiki.wiki/37684/Breaking-Changes).</br> If you want to know the production traffic statistic, please see [ARM Traffic statistic](${openapiHub}/api/pr/query-traffic?pr=${owner}/${repo}/${PRNumber}&days=5). </br> If you think it is false positive breaking change, please provide the reasons in the PR comment, report to Swagger Tooling Team via https://aka.ms/swaggerfeedback. </br> **Note**: To avoid breaking change, you can refer to [Shift Left Solution](https://aka.ms/shiftleft) for detecting breaking change in early phase at your service code repository."
+    label: NewApiVersionRequired
+    booleanFilterExpression: "!(Approved-OkToMerge)"
+    onLabeledComments: >-
+      Hi @${PRAuthor}! The automation detected this pull request introduces changes
+      to at least one existing API version that violate Azure's versioning policy. 
+      To comply with the policy, these changes must be made in a new API version.
+      As a result, the automation added the `NewApiVersionRequired` label.
+      <br/><br/> 
+      You cannot proceed with merging this PR until you complete one of the following action items:
+      <br/><br/>
+      **ACTION ITEM ALTERNATIVE A**: Introduce a new API version. <br/> 
+      Submit a new PR instead of this one, or modify this PR, 
+      so that it adds a new API version instead of introducing changes to existing API versions.
+      <br/><br/>
+      **ACTION ITEM ALTERNATIVE B**: Request approval. <br/>
+      Alternatively, if you cannot avoid modifying existing API versions, 
+      then you can request an approval for them.
+      Please follow the process described in the
+      [High-level Breaking Change Process doc](https://aka.ms/breakingchangesprocess#high-level-breaking-change-process).
+      <br/><br/>
+      **ACTION ITEM ALTERNATIVE C**: Report false positive. <br/>
+      If you think there are no changes in existing API version, 
+      i.e. there should be no `NewApiVersionRequired` label,
+      then please explain why in a PR comment and @ the PR assignee.
+      <br/><br/>   
+      For additional guidance, please see https://aka.ms/NewApiVersionRequired
 
 - rule:
     type: label
@@ -24,22 +59,29 @@
 - rule:
     type: label
     label: "CI-MissingBaseCommit"
-    onLabeledComments: "Hi, @${PRAuthor}, For review efficiency consideration, when creating a new api version, it is required to place API specs of the base version in the first commit, and push new version updates into successive commits. You can use OpenAPIHub to initialize the PR for adding a new version. For more details refer to the [wiki](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/208/OpenAPI-Hub-Adding-new-API-version). Or you could onboard [API spec pipeline](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/606/Enable-API-Spec-Pipeline)"
+    onLabeledComments: >-
+      Hi @${PRAuthor}! For review efficiency consideration, 
+      when creating a new API version, it is required to place API specs of the 
+      base version in the first commit, and push new version updates into successive commits. 
+      You can use OpenAPIHub to initialize the PR for adding a new version. <br/>
+      For more details refer to the [wiki](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/208/OpenAPI-Hub-Adding-new-API-version).
 
 - rule:
     type: label
     repoAllowList:
       - Azure/azure-rest-api-specs-pr
     variables:
-      openapiHub: https://portal.azure-devex-tools.com
+      openapiHub: https://aka.ms/openapihub
       to: Azure/azure-rest-api-specs/main
     label: Approved-OkToMerge
-    onLabeledComments: "Hi @${PRAuthor},Your PR is approved. Congratulations. </br>  <li> Since your PR is in private repo (azure-rest-api-specs-pr),  there won’t be PR merge. If you want to publish the PR to public repo (Azure/azure-rest-api-specs) and get it merged, pls use [OpenAPIHub Publish PR](${openapiHub}/tools/publishpullrequest?pr=${owner}/${repo}/${PRNumber}&to=${to}).</li> <li> For further guidance on how to proceed.  Please refer to this [wiki](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/205/RP-Scenarios-to-Contribute-to-Swagger?anchor=**public-repository-vs.-private-repository**)</li>"
-
-- rule:
-    type: label
-    label: NewApiVersionRequired
-    onLabeledComments: "The automation detected this Pull Request introduces breaking changes to an existing API version and hence it added the <code>NewApiVersionRequired</code> label. This means you cannot proceed with merging this PR until you complete one of the following action items:<br/><br/>- A) Submit a new PR instead of this one, or modify this PR, so that it introduces a new API version instead of introducing breaking changes to an existing API version. The automation will remove the label once it detects there are no more breaking changes.<br/>- B) OR you can request an approval of the breaking changes, get it reviewed, and approved. The reviewer will add <code>Approved-BreakingChange</code> label if they approve.<br/><br/>For additional guidance, please see https://aka.ms/NewApiVersionRequired<br/>  "
+    onLabeledComments: >-
+      Hi @${PRAuthor}! Your PR is approved. Congratulations. :partying_face::rocket: </br>
+      <li>If this PR is targeting 'main' branch, then it cannot be merged, as azure-rest-api-specs-pr repo 'main' branch is mirrored from azure-rest-api-specs 'main' branch.
+      If you want to publish the PR to the public repo (Azure/azure-rest-api-specs) 'main' branch, 
+      please use [OpenAPIHub Publish PR](${openapiHub}/tools/publishpullrequest?pr=${owner}/${repo}/${PRNumber}&to=${to}).
+      </li> 
+      <li>For further guidance on how to proceed please refer to this [wiki doc](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/205/RP-Scenarios-to-Contribute-to-Swagger?anchor=**public-repository-vs.-private-repository**).
+      </li>
 
 - rule:
     type: label
@@ -60,13 +102,15 @@
     type: label
     label: CI-FixRequiredOnFailure
     onLabeledComments: >- 
-      Hi @${PRAuthor}, Your PR has some issues. Please fix the CI sequentially by following the order of `Avocado, semantic validation, model validation, breaking change, lintDiff`. If you have any questions, please post your questions in this channel https://aka.ms/swaggersupport. 
+      Hi @${PRAuthor}! Your PR has some issues. Please fix the CI issues, **if present**, in following order: `Avocado, SemanticValidation, ModelValidation, Breaking Change, LintDiff`.
+      <br/>
       <table><tr><th>Task</th><th>How to fix</th><th>Priority</th></tr>
       <tr><td>Avocado</td><td>[Fix-Avocado](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/ci-fix.md#avocado)</td><td>High</td></tr>
-      <tr><td>Semantic validation</td><td>[Fix-SemanticValidation-Error](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/ci-fix.md#semantic-validation)</td><td>High</td></tr>
-      <tr><td>Model validation</td><td>[Fix-ModelValidation-Error](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/ci-fix.md#model-validation)</td><td>High</td></tr>
-      <tr><td>LintDiff</td><td>[Fix-LintDiff](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/ci-fix.md#linter-validation)</td><td>high</td></tr></table> 
-      If you need further help, please feedback via [swagger feedback](https://aka.ms/swaggerfeedback).
+      <tr><td>Semantic Validation</td><td>[Fix-SemanticValidation-Error](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/ci-fix.md#semantic-validation)</td><td>High</td></tr>
+      <tr><td>Model Validation</td><td>[Fix-ModelValidation-Error](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/ci-fix.md#model-validation)</td><td>High</td></tr>
+      <tr><td>LintDiff</td><td>[Fix-LintDiff](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/ci-fix.md#lintdiff-validation)</td><td>High</td></tr></table>
+      <br/>
+      If you need further help, please reach out on the Teams channel [aka.ms/azsdk/support/specreview-channel](https://aka.ms/azsdk/support/specreview-channel).
 
 - rule:
     type: label
@@ -76,7 +120,7 @@
 - rule:
     type: PROpen
     variables:
-      openapiHub: https://portal.azure-devex-tools.com
+      openapiHub: https://aka.ms/openapihub
     keywords:
       - "I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow."
     onOpenedComments: "Hi, @${PRAuthor} Thanks for your PR. I am workflow bot for review process. Here are some small tips. </br> <li> Please ensure to do self-check against checklists in first PR comment.</li> <li> PR assignee is the person auto-assigned and responsible for your current PR reviewing and merging. </li>   <li> For specs comparison cross API versions,  Use [API Specs Comparison Report Generator](${openapiHub}/tools/diff?pr=${owner}/${repo}/${PRNumber})</li>  <li> If there is CI failure(s), to fix CI error(s) is mandatory for PR merging; or you need to provide justification in PR comment for explanation. [How to fix?](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/ci-fix.md)</li></br> Any feedback about review process or workflow bot, pls contact swagger and tools team. vscswagger@microsoft.com"
@@ -84,10 +128,17 @@
 - rule:
     type: checkbox
     keywords:
-      - "update existing version to fix swagger quality issue in s360"
+      - "Update existing version to fix swagger quality issues in S360"
     onCheckedLabels:
       - FixS360
-      
+
+- rule:
+    type: label
+    label: ARMReview
+    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge)"
+    onLabeledAddLabels:
+        - WaitForARMFeedback
+
 - rule:
     type: label
     label: WaitForARMFeedback
@@ -105,7 +156,14 @@
 - rule:
     type: label
     label: ARMChangesRequested
-    onLabeledComments: "Please ensure to respond feedbacks from the ARM API reviewer. When you are ready to continue the ARM API review, please remove `ARMChangesRequested`"
+    onLabeledComments: >-
+      Please address or respond to feedback from the ARM API reviewer.
+      When you are ready to continue the ARM API review, please remove the `ARMChangesRequested` label.
+      This will notify the reviewer to have another look. <br/>
+      If the feedback provided needs further discussion, please use this Teams channel to post your questions - 
+      https://aka.ms/azsdk/support/specreview-channel. <br/>
+      Please indicate that this is an ARM-related question in the title of your post by including "[ARM Query]"
+      in the title.
     onLabeledRemoveLabels:
         - WaitForARMFeedback
 
@@ -115,12 +173,10 @@
     booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
     onLabeledAddLabels:
         - WaitForARMFeedback
-      
-        
+
 - rule:
     type: unlabeled
     label: ARMChangesRequested
     onUnlabeledAddLabels:
         - WaitForARMFeedback
         - ARMReview
-


### PR DESCRIPTION
This is a PR made by the Azure SDK Engineering System team.

This PR is related to:
- openapi-alps [Pull Request 474083](https://devdiv.visualstudio.com/DevDiv/_git/openapi-alps/pullrequest/474083): Rewrite `isOkToAddWaitForARMFeedback` to be `getArmReviewWorkflowLabelToAdd`, properly adding `WaitForARMFeedback` or `ARMChangesRequested`.

### Changes made

1. Simplified the control plane PR comment template. Got rid of a lot of information that is most likely obsolete or unused. Fixed some obsolete links. Notably, got rid of the checkbox that resulted in addition of `WaitForArmFeedback` label. Instead, added instructions to manually add the `ARMReview` label.
2. Simplified related workflow bot rules, deleting some, and updating GitHub comments added by others.
    - Notably, added this rule:
      ``` yaml
      - rule:
          type: label
          label: ARMReview
          booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge)"
          onLabeledAddLabels:
              - WaitForARMFeedback
      ```
      Based on [this discussion](https://github.com/Azure/azure-rest-api-specs/pull/24227#discussion_r1228828468).

### Testing done

Deployed changes in this PR to `main` branch of the test repo `test-repo-billy`, via this PR:
- https://github.com/test-repo-billy/azure-rest-api-specs/pull/2931

Then submitted a PR against it:
- https://github.com/test-repo-billy/azure-rest-api-specs/pull/2932

Then I verified that:
- a new ARM PR description template is used and all the links work;
- manual addition of `ARMReview` label results in workflow-bot adding `WaitForARMFeedback` label;
- manual checkmarking the relevant checkbox results in addition of `FixS360` label;
- manual addition of `BreakingChangeReviewRequired` label results in he new workflow-bot comment being added.