### PR TITLE
[OpenAI] Removed `FunctionDefinition` as custom class

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
+++ b/specification/cognitiveservices/OpenAI.Inference/tspconfig.yaml
@@ -24,7 +24,7 @@ options:
     enable-sync-stack: true
     generate-tests: false
     custom-types-subpackage: "implementation.models"
-    custom-types: "FunctionCallModelBase,FunctionCallPreset,FunctionCallPresetFunctionCallModel,FunctionDefinition,FunctionNameFunctionCallModel"
+    custom-types: "FunctionCallModelBase,FunctionCallPreset,FunctionCallPresetFunctionCallModel,FunctionNameFunctionCallModel"
   # "@azure-tools/typespec-ts":
   #   package-dir: "azure-ai-openai"
   #   emitter-output-dir: "{project-root}/generated"


### PR DESCRIPTION
We need to make `FunctionDefinition` public to the user as it's part of the request object for `ChatCompletions`