### PR TITLE
Fixing additionalProperties to use {} instead of object

### DIFF
--- a/specification/azurearcdata/resource-manager/Microsoft.AzureArcData/preview/2023-01-15-preview/sqlManagedInstances.json
+++ b/specification/azurearcdata/resource-manager/Microsoft.AzureArcData/preview/2023-01-15-preview/sqlManagedInstances.json
@@ -255,9 +255,7 @@
           "$ref": "#/definitions/k8stransparentDataEncryption"
         }
       },
-      "additionalProperties": {
-        "type": "object"
-      }
+      "additionalProperties": {}
     },
     "K8sActiveDirectory": {
       "type": "object",
@@ -315,9 +313,7 @@
           "$ref": "#/definitions/K8sNetworkSettings"
         }
       },
-      "additionalProperties": {
-        "type": "object"
-      }
+      "additionalProperties": {}
     },
     "K8sNetworkSettings": {
       "type": "object",


### PR DESCRIPTION
RPaaS is planning to rollout a new Swagger spec linter rule where free-form type additionalProperties should be set to "true" or "{}" as noted in the OpenAPI docs under [Free-Form Objects](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fswagger.io%2Fdocs%2Fspecification%2Fdata-models%2Fdictionaries%2F&data=05%7C01%7Cwendychang%40microsoft.com%7C27e63edf5a22499ad8a308db66d30f24%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638216828913714888%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=8WssKvWe7x27fkCAHU4MVEqUVcdkw7aHYauvICbQcJQ%3D&reserved=0).

All new API versions are subject to the new rule and this can potentially be a breaking change for existing API versions once it goes into effect by the end of August 2023.

Your resource provider has been flagged for this validation in one or more API versions. Please check all the environments you've onboarded to and take the action outlined below to avoid any issues or service outages once the rule goes into effect.
There are two ways to mitigate this linter rule:

(Recommended) Check your RP's Swagger specifications for the following API versions in their respective repos and make the necessary corrections. If the PR is flagged for breaking change, let the reviewer know it's to comply with the additionalProperties validation.
