### PR TITLE
asm: update examples to use asm- prefix for revisions

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-07-02-preview/examples/ManagedClustersGet_MeshRevisionProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-07-02-preview/examples/ManagedClustersGet_MeshRevisionProfile.json
@@ -14,7 +14,7 @@
         "properties": {
           "meshRevisions": [
             {
-              "revision": "1-17",
+              "revision": "asm-1-17",
               "upgrades": [
                 "1-18"
               ],
@@ -31,7 +31,7 @@
               ]
             },
             {
-              "revision": "1-18",
+              "revision": "asm-1-18",
               "upgrades": [],
               "compatibleWith": [
                 {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-07-02-preview/examples/ManagedClustersGet_MeshUpgradeProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-07-02-preview/examples/ManagedClustersGet_MeshUpgradeProfile.json
@@ -13,7 +13,7 @@
         "type": "Microsoft.ContainerService/managedClusters/meshUpgradeProfiles",
         "name": "istio",
         "properties": {
-          "revision": "1-17",
+          "revision": "asm-1-17",
           "upgrades": [
             "1-18"
           ],

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-07-02-preview/examples/ManagedClustersList_MeshRevisionProfiles.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-07-02-preview/examples/ManagedClustersList_MeshRevisionProfiles.json
@@ -15,7 +15,7 @@
             "properties": {
               "meshRevisions": [
                 {
-                  "revision": "1-17",
+                  "revision": "asm-1-17",
                   "upgrades": [
                     "1-18"
                   ],
@@ -32,7 +32,7 @@
                   ]
                 },
                 {
-                  "revision": "1-18",
+                  "revision": "asm-1-18",
                   "upgrades": [],
                   "compatibleWith": [
                     {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-07-02-preview/examples/ManagedClustersList_MeshUpgradeProfiles.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2023-07-02-preview/examples/ManagedClustersList_MeshUpgradeProfiles.json
@@ -14,7 +14,7 @@
             "type": "Microsoft.ContainerService/managedClusters/meshUpgradeProfiles",
             "name": "istio",
             "properties": {
-              "revision": "1-17",
+              "revision": "asm-1-17",
               "upgrades": [
                 "1-18"
               ],


### PR DESCRIPTION
Updates the examples for service mesh operations to use "asm-1-17" instead of "1-17" as this is what we use in our charts