### PR TITLE
Revert the change for adding retention policy in ChatThreadItem

### DIFF
--- a/specification/communication/data-plane/Chat/preview/2023-07-01-preview/communicationserviceschat.json
+++ b/specification/communication/data-plane/Chat/preview/2023-07-01-preview/communicationserviceschat.json
@@ -1711,9 +1711,6 @@
           "type": "string",
           "readOnly": true,
           "example": "2020-10-30T10:50:50Z"
-        },
-        "retentionPolicy": {
-          "$ref": "#/definitions/ChatRetentionPolicy"
         }
       }
     },


### PR DESCRIPTION
The Data Retention property is not going to be supported in Chat Thread Item.

The data retention feature has not been released or implemented yet. The change is not a breaking change.