### PR TITLE
ServiceBus: correcting the order of forwardDeadLetteredMessagesTo

### DIFF
--- a/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
+++ b/specification/servicebus/data-plane/Microsoft.ServiceBus/stable/2021-05/servicebus.json
@@ -786,19 +786,19 @@
         "entityAvailabilityStatus": {
           "$ref": "#/definitions/EntityAvailabilityStatus"
         },
-        "enableExpress": {
-          "description": "A value that indicates whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage.",
-          "type": "boolean",
-          "xml": {
-            "name": "EnableExpress",
-            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-          }
-        },
         "forwardDeadLetteredMessagesTo": {
           "description": "The name of the recipient entity to which all the dead-lettered messages of this subscription are forwarded to.",
           "type": "string",
           "xml": {
             "name": "ForwardDeadLetteredMessagesTo",
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "enableExpress": {
+          "description": "A value that indicates whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage.",
+          "type": "boolean",
+          "xml": {
+            "name": "EnableExpress",
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
         },


### PR DESCRIPTION
The ATOM endpoint requires the nodes in the XML payload to follow certain order. In this case ForwardDeadLetteredMessagesTo property in the swagger was not in the expected place in the PUT model. This caused the generated SDK layer to send payload with wrong order, this property never reflected in the portal queue properties section (though returned upon GET) and dead letter forwarding didn’t work.

This PR corrects the order so that ForwardDeadLetteredMessagesTo property will set correctly, and forwarding upon dead-lettering works as expected.

Note: If we look at the hand written layer of Track2 .NET SDK ([here](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/QueuePropertiesExtensions.cs#L39-L40)) or the hand written version of T1 Java SDK [here](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/servicebus/microsoft-azure-servicebus/src/main/java/com/microsoft/azure/servicebus/management/QueueDescriptionSerializer.java#L137-L145), we will see the expected place of  ForwardDeadLetteredMessagesTo (that we are now updating the swagger to).
