### PR TITLE
digitaltwins: `recordPropertyAndItemRemovals` is defined as a string constant when the API returns a boolean

### DIFF
--- a/specification/digitaltwins/resource-manager/Microsoft.DigitalTwins/stable/2023-01-31/digitaltwins.json
+++ b/specification/digitaltwins/resource-manager/Microsoft.DigitalTwins/stable/2023-01-31/digitaltwins.json
@@ -2207,16 +2207,7 @@
         },
         "recordPropertyAndItemRemovals": {
           "description": "Specifies whether or not to record twin / relationship property and item removals, including removals of indexed or keyed values (such as map entries, array elements, etc.). This feature is de-activated unless explicitly set to 'true'. Setting this property to 'true' will generate an additional column in the property events table in ADX.",
-          "enum": [
-            "true",
-            "false"
-          ],
-          "type": "string",
-          "x-ms-enum": {
-            "name": "recordPropertyAndItemRemovals",
-            "modelAsString": true
-          },
-          "default": "false",
+          "type": "boolean",
           "x-nullable": true
         }
       }

--- a/specification/digitaltwins/resource-manager/Microsoft.DigitalTwins/stable/2023-01-31/examples/TimeSeriesDatabaseConnectionsPut_WithUserIdentity_example.json
+++ b/specification/digitaltwins/resource-manager/Microsoft.DigitalTwins/stable/2023-01-31/examples/TimeSeriesDatabaseConnectionsPut_WithUserIdentity_example.json
@@ -44,7 +44,7 @@
           "eventHubNamespaceResourceId": "/subscriptions/c493073e-2460-45ba-a403-f3e0df1e9feg/resourceGroups/testrg/providers/Microsoft.EventHub/namespaces/myeh",
           "eventHubEntityPath": "myeh",
           "eventHubConsumerGroup": "$Default",
-          "recordPropertyAndItemRemovals": "false",
+          "recordPropertyAndItemRemovals": false,
           "identity": {
             "type": "UserAssigned",
             "userAssignedIdentity": "/subscriptions/50016170-c839-41ba-a724-51e9df440b9e/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity"
@@ -67,7 +67,7 @@
           "eventHubEndpointUri": "sb://myeh.servicebus.windows.net/",
           "eventHubEntityPath": "myeh",
           "eventHubConsumerGroup": "$Default",
-          "recordPropertyAndItemRemovals": "false",
+          "recordPropertyAndItemRemovals": false,
           "eventHubNamespaceResourceId": "/subscriptions/c493073e-2460-45ba-a403-f3e0df1e9feg/resourceGroups/testrg/providers/Microsoft.EventHub/namespaces/myeh",
           "identity": {
             "type": "UserAssigned",

--- a/specification/digitaltwins/resource-manager/Microsoft.DigitalTwins/stable/2023-01-31/examples/TimeSeriesDatabaseConnectionsPut_example.json
+++ b/specification/digitaltwins/resource-manager/Microsoft.DigitalTwins/stable/2023-01-31/examples/TimeSeriesDatabaseConnectionsPut_example.json
@@ -17,7 +17,7 @@
         "eventHubEndpointUri": "sb://myeh.servicebus.windows.net/",
         "eventHubNamespaceResourceId": "/subscriptions/c493073e-2460-45ba-a403-f3e0df1e9feg/resourceGroups/testrg/providers/Microsoft.EventHub/namespaces/myeh",
         "eventHubEntityPath": "myeh",
-        "recordPropertyAndItemRemovals": "true"
+        "recordPropertyAndItemRemovals": true
       }
     }
   },
@@ -45,7 +45,7 @@
           "eventHubNamespaceResourceId": "/subscriptions/c493073e-2460-45ba-a403-f3e0df1e9feg/resourceGroups/testrg/providers/Microsoft.EventHub/namespaces/myeh",
           "eventHubEntityPath": "myeh",
           "eventHubConsumerGroup": "$Default",
-          "recordPropertyAndItemRemovals": "true"
+          "recordPropertyAndItemRemovals": true
         }
       }
     },
@@ -67,7 +67,7 @@
           "eventHubNamespaceResourceId": "/subscriptions/c493073e-2460-45ba-a403-f3e0df1e9feg/resourceGroups/testrg/providers/Microsoft.EventHub/namespaces/myeh",
           "eventHubEntityPath": "myeh",
           "eventHubConsumerGroup": "$Default",
-          "recordPropertyAndItemRemovals": "true"
+          "recordPropertyAndItemRemovals": true
         }
       }
     }


### PR DESCRIPTION
API Response:

```
{
	"id": "/subscriptions/XXXXX/resourceGroups/acctestRG-digitaltwin-230802144535974018/providers/Microsoft.DigitalTwins/digitalTwinsInstances/acctest-DT-230802144535974018/timeSeriesDatabaseConnections/connection-230802144535974018",
	"name": "connection-230802144535974018",
	"type": "Microsoft.DigitalTwins/digitalTwinsInstances/timeSeriesDatabaseConnections",
	"properties": {
		"connectionType": "AzureDataExplorer",
		"adxEndpointUri": "https://acctestkcla4eo.eastus2.kusto.windows.net",
		"adxResourceId": "/subscriptions/XXXXX/resourceGroups/acctestRG-digitaltwin-230802144535974018/providers/Microsoft.Kusto/clusters/acctestkcla4eo",
		"adxDatabaseName": "acctestkd-230802144535974018",
		"adxTableName": "AdtPropertyEvents",
		"eventHubNamespaceResourceId": "/subscriptions/XXXXX/resourceGroups/acctestRG-digitaltwin-230802144535974018/providers/Microsoft.EventHub/namespaces/acctesteventhubnamespace-230802144535974018",
		"eventHubEndpointUri": "sb://acctesteventhubnamespace-230802144535974018.servicebus.windows.net",
		"eventHubEntityPath": "acctesteventhub-230802144535974018",
		"eventHubConsumerGroup": "$Default",
		"recordPropertyAndItemRemovals": false,
		"provisioningState": "Succeeded"
	},
	"systemData": {
		"createdBy": "XXXXX",
		"createdByType": "Application",
		"createdAt": "2023-08-02T15:00:09.2909952Z",
		"lastModifiedBy": "XXXXX",
		"lastModifiedByType": "Application",
		"lastModifiedAt": "2023-08-02T15:00:09.2909952Z"
	}
}
```

As such this should be defined as a Boolean in the API Definition - since parsing a Boolean as a literal String value will fail