### PR TITLE
java mgmt api center, fix service-name case

### DIFF
--- a/specification/apicenter/resource-manager/readme.java.md
+++ b/specification/apicenter/resource-manager/readme.java.md
@@ -1,0 +1,7 @@
+## Java
+
+These settings apply only when `--java` is specified on the command line.
+
+```yaml $(java)
+service-name: ApiCenter
+```

--- a/specification/apicenter/resource-manager/readme.md
+++ b/specification/apicenter/resource-manager/readme.md
@@ -77,3 +77,7 @@ See configuration in [readme.typescript.md](./readme.typescript.md)
 ## CSharp
 
 See configuration in [readme.csharp.md](./readme.csharp.md)
+
+## Java
+
+See configuration in [readme.java.md](./readme.java.md)


### PR DESCRIPTION
For java SDK codegen. https://github.com/Azure/azure-sdk-for-java/pull/36514/files#r1305092407