### PR TITLE
updated minWidth param default value and description

### DIFF
--- a/specification/maps/data-plane/Creator/preview/2022-09-01-preview/wayfind.json
+++ b/specification/maps/data-plane/Creator/preview/2022-09-01-preview/wayfind.json
@@ -259,7 +259,7 @@
     },
     "MinWidth": {
       "name": "minWidth",
-      "description": "The minimum width (in meters) of openings in the searched path. For example, if you specified a minimum width of 0.85, the searched path will avoid openings less than 85 centimiters wide. Note: by using this value, the resulting path points will be buffered from walls and other vertical obstacles by half of the width provided.",
+      "description": "The minimum width (in meters) of openings in the searched path. For example, if you specified a minimum width of 0.85, the searched path will avoid openings less than 85 centimeters wide. Note: by using this value, the resulting path points will be buffered from walls and other vertical obstacles by half of the width provided.",
       "type": "number",
       "in": "query",
       "default": "0.55",

--- a/specification/maps/data-plane/Creator/preview/2022-09-01-preview/wayfind.json
+++ b/specification/maps/data-plane/Creator/preview/2022-09-01-preview/wayfind.json
@@ -259,10 +259,10 @@
     },
     "MinWidth": {
       "name": "minWidth",
-      "description": "The minimum width (in meters) of openings in the resulting path. For example, if you specified a minimum width of 0.5, the searched path will avoid openings less than 0.5 meters wide. Note: by using this value, the resulting path points will be buffered from walls and other vertical obstacles by half of the distance provided.",
+      "description": "The minimum width (in meters) of openings in the searched path. For example, if you specified a minimum width of 0.85, the searched path will avoid openings less than 85 centimiters wide. Note: by using this value, the resulting path points will be buffered from walls and other vertical obstacles by half of the width provided.",
       "type": "number",
       "in": "query",
-      "default": "0.0",
+      "default": "0.55",
       "x-ms-parameter-location": "client"
     }
   },

--- a/specification/maps/data-plane/Creator/preview/2023-03-01-preview/wayfind.json
+++ b/specification/maps/data-plane/Creator/preview/2023-03-01-preview/wayfind.json
@@ -249,7 +249,7 @@
     },
     "MinWidth": {
       "name": "minWidth",
-      "description": "The minimum width (in meters) of openings in the searched path. For example, if you specified a minimum width of 0.85, the searched path will avoid openings less than 85 centimiters wide. Note: by using this value, the resulting path points will be buffered from walls and other vertical obstacles by half of the width provided.",
+      "description": "The minimum width (in meters) of openings in the searched path. For example, if you specified a minimum width of 0.85, the searched path will avoid openings less than 85 centimeters wide. Note: by using this value, the resulting path points will be buffered from walls and other vertical obstacles by half of the width provided.",
       "type": "number",
       "in": "query",
       "default": "0.55",

--- a/specification/maps/data-plane/Creator/preview/2023-03-01-preview/wayfind.json
+++ b/specification/maps/data-plane/Creator/preview/2023-03-01-preview/wayfind.json
@@ -249,10 +249,10 @@
     },
     "MinWidth": {
       "name": "minWidth",
-      "description": "The minimum width (in meters) of openings in the resulting path. For example, if you specified a minimum width of 0.5, the searched path will avoid openings less than 0.5 meters wide. Note: by using this value, the resulting path points will be buffered from walls and other vertical obstacles by half of the distance provided.",
+      "description": "The minimum width (in meters) of openings in the searched path. For example, if you specified a minimum width of 0.85, the searched path will avoid openings less than 85 centimiters wide. Note: by using this value, the resulting path points will be buffered from walls and other vertical obstacles by half of the width provided.",
       "type": "number",
       "in": "query",
-      "default": "0.0",
+      "default": "0.55",
       "x-ms-parameter-location": "client"
     }
   },


### PR DESCRIPTION
# Data Plane API - Pull Request
updated minWidth param default value and description. Not a breaking change.

## API Info: The Basics
Current default of 0 is meaningless, since any type of character whose type a path is searched for has some width in the physical world. Fixed terminology in the description as well.
