### PR TITLE
[ManagedCcf] Remove import of typespec-autorest

### DIFF
--- a/specification/confidentialledger/Microsoft.ManagedCcf/main.tsp
+++ b/specification/confidentialledger/Microsoft.ManagedCcf/main.tsp
@@ -1,6 +1,5 @@
 import "@typespec/http";
 import "@typespec/versioning";
-import "@azure-tools/typespec-autorest";
 
 import "./acks.tsp";
 import "./proposals.tsp";


### PR DESCRIPTION
- Import appears to be completely unused
- Partially fixes #24565