### PR TITLE
Re-incorporate support for arm-id

### DIFF
--- a/specification/common-types/resource-management/v4/customermanagedkeys.json
+++ b/specification/common-types/resource-management/v4/customermanagedkeys.json
@@ -51,6 +51,7 @@
             },
             "userAssignedIdentityResourceId": {
               "type": "string",
+              "format": "arm-id",
               "description": "user assigned identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity and delegatedResourceIdentity."
             },
             "delegatedIdentityClientId": {

--- a/specification/common-types/resource-management/v4/types.json
+++ b/specification/common-types/resource-management/v4/types.json
@@ -14,6 +14,7 @@
         "id": {
           "readOnly": true,
           "type": "string",
+          "format": "arm-id",
           "description": "Fully qualified resource ID for the resource. E.g. \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\""
         },
         "name": {

--- a/specification/common-types/resource-management/v5/types.json
+++ b/specification/common-types/resource-management/v5/types.json
@@ -14,6 +14,7 @@
         "id": {
           "readOnly": true,
           "type": "string",
+          "format": "arm-id",
           "description": "Fully qualified resource ID for the resource. E.g. \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\""
         },
         "name": {

--- a/specification/common-types/resource-management/v5/types.json
+++ b/specification/common-types/resource-management/v5/types.json
@@ -428,11 +428,13 @@
       "properties": {
         "id": {
           "description": "Fully qualified ID for the async operation.",
-          "type": "string"
+          "type": "string",
+          "format": "arm-id"
         },
         "resourceId": {
           "description": "Fully qualified ID of the resource against which the original async operation was started.",
           "type": "string",
+          "format": "arm-id",
           "readOnly": true
         },
         "name": {


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#21860

Re-incorporating arm-id back to common types now that it's supported by API validation in RPaaS.