### PR TITLE
Re-enabling Java checks for Azure OpenAI

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
+++ b/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
@@ -27,12 +27,12 @@ options:
   #   clear-output-folder: true
   #   model-namespace: false
   # https://github.com/Azure/azure-rest-api-specs/issues/24497
-  # "@azure-tools/typespec-java":
-  #   package-dir: "azure-ai-openai"
-  #   namespace: "com.azure.ai.openai"
-  #   partial-update: true
-  #   enable-sync-stack: true
-  #   generate-tests: false
+  "@azure-tools/typespec-java":
+    package-dir: "azure-ai-openai"
+    namespace: "com.azure.ai.openai"
+    partial-update: true
+    enable-sync-stack: true
+    generate-tests: false
   # https://github.com/Azure/azure-rest-api-specs/issues/24498
   # "@azure-tools/typespec-ts":
   #   package-dir: "azure-ai-openai"


### PR DESCRIPTION
Closes #24497

Introduced changes:
- In this repo: re-enable the check
- In the `azure-sdk-for-java`: mainly, adding `azure-core-experimental` dependency to `pom.xml` file. More details in this [PR](https://github.com/Azure/azure-sdk-for-java/pull/35549/)