### PR TITLE
Remove redundant, obsolete guidance - PR 2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
@@ -52,6 +52,17 @@ and followed the instructions by checking all the boxes:
 - If you want to force ARM review, add the label yourself.
 - Proceed according to the diagram at the top of this comment.
 
+## Viewing API changes
+
+For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
+in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 
+
+## Suppressing failures
+
+If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
+[Swagger-Suppression-Process](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/85/Swagger-Suppression-Process) 
+to get approval.
+
 ## Getting help
 
 - For general PR approval workflow, see the diagram at the top of this comment.

--- a/.github/PULL_REQUEST_TEMPLATE/data_plane_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/data_plane_template.md
@@ -13,10 +13,22 @@ Is this review for (select one):
 - [ ] GA release
 
 ### Change Scope
+
 <sup>This section will help us focus on the specific parts of your API that are new or have been modified. <br/>Please share a link to the design document for the new APIs, a link to the previous API Spec document (if applicable), and the root paths that have been updated. </sup>
 * Design Document:
 * Previous API Spec Doc:
 * Updated paths:
+
+### Viewing API changes
+
+For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
+in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 
+
+### Suppressing failures
+
+If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
+[Swagger-Suppression-Process](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/85/Swagger-Suppression-Process) 
+to get approval.
 
 ## ❔Got questions? Need additional info?? We are here to help!
 
@@ -33,16 +45,19 @@ The [Azure API Review Board](https://aka.ms/azsdk/onboarding/restapischedule) is
   <summary>Click here for links to tools, specs, guidelines & other good stuff</summary>
 
 ### Tooling
+
  * [Open API validation tools](https://aka.ms/swaggertools) were run on this PR. Go here to see [how to fix errors](https://aka.ms/ci-fix)
  * [Spectral Linting](https://aka.ms/style)
  * [Open API Hub](https://aka.ms/openapiportal)
 
 ### Guidelines & Specifications
+
  * [Azure REST API Guidelines](https://aka.ms/guidelines)
  * [OpenAPI Style Guidelines](https://aka.ms/style)
  * [Azure Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy)
 
 ### Helpful Links
+
  * [Azure DevTools Wiki](https://aka.ms/azapi)
 
 </details>

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -1,11 +1,6 @@
 ---
 - rule:
     type: label
-    label: SuppressionReviewRequired
-    onLabeledComments: "Hi @${PRAuthor}, one or multiple validation error/warning suppression(s) is detected in your PR. Please follow the [Swagger-Suppression-Process](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/85/Swagger-Suppression-Process) to get approval."
-
-- rule:
-    type: label
     label: "CI-MissingBaseCommit"
     onLabeledComments: >-
       Hi @${PRAuthor}! For review efficiency consideration, 


### PR DESCRIPTION
This is a PR made by the Azure SDK Engineering System team

This is a follow-up to:
- https://github.com/Azure/azure-rest-api-specs/pull/25341