### PR TITLE
Search document python config (DO NOT MERGE)

### DIFF
--- a/specification/search/data-plane/Azure.Search/readme.python.md
+++ b/specification/search/data-plane/Azure.Search/readme.python.md
@@ -4,19 +4,21 @@ These settings apply only when `--python` is specified on the command line.
 Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
 Use `--python-mode=update` if you already have a setup.py and just want to update the code itself.
 
-``` yaml
+``` yaml $(python)
 license-header: MICROSOFT_MIT_NO_VERSION
 payload-flattening-threshold: 1
 package-name: azure-search-documents
 clear-output-folder: true
 no-namespace-folders: true
+version-tolerant: false
+models-mode: msrest
 ```
 
 ### Python multi-client
 
 Generate all API versions currently shipped for this package
 
-```yaml
+``` yaml $(python)
 batch:
   - tag: package-2021-04-searchservice-preview
   - tag: package-2021-04-searchindex-preview

--- a/specification/search/data-plane/Azure.Search/readme.python.md
+++ b/specification/search/data-plane/Azure.Search/readme.python.md
@@ -12,22 +12,14 @@ clear-output-folder: true
 no-namespace-folders: true
 ```
 
-### Tag: package-2020-06-searchservice-preview
+### Python multi-client
 
-These settings apply only when `--tag=package-2020-06-searchservice-preview` is specified on the command line.
+Generate all API versions currently shipped for this package
 
-``` yaml $(tag) == 'package-2020-06-searchservice-preview'
-namespace: azure.search.documents.indexes
-output-folder: $(python-sdks-folder)/search/azure-search-documents/azure/search/documents/indexes/_generated
-```
-
-### Tag: package-2020-06-searchindex-preview
-
-These settings apply only when `--tag=package-2020-06-searchindex-preview` is specified on the command line.
-
-``` yaml $(tag) == 'package-2020-06-searchindex-preview'
-namespace: azure.search.documents
-output-folder: $(python-sdks-folder)/search/azure-search-documents/azure/search/documents/_generated
+```yaml
+batch:
+  - tag: package-2021-04-searchservice-preview
+  - tag: package-2021-04-searchindex-preview
 ```
 
 ### Tag: package-2021-04-searchservice-preview

--- a/specification/search/data-plane/Azure.Search/readme.python.md
+++ b/specification/search/data-plane/Azure.Search/readme.python.md
@@ -29,6 +29,7 @@ batch:
 These settings apply only when `--tag=package-2021-04-searchservice-preview` is specified on the command line.
 
 ``` yaml $(tag) == 'package-2021-04-searchservice-preview'
+title: SearchServiceClient
 namespace: azure.search.documents.indexes
 output-folder: $(python-sdks-folder)/search/azure-search-documents/azure/search/documents/indexes/_generated
 ```
@@ -38,6 +39,7 @@ output-folder: $(python-sdks-folder)/search/azure-search-documents/azure/search/
 These settings apply only when `--tag=package-2021-04-searchindex-preview` is specified on the command line.
 
 ``` yaml $(tag) == 'package-2021-04-searchindex-preview'
+title: SearchIndexClient
 namespace: azure.search.documents
 output-folder: $(python-sdks-folder)/search/azure-search-documents/azure/search/documents/_generated
 ```


### PR DESCRIPTION
After this PR merged, it will be very convenient to regenerate SDK with cmd:
`autorest D:\dev\azure-rest-api-specs\specification\search\data-plane\Azure.Search\readme.md --use=@autorest\modelerfour@4.26.2 --version=3.9.7   --use=@autorest/python@6.7.1  --python --python-sdks-folder=D:\dev\azure-sdk-for-python\sdk`