### PR TITLE
[TypeSpec Validation] Require minimum Node versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/eng/tools/TypeSpecValidation/package.json
+++ b/eng/tools/TypeSpecValidation/package.json
@@ -18,5 +18,8 @@
     },
     "scripts": {
         "postinstall": "tsc"
+    },
+    "engines": {
+        "node": "^16.17.0 || ^18.3.0 || ^20.0.0"
     }
 }


### PR DESCRIPTION
- Prevents downstream errors if users have incompatible Node version
- Fixes #25315

```
$ nvm use 16.16.0
$ npm ci
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: @azure-tools/typespec-validation@0.0.1
npm ERR! notsup Required: {"node":"^16.17.0 || ^18.3.0 || ^20.0.0"}
npm ERR! notsup Actual:   {"npm":"8.11.0","node":"v16.16.0"}

$ nvm use 16.17.0
$ npm ci
added 216 packages, and audited 219 packages in 4s
```