### PR TITLE
Added a wrapper script for writer to generate sdk

### DIFF
--- a/eng/scripts/TypeSpec-Generate-Sdk.ps1
+++ b/eng/scripts/TypeSpec-Generate-Sdk.ps1
@@ -1,0 +1,35 @@
+[CmdletBinding()]
+param (
+  [Parameter(Position = 0)]
+  [ValidateNotNullOrEmpty()]
+  [string] $SdkRepoRootDirectory,
+  [Parameter(Position = 1)]
+  [string] $TypeSpecProjectDirectory, # A directory of `tspconfig.yaml` or a remoteUrl of `tspconfig.yaml`
+  [Parameter(Position = 2)]
+  [string] $CommitHash,
+  [Parameter(Position = 3)]
+  [string] $RepoUrl
+)
+
+if ($TypeSpecProjectDirectory -contains ".") {
+  $TypeSpecProjectDirectory = Resolve-Path $TypeSpecProjectDirectory
+}
+
+try {
+  Push-Location $SdkRepoRootDirectory
+  $commonScript = Join-Path . "eng/common/scripts/TypeSpec-Project-Process.ps1"
+  if (Test-Path $commonScript) {
+    . $commonScript -TypeSpecProjectDirectory $TypeSpecProjectDirectory -CommitHash $CommitHash -RepoUrl $RepoUrl
+    if ($LASTEXITCODE) {
+      exit $LASTEXITCODE
+    }
+  }
+  else {
+    Write-Error "Cannot find $commonScript"
+  }
+}
+finally {
+  Pop-Location
+}
+
+exit 0

--- a/eng/scripts/TypeSpec-Generate-Sdk.ps1
+++ b/eng/scripts/TypeSpec-Generate-Sdk.ps1
@@ -4,7 +4,7 @@ param (
   [ValidateNotNullOrEmpty()]
   [string] $SdkRepoRootDirectory,
   [Parameter(Position = 1)]
-  [string] $TypeSpecProjectDirectory, # A directory of `tspconfig.yaml` or a remoteUrl of `tspconfig.yaml`
+  [string] $TypeSpecProjectDirectory = ".", # A directory of `tspconfig.yaml` or a remoteUrl of `tspconfig.yaml`
   [Parameter(Position = 2)]
   [string] $CommitHash,
   [Parameter(Position = 3)]

--- a/eng/scripts/TypeSpec-Generate-Sdk.ps1
+++ b/eng/scripts/TypeSpec-Generate-Sdk.ps1
@@ -25,7 +25,7 @@ try {
     }
   }
   else {
-    Write-Error "Cannot find $commonScript"
+    Write-Error "Cannot find $commonScript at $SdkRepoRootDirectory"
   }
 }
 finally {


### PR DESCRIPTION
- for new sdk project, the writer should input `CommitHash` and `RepoUrl` in order to create `tsp-location.yaml`.
- for existed sdk project, the writer can only input local `TypeSpecProjectDirectory` to re-generate sdk based on local type specs.

@weshaggard @m-nash , please review this PR.