### PR TITLE
[TypeSpec Validation] Get-TypeSpec-Folders.ps1 should only validate all specs on selected files

### DIFF
--- a/eng/scripts/Get-TypeSpec-Folders.ps1
+++ b/eng/scripts/Get-TypeSpec-Folders.ps1
@@ -30,7 +30,16 @@ else {
   Write-Host
 
   $engFiles = $changedFiles | Where-Object {if ($_) { $_.StartsWith('eng') }}
-  $repoRootFiles = $changedFiles | Where-Object {$_ -notmatch [Regex]::Escape([IO.Path]::DirectorySeparatorChar)}
+
+  $rootFilesImpactingTypeSpec = @(
+    ".gitattributes",
+    ".prettierrc.json",
+    "package-lock.json",
+    "package.json",
+    "tsconfig.json"
+  )
+  $repoRootFiles = $changedFiles | Where-Object {$_ -in $rootFilesImpactingTypeSpec}
+
   if ($engFiles -or $repoRootFiles) {
     $changedFiles = $allChangedFiles
   }


### PR DESCRIPTION
- Fixes #25006
