### PR TITLE
Add flush operation to 2023-08-01 Redis API version

### DIFF
--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
@@ -11,7 +11,6 @@
         "location": "https://management.azure.com/subscriptions/subscription-id/providers/Microsoft.Cache/...pathToOperationResult...",
         "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subscription-id/providers/Microsoft.Cache/...pathToOperationResult..."
       }
-    },
-    "200": {}
+    }
   }
 }

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "name": "cache-name",
+    "cacheName": "cache-name",
     "resourceGroupName": "resource-group-name",
     "api-version": "2023-08-01",
     "subscriptionId": "subcription-id"

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "cache-name",
+    "resourceGroupName": "resource-group-name",
+    "api-version": "2023-08-01",
+    "subscriptionId": "subcription-id"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/subscription-id/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  }
+}

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
@@ -13,7 +13,9 @@
       }
     },
     "200": {
-      "body": {}
+      "body": {
+        "status": "Succeeded"
+      }
     }
   }
 }

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
@@ -8,8 +8,10 @@
   "responses": {
     "202": {
       "headers": {
-        "location": "https://management.azure.com/subscriptions/subscription-id/providers/Microsoft.Cache/...pathToOperationResult..."
+        "location": "https://management.azure.com/subscriptions/subscription-id/providers/Microsoft.Cache/...pathToOperationResult...",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subscription-id/providers/Microsoft.Cache/...pathToOperationResult..."
       }
-    }
+    },
+    "200": {}
   }
 }

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
@@ -11,6 +11,7 @@
         "location": "https://management.azure.com/subscriptions/subscription-id/providers/Microsoft.Cache/...pathToOperationResult...",
         "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subscription-id/providers/Microsoft.Cache/...pathToOperationResult..."
       }
-    }
+    },
+    "200": {}
   }
 }

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheFlush.json
@@ -12,6 +12,8 @@
         "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subscription-id/providers/Microsoft.Cache/...pathToOperationResult..."
       }
     },
-    "200": {}
+    "200": {
+      "body": {}
+    }
   }
 }

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -791,9 +791,6 @@
                 "description": "URL to query for the status of the operation.",
                 "type": "string"
               }
-            },
-            "schema" : {
-              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationStatusResult"
             }
           },
           "200": {
@@ -807,6 +804,7 @@
                 "description": "URL to query for the status of the operation.",
                 "type": "string"
               }
+            }
           },
           "default": {
             "description": "Error response describing why the operation failed.",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -804,7 +804,8 @@
                 "description": "URL to query for the status of the operation.",
                 "type": "string"
               }
-            }
+            },
+            "schema": {}
           },
           "default": {
             "description": "Error response describing why the operation failed.",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -793,6 +793,19 @@
               }
             }
           },
+          "200": {
+            "description": "Flush operation succeeded.",
+            "headers": {
+              "Location": {
+                "description": "URL to query for the status of the operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "URL to query for the status of the operation.",
+                "type": "string"
+              }
+            }
+          },
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -744,6 +744,53 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{name}/flush": {
+      "post": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_FlushCache",
+        "x-ms-examples": {
+          "RedisCacheFlush": {
+            "$ref": "./examples/RedisCacheFlush.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "description": "Deletes all of the keys in a cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Redis cache."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Flush operation successfully enqueued; follow the Location header to poll for final outcome."
+          },
+          "200": {
+            "description": "Flush operation succeeded."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{cacheName}/firewallRules": {
       "get": {
         "tags": [

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -805,7 +805,9 @@
                 "type": "string"
               }
             },
-            "schema": {}
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/OperationStatusResult"
+            }
           },
           "default": {
             "description": "Error response describing why the operation failed.",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -766,11 +766,7 @@
             "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "The name of the Redis cache."
+            "$ref": "#/parameters/CacheNameParameter"
           },
           {
             "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -756,6 +756,10 @@
           }
         },
         "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "../../../../../common-types/resource-management/v5/types.json#/definitions/OperationStatusResult"
+        },
         "description": "Deletes all of the keys in a cache.",
         "parameters": [
           {
@@ -777,10 +781,32 @@
         ],
         "responses": {
           "202": {
-            "description": "Flush operation successfully enqueued; follow the Location header to poll for final outcome."
+            "description": "Flush operation successfully enqueued; follow the Location header to poll for final outcome.",
+            "headers": {
+              "Location": {
+                "description": "URL to query for the status of the operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "URL to query for the status of the operation.",
+                "type": "string"
+              }
+            },
+            "schema" : {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationStatusResult"
+            }
           },
           "200": {
-            "description": "Flush operation succeeded."
+            "description": "Flush operation succeeded.",
+            "headers": {
+              "Location": {
+                "description": "URL to query for the status of the operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "URL to query for the status of the operation.",
+                "type": "string"
+              }
           },
           "default": {
             "description": "Error response describing why the operation failed.",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -793,19 +793,6 @@
               }
             }
           },
-          "200": {
-            "description": "Flush operation succeeded.",
-            "headers": {
-              "Location": {
-                "description": "URL to query for the status of the operation.",
-                "type": "string"
-              },
-              "Azure-AsyncOperation": {
-                "description": "URL to query for the status of the operation.",
-                "type": "string"
-              }
-            }
-          },
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -744,7 +744,7 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{name}/flush": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{cacheName}/flush": {
       "post": {
         "tags": [
           "Redis"


### PR DESCRIPTION
Adds the flush endpoint to the OpenAPI spec for Redis in the 2023-08-01 API version.

This PR is into a dev branch, so does not need to be reviewed by ARM reviewers. 