### PR TITLE
Adding new disk property - LastOwnershipUpdateTime

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/DiskRP/stable/2023-04-02/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/DiskRP/stable/2023-04-02/disk.json
@@ -766,6 +766,12 @@
         "optimizedForFrequentAttach": {
           "type": "boolean",
           "description": "Setting this property to true improves reliability and performance of data disks that are frequently (more than 5 times a day) by detached from one virtual machine and attached to another. This property should not be set for disks that are not detached and attached frequently as it causes the disks to not align with the fault domain of the virtual machine."
+        },
+        "LastOwnershipUpdateTime": {
+          "readOnly": true,
+          "type": "string",
+          "format": "date-time",
+          "description": "The time when the disk ownership last updated."
         }
       },
       "required": [

--- a/specification/compute/resource-manager/Microsoft.Compute/DiskRP/stable/2023-04-02/examples/diskExamples/Disk_Get.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/DiskRP/stable/2023-04-02/examples/diskExamples/Disk_Get.json
@@ -56,6 +56,7 @@
           "encryption": {
             "type": "EncryptionAtRestWithPlatformKey"
           },
+          "LastOwnershipUpdateTime": "2016-12-28T04:41:35.079872+00:00",
           "timeCreated": "2016-12-28T04:41:35.079872+00:00",
           "provisioningState": "Succeeded"
         },


### PR DESCRIPTION
Adding new disk property - LastOwnershipUpdateTime.
This property provides the time when the disk switched between the states - attached/detached/reserved.