### PR TITLE
Update `workflows/comment.yml`: add exponential backoff to adding `MergeRequested` label

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -28,11 +28,37 @@ jobs:
             return
           }
           $label = 'MergeRequested'
-          Write-Host "gh pr edit $($payload.issue.number) --add-label `"$label`""
-          gh pr edit $payload.issue.html_url --add-label "$label"
-          if ($LASTEXITCODE) {
-            Write-Warning "Failed to add label"
-            exit $LASTEXITCODE
+          
+          $retryCount = 0
+          $maxRetries = 5
+          $retryDelay = 5 # Initial retry delay in seconds
+
+          while ($retryCount -lt $maxRetries) {
+            Write-Host "Attempt $(retryCount+1) out of $(maxRetries): gh pr edit $($payload.issue.number) --add-label `"$label`""
+            gh pr edit $payload.issue.html_url --add-label "$label"
+            
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "Label added successfully on attempt $(retryCount+1) out of $maxRetries"
+              break
+            } else {
+              Write-Warning "Failed to add label on attempt $(retryCount+1) out of $maxRetries"
+              $retryCount++
+              if ($retryCount -lt $maxRetries) {
+                # Exponential backoff in seconds: 
+                #  5 =  1*5
+                # 10 =  2*5
+                # 20 =  4*5
+                # 40 =  8*5
+                $retryDelay = [math]::Pow(2, $retryCount) * $retryDelay
+                Write-Host "Sleeping for $retryDelay seconds."
+                Start-Sleep -Seconds $retryDelay
+              }
+            }
+          }
+
+          if ($retryCount -ge $maxRetries) {
+            Write-Error "Max retry attempts of $maxRetries exhausted. Exiting with error."
+            exit 1
           }
         env:
           PAYLOAD: ${{ toJson(github.event) }}

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -16,15 +16,15 @@ jobs:
       - name: Process comment
         shell: pwsh
         run: |
-          $payload = echo $env:PAYLOAD | ConvertFrom-Json -AsHashtable
+          $payload = Write-Output $env:PAYLOAD | ConvertFrom-Json -AsHashtable
           if (!$payload.comment -or !$payload.comment.body) {
-            Write-Host "Empty comment, returning..."
+            Write-Host "Skipping: empty comment."
             return
           }
           $body = $payload.comment.body.Trim().ToLowerInvariant()
           $expected = '/pr requestmerge'
           if ($body -ne $expected) {
-            Write-Host "Comment did not equal '$expected', skipping..."
+            Write-Host "Skipping: comment did not equal '$expected'."
             return
           }
           $label = 'MergeRequested'
@@ -34,34 +34,33 @@ jobs:
           $retryDelay = 5 # Initial retry delay in seconds
 
           while ($retryCount -lt $maxRetries) {
-            Write-Host "Attempt $(retryCount+1) out of $(maxRetries): gh pr edit $($payload.issue.number) --add-label `"$label`""
+            
+            Write-Host "Attempt $($retryCount+1) out of $($maxRetries): gh pr edit $($payload.issue.number) --add-label `"$label`""
             gh pr edit $payload.issue.html_url --add-label "$label"
             
             if ($LASTEXITCODE -eq 0) {
-              Write-Host "Label added successfully on attempt $(retryCount+1) out of $maxRetries"
+              Write-Host "Label added successfully on attempt $($retryCount+1) out of $($maxRetries)."
               break
             } else {
-              Write-Warning "Failed to add label on attempt $(retryCount+1) out of $maxRetries"
+              Write-Warning "Failed to add label on attempt $($retryCount+1) out of $($maxRetries)."
               $retryCount++
               if ($retryCount -lt $maxRetries) {
-                # Exponential backoff in seconds: 
-                #  5 =  1*5
-                # 10 =  2*5
-                # 20 =  4*5
-                # 40 =  8*5
-                $retryDelay = [math]::Pow(2, $retryCount) * $retryDelay
-                Write-Host "Sleeping for $retryDelay seconds."
+                # $retryDelay = 5 exponential backoff in seconds:
+                # attempt 2:  5 =  1*5
+                # attempt 3: 10 =  2*5
+                # attempt 4: 20 =  4*5
+                # attempt 5: 40 =  8*5
+                Write-Host "Sleeping for $retryDelay seconds..."
                 Start-Sleep -Seconds $retryDelay
+                $retryDelay = $retryDelay * 2
               }
             }
           }
 
           if ($retryCount -ge $maxRetries) {
-            Write-Error "Max retry attempts of $maxRetries exhausted. Exiting with error."
+            Write-Error "Max retry attempts of $maxRetries exhausted. Exiting with error ('exit 1')."
             exit 1
           }
         env:
           PAYLOAD: ${{ toJson(github.event) }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-


### PR DESCRIPTION
Addresses:
- https://github.com/Azure/azure-sdk-tools/issues/6768

Applies fix proposed by @benbp:
- https://github.com/Azure/azure-sdk-tools/issues/6768#issuecomment-1698233802

Modifies code originally added in:
- https://github.com/Azure/azure-rest-api-specs/pull/25091

## Testing

Tests done on my fork:
- https://github.com/konrad-jamrozik/azure-rest-api-specs/pull/1

Test for all retries exhausted (forced failure by ensuring `MergeRequested` label is not present in my fork):
- https://github.com/konrad-jamrozik/azure-rest-api-specs/actions/runs/6280142753/job/17056916233

![image](https://github.com/Azure/azure-rest-api-specs/assets/4429827/b87c95f2-a1c2-4f9c-a436-3f9e1cb6e96f)

Test for happy path:
- https://github.com/konrad-jamrozik/azure-rest-api-specs/actions/runs/6280153930/job/17056944664

![image](https://github.com/Azure/azure-rest-api-specs/assets/4429827/8d93e9fa-6192-42a5-abd2-af6b76c35b08)
