### PR TITLE
[networkanalytics] Enable linter ruleset

### DIFF
--- a/specification/networkanalytics/NetworkAnalytics.Management/main.tsp
+++ b/specification/networkanalytics/NetworkAnalytics.Management/main.tsp
@@ -292,12 +292,10 @@ model ConsumptionEndpointsProperties {
 @added(Versions.v2023_11_15)
 model AccountSas {
   @doc("Sas token start timestamp.")
-  @format("date-time")
-  startTimeStamp: string;
+  startTimeStamp: utcDateTime;
 
   @doc("Sas token expiry timestamp.")
-  @format("date-time")
-  expiryTimeStamp: string;
+  expiryTimeStamp: utcDateTime;
 
   @doc("Ip Address")
   ipAddress: string;

--- a/specification/networkanalytics/NetworkAnalytics.Management/tspconfig.yaml
+++ b/specification/networkanalytics/NetworkAnalytics.Management/tspconfig.yaml
@@ -1,5 +1,8 @@
 emit:
   - '@azure-tools/typespec-autorest'
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-resource-manager/all"
 options:
   '@azure-tools/typespec-autorest':
     emitter-output-dir: "{project-root}/.."


### PR DESCRIPTION
- Enable linter ruleset as required by latest version of TypeSpec
- Fix linter violation by replacing 'format("date-time")' with 'utcDateTime'
