### PR TITLE
[dataprotection] Set `final-state-via` to "location" for some APIs due to updated AAZ behaviour.

### DIFF
--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-01-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-01-01/dataprotection.json
@@ -1275,7 +1275,10 @@
             "$ref": "./examples/BackupInstanceOperations/TriggerBackup.json"
           }
         },
-        "x-ms-long-running-operation": true
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/validateForBackup": {
@@ -1348,7 +1351,10 @@
             "$ref": "./examples/BackupInstanceOperations/ValidateForBackup.json"
           }
         },
-        "x-ms-long-running-operation": true
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/operationResults/{operationId}": {
@@ -1670,6 +1676,9 @@
           }
         },
         "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
         "x-ms-examples": {
           "Trigger Restore": {
             "$ref": "./examples/BackupInstanceOperations/TriggerRestore.json"
@@ -2081,6 +2090,9 @@
           }
         },
         "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
         "x-ms-examples": {
           "Validate Restore": {
             "$ref": "./examples/BackupInstanceOperations/ValidateRestore.json"

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-05-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2023-05-01/dataprotection.json
@@ -1275,7 +1275,10 @@
             "$ref": "./examples/BackupInstanceOperations/TriggerBackup.json"
           }
         },
-        "x-ms-long-running-operation": true
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/validateForBackup": {
@@ -1348,7 +1351,10 @@
             "$ref": "./examples/BackupInstanceOperations/ValidateForBackup.json"
           }
         },
-        "x-ms-long-running-operation": true
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/operationResults/{operationId}": {
@@ -1670,6 +1676,9 @@
           }
         },
         "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
         "x-ms-examples": {
           "Trigger Restore": {
             "$ref": "./examples/BackupInstanceOperations/TriggerRestore.json"
@@ -2081,6 +2090,9 @@
           }
         },
         "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
         "x-ms-examples": {
           "Validate Restore": {
             "$ref": "./examples/BackupInstanceOperations/ValidateRestore.json"


### PR DESCRIPTION
Autorest-generated code from swagger (previous version of the dataprotection CLI extension, and present versions of the Powershell extension) defaulted to "location" as their default `final-state-via` value. However, the new AAZ codegen tool for CLI defaults to "azure-async-operation" instead.

This is a correctness PR that explicitly sets the `final-state-via` value to "location" for the affected APIs.