### PR TITLE
{AzureRESTAPISpecs} Broken link in Getting started with OpenAPI specifications content

### DIFF
--- a/documentation/Getting started with OpenAPI specifications.md
+++ b/documentation/Getting started with OpenAPI specifications.md
@@ -11,7 +11,7 @@ Currently, we only support `OpenAPI Specification 2.0` or `Swagger V2.0`.
 
 * **[`Understanding the GitHub flow`](https://guides.github.com/introduction/flow/)**
 * **[`CONTRIBUTING.md`](https://github.com/Azure/azure-rest-api-specs/blob/main/CONTRIBUTING.md)**
-* **[`Azure REST API guidelines`](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md)**
+* **[`Azure REST API guidelines`](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md)**
 * **[`Azure OpenAPI Style Guide`](https://github.com/Azure/azure-api-style-guide/blob/main/openapi-style-guide.md)**
 * **[`Resource Provider Guidelines`](https://aka.ms/rpguidelines)**
 * **[`Directory structure`](https://github.com/Azure/azure-rest-api-specs/blob/main/README.md#directory-structure)**

--- a/documentation/Getting started with OpenAPI specifications.md
+++ b/documentation/Getting started with OpenAPI specifications.md
@@ -11,7 +11,7 @@ Currently, we only support `OpenAPI Specification 2.0` or `Swagger V2.0`.
 
 * **[`Understanding the GitHub flow`](https://guides.github.com/introduction/flow/)**
 * **[`CONTRIBUTING.md`](https://github.com/Azure/azure-rest-api-specs/blob/main/CONTRIBUTING.md)**
-* **[`Azure REST API guidelines`](https://github.com/microsoft/api-guidelines/blob/vNext/Azure/Guidelines.md)**
+* **[`Azure REST API guidelines`](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md)**
 * **[`Azure OpenAPI Style Guide`](https://github.com/Azure/azure-api-style-guide/blob/main/openapi-style-guide.md)**
 * **[`Resource Provider Guidelines`](https://aka.ms/rpguidelines)**
 * **[`Directory structure`](https://github.com/Azure/azure-rest-api-specs/blob/main/README.md#directory-structure)**


### PR DESCRIPTION
Fixes Azure/azure-rest-api-specs#25243

Reference docs: https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/Getting%20started%20with%20OpenAPI%20specifications.md

Azure REST API guidelines hyper link is incorrect.

Incorrect Link: https://github.com/microsoft/api-guidelines/blob/vNext/Azure/Guidelines.md

Correct Link: https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
