### PR TITLE
Attempt to fix the pr MergeRequested workflow

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -4,7 +4,9 @@ on:
   issue_comment:
     types: [created]
 
-permissions: {}
+permissions:
+  pull-requests: write
+  repository-projects: read
 
 jobs:
   comment-handler:


### PR DESCRIPTION
We are getting the following error in our workflow:
```
GraphQL: Resource not accessible by integration (repository.pullRequest.projectCards.nodes)
```
When we call `gh pr edit`

Based on the issue at https://github.com/cli/cli/issues/6274 we can try adding the repository-projects: read permission to workaround this.

Not this seems to only happen on the private repo not the public one.