### PR TITLE
Samiakamal microsoft  containerinstance microsoft.container instance 2023 05 01

### DIFF
--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/stable/2023-05-01/containerInstance.json
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/stable/2023-05-01/containerInstance.json
@@ -2325,7 +2325,6 @@
       },
       "required": [
         "vaultBaseUrl",
-        "keyName",
         "keyVersion"
       ]
     },

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/stable/2023-05-01/containerInstance.json
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/stable/2023-05-01/containerInstance.json
@@ -2325,7 +2325,7 @@
       },
       "required": [
         "vaultBaseUrl",
-        "KeyName"
+        "keyName"
       ]
     },
     "InitContainerDefinition": {

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/stable/2023-05-01/containerInstance.json
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/stable/2023-05-01/containerInstance.json
@@ -2325,7 +2325,7 @@
       },
       "required": [
         "vaultBaseUrl",
-        "keyVersion"
+        "KeyName"
       ]
     },
     "InitContainerDefinition": {


### PR DESCRIPTION
EncryptionProperties.KeyVersion is no longer a required property. ACI will use the latest version of the key for encryption.
When a new version of the key is generated, ACI will reencrypt the customer data with the latest version.