### PR TITLE
Azure OpenAI: (known preview-breaking) in-place rename of RAI prompt_filter_results

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/chat.completions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/chat.completions.tsp
@@ -272,7 +272,7 @@ model ChatCompletions {
   results for different prompts may arrive at different times or in different orders.
   """)
   @added(ServiceApiVersions.v2023_06_01_Preview)
-  @projectedName("json", "prompt_annotations")
+  @projectedName("json", "prompt_filter_results")
   promptFilterResults?: PromptFilterResult[];
 
   @doc("""

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions.create.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions.create.tsp
@@ -167,7 +167,7 @@ model Completions {
   results for different prompts may arrive at different times or in different orders.
   """)
   @added(ServiceApiVersions.v2023_06_01_Preview)
-  @projectedName("json", "prompt_annotations")
+  @projectedName("json", "prompt_filter_results")
   promptFilterResults?: PromptFilterResult[];
 
   @doc("""

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-06-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-06-01-preview/generated.json
@@ -504,7 +504,7 @@
           },
           "x-ms-identifiers": []
         },
-        "prompt_annotations": {
+        "prompt_filter_results": {
           "type": "array",
           "description": "Content filtering results for zero or more prompts in the request. In a streaming request, \nresults for different prompts may arrive at different times or in different orders.",
           "items": {
@@ -708,7 +708,7 @@
           "format": "unixtime",
           "description": "The first timestamp associated with generation activity for this completions response,\nrepresented as seconds since the beginning of the Unix epoch of 00:00 on 1 Jan 1970."
         },
-        "prompt_annotations": {
+        "prompt_filter_results": {
           "type": "array",
           "description": "Content filtering results for zero or more prompts in the request. In a streaming request, \nresults for different prompts may arrive at different times or in different orders.",
           "items": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-07-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-07-01-preview/generated.json
@@ -504,7 +504,7 @@
           },
           "x-ms-identifiers": []
         },
-        "prompt_annotations": {
+        "prompt_filter_results": {
           "type": "array",
           "description": "Content filtering results for zero or more prompts in the request. In a streaming request, \nresults for different prompts may arrive at different times or in different orders.",
           "items": {
@@ -735,7 +735,7 @@
           "format": "unixtime",
           "description": "The first timestamp associated with generation activity for this completions response,\nrepresented as seconds since the beginning of the Unix epoch of 00:00 on 1 Jan 1970."
         },
-        "prompt_annotations": {
+        "prompt_filter_results": {
           "type": "array",
           "description": "Content filtering results for zero or more prompts in the request. In a streaming request, \nresults for different prompts may arrive at different times or in different orders.",
           "items": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-08-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-08-01-preview/generated.json
@@ -604,7 +604,7 @@
           },
           "x-ms-identifiers": []
         },
-        "prompt_annotations": {
+        "prompt_filter_results": {
           "type": "array",
           "description": "Content filtering results for zero or more prompts in the request. In a streaming request, \nresults for different prompts may arrive at different times or in different orders.",
           "items": {
@@ -853,7 +853,7 @@
           "format": "unixtime",
           "description": "The first timestamp associated with generation activity for this completions response,\nrepresented as seconds since the beginning of the Unix epoch of 00:00 on 1 Jan 1970."
         },
-        "prompt_annotations": {
+        "prompt_filter_results": {
           "type": "array",
           "description": "Content filtering results for zero or more prompts in the request. In a streaming request, \nresults for different prompts may arrive at different times or in different orders.",
           "items": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-09-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-09-01-preview/generated.json
@@ -20,8 +20,8 @@
       {
         "name": "endpoint",
         "in": "path",
-        "required": true,
         "description": "Supported Cognitive Services endpoints (protocol and hostname, for example:\nhttps://westus.api.cognitive.microsoft.com).",
+        "required": true,
         "type": "string"
       }
     ]
@@ -110,8 +110,8 @@
             },
             "headers": {
               "x-ms-error-code": {
-                "description": "String error code indicating what went wrong.",
-                "type": "string"
+                "type": "string",
+                "description": "String error code indicating what went wrong."
               }
             }
           }
@@ -171,8 +171,8 @@
             },
             "headers": {
               "x-ms-error-code": {
-                "description": "String error code indicating what went wrong.",
-                "type": "string"
+                "type": "string",
+                "description": "String error code indicating what went wrong."
               }
             }
           }
@@ -222,8 +222,8 @@
             },
             "headers": {
               "x-ms-error-code": {
-                "description": "String error code indicating what went wrong.",
-                "type": "string"
+                "type": "string",
+                "description": "String error code indicating what went wrong."
               }
             }
           }
@@ -273,8 +273,8 @@
             },
             "headers": {
               "x-ms-error-code": {
-                "description": "String error code indicating what went wrong.",
-                "type": "string"
+                "type": "string",
+                "description": "String error code indicating what went wrong."
               }
             }
           }
@@ -324,8 +324,8 @@
             },
             "headers": {
               "x-ms-error-code": {
-                "description": "String error code indicating what went wrong.",
-                "type": "string"
+                "type": "string",
+                "description": "String error code indicating what went wrong."
               }
             }
           }
@@ -375,8 +375,8 @@
             },
             "headers": {
               "x-ms-error-code": {
-                "description": "String error code indicating what went wrong.",
-                "type": "string"
+                "type": "string",
+                "description": "String error code indicating what went wrong."
               }
             }
           }
@@ -426,8 +426,8 @@
             },
             "headers": {
               "x-ms-error-code": {
-                "description": "String error code indicating what went wrong.",
-                "type": "string"
+                "type": "string",
+                "description": "String error code indicating what went wrong."
               }
             }
           }
@@ -470,8 +470,8 @@
             },
             "headers": {
               "x-ms-error-code": {
-                "description": "String error code indicating what went wrong.",
-                "type": "string"
+                "type": "string",
+                "description": "String error code indicating what went wrong."
               }
             }
           }
@@ -1117,7 +1117,7 @@
           },
           "x-ms-identifiers": []
         },
-        "prompt_annotations": {
+        "prompt_filter_results": {
           "type": "array",
           "description": "Content filtering results for zero or more prompts in the request. In a streaming request, \nresults for different prompts may arrive at different times or in different orders.",
           "items": {
@@ -1366,7 +1366,7 @@
           "format": "unixtime",
           "description": "The first timestamp associated with generation activity for this completions response,\nrepresented as seconds since the beginning of the Unix epoch of 00:00 on 1 Jan 1970."
         },
-        "prompt_annotations": {
+        "prompt_filter_results": {
           "type": "array",
           "description": "Content filtering results for zero or more prompts in the request. In a streaming request, \nresults for different prompts may arrive at different times or in different orders.",
           "items": {
@@ -1456,7 +1456,12 @@
           "type": "array",
           "description": "A mapping of tokens to maximum log probability values in this completions data.",
           "items": {
-            "type": "object"
+            "type": "object",
+            "additionalProperties": {
+              "format": "float",
+              "type": "number",
+              "x-nullable": true
+            }
           },
           "x-ms-client-name": "topLogprobs",
           "x-ms-identifiers": []


### PR DESCRIPTION
- Responsible AI content filter annotations were introduced as an AOAI-exclusive feature beginning with the `2023-06-01-preview` service API version
- These annotations include a response payload object for annotations concerning input prompt data (rooted to the top-level response object) along with one for each choice's content
- The object for prompt information was initially named `prompt_annotations` -- it was agreed during API review that this was inconsistent with its (clearer) counterpart of `content_filter_results` and that we'd realign `prompt_annotations` in a future service API version
- A series of miscommunications resulted in `prompt_annotations` being renamed to `prompt_filter_results` across *all* preview service API versions (not just new ones), effective in the last few days
- After extensive discussion around mitigation/remediation options and relative impact and risk of disruption to customers, it's been decided that we'll exceptionally retain the retroactive schema change across all impacted preview versions

This change simply updates the `projectedName` definition for the affected field to match new wire format reality. It's known and expected that this will show up in CI as an unexpected breaking change because it in fact *is* an initially unexpected breaking change that we're reacting to.