### PR TITLE
Update links in comment for private prs

### DIFF
--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -14,7 +14,7 @@
     repoAllowList:
       - Azure/azure-rest-api-specs-pr
     variables:
-      openapiHub: https://aka.ms/openapihub
+      openapiHub: https://portal.azure-devex-tools.com
       to: Azure/azure-rest-api-specs/main
     label: Approved-OkToMerge
     onLabeledComments: >-
@@ -25,8 +25,7 @@
       If you want to publish the PR to the public repo (`Azure/azure-rest-api-specs`) `main` branch, 
       please use [OpenAPIHub Publish PR](${openapiHub}/tools/publishpullrequest?pr=${owner}/${repo}/${PRNumber}&to=${to}).
       </li><li>
-      For further guidance on how to proceed please refer to this 
-      [wiki article](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/205/RP-Scenarios-to-Contribute-to-Swagger?anchor=**public-repository-vs.-private-repository**).
+      For further guidance see [Spec Repos](https://eng.ms/docs/products/azure-developer-experience/design/api-specs-pr/api-repos).
       </li>
 
 - rule:


### PR DESCRIPTION
Update link from aka.ms to the portal link directly because the aka.ms link will not correctly carry that path parameters to the redirects.

Also update the wiki link to use our new eng.ms site.
