### PR TITLE
Adds an optional object property `customerDataStorage` to the `Microsoft.Chaos/experiments` resource-type

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/CreateOrUpdateAExperiment.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/CreateOrUpdateAExperiment.json
@@ -98,7 +98,11 @@
                 }
               ]
             }
-          ]
+          ],
+          "customerDataStorage": {
+            "storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage",
+            "blobContainerName": "azurechaosstudioexperiments"
+          }
         },
         "systemData": {
           "createdAt": "2021-07-01T00:00:00.0Z",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/GetAExperiment.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/GetAExperiment.json
@@ -54,7 +54,11 @@
                 }
               ]
             }
-          ]
+          ],
+          "customerDataStorage": {
+            "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage",
+            "blobContainerName": "azurechaosstudioexperiments"
+          }
         },
         "systemData": {
           "createdAt": "2021-07-01T00:00:00.0Z",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/ListExperimentsInAResourceGroup.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/ListExperimentsInAResourceGroup.json
@@ -56,7 +56,11 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "customerDataStorage": {
+                "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage",
+                "blobContainerName": "azurechaosstudioexperiments"
+              }
             },
             "systemData": {
               "createdAt": "2021-07-01T00:00:00.0Z",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/ListExperimentsInASubscription.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/ListExperimentsInASubscription.json
@@ -55,7 +55,11 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "customerDataStorage": {
+                "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage",
+                "blobContainerName": "azurechaosstudioexperiments"
+              }
             },
             "systemData": {
               "createdAt": "2021-07-01T00:00:00.0Z",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/PatchExperiment.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/examples/PatchExperiment.json
@@ -65,7 +65,11 @@
                 }
               ]
             }
-          ]
+          ],
+          "customerDataStorage": {
+            "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage",
+            "blobContainerName": "azurechaosstudioexperiments"
+          }
         },
         "systemData": {
           "createdAt": "2021-07-01T00:00:00.0Z",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/types/experiments.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/types/experiments.json
@@ -109,12 +109,36 @@
           "description": "A boolean value that indicates if experiment should be started on creation or not.",
           "type": "boolean",
           "x-nullable": true
+        },
+        "customerDataStorage": {
+          "description": "Optional customer-managed Storage account where Experiment schema will be stored.",
+          "$ref": "#/definitions/customerDataStorageProperties",
+          "x-nullable": true
         }
       },
       "required": [
         "steps",
         "selectors"
       ],
+      "additionalProperties": false
+    },
+    "customerDataStorageProperties": {
+      "description": "Model that represents the Customer Managed Storage for an Experiment.",
+      "type": "object",
+      "properties": {
+        "storageAccountResourceId": {
+          "type": "string",
+          "description": "ARM Resource ID of the Storage account to use for Customer Data storage."
+        },
+        "blobContainerName": {
+          "type": "string",
+          "description": "Name of the Azure Blob Storage container to use or create.",
+          "maxLength": 63,
+          "minLength": 3,
+          "pattern": "^[a-z0-9]([a-z0-9]|(-(?!-))){1,61}[a-z0-9]$",
+          "x-nullable": true
+        }
+      },
       "additionalProperties": false
     },
     "experimentListResult": {

--- a/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/types/experiments.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/preview/2023-10-27-preview/types/experiments.json
@@ -128,7 +128,15 @@
       "properties": {
         "storageAccountResourceId": {
           "type": "string",
-          "description": "ARM Resource ID of the Storage account to use for Customer Data storage."
+          "description": "ARM Resource ID of the Storage account to use for Customer Data storage.",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          }
         },
         "blobContainerName": {
           "type": "string",


### PR DESCRIPTION
Adds an optional object property `customerDataStorage` to the `Microsoft.Chaos/experiments` resource-type.

Examples are updated to include examples of valid strings.