### PR TITLE
Shorten emitted SDK folder path

### DIFF
--- a/specification/cognitiveservices/Vision.ImageAnalysis/tspconfig.yaml
+++ b/specification/cognitiveservices/Vision.ImageAnalysis/tspconfig.yaml
@@ -1,8 +1,6 @@
 parameters:
   "service-dir":
-    default: "sdk/cognitiveservices/imageAnalysis"
-  "dependencies":
-    default: ""
+    default: "sdk/cognitiveservices"
 emit:
  - "@azure-tools/typespec-autorest"
 options:
@@ -24,11 +22,7 @@ options:
   "@azure-tools/typespec-java":
     package-dir: "azure-ai-vision-imageanalysis"
     namespace: "com.azure.ai.vision.imageanalysis"
-    partial-update: true
-    enable-sync-stack: true
-    generate-tests: false
-    custom-types-subpackage: "implementation.models"
-    custom-types: "FunctionCallModelBase,FunctionCallPreset,FunctionCallPresetFunctionCallModel,FunctionNameFunctionCallModel"
+    examples-directory: examples
   "@azure-tools/typespec-ts":
     package-dir: "imageAnalysis"
     generateMetadata: false


### PR DESCRIPTION
Per advice from Azure SDK folks in [this Teams IM](https://teams.microsoft.com/l/message/19:5e673e41085f4a7eaaf20823b85b2b53@thread.skype/1695657602003?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1695657602003&teamName=Azure%20SDK&channelName=Language%20-%20Java&createdTime=1695657602003), the emitted SDK needs to be under \sdk\<service-name>\<module-name> (a 3-level directory) for some tools to work and to comply with the current standard and instructions. We currently have a 4-level directory. The final values of service-name & module-name will be determined by review board, and not important right now.

I confirmed that with this change (3-level folder path) I can now do the Java package install and run tools for the auto-generated Image Analysis SDK, per the Wiki instructions: 
```
mvn install -f sdk\cognitiveservices\azure-ai-vision-imageanalysis\pom.xml -Dgpg.skip -Drevapi.skip -DskipTests
```
Without this change (4-level folder path) I got some errors, and had to skip additional steps in order to get unblocked (by adding these flags `-Dmaven.javadoc.skip -Dcheckstyle.skip -Dspotbugs.skip`).

Also remove some unneeded Java emitter options (looks like they were copied from `pecification\cognitiveservices\OpenAI.Inference\tspconfig.yaml`). I may or may not bring some of them back as work progresses, but right now they are not needed.
