### PR TITLE
Remove repeatability support for token revocation endpoint

### DIFF
--- a/specification/communication/data-plane/Identity/stable/2023-08-01/CommunicationIdentity.json
+++ b/specification/communication/data-plane/Identity/stable/2023-08-01/CommunicationIdentity.json
@@ -133,20 +133,6 @@
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
-          },
-          {
-            "in": "header",
-            "name": "Repeatability-Request-ID",
-            "description": "If specified, the client directs that the request is repeatable; that is, that the client can make the request multiple times with the same Repeatability-Request-Id and get back an appropriate response without the server executing the request multiple times. The value of the Repeatability-Request-Id is an opaque string representing a client-generated, globally unique for all time, identifier for the request. It is recommended to use version 4 (random) UUIDs. Internal identifiers shouldn't be used. The value should be an opaque meaningless string in UUID format.",
-            "type": "string",
-            "format": "uuid"
-          },
-          {
-            "in": "header",
-            "name": "Repeatability-First-Sent",
-            "description": "If Repeatability-Request-ID header is specified, then Repeatability-First-Sent header must also be specified. The value should be the date and time at which the request was first created, expressed using the IMF-fixdate form of HTTP-date",
-            "type": "string",
-            "format": "date-time-rfc1123"
           }
         ],
         "responses": {
@@ -157,17 +143,11 @@
             }
           },
           "204": {
-            "description": "No Content",
-            "headers": {
-              "Repeatability-Result": {
-                "description": "Result of idempotent request. Present only in case of idempotent processing.",
-                "type": "string"
-              }
-            }
+            "description": "No Content"
           }
         },
         "x-ms-examples": {
-          "Revoke access tokens with optional idempotent processing using Repeatability-Request-ID and Repeatability-First-Sent headers. If the headers are not provided, the request will be processed in a non-idempotent way which can lead to more tokens being revoked than intended on a retry.": {
+          "Revoke access tokens": {
             "$ref": "./examples/RevokeAccessTokens.json"
           }
         }

--- a/specification/communication/data-plane/Identity/stable/2023-08-01/examples/RevokeAccessTokens.json
+++ b/specification/communication/data-plane/Identity/stable/2023-08-01/examples/RevokeAccessTokens.json
@@ -3,17 +3,9 @@
     "api-version": "2023-08-01",
     "content-type": "application/json",
     "id": "8:acs:2dee53b4-368b-45b4-ab52-8493fb117652_00000005-14a2-493b-8a72-5a3a0d000081",
-    "endpoint": "https://my-resource.communication.azure.com",
-    "headers": {
-      "Repeatability-Request-ID": "4e7d453c-ae97-4778-ad51-cb3b4a701100",
-      "Repeatability-First-Sent": "Sun, 10 Sep 2023 20:39:30 GMT"
-    }
+    "endpoint": "https://my-resource.communication.azure.com"
   },
   "responses": {
-    "204": {
-      "headers": {
-        "Repeatability-Result": "accepted"
-      }
-    }
+    "204": {}
   }
 }


### PR DESCRIPTION
Removing repeatability support for /identities/{id}/:revokeAccessTokens endpoint. Support will be implemented later in MVP1 feature.

This version is not GA yet -> no breaking change.