### PR TITLE
Azure OpenAI: correct optionality of completions content filter category specification 

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/completions.common.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions.common.tsp
@@ -98,13 +98,13 @@ model ContentFilterResults {
    those portrayed as an assault or a forced sexual violent act against one’s will, 
    prostitution, pornography, and abuse.
   """)
-  sexual: ContentFilterResult;
+  sexual?: ContentFilterResult;
 
   @doc("""
   Describes language related to physical actions intended to hurt, injure, damage, or 
   kill someone or something; describes weapons, etc.
   """)
-  violence: ContentFilterResult;
+  violence?: ContentFilterResult;
 
   @doc("""
   Describes language attacks or uses that include pejorative or discriminatory language 
@@ -113,14 +113,14 @@ model ContentFilterResults {
   gender identity and expression, sexual orientation, religion, immigration status, ability
   status, personal appearance, and body size.
   """)
-  hate: ContentFilterResult;
+  hate?: ContentFilterResult;
 
   @doc("""
   Describes language related to physical actions intended to purposely hurt, injure,
   or damage one’s body, or kill oneself.
   """)
   @projectedName("json", "self_harm")
-  selfHarm: ContentFilterResult;
+  selfHarm?: ContentFilterResult;
 }
 
 @added(ServiceApiVersions.v2023_06_01_Preview)

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-06-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-06-01-preview/generated.json
@@ -972,13 +972,7 @@
           "description": "Describes language related to physical actions intended to purposely hurt, injure,\nor damage one’s body, or kill oneself.",
           "x-ms-client-name": "selfHarm"
         }
-      },
-      "required": [
-        "sexual",
-        "violence",
-        "hate",
-        "self_harm"
-      ]
+      }
     },
     "ContentFilterSeverity": {
       "type": "string",

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-07-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-07-01-preview/generated.json
@@ -1005,13 +1005,7 @@
           "description": "Describes language related to physical actions intended to purposely hurt, injure,\nor damage one’s body, or kill oneself.",
           "x-ms-client-name": "selfHarm"
         }
-      },
-      "required": [
-        "sexual",
-        "violence",
-        "hate",
-        "self_harm"
-      ]
+      }
     },
     "ContentFilterSeverity": {
       "type": "string",


### PR DESCRIPTION
This is a very small correction to the prior PR for content filter annotations.

- Our current TypeSpec definition marks each of the four content filter categories (`hate`, etc.) as required properties on the `ContentFilterResults`
- In most cases, this is correct; when the model replies with a `function_call` for Chat Functions, however, `content_filter_results` is populated with an empty JSON object (`"content_filter_results": {}`)
- Treating the individual category properties as optional is correct and aligned with [[the REST API specification for 2023-06-01-preview](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-06-01-preview/inference.json#L991)], which does *not* mark the categories as required
- The inaccurate specification causes some code-generated deserialization of function call responses to fail, as the specification permits enforcing an explicit null check
-  This wasn't caught until now because it's only been recently that a single model deployment supported Chat Functions and content filter annotations simultaneously