### PR TITLE
Adds UpdateChannel property to Redis-API

### DIFF
--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheCreate.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheCreate.json
@@ -54,6 +54,7 @@
           "enableNonSslPort": false,
           "replicasPerMaster": 2,
           "replicasPerPrimary": 2,
+          "updateChannel": "Stable",
           "redisConfiguration": {
             "maxmemory-policy": "allkeys-lru"
           },
@@ -139,6 +140,7 @@
           "enableNonSslPort": false,
           "replicasPerMaster": 2,
           "replicasPerPrimary": 2,
+          "updateChannel": "Stable",
           "redisConfiguration": {
             "maxclients": "1000",
             "maxmemory-reserved": "50",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheCreateDefaultVersion.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheCreateDefaultVersion.json
@@ -53,6 +53,7 @@
           "enableNonSslPort": false,
           "replicasPerMaster": 2,
           "replicasPerPrimary": 2,
+          "updateChannel": "Stable",
           "redisConfiguration": {
             "maxmemory-policy": "allkeys-lru"
           },
@@ -138,6 +139,7 @@
           "enableNonSslPort": false,
           "replicasPerMaster": 2,
           "replicasPerPrimary": 2,
+          "updateChannel": "Stable",
           "redisConfiguration": {
             "maxclients": "1000",
             "maxmemory-reserved": "50",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheCreateLatestVersion.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheCreateLatestVersion.json
@@ -54,6 +54,7 @@
           "enableNonSslPort": false,
           "replicasPerMaster": 2,
           "replicasPerPrimary": 2,
+          "updateChannel": "Stable",
           "redisConfiguration": {
             "maxmemory-policy": "allkeys-lru"
           },
@@ -139,6 +140,7 @@
           "enableNonSslPort": false,
           "replicasPerMaster": 2,
           "replicasPerPrimary": 2,
+          "updateChannel": "Stable",
           "redisConfiguration": {
             "maxclients": "1000",
             "maxmemory-reserved": "50",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheGet.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheGet.json
@@ -24,6 +24,7 @@
           "enableNonSslPort": true,
           "replicasPerMaster": 2,
           "replicasPerPrimary": 2,
+          "updateChannel": "Stable",
           "redisConfiguration": {},
           "hostName": "cache1.redis.cache.windows.net",
           "port": 6379,

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheList.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheList.json
@@ -24,6 +24,7 @@
               "enableNonSslPort": true,
               "replicasPerMaster": 2,
               "replicasPerPrimary": 2,
+              "updateChannel": "Stable",
               "redisConfiguration": {},
               "hostName": "cache1.redis.cache.windows.net",
               "port": 6379,

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheUpdate.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/examples/RedisCacheUpdate.json
@@ -34,6 +34,7 @@
           "enableNonSslPort": true,
           "replicasPerMaster": 2,
           "replicasPerPrimary": 2,
+          "updateChannel": "Stable",
           "redisConfiguration": {
             "maxclients": "1000",
             "maxmemory-reserved": "50",
@@ -87,6 +88,7 @@
           "enableNonSslPort": true,
           "replicasPerMaster": 2,
           "replicasPerPrimary": 2,
+          "updateChannel": "Stable",
           "redisConfiguration": {
             "maxclients": "1000",
             "maxmemory-reserved": "50",

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -2305,7 +2305,7 @@
         },
         "updateChannel": {
           "type": "string",
-          "description": "Optional: Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using 'Preview' update channel get latest Redis updates ahead of 'Stable' channel caches. Default value is 'Stable'.",
+          "description": "Optional: Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using 'Preview' update channel get latest Redis updates at least 4 weeks ahead of 'Stable' channel caches. Default value is 'Stable'.",
           "enum": [
             "Stable",
             "Preview"

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -2305,7 +2305,7 @@
         },
         "updateChannel": {
           "type": "string",
-          "description": "Optional: Specifies the update channel for the monthly Redis Bits the Redis Cache will receive. Preview contains our latest features. Default value is 'Stable'.",
+          "description": "Optional: Specifies the update channel for the monthly Redis updates your Redis Cache will receive. Caches using 'Preview' update channel get latest Redis updates ahead of 'Stable' channel caches. Default value is 'Stable'.",
           "enum": [
             "Stable",
             "Preview"

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -2305,7 +2305,7 @@
         },
         "updateChannel": {
           "type": "string",
-          "description": "Optional: Specifies the update channel for the Redis Cache. Default value is 'Stable'.",
+          "description": "Optional: Specifies the update channel for the monthly Redis Bits the Redis Cache will receive. Preview contains our latest features. Default value is 'Stable'.",
           "enum": [
             "Stable",
             "Preview"

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -2302,6 +2302,18 @@
             "name": "PublicNetworkAccess",
             "modelAsString": true
           }
+        },
+        "updateChannel": {
+          "type": "string",
+          "description": "Optional: Specifies the update channel for the Redis Cache. Default value is 'Stable'.",
+          "enum": [
+            "Stable",
+            "Preview"
+          ],
+          "x-ms-enum": {
+            "name": "UpdateChannel",
+            "modelAsString": true
+          }
         }
       },
       "description": "Create/Update/Get common properties of the redis cache.",


### PR DESCRIPTION
Adds the updateChannel property to the OpenAPI spec for Redis in the 2023-08-01 API version.

This PR is into a dev branch, so does not need to be reviewed by ARM reviewers.