### PR TITLE
[TypeSpecValidation] Initialize "errorOutput" to avoid getting string "undefined"

### DIFF
--- a/eng/tools/TypeSpecValidation/src/rules/compile.ts
+++ b/eng/tools/TypeSpecValidation/src/rules/compile.ts
@@ -10,7 +10,7 @@ export class CompileRule implements Rule {
   async execute(folder: string): Promise<RuleResult> {
     let success = true;
     let stdOutput = "";
-    let errorOutput: string | undefined;
+    let errorOutput = "";
 
     if (await checkFileExists(path.join(folder, "main.tsp"))) {
       let [err, stdout, stderr] = await runCmd(`npx --no tsp compile . --warn-as-error`, folder);

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
@@ -2,6 +2,7 @@ import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-providerhub-controller";
 import "../Contoso.WidgetManager.Shared";
 
 using TypeSpec.Http;

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
@@ -2,7 +2,6 @@ import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
-import "@azure-tools/typespec-providerhub-controller";
 import "../Contoso.WidgetManager.Shared";
 
 using TypeSpec.Http;


### PR DESCRIPTION
Fixes output like this:

```
Rule Compile failed
undefinedCommand failed: npx --no tsp compile . --warn-as-error
^^^^^^^^^
```