### PR TITLE
authorization: adding the missing `$filter` option

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/stable/2020-10-01/RoleManagementPolicy.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/stable/2020-10-01/RoleManagementPolicy.json
@@ -203,6 +203,13 @@
             "x-ms-skip-url-encoding": true
           },
           {
+            "name": "$filter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "The filter to apply on the operation. For example '$filter=roleDefinitionId%20eq%20'{scope}/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}'"
+          },
+          {
             "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
           }
         ],


### PR DESCRIPTION
This is defined here: https://learn.microsoft.com/en-us/rest/api/authorization/privileged-role-policy-rest-sample
Fixes https://github.com/hashicorp/go-azure-sdk/issues/288