### PR TITLE
Remove no-op Avocado suppressions

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/readme.md
+++ b/dev/cognitiveservices/data-plane/Language/readme.md
@@ -46,11 +46,3 @@ swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
   - repo: azure-sdk-for-python
 ```
-
-## Suppression
-
-``` yaml
-directive:
-  - suppress: MISSING_APIS_IN_DEFAULT_TAG
-    reason: Not every service will ship new versions within the Language pillar.
-```

--- a/specification/cognitiveservices/data-plane/Language/readme.md
+++ b/specification/cognitiveservices/data-plane/Language/readme.md
@@ -205,11 +205,3 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
 ```
-
-## Suppression
-
-``` yaml
-directive:
-  - suppress: MISSING_APIS_IN_DEFAULT_TAG
-    reason: Not every service will ship new versions within the Language pillar.
-```


### PR DESCRIPTION
This is a PR made by the Azure SDK Engineering System team.

This PR removes incorrect suppression of Avocado that never worked. See:
- https://github.com/Azure/azure-sdk-tools/issues/6455