### PR TITLE
[TypeSpec Verification] Improve error message when folder does not exist

### DIFF
--- a/eng/tools/TypeSpecValidation/src/rules/folder-structure.ts
+++ b/eng/tools/TypeSpecValidation/src/rules/folder-structure.ts
@@ -9,11 +9,21 @@ export class FolderStructureRule implements Rule {
   readonly description = "Verify spec directory's folder structure and naming conventions.";
   async execute(folder: string): Promise<RuleResult> {
     let success = true;
+    let stdOutput = "";
     let errorOutput = "";
 
-    let stdOutput = "Verify tspconfig file extension";
-    const tspConfig = await globby([`${folder}/**tspconfig.*`]);
-    tspConfig.forEach((file: string) => {
+    stdOutput += `folder: ${folder}\n`;
+    if (!(await checkFileExists(folder))) {
+      return {
+        success: false,
+        stdOutput: stdOutput,
+        errorOutput: `Folder '${folder}' does not exist.\n`,
+      };
+    }
+
+    const tspConfigs = await globby([`${folder}/**tspconfig.*`]);
+    stdOutput += `config files: ${JSON.stringify(tspConfigs)}\n`;
+    tspConfigs.forEach((file: string) => {
       if (!file.endsWith("tspconfig.yaml")) {
         success = false;
         errorOutput += `Invalid config file '${file}'.  Must be named 'tspconfig.yaml'.\n`;


### PR DESCRIPTION
- Fixes #26089

Examples:

```
$ npx tsv /foo/bar

Executing rule: FolderStructure
folder: /foo/bar

Rule FolderStructure failed
Folder '/foo/bar' does not exist.
```

```
$ npx tsv specification/contosowidgetmanager/Contoso.WidgetManager

Executing rule: FolderStructure
folder: specification/contosowidgetmanager/Contoso.WidgetManager
config files: ["specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml"]
```