### PR TITLE
Added generator config for OpenAI `Functions` for the Java SDK

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
+++ b/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
@@ -23,6 +23,8 @@ options:
     partial-update: true
     enable-sync-stack: true
     generate-tests: false
+    custom-types-subpackage: "implementation"
+    custom-types: "FunctionCall,FunctionCallModelBase,FunctionCallPreset,FunctionCallPresetFunctionCallModel,FunctionDefinition,FunctionNameFunctionCallModel"
   # "@azure-tools/typespec-ts":
   #   package-dir: "azure-ai-openai"
   #   emitter-output-dir: "{project-root}/generated"

--- a/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
+++ b/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
@@ -23,7 +23,7 @@ options:
     partial-update: true
     enable-sync-stack: true
     generate-tests: false
-    custom-types-subpackage: "implementation"
+    custom-types-subpackage: "implementation.models"
     custom-types: "FunctionCall,FunctionCallModelBase,FunctionCallPreset,FunctionCallPresetFunctionCallModel,FunctionDefinition,FunctionNameFunctionCallModel"
   # "@azure-tools/typespec-ts":
   #   package-dir: "azure-ai-openai"

--- a/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
+++ b/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
@@ -24,7 +24,7 @@ options:
     enable-sync-stack: true
     generate-tests: false
     custom-types-subpackage: "implementation.models"
-    custom-types: "FunctionCall,FunctionCallModelBase,FunctionCallPreset,FunctionCallPresetFunctionCallModel,FunctionDefinition,FunctionNameFunctionCallModel"
+    custom-types: "FunctionCallModelBase,FunctionCallPreset,FunctionCallPresetFunctionCallModel,FunctionDefinition,FunctionNameFunctionCallModel"
   # "@azure-tools/typespec-ts":
   #   package-dir: "azure-ai-openai"
   #   emitter-output-dir: "{project-root}/generated"


### PR DESCRIPTION
- Adding `custom-types` and ` custom-types-subpackage` for the java emitter config to account for custom code for OpenAI functions feature 
- Motivation: `unions` in TSP generate in Java using inheritance. There are issues with serialization with the abstract class that gets generated. We've worked around that difficulty in the SDK itself with customizations. So we are simply redirecting the unused classes generation to a package that is not part of the public API exposed to the user by the SDK.

Using these [docs](https://github.com/Azure/autorest.java#settings) as a reference.