### PR TITLE
Mgmt containerregistry, add readOnly

### DIFF
--- a/specification/containerregistry/resource-manager/readme.java.md
+++ b/specification/containerregistry/resource-manager/readme.java.md
@@ -19,6 +19,16 @@ directive:
   - rename-model:
       from: DockerBuildStep
       to: DockerTaskStep
+  - from: containerregistry_build.json
+    where: $.definitions.IdentityProperties.properties
+    transform: >
+      $.principalId['readOnly'] = true;
+      $.tenantId['readOnly'] = true;
+  - from: containerregistry_build.json
+    where: $.definitions.UserIdentityProperties.properties
+    transform: >
+      $.principalId['readOnly'] = true;
+      $.clientId['readOnly'] = true;
 ```
 
 ### Java multi-api


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-java/pull/36688#discussion_r1321079850

For mitigating duplicate generated models due to two properties change to `readOnly`.

JS and Go made the same effort. https://github.com/Azure/azure-rest-api-specs/blob/main/specification/containerregistry/resource-manager/readme.go.md
