### PR TITLE
[TypeSpec] Suppress "documentation-required" lint rule

### DIFF
--- a/specification/cognitiveservices/AnomalyDetector/main.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/main.tsp
@@ -51,6 +51,5 @@ model AnomalyDetectorApiKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-S
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next update"
 enum APIVersion {
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next update"
   v1_1: "v1.1",
 }

--- a/specification/cognitiveservices/AnomalyDetector/main.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/main.tsp
@@ -49,7 +49,7 @@ namespace AnomalyDetector;
 @doc("The secret key for your Azure Cognitive Services subscription.")
 model AnomalyDetectorApiKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next update"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 enum APIVersion {
   v1_1: "v1.1",
 }

--- a/specification/cognitiveservices/AnomalyDetector/main.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/main.tsp
@@ -49,6 +49,8 @@ namespace AnomalyDetector;
 @doc("The secret key for your Azure Cognitive Services subscription.")
 model AnomalyDetectorApiKeyAuth is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next update"
 enum APIVersion {
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next update"
   v1_1: "v1.1",
 }

--- a/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
@@ -8,6 +8,7 @@ using Azure.Core;
 
 namespace AnomalyDetector.Multivariate;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 @doc("Field that indicates how missing values will be filled.")
 enum FillNAMethod {
   "Previous",
@@ -17,6 +18,7 @@ enum FillNAMethod {
   "Fixed",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 enum MultivariateBatchDetectionStatus {
   Created: "CREATED",
   Running: "RUNNING",
@@ -32,11 +34,13 @@ enum DataSchema {
   "MultiTable",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 enum AlignMode {
   "Inner",
   "Outer",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 enum ModelStatus {
   @doc("The model has been created. Training has been scheduled but not yet started.")
   Created: "CREATED",

--- a/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
@@ -8,7 +8,7 @@ using Azure.Core;
 
 namespace AnomalyDetector.Multivariate;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Field that indicates how missing values will be filled.")
 enum FillNAMethod {
   "Previous",
@@ -18,7 +18,7 @@ enum FillNAMethod {
   "Fixed",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum MultivariateBatchDetectionStatus {
   Created: "CREATED",
   Running: "RUNNING",
@@ -34,13 +34,13 @@ enum DataSchema {
   "MultiTable",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum AlignMode {
   "Inner",
   "Outer",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum ModelStatus {
   @doc("The model has been created. Training has been scheduled but not yet started.")
   Created: "CREATED",

--- a/specification/cognitiveservices/AnomalyDetector/univariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/univariate/models.tsp
@@ -8,7 +8,7 @@ using Azure.Core;
 
 namespace AnomalyDetector.Univariate;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum ImputeMode {
   Auto: "auto",
   Previous: "previous",
@@ -18,7 +18,7 @@ enum ImputeMode {
   NotFill: "notFill",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum AnomalyDetectorErrorCodes {
   "InvalidCustomInterval",
   "BadArgument",
@@ -33,7 +33,7 @@ enum AnomalyDetectorErrorCodes {
   "InvalidImputeFixedValue",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum TimeGranularity {
   Yearly: "yearly",
   Monthly: "monthly",

--- a/specification/cognitiveservices/AnomalyDetector/univariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/univariate/models.tsp
@@ -8,6 +8,7 @@ using Azure.Core;
 
 namespace AnomalyDetector.Univariate;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 enum ImputeMode {
   Auto: "auto",
   Previous: "previous",
@@ -17,6 +18,7 @@ enum ImputeMode {
   NotFill: "notFill",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 enum AnomalyDetectorErrorCodes {
   "InvalidCustomInterval",
   "BadArgument",
@@ -31,6 +33,7 @@ enum AnomalyDetectorErrorCodes {
   "InvalidImputeFixedValue",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 enum TimeGranularity {
   Yearly: "yearly",
   Monthly: "monthly",

--- a/specification/cognitiveservices/ContentSafety/main.tsp
+++ b/specification/cognitiveservices/ContentSafety/main.tsp
@@ -28,7 +28,7 @@ https://<resource-name>.cognitiveservices.azure.com).
 @doc("Analyze harmful content")
 namespace ContentSafety;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next update"
 enum Versions {
   @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2023_04_30_Preview: "2023-04-30-preview",

--- a/specification/cognitiveservices/ContentSafety/main.tsp
+++ b/specification/cognitiveservices/ContentSafety/main.tsp
@@ -28,7 +28,7 @@ https://<resource-name>.cognitiveservices.azure.com).
 @doc("Analyze harmful content")
 namespace ContentSafety;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next update"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 enum Versions {
   @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2023_04_30_Preview: "2023-04-30-preview",

--- a/specification/cognitiveservices/ContentSafety/main.tsp
+++ b/specification/cognitiveservices/ContentSafety/main.tsp
@@ -28,6 +28,7 @@ https://<resource-name>.cognitiveservices.azure.com).
 @doc("Analyze harmful content")
 namespace ContentSafety;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 enum Versions {
   @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2023_04_30_Preview: "2023-04-30-preview",

--- a/specification/cognitiveservices/ContentSafety/models.tsp
+++ b/specification/cognitiveservices/ContentSafety/models.tsp
@@ -6,7 +6,7 @@ using TypeSpec.Rest;
 
 namespace ContentSafety;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Text analyze category")
 enum TextCategory {
   Hate,
@@ -15,7 +15,7 @@ enum TextCategory {
   Violence,
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Image analyze category")
 enum ImageCategory {
   Hate,

--- a/specification/cognitiveservices/ContentSafety/models.tsp
+++ b/specification/cognitiveservices/ContentSafety/models.tsp
@@ -6,6 +6,7 @@ using TypeSpec.Rest;
 
 namespace ContentSafety;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 @doc("Text analyze category")
 enum TextCategory {
   Hate,
@@ -14,6 +15,7 @@ enum TextCategory {
   Violence,
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy spec"
 @doc("Image analyze category")
 enum ImageCategory {
   Hate,

--- a/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.request.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.request.tsp
@@ -46,7 +46,7 @@ model PatientInfo {
   clinicalInfo?: ClinicalCodedElement[];
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("The patient's sex.")
 enum PatientInfoSex {
   Female: "female",
@@ -54,7 +54,7 @@ enum PatientInfoSex {
   Unspecified: "unspecified",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("The type of the patient document, such as 'note' (text document) or 'fhirBundle' (FHIR JSON document).")
 enum DocumentType {
   Note: "note",
@@ -63,7 +63,7 @@ enum DocumentType {
   GenomicSequencing: "genomicSequencing",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("The type of the clinical document.")
 enum ClinicalDocumentType {
   Consultation: "consultation",
@@ -76,7 +76,7 @@ enum ClinicalDocumentType {
   Pathology: "pathology",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("""
 The type of the content's source. 
 In case the source type is 'inline', the content is given as a string (for instance, text). 

--- a/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.request.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.request.tsp
@@ -46,6 +46,7 @@ model PatientInfo {
   clinicalInfo?: ClinicalCodedElement[];
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("The patient's sex.")
 enum PatientInfoSex {
   Female: "female",
@@ -53,6 +54,7 @@ enum PatientInfoSex {
   Unspecified: "unspecified",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("The type of the patient document, such as 'note' (text document) or 'fhirBundle' (FHIR JSON document).")
 enum DocumentType {
   Note: "note",
@@ -61,6 +63,7 @@ enum DocumentType {
   GenomicSequencing: "genomicSequencing",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("The type of the clinical document.")
 enum ClinicalDocumentType {
   Consultation: "consultation",
@@ -73,6 +76,7 @@ enum ClinicalDocumentType {
   Pathology: "pathology",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("""
 The type of the content's source. 
 In case the source type is 'inline', the content is given as a string (for instance, text). 

--- a/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.response.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.response.tsp
@@ -88,7 +88,7 @@ model TrialMatcherInferenceEvidence {
   ...InferenceEvidence;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next version"
 @doc("The status of the processing job.")
 enum JobStatus {
   NotStarted: "notStarted",

--- a/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.response.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.common/model.common.response.tsp
@@ -88,6 +88,7 @@ model TrialMatcherInferenceEvidence {
   ...InferenceEvidence;
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API"
 @doc("The status of the processing job.")
 enum JobStatus {
   NotStarted: "notStarted",

--- a/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/model.oncophenotype.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/model.oncophenotype.tsp
@@ -73,7 +73,7 @@ An indication whether to perform a preliminary step on the patient's documents t
 }
 
 
-
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("The type of the Onco Phenotype inference.")
 enum OncoPhenotypeInferenceType {
   TumorSite: "tumorSite",

--- a/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/model.oncophenotype.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/model.oncophenotype.tsp
@@ -73,6 +73,7 @@ An indication whether to perform a preliminary step on the patient's documents t
 }
 
 
+
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("The type of the Onco Phenotype inference.")
 enum OncoPhenotypeInferenceType {

--- a/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/model.oncophenotype.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.oncophenotype/model.oncophenotype.tsp
@@ -74,7 +74,7 @@ An indication whether to perform a preliminary step on the patient's documents t
 
 
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("The type of the Onco Phenotype inference.")
 enum OncoPhenotypeInferenceType {
   TumorSite: "tumorSite",

--- a/specification/cognitiveservices/HealthInsights/healthinsights.openapi/service.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.openapi/service.tsp
@@ -20,7 +20,7 @@ using TypeSpec.Versioning;
 
 namespace AzureHealthInsights;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next version"
 enum ApiVersion {
   @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2023_03_01_preview: "2023-03-01-preview"

--- a/specification/cognitiveservices/HealthInsights/healthinsights.openapi/service.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.openapi/service.tsp
@@ -20,7 +20,7 @@ using TypeSpec.Versioning;
 
 namespace AzureHealthInsights;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next version"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 enum ApiVersion {
   @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2023_03_01_preview: "2023-03-01-preview"

--- a/specification/cognitiveservices/HealthInsights/healthinsights.openapi/service.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.openapi/service.tsp
@@ -20,6 +20,7 @@ using TypeSpec.Versioning;
 
 namespace AzureHealthInsights;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API"
 enum ApiVersion {
   @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2023_03_01_preview: "2023-03-01-preview"

--- a/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/model.trialmatcher.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/model.trialmatcher.tsp
@@ -330,7 +330,7 @@ model ClinicalTrialResearchFacility {
   ...GeographicLocation;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Possible values for the Sex eligibility criterion as accepted by clinical trials, which indicates the sex of people who may participate in a clinical study.")
 enum ClinicalTrialAcceptedSex {
   All: "all",
@@ -338,7 +338,7 @@ enum ClinicalTrialAcceptedSex {
   Male: "male"
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Possible units for a person's age.")
 enum AgeUnit {
   Years: "years",
@@ -346,7 +346,7 @@ enum AgeUnit {
   Days: "days",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Possible phases of a clinical trial.")
 enum ClinicalTrialPhase {
   NotApplicable: "notApplicable",
@@ -357,7 +357,7 @@ enum ClinicalTrialPhase {
   Phase4: "phase4",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Possible study types of a clinical trial.")
 enum ClinicalTrialStudyType {
   Interventional: "interventional",
@@ -366,7 +366,7 @@ enum ClinicalTrialStudyType {
   PatientRegistries: "patientRegistries",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Possible recruitment status of a clinical trial.")
 enum ClinicalTrialRecruitmentStatus {
   UnknownStatus: "unknownStatus",
@@ -374,7 +374,7 @@ enum ClinicalTrialRecruitmentStatus {
   Recruiting: "recruiting",
   EnrollingByInvitation: "enrollingByInvitation",
 }
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Possible purposes of a clinical trial.")
 enum ClinicalTrialPurpose {
   NotApplicable: "notApplicable",
@@ -389,32 +389,32 @@ enum ClinicalTrialPurpose {
   Other: "other",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Possible sources of a clinical trial.")
 enum ClinicalTrialSource {
   Custom: "custom",
   ClinicaltrialsGov: "clinicaltrials.gov",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("`GeoJSON` type.")
 enum GeoJsonType {
   Feature: "Feature",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("`GeoJSON` geometry type.")
 enum GeoJsonGeometryType {
   Point: "Point",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("`GeoJSON` object sub-type.")
 enum GeoJsonPropertiesSubType {
   Circle: "Circle",
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("The type of the Trial Matcher inference.")
 enum TrialMatcherInferenceType {
   TrialEligibility: "trialEligibility",

--- a/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/model.trialmatcher.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/model.trialmatcher.tsp
@@ -330,6 +330,7 @@ model ClinicalTrialResearchFacility {
   ...GeographicLocation;
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("Possible values for the Sex eligibility criterion as accepted by clinical trials, which indicates the sex of people who may participate in a clinical study.")
 enum ClinicalTrialAcceptedSex {
   All: "all",
@@ -337,6 +338,7 @@ enum ClinicalTrialAcceptedSex {
   Male: "male"
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("Possible units for a person's age.")
 enum AgeUnit {
   Years: "years",
@@ -344,6 +346,7 @@ enum AgeUnit {
   Days: "days",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("Possible phases of a clinical trial.")
 enum ClinicalTrialPhase {
   NotApplicable: "notApplicable",
@@ -354,6 +357,7 @@ enum ClinicalTrialPhase {
   Phase4: "phase4",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("Possible study types of a clinical trial.")
 enum ClinicalTrialStudyType {
   Interventional: "interventional",
@@ -362,6 +366,7 @@ enum ClinicalTrialStudyType {
   PatientRegistries: "patientRegistries",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("Possible recruitment status of a clinical trial.")
 enum ClinicalTrialRecruitmentStatus {
   UnknownStatus: "unknownStatus",
@@ -369,7 +374,7 @@ enum ClinicalTrialRecruitmentStatus {
   Recruiting: "recruiting",
   EnrollingByInvitation: "enrollingByInvitation",
 }
-
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("Possible purposes of a clinical trial.")
 enum ClinicalTrialPurpose {
   NotApplicable: "notApplicable",
@@ -384,27 +389,32 @@ enum ClinicalTrialPurpose {
   Other: "other",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("Possible sources of a clinical trial.")
 enum ClinicalTrialSource {
   Custom: "custom",
   ClinicaltrialsGov: "clinicaltrials.gov",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("`GeoJSON` type.")
 enum GeoJsonType {
   Feature: "Feature",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("`GeoJSON` geometry type.")
 enum GeoJsonGeometryType {
   Point: "Point",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("`GeoJSON` object sub-type.")
 enum GeoJsonPropertiesSubType {
   Circle: "Circle",
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy API"
 @doc("The type of the Trial Matcher inference.")
 enum TrialMatcherInferenceType {
   TrialEligibility: "trialEligibility",

--- a/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/model.trialmatcher.tsp
+++ b/specification/cognitiveservices/HealthInsights/healthinsights.trialmatcher/model.trialmatcher.tsp
@@ -374,6 +374,7 @@ enum ClinicalTrialRecruitmentStatus {
   Recruiting: "recruiting",
   EnrollingByInvitation: "enrollingByInvitation",
 }
+
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("Possible purposes of a clinical trial.")
 enum ClinicalTrialPurpose {

--- a/specification/cognitiveservices/HealthInsights/service.tsp
+++ b/specification/cognitiveservices/HealthInsights/service.tsp
@@ -20,6 +20,7 @@ using TypeSpec.Versioning;
 
 namespace AzureHealthInsights;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 enum ApiVersion {
   v2023_03_01_preview: "2023-03-01-preview"
 }

--- a/specification/cognitiveservices/OpenAI.Inference/main.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/main.tsp
@@ -35,6 +35,7 @@ https://westus.api.cognitive.microsoft.com).
 @doc("Azure OpenAI APIs for completions and search")
 namespace Azure.OpenAI;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 enum ServiceApiVersions {
   @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2022_12_01: "2022-12-01",

--- a/specification/containerservice/Fleet.Management/fleet.tsp
+++ b/specification/containerservice/Fleet.Management/fleet.tsp
@@ -64,6 +64,7 @@ model FleetHubProfile {
   kubernetesVersion?: string;
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
 @lroStatus
 @doc("The provisioning state of the last accepted operation.")
 enum FleetProvisioningState {

--- a/specification/containerservice/Fleet.Management/fleet.tsp
+++ b/specification/containerservice/Fleet.Management/fleet.tsp
@@ -64,7 +64,7 @@ model FleetHubProfile {
   kubernetesVersion?: string;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @lroStatus
 @doc("The provisioning state of the last accepted operation.")
 enum FleetProvisioningState {

--- a/specification/containerservice/Fleet.Management/fleetmember.tsp
+++ b/specification/containerservice/Fleet.Management/fleetmember.tsp
@@ -56,6 +56,7 @@ model FleetMemberProperties {
   provisioningState?: FleetMemberProvisioningState;
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
 @lroStatus
 @doc("The provisioning state of the last accepted operation.")
 enum FleetMemberProvisioningState {

--- a/specification/containerservice/Fleet.Management/fleetmember.tsp
+++ b/specification/containerservice/Fleet.Management/fleetmember.tsp
@@ -56,7 +56,7 @@ model FleetMemberProperties {
   provisioningState?: FleetMemberProvisioningState;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @lroStatus
 @doc("The provisioning state of the last accepted operation.")
 enum FleetMemberProvisioningState {

--- a/specification/containerservice/Fleet.Management/main.tsp
+++ b/specification/containerservice/Fleet.Management/main.tsp
@@ -19,7 +19,7 @@ namespace Microsoft.ContainerService;
 
 interface Operations extends Azure.ResourceManager.Operations {}
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Version does not need documentation"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 enum Versions {
   @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
   v2022_09_02_preview: "2022-09-02-preview",

--- a/specification/containerservice/Fleet.Management/main.tsp
+++ b/specification/containerservice/Fleet.Management/main.tsp
@@ -19,6 +19,7 @@ namespace Microsoft.ContainerService;
 
 interface Operations extends Azure.ResourceManager.Operations {}
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Version does not need documentation"
 enum Versions {
   @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
   v2022_09_02_preview: "2022-09-02-preview",

--- a/specification/containerservice/Fleet.Management/updaterun.tsp
+++ b/specification/containerservice/Fleet.Management/updaterun.tsp
@@ -134,7 +134,7 @@ enum ManagedClusterUpgradeType{
     NodeImageOnly
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @doc("The state of the UpdateRun, UpdateStage, UpdateGroup, or MemberUpdate.")
 enum UpdateState {
     NotStarted,

--- a/specification/containerservice/Fleet.Management/updaterun.tsp
+++ b/specification/containerservice/Fleet.Management/updaterun.tsp
@@ -134,6 +134,7 @@ enum ManagedClusterUpgradeType{
     NodeImageOnly
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
 @doc("The state of the UpdateRun, UpdateStage, UpdateGroup, or MemberUpdate.")
 enum UpdateState {
     NotStarted,

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
@@ -16,6 +16,7 @@ using Azure.Core;
 
 namespace Azure.Contoso.WidgetManager;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 enum Versions {
   @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2022_11_01_Preview: "2022-11-01-preview",

--- a/specification/eventgrid/Azure.Messaging.EventGrid/main.tsp
+++ b/specification/eventgrid/Azure.Messaging.EventGrid/main.tsp
@@ -39,6 +39,7 @@ namespace Azure.Messaging.EventGrid {
   using Azure.Core;
   using Azure.Core.Foundations;
 
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
   enum ServiceApiVersions {
     @useDependency(Azure.Core.Versions.v1_0_Preview_2)
     v2023_06_01_preview: "2023-06-01-preview"

--- a/specification/liftrqumulo/Qumulo.Management/main.cadl
+++ b/specification/liftrqumulo/Qumulo.Management/main.cadl
@@ -25,6 +25,7 @@ enum StorageSku {
   "Performance"
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 enum Versions {
   v2022_06_27_preview: "2022-06-27-preview",
   v2022_10_12_preview: "2022-10-12-preview",

--- a/specification/servicenetworking/ServiceNetworking.Management/main.tsp
+++ b/specification/servicenetworking/ServiceNetworking.Management/main.tsp
@@ -71,6 +71,7 @@ model AssociationProperties {
 
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
 enum AssociationType {
   "subnets",
 }
@@ -108,6 +109,7 @@ model TrafficControllerProperties {
   provisioningState?: ProvisioningState;
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
 @lroStatus
 enum ProvisioningState{
   Provisioning,

--- a/specification/servicenetworking/ServiceNetworking.Management/main.tsp
+++ b/specification/servicenetworking/ServiceNetworking.Management/main.tsp
@@ -71,7 +71,7 @@ model AssociationProperties {
 
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum AssociationType {
   "subnets",
 }
@@ -109,7 +109,7 @@ model TrafficControllerProperties {
   provisioningState?: ProvisioningState;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Spec"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 @lroStatus
 enum ProvisioningState{
   Provisioning,

--- a/specification/translation/Azure.AI.TextTranslation/main.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/main.tsp
@@ -44,6 +44,7 @@ Dictionary example Returns grammatical structure and context examples for the so
 @versioned(APIVersion)
 namespace TextTranslation;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Version enums should not require documentation"
 @doc("Text Translation supported versions")
 enum APIVersion {
   v3_0: "3.0",

--- a/specification/translation/Azure.AI.TextTranslation/main.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/main.tsp
@@ -44,7 +44,7 @@ Dictionary example Returns grammatical structure and context examples for the so
 @versioned(APIVersion)
 namespace TextTranslation;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Version enums should not require documentation"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next update"
 @doc("Text Translation supported versions")
 enum APIVersion {
   v3_0: "3.0",

--- a/specification/translation/Azure.AI.TextTranslation/main.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/main.tsp
@@ -44,7 +44,7 @@ Dictionary example Returns grammatical structure and context examples for the so
 @versioned(APIVersion)
 namespace TextTranslation;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "SHOULD fix in next update"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 @doc("Text Translation supported versions")
 enum APIVersion {
   v3_0: "3.0",

--- a/specification/translation/Azure.AI.TextTranslation/models-translate.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/models-translate.tsp
@@ -138,6 +138,7 @@ model TranslationResult {
   meteredUsage: int32;
 }
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Service"
 enum TextTypeKnownValues {
   Plain: "Plain",
   Html: "Html",
@@ -147,6 +148,7 @@ enum TextTypeKnownValues {
 @knownValues(TextTypeKnownValues)
 scalar TextType extends string;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Service"
 enum ProfanityActionKnownValues {
   NoAction: "NoAction",
   Marked: "Marked",
@@ -157,6 +159,7 @@ enum ProfanityActionKnownValues {
 @knownValues(ProfanityActionKnownValues)
 scalar ProfanityAction extends string;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Service"
 enum ProfanityMarkerKnownValues {
   Asterisk: "Asterisk",
   Tag: "Tag",

--- a/specification/translation/Azure.AI.TextTranslation/models-translate.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/models-translate.tsp
@@ -138,7 +138,7 @@ model TranslationResult {
   meteredUsage: int32;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Service"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum TextTypeKnownValues {
   Plain: "Plain",
   Html: "Html",
@@ -148,7 +148,7 @@ enum TextTypeKnownValues {
 @knownValues(TextTypeKnownValues)
 scalar TextType extends string;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Service"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum ProfanityActionKnownValues {
   NoAction: "NoAction",
   Marked: "Marked",
@@ -159,7 +159,7 @@ enum ProfanityActionKnownValues {
 @knownValues(ProfanityActionKnownValues)
 scalar ProfanityAction extends string;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Legacy Service"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "MUST fix in next update"
 enum ProfanityMarkerKnownValues {
   Asterisk: "Asterisk",
   Tag: "Tag",

--- a/specification/voiceservices/resource-manager/Microsoft.VoiceServices/cadl/voiceservices.cadl
+++ b/specification/voiceservices/resource-manager/Microsoft.VoiceServices/cadl/voiceservices.cadl
@@ -37,6 +37,7 @@ using Azure.ResourceManager;
 )
 namespace Microsoft.VoiceServices;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "https://github.com/Azure/typespec-azure/issues/3107"
 enum Versions {
   v2022_12_01_preview: "2022-12-01-preview",
   v2023_01_31: "2023-01-31",


### PR DESCRIPTION
- New rule coming in TypeSpec 0.45.0
- Does not break TypeSpec 0.44.0, so can be merged now
- Fixes #24298

## CI targeting "main"
- Should be passing
- https://dev.azure.com/azure-sdk/public/_build/results?buildId=2824512&view=results

## CI targeting "typespec-next"
- Should have no missing doc warnings, but may have other failures that will be fixed in later PRs
- https://dev.azure.com/azure-sdk/public/_build/results?buildId=2824509&view=results

## Check Failures
- TypeSpecValidation
  - OpenAI.Inference: Known issues in specs repo
  - Fleet.Management, ServiceNetworking.Management: Known issues in TypeSpecValidation tool
- TypeSpecApiView: #24300