### PR TITLE
Add comment handler for `/pr RequestMerge`

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,41 @@
+name: Comment Processor
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  comment-handler:
+    permissions:
+      pull-requests: write # to read pull requests and write comments
+    name: Handle ${{ github.event_name }} ${{ github.event.action }} event
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process comment
+        shell: pwsh
+        run: |
+          $payload = echo $env:PAYLOAD | ConvertFrom-Json -AsHashtable
+          if (!$payload.comment -or !$payload.comment.body) {
+            Write-Host "Empty comment, returning..."
+            return
+          }
+          $body = $payload.comment.body.Trim().ToLowerInvariant()
+          $expected = '/pr requestmerge'
+          if ($body -ne $expected) {
+            Write-Host "Comment did not equal '$expected', skipping..."
+            return
+          }
+          $label = 'MergeRequested'
+          Write-Host "gh pr edit $($payload.issue.number) --add-label `"$label`""
+          gh pr edit $payload.issue.html_url --add-label "$label"
+          if ($LASTEXITCODE) {
+            Write-Warning "Failed to add label"
+            exit $LASTEXITCODE
+          }
+        env:
+          PAYLOAD: ${{ toJson(github.event) }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+


### PR DESCRIPTION
This adds a way for PR users to update labels related to the arm review/merge workflows, but without requiring the user to have label edit permissions.

A user can comment `/pr RequestMerge` to add the `MergeRequested` label. 

NOTE: This is intended to be a very short term workaround to unblock some workflows until we can move this functionality behind either the workflow bot or the github event processor.