### PR TITLE
[OpenAI.Inference] Change indent from 4 to 2 spaces for Windows compat

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/routes/audio_transcription.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/routes/audio_transcription.tsp
@@ -27,10 +27,10 @@ written language corresponding to the language it was spoken in.
 @action("audio/transcriptions")
 @sharedRoute
 op getAudioTranscriptionAsPlainText is Azure.Core.Foundations.ResourceOperation<
-    Deployment,
-    AudioTranscriptionOptions,  // response_format must be one of: text, srt, vtt
-    string,
-    MultipartFormDataRequestHeadersTraits
+  Deployment,
+  AudioTranscriptionOptions,  // response_format must be one of: text, srt, vtt
+  string,
+  MultipartFormDataRequestHeadersTraits
 >;
 
 #suppress "@azure-tools/typespec-azure-core/byos" "representation of existing multipart/form-data operation"
@@ -43,8 +43,8 @@ written language corresponding to the language it was spoken in.
 @action("audio/transcriptions")
 @sharedRoute
 op getAudioTranscriptionAsResponseObject is Azure.Core.ResourceAction<
-    Deployment,
-    AudioTranscriptionOptions,  // response_format must be unspecified (json) or one of: json, verbose_json
-    AudioTranscription,
-    MultipartFormDataRequestHeadersTraits
+  Deployment,
+  AudioTranscriptionOptions,  // response_format must be unspecified (json) or one of: json, verbose_json
+  AudioTranscription,
+  MultipartFormDataRequestHeadersTraits
 >;

--- a/specification/cognitiveservices/OpenAI.Inference/routes/audio_translation.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/routes/audio_translation.tsp
@@ -26,10 +26,10 @@ Gets English language transcribed text and associated metadata from provided spo
 @action("audio/translations")
 @sharedRoute
 op getAudioTranslationAsPlainText is Azure.Core.Foundations.ResourceOperation<
-    Deployment,
-    AudioTranslationOptions,  // response_format must be one of: text, srt, vtt
-    string,
-    MultipartFormDataRequestHeadersTraits
+  Deployment,
+  AudioTranslationOptions,  // response_format must be one of: text, srt, vtt
+  string,
+  MultipartFormDataRequestHeadersTraits
 >;
 
 #suppress "@azure-tools/typespec-azure-core/byos" "representation of existing multipart/form-data operation"
@@ -41,8 +41,8 @@ Gets English language transcribed text and associated metadata from provided spo
 @action("audio/translations")
 @sharedRoute
 op getAudioTranslationAsResponseObject is Azure.Core.ResourceAction<
-    Deployment,
-    AudioTranslationOptions,  // response_format must be unspecified (json) or one of: json, verbose_json
-    AudioTranslation,
-    MultipartFormDataRequestHeadersTraits
+  Deployment,
+  AudioTranslationOptions,  // response_format must be unspecified (json) or one of: json, verbose_json
+  AudioTranslation,
+  MultipartFormDataRequestHeadersTraits
 >;

--- a/specification/cognitiveservices/OpenAI.Inference/routes/common.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/routes/common.tsp
@@ -11,11 +11,11 @@ using TypeSpec.Rest;
 @doc("A specific deployment")
 @TypeSpec.Rest.resource("deployments")
 model Deployment {
-    @visibility("read")
-    @doc("Specifies either the model deployment name (when using Azure OpenAI) or model name (when using non-Azure OpenAI) to use for this request.")
-    @projectedName("java", "deploymentOrModelName")
-    @key
-    deploymentId: string;
+  @visibility("read")
+  @doc("Specifies either the model deployment name (when using Azure OpenAI) or model name (when using non-Azure OpenAI) to use for this request.")
+  @projectedName("java", "deploymentOrModelName")
+  @key
+  deploymentId: string;
 }
 
 // Audio implementation note: depending on the response_format provided in operation request bodies, these operations
@@ -26,7 +26,7 @@ model Deployment {
 // that share common characteristics whenever possible.
 
 alias MultipartFormDataRequestHeadersTraits = Azure.Core.Traits.RequestHeadersTrait<{
-    @doc("The content type for the operation. Always multipart/form-data for this operation.")
-    @header("content-type")
-    contentType: "multipart/form-data";
+  @doc("The content type for the operation. Always multipart/form-data for this operation.")
+  @header("content-type")
+  contentType: "multipart/form-data";
 }>;

--- a/specification/cognitiveservices/OpenAI.Inference/routes/completions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/routes/completions.tsp
@@ -22,9 +22,9 @@ provided prompt data.
 @actionSeparator("/")
 @action("completions") //@convenientAPI(true)
 op getCompletions is Azure.Core.ResourceAction<
-    Deployment,
-    CompletionsOptions,
-    Completions
+  Deployment,
+  CompletionsOptions,
+  Completions
 >;
 
 @doc("""
@@ -36,9 +36,9 @@ provided prompt data.
 @actionSeparator("/")
 @action("chat/completions") //@convenientAPI(true)
 op getChatCompletions is ResourceAction<
-    Deployment,
-    ChatCompletionsOptions,
-    ChatCompletions
+  Deployment,
+  ChatCompletionsOptions,
+  ChatCompletions
 >;
 
 @doc("""
@@ -54,7 +54,7 @@ other augmentations to the base chat completions capabilities.
 @actionSeparator("/")
 @action("extensions/chat/completions")
 op getChatCompletionsWithAzureExtensions is ResourceAction<
-    Deployment,
-    ChatCompletionsOptions,
-    ChatCompletions
+  Deployment,
+  ChatCompletionsOptions,
+  ChatCompletions
 >;

--- a/specification/cognitiveservices/OpenAI.Inference/routes/embeddings.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/routes/embeddings.tsp
@@ -17,7 +17,7 @@ namespace Azure.OpenAI;
 @actionSeparator("/")
 @action("embeddings") //@convenientAPI(true)
 op getEmbeddings is Azure.Core.ResourceAction<
-    Deployment,
-    EmbeddingsOptions,
-    Embeddings
+  Deployment,
+  EmbeddingsOptions,
+  Embeddings
 >;

--- a/specification/cognitiveservices/OpenAI.Inference/routes/images.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/routes/images.tsp
@@ -23,10 +23,10 @@ namespace Azure.OpenAI;
 @added(ServiceApiVersions.v2023_06_01_Preview)
 @route("/operations/images/{operationId}")
 op getAzureBatchImageGenerationOperationStatus is RpcOperation<
-    {
-        @doc(".") @path operationId: string;
-    },
-    BatchImageGenerationOperationResponse
+  {
+    @doc(".") @path operationId: string;
+  },
+  BatchImageGenerationOperationResponse
 >;
 
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
@@ -34,13 +34,13 @@ op getAzureBatchImageGenerationOperationStatus is RpcOperation<
 @added(ServiceApiVersions.v2023_06_01_Preview)
 @route("/images/generations:submit")
 @pollingOperation(
-    getAzureBatchImageGenerationOperationStatus,
-    {
-        operationId: ResponseProperty<"id">,
-    }
+  getAzureBatchImageGenerationOperationStatus,
+  {
+    operationId: ResponseProperty<"id">,
+  }
 )
 op beginAzureBatchImageGeneration is OaiLongRunningRpcOperation<
-    ImageGenerationOptions,
-    BatchImageGenerationOperationResponse,
-    BatchImageGenerationOperationResponse
+  ImageGenerationOptions,
+  BatchImageGenerationOperationResponse,
+  BatchImageGenerationOperationResponse
 >;


### PR DESCRIPTION
- Linux seems to allow either 4 or 2 spaces, while Windows requires 2 spaces (microsoft/typespec#2568)
