### PR TITLE
Revert prettier update from https://github.com/Azure/azure-rest-api-specs/pull/25496

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,14 @@
         "@azure-tools/typespec-client-generator-core": "0.33.0",
         "@azure-tools/typespec-providerhub": "0.33.0",
         "@azure/avocado": "^0.8.4",
+        "@types/prettier": "^2.7.2",
         "@typespec/compiler": "0.47.0",
         "@typespec/http": "0.47.0",
         "@typespec/openapi": "0.47.0",
         "@typespec/rest": "0.47.0",
         "@typespec/versioning": "0.47.0",
         "azure-rest-api-specs-eng-tools": "file:eng/tools",
-        "prettier": "~3.0.1",
+        "prettier": "^2.8.8",
         "typescript": "~5.1.3"
       }
     },
@@ -604,6 +605,12 @@
         "form-data": "^3.0.0"
       }
     },
+    "node_modules/@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "dev": true
+    },
     "node_modules/@types/retry": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
@@ -701,6 +708,21 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@typespec/compiler/node_modules/prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@typespec/compiler/node_modules/wrap-ansi": {
@@ -1811,15 +1833,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
-        "prettier": "bin/prettier.cjs"
+        "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@azure-tools/typespec-azure-resource-manager": "0.33.0",
     "@azure-tools/typespec-client-generator-core": "0.33.0",
     "@azure-tools/typespec-providerhub": "0.33.0",
+    "@types/prettier": "^2.7.2",
     "@typespec/compiler": "0.47.0",
     "@typespec/http": "0.47.0",
     "@typespec/openapi": "0.47.0",
@@ -14,7 +15,7 @@
     "@typespec/versioning": "0.47.0",
     "@azure/avocado": "^0.8.4",
     "azure-rest-api-specs-eng-tools": "file:eng/tools",
-    "prettier": "~3.0.1",
+    "prettier": "^2.8.8",
     "typescript": "~5.1.3"
   },
   "private": true


### PR DESCRIPTION
Revert https://github.com/Azure/azure-rest-api-specs/pull/25496

This broke the running of prettier on the json files in the repo because the prettier-swagger-plugin no longer compiles as there seems to be a breaking change between prettier 2.x and 3.x. We will need to further investigate this if we want to take this change.