### PR TITLE
update parameter name in selfhelp sample

### DIFF
--- a/specification/help/resource-manager/Microsoft.Help/stable/2023-06-01/examples/CreateDiagnosticForKeyVaultResource.json
+++ b/specification/help/resource-manager/Microsoft.Help/stable/2023-06-01/examples/CreateDiagnosticForKeyVaultResource.json
@@ -3,7 +3,7 @@
     "api-version": "2023-06-01",
     "scope": "subscriptions/0d0fcd2e-c4fd-4349-8497-200edb3923c6/resourcegroups/myresourceGroup/providers/Microsoft.KeyVault/vaults/test-keyvault-non-read",
     "diagnosticsResourceName": "VMNotWorkingInsight",
-    "diagnosticItemRequest": {
+    "diagnosticResourceRequest": {
       "properties": {
         "insights": [
           {


### PR DESCRIPTION
fix :https://github.com/Azure/azure-sdk-for-js/issues/26371
we notice that above issue is because the wrong parameter name between swagger and example, this pr is to fix this