### PR TITLE
`comment.yml` (workflow-bot comments): update breaking changes alternative C to point to alternative B

### DIFF
--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -20,7 +20,9 @@
       **ACTION ITEM ALTERNATIVE C**: Report false positive. <br/>
       If you think there are no breaking changes, 
       i.e. the validation should pass yet it fails, 
-      then please explain why in a PR comment and @ the PR assignee.
+      then proceed as explained in **ACTION ITEM ALTERNATIVE B**.<br/>
+      This applies even if the breaking change tool fails with internal runtime error. 
+      In such case a manual breaking change review is necessary.
 
 - rule:
     type: label
@@ -47,7 +49,9 @@
       **ACTION ITEM ALTERNATIVE C**: Report false positive. <br/>
       If you think there are no changes in existing API version, 
       i.e. there should be no `NewApiVersionRequired` label,
-      then please explain why in a PR comment and @ the PR assignee.
+      then proceed as explained in **ACTION ITEM ALTERNATIVE B**.<br/>
+      This applies even if the breaking change tool fails with internal runtime error. 
+      In such case a manual breaking change review is necessary.
       <br/><br/>   
       For additional guidance, please see https://aka.ms/NewApiVersionRequired
 


### PR DESCRIPTION
This is a PR made by the Azure SDK Engineering System team.

Updating the comments generated on the PR by workflow-bot automation, as requested by @rkmanda  in [this Teams thread](https://teams.microsoft.com/l/message/19:4cd6304470ed4ae982dc851dbffd77f4@thread.v2/1689100091965?context=%7B%22contextType%22%3A%22chat%22%7D).