### PR TITLE
EventGrid Eventhub system events: Add format type to Integer

### DIFF
--- a/specification/eventgrid/data-plane/Microsoft.EventHub/stable/2018-01-01/EventHub.json
+++ b/specification/eventgrid/data-plane/Microsoft.EventHub/stable/2018-01-01/EventHub.json
@@ -26,18 +26,22 @@
         },
         "sizeInBytes": {
           "description": "The file size.",
+          "format": "int32",
           "type": "integer"
         },
         "eventCount": {
           "description": "The number of events in the file.",
+          "format": "int32",
           "type": "integer"
         },
         "firstSequenceNumber": {
           "description": "The smallest sequence number from the queue.",
+          "format": "int32",
           "type": "integer"
         },
         "lastSequenceNumber": {
           "description": "The last sequence number from the queue.",
+          "format": "int32",
           "type": "integer"
         },
         "firstEnqueueTime": {


### PR DESCRIPTION
Updating SystemEvent to contain the format of `integer`. Either `int32` or `int64`