### PR TITLE
Update Minimal TLS Version enforcement for new Azure Cosmos DB Accounts

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2023-04-15/cosmos-db.json
@@ -7026,7 +7026,7 @@
           "type": "boolean"
         },
         "minimalTlsVersion": {
-          "description": "Indicates the minimum allowed Tls version. The default is Tls 1.0, except for Cassandra and Mongo API's, which only work with Tls 1.2.",
+          "description": "Indicates the minimum allowed Tls version. The default value is Tls 1.2. Cassandra and Mongo APIs only work with Tls 1.2.",
           "type": "string",
           "$ref": "#/definitions/MinimalTlsVersion"
         }
@@ -7176,7 +7176,7 @@
           "type": "boolean"
         },
         "minimalTlsVersion": {
-          "description": "Indicates the minimum allowed Tls version. The default is Tls 1.0, except for Cassandra and Mongo API's, which only work with Tls 1.2.",
+          "description": "Indicates the minimum allowed Tls version. The default value is Tls 1.2. Cassandra and Mongo APIs only work with Tls 1.2.",
           "type": "string",
           "$ref": "#/definitions/MinimalTlsVersion"
         }
@@ -7350,7 +7350,7 @@
           "type": "boolean"
         },
         "minimalTlsVersion": {
-          "description": "Indicates the minimum allowed Tls version. The default is Tls 1.0, except for Cassandra and Mongo API's, which only work with Tls 1.2.",
+          "description": "Indicates the minimum allowed Tls version. The default value is Tls 1.2. Cassandra and Mongo APIs only work with Tls 1.2.",
           "type": "string",
           "$ref": "#/definitions/MinimalTlsVersion"
         }
@@ -9901,7 +9901,7 @@
       }
     },
     "MinimalTlsVersion": {
-      "description": "Indicates the minimum allowed Tls version. The default is Tls 1.0, except for Cassandra and Mongo API's, which only work with Tls 1.2.",
+      "description": "Indicates the minimum allowed Tls version. The default value is Tls 1.2. Cassandra and Mongo APIs only work with Tls 1.2.",
       "type": "string",
       "enum": [
         "Tls",


### PR DESCRIPTION
# Cosmos DB - Minimal TLS Enforcement to TLS 1.2

This update changes the documentation for the MinimalTlsVersion Property in the API Version 2023-04-15. This will only change the default value of the Minimal Tls Version when a Cosmos DB Account is created. 

The enforcement used to be Tls 1.0, now it is Tls 1.2.

This behavior in TLS was already notified to the customers in https://learn.microsoft.com/en-us/azure/cosmos-db/self-serve-minimum-tls-enforcement#how-to-set-the-minimum-tls-version-for-my-cosmos-db-database-account