### PR TITLE
Image Analysis TypeSpec update: Use array of floats for smartCrop aspect ratios

### DIFF
--- a/specification/cognitiveservices/Vision.ImageAnalysis/models.tsp
+++ b/specification/cognitiveservices/Vision.ImageAnalysis/models.tsp
@@ -21,7 +21,7 @@ model BoundingBox {
 @doc("A brief description of what the image depicts.")
 model CaptionResult {
   @doc("The level of confidence the service has in the caption.")
-  confidence: float32;
+  confidence: float64;
 
   @doc("The text of the caption.")
   text: string;
@@ -30,7 +30,7 @@ model CaptionResult {
 @doc("A region identified for smart cropping. There will be one region returned for each requested aspect ratio.")
 model CropRegion {
   @doc("The aspect ratio of the crop region.")
-  aspectRatio: float32;
+  aspectRatio: float64;
 
   @doc("The bounding box of the crop region.")
   boundingBox: BoundingBox;
@@ -39,7 +39,7 @@ model CropRegion {
 @doc("A brief description of what the image depicts.")
 model DenseCaption {
   @doc("The level of confidence the service has in the caption.")
-  confidence: float32;
+  confidence: float64;
 
   @doc("The text of the caption.")
   text: string;
@@ -71,13 +71,13 @@ model DetectedPerson {
 
   @doc("Gets the confidence value of the detected person.")
   @visibility("read")
-  confidence: float32;
+  confidence: float64;
 }
 
 @doc("A content line object consisting of an adjacent sequence of content elements, such as words and selection marks.")
 model DocumentLine {
   @doc("The bounding box of the line.")
-  boundingBox: Array<float32>;
+  boundingBox: Array<float64>;
 
   @doc("Concatenated content of the contained elements in reading order.")
   content: string;
@@ -89,10 +89,10 @@ model DocumentLine {
 @doc("The content and layout elements extracted from a page from the input.")
 model DocumentPage {
   @doc("The general orientation of the content in clockwise direction, measured in degrees between (-180, 180].")
-  angle: float32;
+  angle: float64;
 
   @doc("The height of the image/PDF in pixels/inches, respectively.")
-  height: float32;
+  height: float64;
 
   @doc("Extracted lines from the page, potentially containing both textual and visual elements.")
   lines: Array<DocumentLine>;
@@ -104,7 +104,7 @@ model DocumentPage {
   spans: Array<DocumentSpan>;
 
   @doc("The width of the image/PDF in pixels/inches, respectively.")
-  width: float32;
+  width: float64;
 
   @doc("Extracted words from the page.")
   words: Array<DocumentWord>;
@@ -122,7 +122,7 @@ model DocumentSpan {
 @doc("An object representing observed text styles.")
 model DocumentStyle {
   @doc("Confidence of correctly identifying the style.")
-  confidence: float32;
+  confidence: float64;
 
   @doc("Is content handwritten or not.")
   isHandwritten: boolean;
@@ -134,10 +134,10 @@ model DocumentStyle {
 @doc("A word object consisting of a contiguous sequence of characters. For non-space delimited languages,\r\nsuch as Chinese, Japanese, and Korean, each character is represented as its own word.")
 model DocumentWord {
   @doc("Bounding box of the word.")
-  boundingBox: Array<float32>;
+  boundingBox: Array<float64>;
 
   @doc("Confidence of correctly extracting the word.")
-  confidence: float32;
+  confidence: float64;
 
   @doc("Text content of the word.")
   content: string;
@@ -233,7 +233,7 @@ model SmartCropsResult {
 @doc("An entity observation in the image, along with the confidence score.")
 model Tag {
   @doc("The level of confidence that the entity was observed.")
-  confidence: float32;
+  confidence: float64;
 
   @doc("Name of the entity.")
   name: string;

--- a/specification/cognitiveservices/Vision.ImageAnalysis/models.tsp
+++ b/specification/cognitiveservices/Vision.ImageAnalysis/models.tsp
@@ -21,7 +21,7 @@ model BoundingBox {
 @doc("A brief description of what the image depicts.")
 model CaptionResult {
   @doc("The level of confidence the service has in the caption.")
-  confidence: float64;
+  confidence: float32;
 
   @doc("The text of the caption.")
   text: string;
@@ -30,7 +30,7 @@ model CaptionResult {
 @doc("A region identified for smart cropping. There will be one region returned for each requested aspect ratio.")
 model CropRegion {
   @doc("The aspect ratio of the crop region.")
-  aspectRatio: float64;
+  aspectRatio: float32;
 
   @doc("The bounding box of the crop region.")
   boundingBox: BoundingBox;
@@ -39,7 +39,7 @@ model CropRegion {
 @doc("A brief description of what the image depicts.")
 model DenseCaption {
   @doc("The level of confidence the service has in the caption.")
-  confidence: float64;
+  confidence: float32;
 
   @doc("The text of the caption.")
   text: string;
@@ -71,13 +71,13 @@ model DetectedPerson {
 
   @doc("Gets the confidence value of the detected person.")
   @visibility("read")
-  confidence: float64;
+  confidence: float32;
 }
 
 @doc("A content line object consisting of an adjacent sequence of content elements, such as words and selection marks.")
 model DocumentLine {
   @doc("The bounding box of the line.")
-  boundingBox: Array<float64>;
+  boundingBox: Array<float32>;
 
   @doc("Concatenated content of the contained elements in reading order.")
   content: string;
@@ -89,10 +89,10 @@ model DocumentLine {
 @doc("The content and layout elements extracted from a page from the input.")
 model DocumentPage {
   @doc("The general orientation of the content in clockwise direction, measured in degrees between (-180, 180].")
-  angle: float64;
+  angle: float32;
 
   @doc("The height of the image/PDF in pixels/inches, respectively.")
-  height: float64;
+  height: float32;
 
   @doc("Extracted lines from the page, potentially containing both textual and visual elements.")
   lines: Array<DocumentLine>;
@@ -104,7 +104,7 @@ model DocumentPage {
   spans: Array<DocumentSpan>;
 
   @doc("The width of the image/PDF in pixels/inches, respectively.")
-  width: float64;
+  width: float32;
 
   @doc("Extracted words from the page.")
   words: Array<DocumentWord>;
@@ -122,7 +122,7 @@ model DocumentSpan {
 @doc("An object representing observed text styles.")
 model DocumentStyle {
   @doc("Confidence of correctly identifying the style.")
-  confidence: float64;
+  confidence: float32;
 
   @doc("Is content handwritten or not.")
   isHandwritten: boolean;
@@ -134,10 +134,10 @@ model DocumentStyle {
 @doc("A word object consisting of a contiguous sequence of characters. For non-space delimited languages,\r\nsuch as Chinese, Japanese, and Korean, each character is represented as its own word.")
 model DocumentWord {
   @doc("Bounding box of the word.")
-  boundingBox: Array<float64>;
+  boundingBox: Array<float32>;
 
   @doc("Confidence of correctly extracting the word.")
-  confidence: float64;
+  confidence: float32;
 
   @doc("Text content of the word.")
   content: string;
@@ -233,7 +233,7 @@ model SmartCropsResult {
 @doc("An entity observation in the image, along with the confidence score.")
 model Tag {
   @doc("The level of confidence that the entity was observed.")
-  confidence: float64;
+  confidence: float32;
 
   @doc("Name of the entity.")
   name: string;

--- a/specification/cognitiveservices/Vision.ImageAnalysis/routes.tsp
+++ b/specification/cognitiveservices/Vision.ImageAnalysis/routes.tsp
@@ -31,6 +31,10 @@ op analyzeStream is Azure.Core.RpcOperation<
     visualFeatures?: Array<visualFeatures>;
 
     @doc("Impl Detail")
+    @query("overload")
+    overload: "stream";
+
+    @doc("Impl Detail")
     @header("Content-Type")
     contentType: "application/octet-stream";
 

--- a/specification/cognitiveservices/Vision.ImageAnalysis/routes.tsp
+++ b/specification/cognitiveservices/Vision.ImageAnalysis/routes.tsp
@@ -47,7 +47,7 @@ op analyzeStream is Azure.Core.RpcOperation<
       format: "csv"
     })
     @doc("A list of aspect ratios to use for smartCrops feature. Aspect ratios are calculated by dividing the target crop width by the height. Supported values are between 0.75 and 1.8 (inclusive). Multiple values should be comma-separated. If this parameter is not specified, the service will return one crop suggestion with an aspect ratio it sees fit between 0.5 and 2.0 (inclusive).")
-    smartCropsAspectRatios?: Array<float32>;
+    smartCropsAspectRatios?: Array<float64>;
 
     @query("gender-neutral-caption")
     @doc("Boolean flag for enabling gender-neutral captioning for caption and denseCaptions features. If this parameter is not specified, the default value is \"false\".")
@@ -92,7 +92,7 @@ op analyzeUrl is Azure.Core.RpcOperation<
       format: "csv"
     })
     @doc("A list of aspect ratios to use for smartCrops feature. Aspect ratios are calculated by dividing the target crop width by the height. Supported values are between 0.75 and 1.8 (inclusive). Multiple values should be comma-separated. If this parameter is not specified, the service will return one crop suggestion with an aspect ratio it sees fit between 0.5 and 2.0 (inclusive).")
-    smartCropsAspectRatios?: Array<float32>;
+    smartCropsAspectRatios?: Array<float64>;
 
     @query("gender-neutral-caption")
     @doc("Boolean flag for enabling gender-neutral captioning for caption and denseCaptions features. If this parameter is not specified, the default value is \"false\".")

--- a/specification/cognitiveservices/Vision.ImageAnalysis/routes.tsp
+++ b/specification/cognitiveservices/Vision.ImageAnalysis/routes.tsp
@@ -31,10 +31,6 @@ op analyzeStream is Azure.Core.RpcOperation<
     visualFeatures?: Array<visualFeatures>;
 
     @doc("Impl Detail")
-    @query("overload")
-    overload: "stream";
-
-    @doc("Impl Detail")
     @header("Content-Type")
     contentType: "application/octet-stream";
 
@@ -46,9 +42,12 @@ op analyzeStream is Azure.Core.RpcOperation<
     @doc("The desired language for output generation. If this parameter is not specified, the default value is \"en\". See https://aka.ms/cv-languages for a list of supported languages.")
     language?: string = "en";
 
-    @query("smartcrops-aspect-ratios")
+    @query({
+      name: "smartcrops-aspect-ratios",
+      format: "csv"
+    })
     @doc("A list of aspect ratios to use for smartCrops feature. Aspect ratios are calculated by dividing the target crop width by the height. Supported values are between 0.75 and 1.8 (inclusive). Multiple values should be comma-separated. If this parameter is not specified, the service will return one crop suggestion with an aspect ratio it sees fit between 0.5 and 2.0 (inclusive).")
-    smartCropsAspectRatios?: string;
+    smartCropsAspectRatios?: Array<float32>;
 
     @query("gender-neutral-caption")
     @doc("Boolean flag for enabling gender-neutral captioning for caption and denseCaptions features. If this parameter is not specified, the default value is \"false\".")
@@ -88,9 +87,12 @@ op analyzeUrl is Azure.Core.RpcOperation<
     @doc("The desired language for output generation. If this parameter is not specified, the default value is \"en\". See https://aka.ms/cv-languages for a list of supported languages.")
     language?: string = "en";
 
-    @query("smartcrops-aspect-ratios")
+    @query({
+      name: "smartcrops-aspect-ratios",
+      format: "csv"
+    })
     @doc("A list of aspect ratios to use for smartCrops feature. Aspect ratios are calculated by dividing the target crop width by the height. Supported values are between 0.75 and 1.8 (inclusive). Multiple values should be comma-separated. If this parameter is not specified, the service will return one crop suggestion with an aspect ratio it sees fit between 0.5 and 2.0 (inclusive).")
-    smartCropsAspectRatios?: string;
+    smartCropsAspectRatios?: Array<float32>;
 
     @query("gender-neutral-caption")
     @doc("Boolean flag for enabling gender-neutral captioning for caption and denseCaptions features. If this parameter is not specified, the default value is \"false\".")


### PR DESCRIPTION
The change was tested by auto-generating the Python SDK from the updated TypeSpec files, installing the resulting Wheel, running my sample code and verifying the correct output (via logs and results console spew). The sample code makes this Analyze call (notice the array of floats when defining the smart crop aspect rations)
```python
   result = client.analyze_url(
        image_contents=sdk.models.ImageUrl(url="https://aka.ms/azai/vision/image-analysis-sample.jpg"),
        visual_features=[
            sdk.models.VisualFeatures.TAGS,
            sdk.models.VisualFeatures.OBJECTS,
            sdk.models.VisualFeatures.CAPTION,
            sdk.models.VisualFeatures.DENSE_CAPTIONS,
            sdk.models.VisualFeatures.READ,
            sdk.models.VisualFeatures.SMART_CROPS,
            sdk.models.VisualFeatures.PEOPLE
        ],
        smart_crops_aspect_ratios=[0.9, 1.33],
        gender_neutral_caption=True,
        language="en")
```