### PR TITLE
Reduce duplication in generated SDKs

### DIFF
--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -61,7 +61,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -106,7 +106,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -160,7 +160,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -231,7 +231,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -291,7 +291,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -339,7 +339,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -383,7 +383,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -422,7 +422,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -461,7 +461,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -510,7 +510,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -565,7 +565,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -620,7 +620,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -679,7 +679,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -738,7 +738,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -808,7 +808,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -851,7 +851,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -919,7 +919,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -967,7 +967,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1015,7 +1015,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1058,7 +1058,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1137,7 +1137,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1196,7 +1196,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1255,7 +1255,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1324,7 +1324,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1381,7 +1381,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1432,7 +1432,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1478,7 +1478,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1523,7 +1523,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1571,7 +1571,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1630,7 +1630,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1673,7 +1673,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1715,7 +1715,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1768,7 +1768,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1830,7 +1830,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1886,7 +1886,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1930,7 +1930,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -1973,7 +1973,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2038,7 +2038,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -2094,7 +2094,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -2138,7 +2138,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         }
@@ -2181,7 +2181,7 @@
           "default": {
             "description": "Error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
         },

--- a/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/stable/2023-08-01/redis.json
@@ -758,7 +758,7 @@
         "x-ms-long-running-operation": true,
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
-          "final-state-schema": "../../../../../common-types/resource-management/v5/types.json#/definitions/OperationStatusResult"
+          "final-state-schema": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationStatusResult"
         },
         "description": "Deletes all of the keys in a cache.",
         "parameters": [
@@ -802,7 +802,7 @@
               }
             },
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/OperationStatusResult"
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationStatusResult"
             }
           },
           "default": {

--- a/specification/redis/resource-manager/readme.go.md
+++ b/specification/redis/resource-manager/readme.go.md
@@ -35,8 +35,6 @@ directive:
   where: $.definitions.OperationStatus
   transform: >
     $["x-ms-external"] = false
-modelerfour:
-  lenient-model-deduplication: true
 ```
 
 ### Go multi-api


### PR DESCRIPTION
The following changes are to reduce duplication in generated Go SDK:
- Changed from using `common-types/resource-management/v5/types.json#/definitions/OperationStatusResult` to `common-types/resource-management/v3/types.json#/definitions/OperationStatusResult`.
- Removed `lenient-model-deduplication: true` property in `readme.go.md`. 
- Updated all references to `../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse` to `../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse`. This is to prevent the following error in the Go SDK pipeline: 
```
cmderr	[generator automation-v2] [ERROR] - properties.details.$ref: "#/components/schemas/schemas:237" => "#/components/schemas/schemas:335"; This error can be *temporarily* avoided by using the 'modelerfour.lenient-model-deduplication' setting.  NOTE: This setting will be removed in a future version of @autorest/modelerfour; schemas should be updated to fix this issue sooner than that.
cmderr	[generator automation-v2] [ERROR] fatal   | Error: 1 errors occured -- cannot continue.
cmderr	[generator automation-v2] [ERROR] fatal   | Process() cancelled due to failure
cmderr	[generator automation-v2] [ERROR] error   |   Error: Plugin prechecker reported failure.
```

The result is 4 breaking changes, which I believe is expected as we are removing the auto-generated types:
```
info	[Changelog] ### Breaking Changes
info	[Changelog]
info	[Changelog] - Type of `OperationStatus.Error` has been changed from `*ErrorDetailAutoGenerated` to `*ErrorDetail`
info	[Changelog] - Type of `OperationStatusResult.Error` has been changed from `*ErrorDetailAutoGenerated` to `*ErrorDetail`
info	[Changelog] - Struct `ErrorDetailAutoGenerated` has been removed
info	[Changelog]
info	[Changelog] ### Features Added
info	[Changelog]
info	[Changelog] - New value `ProvisioningStateConfiguringAAD` added to enum type `ProvisioningState`
info	[Changelog] - New enum type `AccessPolicyAssignmentProvisioningState` with values `AccessPolicyAssignmentProvisioningStateCanceled`, `AccessPolicyAssignmentProvisioningStateDeleted`, `AccessPolicyAssignmentProvisioningStateDeleting`, `AccessPolicyAssignmentProvisioningStateFailed`, `AccessPolicyAssignmentProvisioningStateSucceeded`, `AccessPolicyAssignmentProvisioningStateUpdating`
info	[Changelog] - New enum type `AccessPolicyProvisioningState` with values `AccessPolicyProvisioningStateCanceled`, `AccessPolicyProvisioningStateDeleted`, `AccessPolicyProvisioningStateDeleting`, `AccessPolicyProvisioningStateFailed`, `AccessPolicyProvisioningStateSucceeded`, `AccessPolicyProvisioningStateUpdating`
info	[Changelog] - New enum type `AccessPolicyType` with values `AccessPolicyTypeBuiltIn`, `AccessPolicyTypeCustom`
info	[Changelog] - New enum type `UpdateChannel` with values `UpdateChannelPreview`, `UpdateChannelStable`
info	[Changelog] - New function `NewAccessPolicyAssignmentClient(string, azcore.TokenCredential, *arm.ClientOptions) (*AccessPolicyAssignmentClient, error)`
info	[Changelog] - New function `*AccessPolicyAssignmentClient.BeginCreateUpdate(context.Context, string, string, string, CacheAccessPolicyAssignment, *AccessPolicyAssignmentClientBeginCreateUpdateOptions) (*runtime.Poller[AccessPolicyAssignmentClientCreateUpdateResponse], error)`
info	[Changelog] - New function `*AccessPolicyAssignmentClient.BeginDelete(context.Context, string, string, string, *AccessPolicyAssignmentClientBeginDeleteOptions) (*runtime.Poller[AccessPolicyAssignmentClientDeleteResponse], error)`
info	[Changelog] - New function `*AccessPolicyAssignmentClient.Get(context.Context, string, string, string, *AccessPolicyAssignmentClientGetOptions) (AccessPolicyAssignmentClientGetResponse, error)`
info	[Changelog] - New function `*AccessPolicyAssignmentClient.NewListPager(string, string, *AccessPolicyAssignmentClientListOptions) *runtime.Pager[AccessPolicyAssignmentClientListResponse]`
info	[Changelog] - New function `NewAccessPolicyClient(string, azcore.TokenCredential, *arm.ClientOptions) (*AccessPolicyClient, error)`
info	[Changelog] - New function `*AccessPolicyClient.BeginCreateUpdate(context.Context, string, string, string, CacheAccessPolicy, *AccessPolicyClientBeginCreateUpdateOptions) (*runtime.Poller[AccessPolicyClientCreateUpdateResponse], error)`
info	[Changelog] - New function `*AccessPolicyClient.BeginDelete(context.Context, string, string, string, *AccessPolicyClientBeginDeleteOptions) (*runtime.Poller[AccessPolicyClientDeleteResponse], error)`
info	[Changelog] - New function `*AccessPolicyClient.Get(context.Context, string, string, string, *AccessPolicyClientGetOptions) (AccessPolicyClientGetResponse, error)`
info	[Changelog] - New function `*AccessPolicyClient.NewListPager(string, string, *AccessPolicyClientListOptions) *runtime.Pager[AccessPolicyClientListResponse]`
info	[Changelog] - New function `*Client.BeginFlushCache(context.Context, string, string, *ClientBeginFlushCacheOptions) (*runtime.Poller[ClientFlushCacheResponse], error)`
info	[Changelog] - New function `*ClientFactory.NewAccessPolicyAssignmentClient() *AccessPolicyAssignmentClient`
info	[Changelog] - New function `*ClientFactory.NewAccessPolicyClient() *AccessPolicyClient`
info	[Changelog] - New struct `CacheAccessPolicy`
info	[Changelog] - New struct `CacheAccessPolicyAssignment`
info	[Changelog] - New struct `CacheAccessPolicyAssignmentList`
info	[Changelog] - New struct `CacheAccessPolicyAssignmentProperties`
info	[Changelog] - New struct `CacheAccessPolicyList`
info	[Changelog] - New struct `CacheAccessPolicyProperties`
info	[Changelog] - New struct `ErrorDetail`
info	[Changelog] - New field `AADEnabled` in struct `CommonPropertiesRedisConfiguration`
info	[Changelog] - New field `UpdateChannel` in struct `CreateProperties`
info	[Changelog] - New field `UpdateChannel` in struct `Properties`
info	[Changelog] - New field `UpdateChannel` in struct `UpdateProperties`
info	[Changelog]
info	[Changelog] Total 4 breaking change(s), 52 additive change(s).
```
**This PR is into a dev branch, so does not need to be reviewed by ARM reviewers.**