### PR TITLE
[TypeSpec Validation] Quote argument to "tsp format"

### DIFF
--- a/eng/tools/TypeSpecValidation/src/rules/format.ts
+++ b/eng/tools/TypeSpecValidation/src/rules/format.ts
@@ -9,7 +9,7 @@ export class FormatRule implements Rule {
   async execute(folder: string): Promise<RuleResult> {
     // Format parent folder to include shared files
 
-    let [err, stdOutput, errorOutput] = await runCmd(`npx tsp format ../**/*.tsp`, folder);
+    let [err, stdOutput, errorOutput] = await runCmd(`npx tsp format "../**/*.tsp"`, folder);
     // Failing on both err and errorOutput because of known bug in tsp format where it returns 0 on failed formatting
     // https://github.com/microsoft/typespec/issues/2323
     let success = !err && !errorOutput;


### PR DESCRIPTION
- Prevents shell expansion which may create incomplete file list
- Fixes microsoft/typespec#2568
- Related to #26192