### PR TITLE
Update readme.java.md

### DIFF
--- a/specification/kubernetesconfiguration/resource-manager/readme.java.md
+++ b/specification/kubernetesconfiguration/resource-manager/readme.java.md
@@ -4,13 +4,6 @@ These settings apply only when `--java` is specified on the command line.
 Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-libraries-for-java clone>`.
 
 ``` yaml $(java)
-java:
-  azure-arm: true
-  fluent: true
-  namespace: com.microsoft.azure.management.kubernetesconfiguration
-  license-header: MICROSOFT_MIT_NO_CODEGEN
-  payload-flattening-threshold: 1
-  output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-kubernetesconfiguration
 directive:
   - from: fluxconfiguration.json
     where: $.definitions.KustomizationDefinition.properties.wait

--- a/specification/kubernetesconfiguration/resource-manager/readme.java.md
+++ b/specification/kubernetesconfiguration/resource-manager/readme.java.md
@@ -13,6 +13,10 @@ java:
   output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-kubernetesconfiguration
 directive:
   - from: fluxconfiguration.json
+    where: $.definitions.KustomizationDefinition.properties.wait
+    transform: >
+      $["x-ms-client-name"] = "enableWait"
+  - from: fluxconfiguration.json
     where: $.definitions.KustomizationPatchDefinition.properties.wait
     transform: >
       $["x-ms-client-name"] = "enableWait"

--- a/specification/kubernetesconfiguration/resource-manager/readme.java.md
+++ b/specification/kubernetesconfiguration/resource-manager/readme.java.md
@@ -4,12 +4,18 @@ These settings apply only when `--java` is specified on the command line.
 Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-libraries-for-java clone>`.
 
 ``` yaml $(java)
-azure-arm: true
-fluent: true
-namespace: com.microsoft.azure.management.kubernetesconfiguration
-license-header: MICROSOFT_MIT_NO_CODEGEN
-payload-flattening-threshold: 1
-output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-kubernetesconfiguration
+java:
+  azure-arm: true
+  fluent: true
+  namespace: com.microsoft.azure.management.kubernetesconfiguration
+  license-header: MICROSOFT_MIT_NO_CODEGEN
+  payload-flattening-threshold: 1
+  output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-kubernetesconfiguration
+directive:
+  - from: fluxconfiguration.json
+    where: $.definitions.KustomizationPatchDefinition.properties.wait
+    transform: >
+      $["x-ms-client-name"] = "enableWait"
 ```
 
 ### Java multi-api


### PR DESCRIPTION
![image](https://github.com/Azure/azure-rest-api-specs/assets/87355844/32c0d3bf-6b5b-44cc-9767-f4f1c0ce50d5)

`wait` is added in this version: https://github.com/Azure/azure-rest-api-specs/pull/23676/commits/1d104288c79077fa685d831156a43f04dbc2356b#diff-bd3e233a9fef446a7c3096534d9419a629ff446c1017cdd05ebfc79d7e4a3c6a
But `wait()` is conflict with `Object`'s `wait()`.