### PR TITLE
[package-lock.json] Add names to local dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       }
     },
     "eng/tools": {
+      "name": "azure-rest-api-specs-eng-tools",
       "dev": true,
       "devDependencies": {
         "@azure-tools/typespec-validation": "file:TypeSpecValidation"
@@ -42,6 +43,7 @@
       "dev": true
     },
     "eng/tools/TypeSpecValidation": {
+      "name": "@azure-tools/typespec-validation",
       "version": "0.0.1",
       "dev": true,
       "hasInstallScript": true,


### PR DESCRIPTION
- Command "npm update" removes these names, but "npm install" adds them
- It's probably better to keep the names, since users are more likely to run "npm install"
