### PR TITLE
Align the casing of LifetimeActionsType with the service.

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/examples/GetKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/examples/GetKeyRotationPolicy-example.json
@@ -14,7 +14,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -22,7 +22,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/examples/UpdateKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/examples/UpdateKeyRotationPolicy-example.json
@@ -10,7 +10,7 @@
             "timeAfterCreate": "P90D"
           },
           "action": {
-            "type": "rotate"
+            "type": "Rotate"
           }
         },
         {
@@ -18,7 +18,7 @@
             "timeBeforeExpiry": "P30D"
           },
           "action": {
-            "type": "notify"
+            "type": "Notify"
           }
         }
       ],
@@ -37,7 +37,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -45,7 +45,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
@@ -2195,20 +2195,25 @@
           "type": "string",
           "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "ActionType",
             "modelAsString": false,
             "values": [
               {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy."
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
               },
               {
-                "value": "notify",
-                "description": "Trigger event grid events. For preview, the notification time is not configurable and it is default to 30 days before expiry."
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/examples/GetKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/examples/GetKeyRotationPolicy-example.json
@@ -14,7 +14,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -22,7 +22,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/examples/UpdateKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/examples/UpdateKeyRotationPolicy-example.json
@@ -10,7 +10,7 @@
             "timeAfterCreate": "P90D"
           },
           "action": {
-            "type": "rotate"
+            "type": "Rotate"
           }
         },
         {
@@ -18,7 +18,7 @@
             "timeBeforeExpiry": "P30D"
           },
           "action": {
-            "type": "notify"
+            "type": "Notify"
           }
         }
       ],
@@ -37,7 +37,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -45,7 +45,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
@@ -2223,20 +2223,25 @@
           "type": "string",
           "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "ActionType",
             "modelAsString": false,
             "values": [
               {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy."
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
               },
               {
-                "value": "notify",
-                "description": "Trigger event grid events. For preview, the notification time is not configurable and it is default to 30 days before expiry."
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/examples/GetKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/examples/GetKeyRotationPolicy-example.json
@@ -14,7 +14,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -22,7 +22,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/examples/UpdateKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/examples/UpdateKeyRotationPolicy-example.json
@@ -10,7 +10,7 @@
             "timeAfterCreate": "P90D"
           },
           "action": {
-            "type": "rotate"
+            "type": "Rotate"
           }
         },
         {
@@ -18,7 +18,7 @@
             "timeBeforeExpiry": "P30D"
           },
           "action": {
-            "type": "notify"
+            "type": "Notify"
           }
         }
       ],
@@ -37,7 +37,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -45,7 +45,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
@@ -2201,20 +2201,25 @@
           "type": "string",
           "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
-            "name": "KeyRotationPolicyAction",
+            "name": "ActionType",
             "modelAsString": false,
             "values": [
               {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy."
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
               },
               {
-                "value": "notify",
-                "description": "Trigger event grid events. For preview, the notification time is not configurable and it is default to 30 days before expiry."
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/examples/GetKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/examples/GetKeyRotationPolicy-example.json
@@ -14,7 +14,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -22,7 +22,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/examples/UpdateKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/examples/UpdateKeyRotationPolicy-example.json
@@ -10,7 +10,7 @@
             "timeAfterCreate": "P90D"
           },
           "action": {
-            "type": "rotate"
+            "type": "Rotate"
           }
         },
         {
@@ -18,7 +18,7 @@
             "timeBeforeExpiry": "P30D"
           },
           "action": {
-            "type": "notify"
+            "type": "Notify"
           }
         }
       ],
@@ -37,7 +37,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -45,7 +45,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
@@ -2196,20 +2196,25 @@
           "type": "string",
           "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "ActionType",
             "modelAsString": false,
             "values": [
               {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy."
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
               },
               {
-                "value": "notify",
-                "description": "Trigger event grid events. For preview, the notification time is not configurable and it is default to 30 days before expiry."
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/examples/GetKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/examples/GetKeyRotationPolicy-example.json
@@ -14,7 +14,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -22,7 +22,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/examples/UpdateKeyRotationPolicy-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/examples/UpdateKeyRotationPolicy-example.json
@@ -10,7 +10,7 @@
             "timeAfterCreate": "P90D"
           },
           "action": {
-            "type": "rotate"
+            "type": "Rotate"
           }
         },
         {
@@ -18,7 +18,7 @@
             "timeBeforeExpiry": "P30D"
           },
           "action": {
-            "type": "notify"
+            "type": "Notify"
           }
         }
       ],
@@ -37,7 +37,7 @@
               "timeAfterCreate": "P90D"
             },
             "action": {
-              "type": "rotate"
+              "type": "Rotate"
             }
           },
           {
@@ -45,7 +45,7 @@
               "timeBeforeExpiry": "P30D"
             },
             "action": {
-              "type": "notify"
+              "type": "Notify"
             }
           }
         ],

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/keys.json
@@ -2196,20 +2196,25 @@
           "type": "string",
           "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
-            "name": "KeyRotationPolicyAction",
+            "name": "ActionType",
             "modelAsString": false,
             "values": [
               {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy."
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
               },
               {
-                "value": "notify",
-                "description": "Trigger event grid events. For preview, the notification time is not configurable and it is default to 30 days before expiry."
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/readme.md
+++ b/specification/keyvault/data-plane/readme.md
@@ -496,6 +496,18 @@ directive:
     from: securitydomain.json
     where: $.definitions.TransferKey.properties.key_format
     reason: Consistency with other properties
+  - suppress: EnumUniqueValue
+    from keys.json
+    where: $.definitions.LifetimeActionsType.properties.type
+    reason: SDK, docs workaround for current service behavior.
+  - suppress: EnumUniqueValue
+    from keys.json
+    where: $.definitions.Action.properties.type
+    reason: SDK, docs workaround for current service behavior.
+  - suppress: EnumUniqueValue
+    from keysManagedHsm.json
+    where: $.definitions.ManagedHsmAction.properties.type
+    reason: SDK, docs workaround for current service behavior.
   - suppress: DOUBLE_FORWARD_SLASHES_IN_URL
     from: rbac.json
     reason: / is a valid scope in this scenario.

--- a/specification/keyvault/data-plane/readme.md
+++ b/specification/keyvault/data-plane/readme.md
@@ -497,15 +497,15 @@ directive:
     where: $.definitions.TransferKey.properties.key_format
     reason: Consistency with other properties
   - suppress: EnumUniqueValue
-    from keys.json
+    from: keys.json
     where: $.definitions.LifetimeActionsType.properties.type
     reason: SDK, docs workaround for current service behavior.
   - suppress: EnumUniqueValue
-    from keys.json
+    from: keys.json
     where: $.definitions.Action.properties.type
     reason: SDK, docs workaround for current service behavior.
   - suppress: EnumUniqueValue
-    from keysManagedHsm.json
+    from: keysManagedHsm.json
     where: $.definitions.ManagedHsmAction.properties.type
     reason: SDK, docs workaround for current service behavior.
   - suppress: DOUBLE_FORWARD_SLASHES_IN_URL

--- a/specification/keyvault/data-plane/readme.md
+++ b/specification/keyvault/data-plane/readme.md
@@ -500,14 +500,6 @@ directive:
     from: keys.json
     where: $.definitions.LifetimeActionsType.properties.type
     reason: SDK, docs workaround for current service behavior.
-  - suppress: EnumUniqueValue
-    from: keys.json
-    where: $.definitions.Action.properties.type
-    reason: SDK, docs workaround for current service behavior.
-  - suppress: EnumUniqueValue
-    from: keysManagedHsm.json
-    where: $.definitions.ManagedHsmAction.properties.type
-    reason: SDK, docs workaround for current service behavior.
   - suppress: DOUBLE_FORWARD_SLASHES_IN_URL
     from: rbac.json
     reason: / is a valid scope in this scenario.

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-04-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-04-01-preview/keys.json
@@ -593,14 +593,29 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of action.",
+          "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "KeyRotationPolicyActionType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
+              },
+              {
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+              }
+            ]
           }
         }
       }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-06-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-06-01-preview/keys.json
@@ -611,14 +611,29 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of action.",
+          "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "KeyRotationPolicyActionType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
+              },
+              {
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+              }
+            ]
           }
         }
       },

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-11-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-11-01-preview/keys.json
@@ -611,14 +611,29 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of action.",
+          "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "KeyRotationPolicyActionType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
+              },
+              {
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+              }
+            ]
           }
         }
       },

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2022-02-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2022-02-01-preview/keys.json
@@ -612,14 +612,29 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of action.",
+          "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "KeyRotationPolicyActionType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
+              },
+              {
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+              }
+            ]
           }
         }
       },

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-07-01/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-07-01/keys.json
@@ -613,14 +613,29 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of action.",
+          "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "KeyRotationPolicyActionType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
+              },
+              {
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+              }
+            ]
           }
         }
       },

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keys.json
@@ -613,14 +613,29 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of action.",
+          "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "KeyRotationPolicyActionType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
+              },
+              {
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+              }
+            ]
           }
         }
       },

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keysManagedHsm.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keysManagedHsm.json
@@ -542,14 +542,29 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of action.",
+          "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "KeyRotationPolicyActionType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
+              },
+              {
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+              }
+            ]
           }
         }
       },

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keys.json
@@ -613,14 +613,29 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of action.",
+          "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "KeyRotationPolicyActionType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
+              },
+              {
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+              }
+            ]
           }
         }
       },

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keysManagedHsm.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keysManagedHsm.json
@@ -542,14 +542,29 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of action.",
+          "description": "The type of the action.",
           "enum": [
+            "Rotate",
             "rotate",
-            "notify"
+            "Notify"
           ],
           "x-ms-enum": {
             "name": "KeyRotationPolicyActionType",
-            "modelAsString": false
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "Rotate",
+                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
+              },
+              {
+                "value": "rotate",
+                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+              },
+              {
+                "value": "Notify",
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+              }
+            ]
           }
         }
       },

--- a/specification/keyvault/resource-manager/readme.md
+++ b/specification/keyvault/resource-manager/readme.md
@@ -261,6 +261,15 @@ directive:
   from: keysManagedHsm.json
   reason: This is to keep compatibility with existing data plane property. The 'release_policy' property for KeyCreateParameters does not support camelCase.
 
+- suppress: EnumUniqueValue
+  from: keys.json
+  where: $.definitions.Action.properties.type
+  reason: SDK, docs workaround for current service behavior.
+- suppress: EnumUniqueValue
+  from: keysManagedHsm.json
+  where: $.definitions.ManagedHsmAction.properties.type
+  reason: SDK, docs workaround for current service behavior.
+
 - suppress: INVALID_REQUEST_PARAMETER
   from: keyvault.json
   reason: The Vaults_List API endpoint only supports version 2015-11-01.


### PR DESCRIPTION
# Data Plane (and Control Plane) API - Pull Request
Azure Key Vault's data plane has been using PascalCase for the LifetimeActionsType enum values, while the REST API spec incorrectly specifies the casing to be camelCase. This PR aligns the REST API spec (of both data plane and control plane) with the service.

Note that this is not a breaking change in the service (which has been using PascalCase since GA).

## API Info: The Basics

Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [x] GA release
