### PR TITLE
Remove redundant "rotate" from Keys API

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
@@ -2208,7 +2208,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.3-preview/keys.json
@@ -2193,10 +2193,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -2205,15 +2204,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
@@ -2221,10 +2221,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -2233,15 +2232,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.4-preview.1/keys.json
@@ -2236,7 +2236,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
@@ -2214,7 +2214,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
@@ -2199,10 +2199,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -2211,15 +2210,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
@@ -2194,10 +2194,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -2206,15 +2205,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.3/keys.json
@@ -2209,7 +2209,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/keys.json
@@ -2194,10 +2194,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -2206,15 +2205,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.4/keys.json
@@ -2209,7 +2209,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/data-plane/readme.md
+++ b/specification/keyvault/data-plane/readme.md
@@ -496,10 +496,6 @@ directive:
     from: securitydomain.json
     where: $.definitions.TransferKey.properties.key_format
     reason: Consistency with other properties
-  - suppress: EnumUniqueValue
-    from: keys.json
-    where: $.definitions.LifetimeActionsType.properties.type
-    reason: SDK, docs workaround for current service behavior.
   - suppress: DOUBLE_FORWARD_SLASHES_IN_URL
     from: rbac.json
     reason: / is a valid scope in this scenario.

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-04-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-04-01-preview/keys.json
@@ -593,10 +593,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -605,15 +604,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-04-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-04-01-preview/keys.json
@@ -608,7 +608,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-06-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-06-01-preview/keys.json
@@ -626,7 +626,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-06-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-06-01-preview/keys.json
@@ -611,10 +611,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -623,15 +622,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-11-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-11-01-preview/keys.json
@@ -626,7 +626,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-11-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2021-11-01-preview/keys.json
@@ -611,10 +611,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -623,15 +622,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2022-02-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2022-02-01-preview/keys.json
@@ -612,10 +612,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -624,15 +623,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2022-02-01-preview/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/preview/2022-02-01-preview/keys.json
@@ -627,7 +627,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-07-01/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-07-01/keys.json
@@ -613,10 +613,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -625,15 +624,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-07-01/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-07-01/keys.json
@@ -628,7 +628,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keys.json
@@ -613,10 +613,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -625,15 +624,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keys.json
@@ -628,7 +628,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keysManagedHsm.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keysManagedHsm.json
@@ -542,10 +542,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -554,15 +553,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keysManagedHsm.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2022-11-01/keysManagedHsm.json
@@ -557,7 +557,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keys.json
@@ -613,10 +613,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -625,15 +624,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keys.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keys.json
@@ -628,7 +628,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keysManagedHsm.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keysManagedHsm.json
@@ -542,10 +542,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "The type of the action.",
+          "description": "The type of the action. The value should be compared case-insensitively.",
           "enum": [
             "Rotate",
-            "rotate",
             "Notify"
           ],
           "x-ms-enum": {
@@ -554,15 +553,11 @@
             "values": [
               {
                 "value": "Rotate",
-                "description": "Rotate the key based on the key policy. Key Vault only. Managed HSM uses camelCase 'rotate' instead."
-              },
-              {
-                "value": "rotate",
-                "description": "Rotate the key based on the key policy. Managed HSM only. Key Vault uses PascalCase 'Rotate' instead."
+                "description": "Rotate the key based on the key policy."
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
+                "description": "Trigger Event Grid events."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keysManagedHsm.json
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2023-02-01/keysManagedHsm.json
@@ -557,7 +557,7 @@
               },
               {
                 "value": "Notify",
-                "description": "Trigger Event Grid events."
+                "description": "Trigger Event Grid events. Defaults to 30 days before expiry. Key Vault only."
               }
             ]
           }

--- a/specification/keyvault/resource-manager/readme.md
+++ b/specification/keyvault/resource-manager/readme.md
@@ -261,15 +261,6 @@ directive:
   from: keysManagedHsm.json
   reason: This is to keep compatibility with existing data plane property. The 'release_policy' property for KeyCreateParameters does not support camelCase.
 
-- suppress: EnumUniqueValue
-  from: keys.json
-  where: $.definitions.Action.properties.type
-  reason: SDK, docs workaround for current service behavior.
-- suppress: EnumUniqueValue
-  from: keysManagedHsm.json
-  where: $.definitions.ManagedHsmAction.properties.type
-  reason: SDK, docs workaround for current service behavior.
-
 - suppress: INVALID_REQUEST_PARAMETER
   from: keyvault.json
   reason: The Vaults_List API endpoint only supports version 2015-11-01.


### PR DESCRIPTION
Original goal was to properly document "Rotate" that Key Vault returned and "rotate" that Managed HSM returned (and was originally in the swagger), but that case-insensitively duplicative value caused issues with some code generators.

Reverts parts of #24475
