### PR TITLE
Updated doc for Get Path Properties API for CT and ET header

### DIFF
--- a/specification/storage/data-plane/Microsoft.StorageDataLake/preview/2021-06-08/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/preview/2021-06-08/DataLakeStorage.json
@@ -1619,6 +1619,14 @@
                 "description": "The lease status of the resource.",
                 "type": "string"
               }
+              "x-ms-creation-time": {
+                "description": "The creation time of the given path. The format would be RFC1123.",
+                "type": "string"
+              }
+              "x-ms-expiry-time": {
+                "description": "The expiry time of the given path. The format would be RFC1123.",
+                "type": "string"
+              }
             }
           },
           "default": {


### PR DESCRIPTION
# Updated documentation for Get Path Properties API

The Get Path Status and Get Path Properties API are now enabled to return the following headers for request versions >= 2023_05_03:

- **x-ms-creation-time**: The creation time of the given path. It will have a string type, and the format would be RFC1123.
- **x-ms-expiry-time**: The expiry time of the given path. It will have a string type, and the format would be RFC1123.