### PR TITLE
Image Analysis TypeSpec: Add missing model version on Read result

### DIFF
--- a/specification/cognitiveservices/Vision.ImageAnalysis/models.tsp
+++ b/specification/cognitiveservices/Vision.ImageAnalysis/models.tsp
@@ -222,6 +222,9 @@ model ReadResult {
 
   @doc("Extracted font styles.")
   styles: Array<DocumentStyle>;
+
+  @doc("The model used to generate the Read result.")
+  modelVersion: string;
 }
 
 @doc("Smart cropping result.")


### PR DESCRIPTION
Model version is missing from the readResult in the Swagger:
- https://eastus.dev.cognitive.microsoft.com/docs/services/unified-vision-apis-public-preview-2023-04-01-preview/operations/61d65934cd35050c20f73ab6
- https://msazure.visualstudio.com/Cognitive%20Services/_git/API-UnifiedVisionService?path=/src/WebApi/Operations/Sdk/src/Swagger/Operations_v2023-04-01-preview.json&version=GBdev&line=1653&lineEnd=1654&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents

but the service does return it. I contacted the service folks about this. 

Here is the JSON "read" response for [this image](https://aka.ms/azai/vision/image-analysis-sample.jpg)

```json
{
    "readResult":
    {
        "stringIndexType": "TextElements",
        "content": "Sample text\nHand writing\n123 456",
        "pages":
        [
            {
                "height": 432,
                "width": 648,
                "angle": 0.5729,
                "pageNumber": 1,
                "words":
                [
                    {"content":"Sample","boundingBox":[542,377,588,377,587,389,542,389],"confidence":0.992,"span":{"offset":0,"length":6}},
                    {"content":"text","boundingBox":[598,377,630,376,630,390,598,389],"confidence":0.989,"span":{"offset":7,"length":4}},
                    {"content":"Hand","boundingBox":[540,394,569,394,569,407,540,407],"confidence":0.991,"span":{"offset":12,"length":4}},
                    {"content":"writing","boundingBox":[573,394,613,395,613,409,573,407],"confidence":0.995,"span":{"offset":17,"length":7}},
                    {"content":"123","boundingBox":[542,412,561,411,561,424,542,424],"confidence":0.998,"span":{"offset":25,"length":3}},
                    {"content":"456","boundingBox":[568,411,590,412,590,424,568,424],"confidence":0.998,"span":{"offset":29,"length":3}}
                ],
                "spans":
                [
                    {"offset":0,"length":32}
                ],
                "lines":
                [
                    {"content":"Sample text","boundingBox":[541,376,632,376,632,389,541,389],"spans":[{"offset":0,"length":11}]},
                    {"content":"Hand writing","boundingBox":[540,393,613,395,613,408,540,406],"spans":[{"offset":12,"length":12}]},
                    {"content":"123 456","boundingBox":[542,411,592,411,592,424,542,423],"spans":[{"offset":25,"length":7}]}
                ]
            }
        ],
        "styles": [],
        "modelVersion": "2022-04-30"
    },
    "modelVersion": "2023-02-01-preview",
    "metadata":
    {
        "width": 648,
        "height": 432
    }
}
```