### PR TITLE
Recommend "npm ci" over "npm install"

### DIFF
--- a/documentation/typespec-rest-api-dev-process.md
+++ b/documentation/typespec-rest-api-dev-process.md
@@ -28,7 +28,7 @@ If you are developing within your own ADO repo first and then submitting into `a
 - Run following command in the **repository root folder**. This will install required packages such as TypeSpec compilers and Azure Library packages.
 
 ```
-   npm install
+   npm ci
 ```
 
 - Ensure you can run TypeSpec command within the repo folders.


### PR DESCRIPTION
Command `npm ci` is preferable to ensure the correct versions are installed:

https://docs.npmjs.com/cli/v9/commands/npm-ci#description