### PR TITLE
Update `pull_request_assignment.yml`: remove `armapireview` and other reviewers for ARM paths, except `rkmanda`.

### DIFF
--- a/.github/pull_request_assignment.yml
+++ b/.github/pull_request_assignment.yml
@@ -1,15 +1,5 @@
 ---
 - rule:
-    # resource management plane PR's
-    paths:
-      - "specification/**/*Management/**"
-      - "specification/**/*Management.Shared/**"
-      - "specification/**/resource-manager/**"
-      - "specification/common-types/resource-management/**"
-    reviewers:
-      - rkmanda
-
-- rule:
     # translator data-plane PR
     paths:
       - "specification/cognitiveservices/data-plane/TranslatorText/**"
@@ -129,7 +119,17 @@
     reviewers:
       - weshaggard
       - konrad-jamrozik
-
+      
+- rule:
+    # resource management plane PR's
+    paths:
+      - "specification/**/*Management/**"
+      - "specification/**/*Management.Shared/**"
+      - "specification/**/resource-manager/**"
+      - "specification/common-types/resource-management/**"
+    reviewers:
+      - rkmanda
+      
 - rule:
     # temporary catchall
     paths:

--- a/.github/pull_request_assignment.yml
+++ b/.github/pull_request_assignment.yml
@@ -7,13 +7,6 @@
       - "specification/**/resource-manager/**"
       - "specification/common-types/resource-management/**"
     reviewers:
-      - JackTn
-      - keryul
-      - zedy-wj
-      - v-jiaodi
-      - Wzb123456789
-      - kazrael2119
-      - v-xuto
       - rkmanda
 
 - rule:
@@ -102,107 +95,23 @@
     paths:
       - "specification/network/**"
     reviewers:
-      - JackTn
-      - keryul
+      - rkmanda
     branches:
       - release-network-Microsoft.Network-official
 
 - rule:
     paths: "specification/sql/**"
     reviewers:
-      - v-xuto
+      - rkmanda
     branches:
       - dev-sql-
 
 - rule:
     paths: "specification/@(financialdataservices|standbypool)/**"
     reviewers:
-      - JackTn
-      - keryul
+      - rkmanda
     branches:
       - RPSaaSDev
-
-- rule:
-    paths: "specification/compute/**"
-    reviewers:
-      - JackTn
-      - keryul
-
-- rule:
-    paths:
-      - "specification/machinelearningservices/**"
-    reviewers:
-      - zedy-wj
-      - v-jiaodi
-
-- rule:
-    paths:
-      - "specification/monitor/**"
-    reviewers:
-      - zedy-wj
-      - v-jiaodi
-
-- rule:
-    paths:
-      - "specification/@(azurestackhci|security)/**"
-    reviewers:
-      - Wzb123456789
-      - kazrael2119
-
-- rule:
-    paths:
-      - "specification/@(web|app)/**"
-    reviewers:
-      - Wzb123456789
-      - kazrael2119
-
-- rule:
-    paths: "specification/@(synapse|azurearcdata)/**"
-    reviewers:
-      - zedy-wj
-      - v-jiaodi
-
-- rule:
-    paths: "specification/@(workloads|apimanagement)/**"
-    reviewers:
-      - zedy-wj
-      - v-jiaodi
-
-- rule:
-    paths: "specification/@(securityinsights|impact)/**"
-    reviewers:
-      - JackTn
-      - keryul
-
-- rule:
-    paths: "specification/@(appcomplianceautomation|hybridnetwork)/**"
-    reviewers:
-      - zedy-wj
-      - v-jiaodi
-
-- rule:
-    paths: "specification/@(cost-management|hybridconnectivity)/**"
-    reviewers:
-      - JackTn
-      - keryul
-
-- rule:
-    paths: "specification/@(billing|resources)/**"
-    reviewers:
-      - Wzb123456789
-      - kazrael2119
-
-- rule:
-    paths: "specification/@(testbase|appplatform)/**"
-    reviewers:
-      - JackTn
-      - keryul
-
-- rule:
-    paths: "specification/@(containerservice|paloaltonetworks)/**"
-    reviewers:
-      - zedy-wj
-      - v-jiaodi
 
 - rule:
     paths:

--- a/.github/pull_request_assignment.yml
+++ b/.github/pull_request_assignment.yml
@@ -15,7 +15,6 @@
       - kazrael2119
       - v-xuto
       - rkmanda
-      - armapireview
 
 - rule:
     # translator data-plane PR


### PR DESCRIPTION
This is a PR made by the Azure SDK Engineering System team.

## Original description 6/24/2023

This PR removes `armapireview` from assignees as it appears to be misconfigured. Likely it doesn't have access. I.e. probably this user https://github.com/armapireview should be given permissions to be assignable to the repositories. [This doc](https://eng.ms/docs/products/azure-developer-experience/onboard/access) might be helpful here.

For context, see this [Teams discussion](https://teams.microsoft.com/l/message/19:MwH8IC4_1ZpPH1eVv8r-_KwDMLTl4Y7-N0Cwda-3Wi41@thread.tacv2/1686771957277?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=44f700c4-b03f-4212-8ab8-aef4193145c5&parentMessageId=1686711652793&teamName=Mgmt.%20Plane%20PR%20Review%20Transition%20Support&channelName=General&createdTime=1686771957277).

[This Kusto query](https://dataexplorer.azure.com/clusters/https%3A%2F%2Fade.loganalytics.io%2Fsubscriptions%2F8c0e0d10-c2d6-42b8-b1d9-e7132b6f18a3%2Fresourcegroups%2Frg-container-apps-prod%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Fworkspacergcontainerappsprod9a92/databases/workspacergcontainerappsprod9a92) (from [this doc](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/978/Assignment-bot?anchor=getting-all-assignment-logs-for-given-assignee)) shows the affected PRs since 6/10/2023.

14 pull requests were affected. Even though our logs show the assignment was successful, it actually wasn't.

Here is the list of the PRs:

- https://github.com/Azure/azure-rest-api-specs-pr/pull/13312  
- https://github.com/Azure/azure-rest-api-specs-pr/pull/13309  
- https://github.com/Azure/azure-rest-api-specs-pr/pull/13302  
- https://github.com/Azure/azure-rest-api-specs-pr/pull/13274  
- https://github.com/Azure/azure-rest-api-specs-pr/pull/13256  
- https://github.com/Azure/azure-rest-api-specs-pr/pull/13209  
- https://github.com/Azure/azure-rest-api-specs-pr/pull/13053  
- https://github.com/Azure/azure-rest-api-specs/pull/24503  
- https://github.com/Azure/azure-rest-api-specs/pull/24476  
- https://github.com/Azure/azure-rest-api-specs/pull/24435  
- https://github.com/Azure/azure-rest-api-specs/pull/24426  
- https://github.com/Azure/azure-rest-api-specs/pull/24406  
- https://github.com/Azure/azure-rest-api-specs/pull/24390  
- https://github.com/Azure/azure-rest-api-specs/pull/24148  

## Update 6/25/2023

Per [@rkmanda request](https://github.com/Azure/azure-rest-api-specs/pull/24566#pullrequestreview-1497153431), I removed all reviewers (not only `armapireview`) for the ARM paths except him.

## Update 7/6/2023

Info from @weshaggard:

> you cannot add non-FTE linked accounts into the Azure org do to the SSO sign-in requirements for the org. So, I don’t think it is possible to use a bot for that purpose.
