### PR TITLE
string updates for renamed features and services

### DIFF
--- a/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchindex.json
+++ b/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchindex.json
@@ -317,7 +317,7 @@
                 {
                   "value": "semantic",
                   "name": "Semantic",
-                  "description": "Allows the user to further explore their Semantic search results."
+                  "description": "Allows the user to further explore their reranked results."
                 }
               ]
             },
@@ -562,7 +562,7 @@
             "items": {
               "type": "string"
             },
-            "description": "The list of field names used for semantic search.",
+            "description": "The list of field names used for semantic ranking.",
             "x-ms-parameter-grouping": {
               "name": "SearchOptions"
             }
@@ -1286,7 +1286,7 @@
           }
         ]
       },
-      "description": "Reason that a partial response was returned for a semantic search request."
+      "description": "Reason that a partial response was returned for a semantic ranking request."
     },
     "SemanticPartialResponseType": {
       "type": "string",
@@ -1310,7 +1310,7 @@
           }
         ]
       },
-      "description": "Type of partial response that was returned for a semantic search request."
+      "description": "Type of partial response that was returned for a semantic ranking request."
     },
     "DocumentDebugInfo": {
       "type": "object",
@@ -1318,7 +1318,7 @@
         "semantic": {
           "$ref": "#/definitions/SemanticDebugInfo",
           "readOnly": true,
-          "description": "Contains debugging information specific to semantic search queries."
+          "description": "Contains debugging information specific to semantic ranking requests."
         }
       },
       "description": "Contains debugging information that can be used to further explore your search results."
@@ -1428,7 +1428,7 @@
           "format": "int64",
           "readOnly": true,
           "x-ms-client-name": "Count",
-          "description": "The total count of results found by the search operation, or null if the count was not requested. If present, the count may be greater than the number of results in this response. This can happen if you use the $top or $skip parameters, or if Azure Cognitive Search can't return all the requested documents in a single Search response."
+          "description": "The total count of results found by the search operation, or null if the count was not requested. If present, the count may be greater than the number of results in this response. This can happen if you use the $top or $skip parameters, or if the query can't return all the requested documents in a single response."
         },
         "@search.coverage": {
           "type": "number",
@@ -1463,19 +1463,19 @@
           "$ref": "#/definitions/SearchRequest",
           "readOnly": true,
           "x-ms-client-name": "NextPageParameters",
-          "description": "Continuation JSON payload returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this JSON along with @odata.nextLink to formulate another POST Search request to get the next part of the search response."
+          "description": "Continuation JSON payload returned when the query can't return all the requested results in a single response. You can use this JSON along with @odata.nextLink to formulate another POST Search request to get the next part of the search response."
         },
         "@search.semanticPartialResponseReason": {
           "$ref": "#/definitions/SemanticPartialResponseReason",
           "readOnly": true,
           "x-ms-client-name": "SemanticPartialResponseReason",
-          "description": "Reason that a partial response was returned for a semantic search request."
+          "description": "Reason that a partial response was returned for a semantic ranking request."
         },
         "@search.semanticPartialResponseType": {
           "$ref": "#/definitions/SemanticPartialResponseType",
           "readOnly": true,
           "x-ms-client-name": "SemanticPartialResponseType",
-          "description": "Type of partial response that was returned for a semantic search request."
+          "description": "Type of partial response that was returned for a semantic ranking request."
         },
         "value": {
           "type": "array",
@@ -1490,7 +1490,7 @@
           "type": "string",
           "readOnly": true,
           "x-ms-client-name": "NextLink",
-          "description": "Continuation URL returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this URL to formulate another GET or POST Search request to get the next part of the search response. Make sure to use the same verb (GET or POST) as the request that produced this response."
+          "description": "Continuation URL returned when the query can't return all the requested results in a single response. You can use this URL to formulate another GET or POST Search request to get the next part of the search response. Make sure to use the same verb (GET or POST) as the request that produced this response."
         }
       },
       "required": [
@@ -1713,7 +1713,7 @@
           {
             "value": "semantic",
             "name": "Semantic",
-            "description": "Allows the user to further explore their Semantic search results."
+            "description": "Allows the user to further explore their reranked results."
           }
         ]
       },
@@ -2546,7 +2546,7 @@
         },
         "debug": {
           "$ref": "#/definitions/QueryDebugMode",
-          "description": "Enables a debugging tool that can be used to further explore your Semantic search results."
+          "description": "Enables a debugging tool that can be used to further explore your reranked results."
         },
         "search": {
           "type": "string",
@@ -2593,7 +2593,7 @@
         },
         "semanticFields": {
           "type": "string",
-          "description": "The comma-separated list of field names used for semantic search."
+          "description": "The comma-separated list of field names used for semantic ranking."
         },
         "vectorQueries": {
           "type": "array",
@@ -2793,7 +2793,7 @@
       "required": [
         "message"
       ],
-      "description": "Describes an error condition for the Azure Cognitive Search API."
+      "description": "Describes an error condition for the API."
     }
   },
   "parameters": {

--- a/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchindex.json
+++ b/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchindex.json
@@ -2345,7 +2345,7 @@
           {
             "value": "gl-es",
             "name": "GlEs",
-            "description": "Query language value for Galician (Spain)."
+            "description": "Query language value for Galician."
           },
           {
             "value": "gu-in",

--- a/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchindex.json
+++ b/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchindex.json
@@ -420,7 +420,7 @@
                 }
               ]
             },
-            "description": "This parameter is only valid if the query type is 'semantic'. If set, the query returns answers extracted from key passages in the highest ranked documents. The number of answers returned can be configured by appending the pipe character '|' followed by the 'count-<number of answers>' option after the answers parameter value, such as 'extractive|count-3'. Default count is 1. The confidence threshold can be configured by appending the pipe character '|' followed by the 'threshold-<confidence threshold>' option after the answers parameter value, such as 'extractive|threshold-0.9'. Default threshold is 0.7.",
+            "description": "This parameter is only valid if the query type is `semantic`. If set, the query returns answers extracted from key passages in the highest ranked documents. The number of answers returned can be configured by appending the pipe character `|` followed by the `count-<number of answers>` option after the answers parameter value, such as `extractive|count-3`. Default count is 1. The confidence threshold can be configured by appending the pipe character `|` followed by the `threshold-<confidence threshold>` option after the answers parameter value, such as `extractive|threshold-0.9`. Default threshold is 0.7.",
             "x-ms-parameter-grouping": {
               "name": "SearchOptions"
             }
@@ -550,7 +550,7 @@
                 }
               ]
             },
-            "description": "This parameter is only valid if the query type is 'semantic'. If set, the query returns captions extracted from key passages in the highest ranked documents. When Captions is set to 'extractive', highlighting is enabled by default, and can be configured by appending the pipe character '|' followed by the 'highlight-<true/false>' option, such as 'extractive|highlight-true'. Defaults to 'None'.",
+            "description": "This parameter is only valid if the query type is `semantic`. If set, the query returns captions extracted from key passages in the highest ranked documents. When Captions is set to `extractive`, highlighting is enabled by default, and can be configured by appending the pipe character `|` followed by the `highlight-<true/false>` option, such as `extractive|highlight-true`. Defaults to `None`.",
             "x-ms-parameter-grouping": {
               "name": "SearchOptions"
             }
@@ -1819,7 +1819,7 @@
           }
         ]
       },
-      "description": "This parameter is only valid if the query type is 'semantic'. If set, the query returns answers extracted from key passages in the highest ranked documents. The number of answers returned can be configured by appending the pipe character '|' followed by the 'count-<number of answers>' option after the answers parameter value, such as 'extractive|count-3'. Default count is 1. The confidence threshold can be configured by appending the pipe character '|' followed by the 'threshold-<confidence threshold>' option after the answers parameter value, such as 'extractive|threshold-0.9'. Default threshold is 0.7."
+      "description": "This parameter is only valid if the query type is `semantic`. If set, the query returns answers extracted from key passages in the highest ranked documents. The number of answers returned can be configured by appending the pipe character `|` followed by the `count-<number of answers>` option after the answers parameter value, such as `extractive|count-3`. Default count is 1. The confidence threshold can be configured by appending the pipe character `|` followed by the `threshold-<confidence threshold>` option after the answers parameter value, such as `extractive|threshold-0.9`. Default threshold is 0.7."
     },
     "Captions": {
       "type": "string",
@@ -1843,7 +1843,7 @@
           }
         ]
       },
-      "description": "This parameter is only valid if the query type is 'semantic'. If set, the query returns captions extracted from key passages in the highest ranked documents. When Captions is set to 'extractive', highlighting is enabled by default, and can be configured by appending the pipe character '|' followed by the 'highlight-<true/false>' option, such as 'extractive|highlight-true'. Defaults to 'None'."
+      "description": "This parameter is only valid if the query type is `semantic`. If set, the query returns captions extracted from key passages in the highest ranked documents. When Captions is set to `extractive`, highlighting is enabled by default, and can be configured by appending the pipe character `|` followed by the `highlight-<true/false>` option, such as `extractive|highlight-true`. Defaults to `None`."
     },
     "VectorQuery": {
       "type": "object",

--- a/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchindex.json
+++ b/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchindex.json
@@ -2295,7 +2295,7 @@
           {
             "value": "ca-es",
             "name": "CaEs",
-            "description": "Query language value for Catalan (Spain)."
+            "description": "Query language value for Catalan."
           },
           {
             "value": "fi-fi",
@@ -2340,7 +2340,7 @@
           {
             "value": "eu-es",
             "name": "EuEs",
-            "description": "Query language value for Basque (Spain)."
+            "description": "Query language value for Basque."
           },
           {
             "value": "gl-es",

--- a/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchservice.json
@@ -6488,7 +6488,7 @@
             "url": "https://docs.microsoft.com/rest/api/searchservice/Create-Data-Source"
           },
           "type": "string",
-          "description": "The connection string for the datasource. Set to '<unchanged>' if you do not want the connection string updated."
+          "description": "The connection string for the datasource. Set to `<unchanged>` (with brackets) if you don't want the connection string updated. Set to `<redacted>` if you want to remove the connection string value from the datasource."
         }
       },
       "description": "Represents credentials that can be used to connect to a datasource."
@@ -11728,7 +11728,7 @@
         "keyVaultUri": {
           "x-ms-client-name": "vaultUri",
           "type": "string",
-          "description": "The URI of your Azure Key Vault, also referred to as DNS name, that contains the key to be used to encrypt your data at rest. An example URI might be https://my-keyvault-name.vault.azure.net."
+          "description": "The URI of your Azure Key Vault, also referred to as DNS name, that contains the key to be used to encrypt your data at rest. An example URI might be `https://my-keyvault-name.vault.azure.net`."
         },
         "accessCredentials": {
           "$ref": "#/definitions/AzureActiveDirectoryApplicationCredentials",

--- a/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2023-10-01-Preview/searchservice.json
@@ -2688,7 +2688,7 @@
           }
         ]
       },
-      "description": "Defines the names of all text analyzers supported by Azure Cognitive Search.",
+      "description": "Defines the names of all text analyzers supported by the search engine.",
       "externalDocs": {
         "url": "https://docs.microsoft.com/rest/api/searchservice/Language-support"
       }
@@ -2781,7 +2781,7 @@
           }
         ]
       },
-      "description": "Defines the names of all tokenizers supported by Azure Cognitive Search.",
+      "description": "Defines the names of all tokenizers supported by the search engine.",
       "externalDocs": {
         "url": "https://docs.microsoft.com/rest/api/searchservice/Custom-analyzers-in-Azure-Search"
       }
@@ -3000,7 +3000,7 @@
           }
         ]
       },
-      "description": "Defines the names of all token filters supported by Azure Cognitive Search.",
+      "description": "Defines the names of all token filters supported by the search engine.",
       "externalDocs": {
         "url": "https://docs.microsoft.com/rest/api/searchservice/Custom-analyzers-in-Azure-Search"
       }
@@ -3045,7 +3045,7 @@
           }
         ]
       },
-      "description": "Defines the names of all text normalizers supported by Azure Cognitive Search.",
+      "description": "Defines the names of all text normalizers supported by the search engine.",
       "externalDocs": {
         "url": "https://aka.ms/azs-normalizers"
       }
@@ -3066,7 +3066,7 @@
           }
         ]
       },
-      "description": "Defines the names of all character filters supported by Azure Cognitive Search.",
+      "description": "Defines the names of all character filters supported by the search engine.",
       "externalDocs": {
         "url": "https://docs.microsoft.com/rest/api/searchservice/Custom-analyzers-in-Azure-Search"
       }
@@ -3205,7 +3205,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the analyzer."
+          "description": "A URI fragment specifying the type of analyzer. "
         },
         "name": {
           "type": "string",
@@ -3345,7 +3345,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the normalizer."
+          "description": "A URI fragment specifying the type of normalizer."
         },
         "name": {
           "type": "string",
@@ -3396,7 +3396,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the tokenizer."
+          "description": "A URI fragment specifying the type of tokenizer."
         },
         "name": {
           "type": "string",
@@ -4335,7 +4335,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the token filter."
+          "description": "A URI fragment specifying the type of token filter."
         },
         "name": {
           "type": "string",
@@ -5932,7 +5932,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the char filter."
+          "description": "A URI fragment specifying the type of char filter."
         },
         "name": {
           "type": "string",
@@ -6514,7 +6514,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the identity."
+          "description": "A URI fragment specifying the type of identity."
         }
       },
       "required": [
@@ -6554,7 +6554,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the data change detection policy."
+          "description": "A URI fragment specifying the type of data change detection policy."
         }
       },
       "required": [
@@ -6594,7 +6594,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the data deletion detection policy."
+          "description": "A URI fragment specifying the type of data deletion detection policy."
         }
       },
       "required": [
@@ -6725,7 +6725,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your datasource definition when you want full assurance that no one, not even Microsoft, can decrypt your data source definition in Azure Cognitive Search. Once you have encrypted your data source definition, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your datasource definition will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your datasource definition when you want full assurance that no one, not even Microsoft, can decrypt your data source definition. Once you have encrypted your data source definition, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your datasource definition will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -6920,12 +6920,12 @@
           {
             "value": "jsonArray",
             "name": "JsonArray",
-            "description": "Set to jsonArray to extract individual elements of a JSON array as separate documents in Azure Cognitive Search."
+            "description": "Set to jsonArray to extract individual elements of a JSON array as separate documents."
           },
           {
             "value": "jsonLines",
             "name": "JsonLines",
-            "description": "Set to jsonLines to extract individual JSON entities, separated by a new line, as separate documents in Azure Cognitive Search."
+            "description": "Set to jsonLines to extract individual JSON entities, separated by a new line, as separate documents."
           }
         ]
       },
@@ -7032,7 +7032,7 @@
           {
             "value": "standard",
             "name": "standard",
-            "description": "Indicates that Azure Cognitive Search can determine where the indexer should execute. This is the default environment when nothing is specified and is the recommended value."
+            "description": "Indicates that the search service can determine where the indexer should execute. This is the default environment when nothing is specified and is the recommended value."
           },
           {
             "value": "private",
@@ -7158,7 +7158,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your indexer definition (as well as indexer execution status) when you want full assurance that no one, not even Microsoft, can decrypt them in Azure Cognitive Search. Once you have encrypted your indexer definition, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your indexer definition (and indexer execution status) will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your indexer definition (as well as indexer execution status) when you want full assurance that no one, not even Microsoft, can decrypt them. Once you have encrypted your indexer definition, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your indexer definition (and indexer execution status) will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -7599,7 +7599,7 @@
         },
         "searchable": {
           "type": "boolean",
-          "description": "A value indicating whether the field is full-text searchable. This means it will undergo analysis such as word-breaking during indexing. If you set a searchable field to a value like \"sunny day\", internally it will be split into the individual tokens \"sunny\" and \"day\". This enables full-text searches for these terms. Fields of type Edm.String or Collection(Edm.String) are searchable by default. This property must be false for simple fields of other non-string data types, and it must be null for complex fields. Note: searchable fields consume extra space in your index since Azure Cognitive Search will store an additional tokenized version of the field value for full-text searches. If you want to save space in your index and you don't need a field to be included in searches, set searchable to false."
+          "description": "A value indicating whether the field is full-text searchable. This means it will undergo analysis such as word-breaking during indexing. If you set a searchable field to a value like \"sunny day\", internally it will be split into the individual tokens \"sunny\" and \"day\". This enables full-text searches for these terms. Fields of type Edm.String or Collection(Edm.String) are searchable by default. This property must be false for simple fields of other non-string data types, and it must be null for complex fields. Note: searchable fields consume extra space in your index to accommodate additional tokenized versions of the field value for full-text searches. If you want to save space in your index and you don't need a field to be included in searches, set searchable to false."
         },
         "filterable": {
           "type": "boolean",
@@ -7607,7 +7607,7 @@
         },
         "sortable": {
           "type": "boolean",
-          "description": "A value indicating whether to enable the field to be referenced in $orderby expressions. By default Azure Cognitive Search sorts results by score, but in many experiences users will want to sort by fields in the documents. A simple field can be sortable only if it is single-valued (it has a single value in the scope of the parent document). Simple collection fields cannot be sortable, since they are multi-valued. Simple sub-fields of complex collections are also multi-valued, and therefore cannot be sortable. This is true whether it's an immediate parent field, or an ancestor field, that's the complex collection. Complex fields cannot be sortable and the sortable property must be null for such fields. The default for sortable is true for single-valued simple fields, false for multi-valued simple fields, and null for complex fields."
+          "description": "A value indicating whether to enable the field to be referenced in $orderby expressions. By default, the search engine sorts results by score, but in many experiences users will want to sort by fields in the documents. A simple field can be sortable only if it is single-valued (it has a single value in the scope of the parent document). Simple collection fields cannot be sortable, since they are multi-valued. Simple sub-fields of complex collections are also multi-valued, and therefore cannot be sortable. This is true whether it's an immediate parent field, or an ancestor field, that's the complex collection. Complex fields cannot be sortable and the sortable property must be null for such fields. The default for sortable is true for single-valued simple fields, false for multi-valued simple fields, and null for complex fields."
         },
         "facetable": {
           "type": "boolean",
@@ -8155,7 +8155,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your data when you want full assurance that no one, not even Microsoft, can decrypt your data in Azure Cognitive Search. Once you have encrypted your data, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your data when you want full assurance that no one, not even Microsoft, can decrypt your data. Once you have encrypted your data, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -8307,11 +8307,11 @@
         "cognitiveServices": {
           "x-ms-client-name": "CognitiveServicesAccount",
           "$ref": "#/definitions/CognitiveServicesAccount",
-          "description": "Details about cognitive services to be used when running skills."
+          "description": "Details about the Azure AI service to be used when running skills."
         },
         "knowledgeStore": {
           "$ref": "#/definitions/SearchIndexerKnowledgeStore",
-          "description": "Definition of additional projections to azure blob, table, or files, of enriched data."
+          "description": "Definition of additional projections to Azure blob, table, or files, of enriched data."
         },
         "indexProjections": {
           "$ref": "#/definitions/SearchIndexerIndexProjections",
@@ -8324,7 +8324,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your skillset definition when you want full assurance that no one, not even Microsoft, can decrypt your skillset definition in Azure Cognitive Search. Once you have encrypted your skillset definition, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your skillset definition will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your skillset definition when you want full assurance that no one, not even Microsoft, can decrypt your skillset definition. Once you have encrypted your skillset definition, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your skillset definition will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -8345,17 +8345,17 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the cognitive service resource attached to a skillset."
+          "description": "A URI fragment specifying the type of Azure AI service resource attached to a skillset."
         },
         "description": {
           "type": "string",
-          "description": "Description of the cognitive service resource attached to a skillset."
+          "description": "Description of the Azure AI service resource attached to a skillset."
         }
       },
       "required": [
         "@odata.type"
       ],
-      "description": "Base type for describing any cognitive service resource attached to a skillset."
+      "description": "Base type for describing any Azure AI service resource attached to a skillset."
     },
     "SearchIndexerKnowledgeStore": {
       "properties": {
@@ -8595,7 +8595,7 @@
       "description": "Defines behavior of the index projections in relation to the rest of the indexer."
     },
     "DefaultCognitiveServicesAccount": {
-      "description": "An empty object that represents the default cognitive service resource for a skillset.",
+      "description": "An empty object that represents the default Azure AI service resource for a skillset.",
       "x-ms-discriminator-value": "#Microsoft.Azure.Search.DefaultCognitiveServices",
       "allOf": [
         {
@@ -8604,7 +8604,7 @@
       ]
     },
     "CognitiveServicesAccountKey": {
-      "description": "A cognitive service resource provisioned with a key that is attached to a skillset.",
+      "description": "An Azure AI service resource provisioned with a key that is attached to a skillset.",
       "x-ms-discriminator-value": "#Microsoft.Azure.Search.CognitiveServicesByKey",
       "allOf": [
         {
@@ -8614,7 +8614,7 @@
       "properties": {
         "key": {
           "type": "string",
-          "description": "The key used to provision the cognitive service resource attached to a skillset."
+          "description": "The key used to provision the Azure AI service resource attached to a skillset."
         }
       },
       "required": [
@@ -8626,7 +8626,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the skill."
+          "description": "A URI fragment specifying the type of skill."
         },
         "name": {
           "type": "string",
@@ -8833,7 +8833,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/KeyPhraseExtractionSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "maxKeyPhraseCount": {
           "type": "integer",
@@ -8862,7 +8862,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/OcrSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "detectOrientation": {
           "x-ms-client-name": "ShouldDetectOrientation",
@@ -8890,7 +8890,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/ImageAnalysisSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "visualFeatures": {
           "type": "array",
@@ -8992,7 +8992,7 @@
         },
         "defaultLanguageCode": {
           "$ref": "#/definitions/EntityRecognitionSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "includeTypelessEntities": {
           "type": "boolean",
@@ -9022,7 +9022,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/SentimentSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         }
       },
       "externalDocs": {
@@ -9042,7 +9042,7 @@
         "defaultLanguageCode": {
           "type": "string",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "includeOpinionMining": {
           "type": "boolean",
@@ -9071,7 +9071,7 @@
         "defaultLanguageCode": {
           "type": "string",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "minimumPrecision": {
           "type": "number",
@@ -9111,7 +9111,7 @@
         "defaultLanguageCode": {
           "type": "string",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "minimumPrecision": {
           "type": "number",
@@ -9124,7 +9124,7 @@
         "modelVersion": {
           "type": "string",
           "x-nullable": true,
-          "description": "The version of the model to use when calling the Text Analytics service. It will default to the latest available when not specified. We recommend you do not specify this value unless absolutely necessary."
+          "description": "The version of the model to use when calling the Text Analytics API. It will default to the latest available when not specified. We recommend you do not specify this value unless absolutely necessary."
         }
       },
       "externalDocs": {
@@ -9143,7 +9143,7 @@
         "defaultLanguageCode": {
           "type": "string",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "minimumPrecision": {
           "type": "number",
@@ -9197,7 +9197,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/SplitSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "textSplitMode": {
           "$ref": "#/definitions/TextSplitMode",
@@ -9239,7 +9239,7 @@
         "defaultLanguageCode": {
           "$ref": "#/definitions/CustomEntityLookupSkillLanguage",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "entitiesDefinitionUri": {
           "type": "string",
@@ -9295,7 +9295,7 @@
         "suggestedFrom": {
           "$ref": "#/definitions/TextTranslationSkillLanguage",
           "x-nullable": true,
-          "description": "The language code to translate documents from when neither the fromLanguageCode input nor the defaultFromLanguageCode parameter are provided, and the automatic language detection is unsuccessful. Default is en."
+          "description": "The language code to translate documents from when neither the fromLanguageCode input nor the defaultFromLanguageCode parameter are provided, and the automatic language detection is unsuccessful. Default is `en`."
         }
       },
       "required": [
@@ -11677,7 +11677,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your data when you want full assurance that no one, not even Microsoft, can decrypt your data in Azure Cognitive Search. Once you have encrypted your data, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your data when you want full assurance that no one, not even Microsoft, can decrypt your data. Once you have encrypted your data, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -11748,7 +11748,7 @@
         "keyVaultKeyVersion",
         "keyVaultUri"
       ],
-      "description": "A customer-managed encryption key in Azure Key Vault. Keys that you create and manage can be used to encrypt or decrypt data-at-rest in Azure Cognitive Search, such as indexes and synonym maps."
+      "description": "A customer-managed encryption key in Azure Key Vault. Keys that you create and manage can be used to encrypt or decrypt data-at-rest, such as indexes and synonym maps."
     },
     "SearchIndexerCache": {
       "properties": {
@@ -11935,7 +11935,7 @@
       "required": [
         "message"
       ],
-      "description": "Describes an error condition for the Azure Cognitive Search API."
+      "description": "Describes an error condition for the API."
     }
   },
   "parameters": {

--- a/specification/search/data-plane/Azure.Search/stable/2023-11-01/searchindex.json
+++ b/specification/search/data-plane/Azure.Search/stable/2023-11-01/searchindex.json
@@ -1118,7 +1118,7 @@
           "format": "int64",
           "readOnly": true,
           "x-ms-client-name": "Count",
-          "description": "The total count of results found by the search operation, or null if the count was not requested. If present, the count may be greater than the number of results in this response. This can happen if you use the $top or $skip parameters, or if Azure Cognitive Search can't return all the requested documents in a single Search response."
+          "description": "The total count of results found by the search operation, or null if the count was not requested. If present, the count may be greater than the number of results in this response. This can happen if you use the $top or $skip parameters, or if the query can't return all the requested documents in a single response."
         },
         "@search.coverage": {
           "type": "number",
@@ -1153,7 +1153,7 @@
           "$ref": "#/definitions/SearchRequest",
           "readOnly": true,
           "x-ms-client-name": "NextPageParameters",
-          "description": "Continuation JSON payload returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this JSON along with @odata.nextLink to formulate another POST Search request to get the next part of the search response."
+          "description": "Continuation JSON payload returned when the query can't return all the requested results in a single response. You can use this JSON along with @odata.nextLink to formulate another POST Search request to get the next part of the search response."
         },
         "value": {
           "type": "array",
@@ -1168,19 +1168,19 @@
           "type": "string",
           "readOnly": true,
           "x-ms-client-name": "NextLink",
-          "description": "Continuation URL returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this URL to formulate another GET or POST Search request to get the next part of the search response. Make sure to use the same verb (GET or POST) as the request that produced this response."
+          "description": "Continuation URL returned when the query can't return all the requested results in a single response. You can use this URL to formulate another GET or POST Search request to get the next part of the search response. Make sure to use the same verb (GET or POST) as the request that produced this response."
         },
         "@search.semanticPartialResponseReason": {
           "$ref": "#/definitions/SemanticPartialResponseReason",
           "readOnly": true,
           "x-ms-client-name": "SemanticPartialResponseReason",
-          "description": "Reason that a partial response was returned for a semantic search request."
+          "description": "Reason that a partial response was returned for a semantic ranking request."
         },
         "@search.semanticPartialResponseType": {
           "$ref": "#/definitions/SemanticPartialResponseType",
           "readOnly": true,
           "x-ms-client-name": "SemanticPartialResponseType",
-          "description": "Type of partial response that was returned for a semantic search request."
+          "description": "Type of partial response that was returned for a semantic ranking request."
         }
       },
       "required": [
@@ -1867,7 +1867,7 @@
       "required": [
         "message"
       ],
-      "description": "Describes an error condition for the Azure Cognitive Search API."
+      "description": "Describes an error condition for the API."
     },
     "AnswerResult": {
       "properties": {
@@ -1942,7 +1942,7 @@
           }
         ]
       },
-      "description": "Reason that a partial response was returned for a semantic search request."
+      "description": "Reason that a partial response was returned for a semantic ranking request."
     },
     "SemanticPartialResponseType": {
       "type": "string",
@@ -1966,7 +1966,7 @@
           }
         ]
       },
-      "description": "Type of partial response that was returned for a semantic search request."
+      "description": "Type of partial response that was returned for a semantic ranking request."
     },
     "SemanticErrorHandling": {
       "type": "string",

--- a/specification/search/data-plane/Azure.Search/stable/2023-11-01/searchindex.json
+++ b/specification/search/data-plane/Azure.Search/stable/2023-11-01/searchindex.json
@@ -434,7 +434,7 @@
                 }
               ]
             },
-            "description": "This parameter is only valid if the query type is 'semantic'. If set, the query returns answers extracted from key passages in the highest ranked documents. The number of answers returned can be configured by appending the pipe character '|' followed by the 'count-<number of answers>' option after the answers parameter value, such as 'extractive|count-3'. Default count is 1. The confidence threshold can be configured by appending the pipe character '|' followed by the 'threshold-<confidence threshold>' option after the answers parameter value, such as 'extractive|threshold-0.9'. Default threshold is 0.7.",
+            "description": "This parameter is only valid if the query type is `semantic`. If set, the query returns answers extracted from key passages in the highest ranked documents. The number of answers returned can be configured by appending the pipe character `|` followed by the `count-<number of answers>` option after the answers parameter value, such as `extractive|count-3`. Default count is 1. The confidence threshold can be configured by appending the pipe character `|` followed by the `threshold-<confidence threshold>` option after the answers parameter value, such as `extractive|threshold-0.9`. Default threshold is 0.7.",
             "x-ms-parameter-grouping": {
               "name": "SearchOptions"
             }
@@ -463,7 +463,7 @@
                 }
               ]
             },
-            "description": "This parameter is only valid if the query type is 'semantic'. If set, the query returns captions extracted from key passages in the highest ranked documents. When Captions is set to 'extractive', highlighting is enabled by default, and can be configured by appending the pipe character '|' followed by the 'highlight-<true/false>' option, such as 'extractive|highlight-true'. Defaults to 'None'.",
+            "description": "This parameter is only valid if the query type is `semantic`. If set, the query returns captions extracted from key passages in the highest ranked documents. When Captions is set to `extractive`, highlighting is enabled by default, and can be configured by appending the pipe character `|` followed by the `highlight-<true/false>` option, such as `extractive|highlight-true`. Defaults to `None`.",
             "x-ms-parameter-grouping": {
               "name": "SearchOptions"
             }
@@ -1204,7 +1204,7 @@
           "readOnly": true,
           "x-ms-client-name": "RerankerScore",
           "x-nullable": true,
-          "description": "The relevance score computed by the semantic ranker for the top search results. Search results are sorted by the RerankerScore first and then by the Score. RerankerScore is only returned for queries of type 'semantic'."
+          "description": "The relevance score computed by the semantic ranker for the top search results. Search results are sorted by the RerankerScore first and then by the Score. RerankerScore is only returned for queries of type `semantic`."
         },
         "@search.highlights": {
           "type": "object",
@@ -1226,7 +1226,7 @@
           "readOnly": true,
           "x-ms-client-name": "Captions",
           "x-nullable": true,
-          "description": "Captions are the most representative passages from the document relatively to the search query. They are often used as document summary. Captions are only returned for queries of type 'semantic'."
+          "description": "Captions are the most representative passages from the document relatively to the search query. They are often used as document summary. Captions are only returned for queries of type `semantic`."
         }
       },
       "required": [
@@ -1912,7 +1912,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Captions are the most representative passages from the document relatively to the search query. They are often used as document summary. Captions are only returned for queries of type 'semantic'.."
+      "description": "Captions are the most representative passages from the document relatively to the search query. They are often used as document summary. Captions are only returned for queries of type `semantic`."
     },
     "SemanticPartialResponseReason": {
       "type": "string",
@@ -1928,7 +1928,7 @@
           {
             "value": "maxWaitExceeded",
             "name": "MaxWaitExceeded",
-            "description": "If 'semanticMaxWaitInMilliseconds' was set and the semantic processing duration exceeded that value. Only the base results were returned."
+            "description": "If `semanticMaxWaitInMilliseconds` was set and the semantic processing duration exceeded that value. Only the base results were returned."
           },
           {
             "value": "capacityOverloaded",
@@ -2014,7 +2014,7 @@
           }
         ]
       },
-      "description": "This parameter is only valid if the query type is 'semantic'. If set, the query returns answers extracted from key passages in the highest ranked documents. The number of answers returned can be configured by appending the pipe character '|' followed by the 'count-<number of answers>' option after the answers parameter value, such as 'extractive|count-3'. Default count is 1. The confidence threshold can be configured by appending the pipe character '|' followed by the 'threshold-<confidence threshold>' option after the answers parameter value, such as 'extractive|threshold-0.9'. Default threshold is 0.7."
+      "description": "This parameter is only valid if the query type is `semantic`. If set, the query returns answers extracted from key passages in the highest ranked documents. The number of answers returned can be configured by appending the pipe character `|` followed by the `count-<number of answers>` option after the answers parameter value, such as `extractive|count-3`. Default count is 1. The confidence threshold can be configured by appending the pipe character `|` followed by the `threshold-<confidence threshold>` option after the answers parameter value, such as `extractive|threshold-0.9`. Default threshold is 0.7."
     },
     "Captions": {
       "type": "string",
@@ -2038,7 +2038,7 @@
           }
         ]
       },
-      "description": "This parameter is only valid if the query type is 'semantic'. If set, the query returns captions extracted from key passages in the highest ranked documents. When Captions is set to 'extractive', highlighting is enabled by default, and can be configured by appending the pipe character '|' followed by the 'highlight-<true/false>' option, such as 'extractive|highlight-true'. Defaults to 'None'."
+      "description": "This parameter is only valid if the query type is `semantic`. If set, the query returns captions extracted from key passages in the highest ranked documents. When Captions is set to `extractive`, highlighting is enabled by default, and can be configured by appending the pipe character `|` followed by the `highlight-<true/false>` option, such as `extractive|highlight-true`. Defaults to `None`."
     }
   },
   "parameters": {

--- a/specification/search/data-plane/Azure.Search/stable/2023-11-01/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/stable/2023-11-01/searchservice.json
@@ -2272,7 +2272,7 @@
           }
         ]
       },
-      "description": "Defines the names of all text analyzers supported by Azure Cognitive Search.",
+      "description": "Defines the names of all text analyzers supported by the search engine.",
       "externalDocs": {
         "url": "https://learn.microsoft.com/rest/api/searchservice/Language-support"
       }
@@ -2365,7 +2365,7 @@
           }
         ]
       },
-      "description": "Defines the names of all tokenizers supported by Azure Cognitive Search.",
+      "description": "Defines the names of all tokenizers supported by the search engine.",
       "externalDocs": {
         "url": "https://learn.microsoft.com/rest/api/searchservice/Custom-analyzers-in-Azure-Search"
       }
@@ -2584,7 +2584,7 @@
           }
         ]
       },
-      "description": "Defines the names of all token filters supported by Azure Cognitive Search.",
+      "description": "Defines the names of all token filters supported by the search engine.",
       "externalDocs": {
         "url": "https://learn.microsoft.com/rest/api/searchservice/Custom-analyzers-in-Azure-Search"
       }
@@ -2605,7 +2605,7 @@
           }
         ]
       },
-      "description": "Defines the names of all character filters supported by Azure Cognitive Search.",
+      "description": "Defines the names of all character filters supported by the search engine.",
       "externalDocs": {
         "url": "https://learn.microsoft.com/rest/api/searchservice/Custom-analyzers-in-Azure-Search"
       }
@@ -2738,7 +2738,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the analyzer."
+          "description": "A URI fragment specifying the type of analyzer."
         },
         "name": {
           "type": "string",
@@ -2878,7 +2878,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the tokenizer."
+          "description": "A URI fragment specifying the type of tokenizer."
         },
         "name": {
           "type": "string",
@@ -3817,7 +3817,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the token filter."
+          "description": "A URI fragment specifying the type of token filter."
         },
         "name": {
           "type": "string",
@@ -5414,7 +5414,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the char filter."
+          "description": "A URI fragment specifying the type of char filter."
         },
         "name": {
           "type": "string",
@@ -5764,7 +5764,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the data change detection policy."
+          "description": "A URI fragment specifying the type of data change detection policy."
         }
       },
       "required": [
@@ -5804,7 +5804,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the data deletion detection policy."
+          "description": "A URI fragment specifying the type of data deletion detection policy."
         }
       },
       "required": [
@@ -5921,7 +5921,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your datasource definition when you want full assurance that no one, not even Microsoft, can decrypt your data source definition in Azure Cognitive Search. Once you have encrypted your data source definition, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your datasource definition will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your datasource definition when you want full assurance that no one, not even Microsoft, can decrypt your data source definition. Once you have encrypted your data source definition, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your datasource definition will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -6116,12 +6116,12 @@
           {
             "value": "jsonArray",
             "name": "JsonArray",
-            "description": "Set to jsonArray to extract individual elements of a JSON array as separate documents in Azure Cognitive Search."
+            "description": "Set to jsonArray to extract individual elements of a JSON array as separate documents."
           },
           {
             "value": "jsonLines",
             "name": "JsonLines",
-            "description": "Set to jsonLines to extract individual JSON entities, separated by a new line, as separate documents in Azure Cognitive Search."
+            "description": "Set to jsonLines to extract individual JSON entities, separated by a new line, as separate documents."
           }
         ]
       },
@@ -6228,7 +6228,7 @@
           {
             "value": "standard",
             "name": "standard",
-            "description": "Indicates that Azure Cognitive Search can determine where the indexer should execute. This is the default environment when nothing is specified and is the recommended value."
+            "description": "Indicates that the search service can determine where the indexer should execute. This is the default environment when nothing is specified and is the recommended value."
           },
           {
             "value": "private",
@@ -6353,7 +6353,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your indexer definition (as well as indexer execution status) when you want full assurance that no one, not even Microsoft, can decrypt them in Azure Cognitive Search. Once you have encrypted your indexer definition, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your indexer definition (and indexer execution status) will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your indexer definition (as well as indexer execution status) when you want full assurance that no one, not even Microsoft, can decrypt them. Once you have encrypted your indexer definition, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your indexer definition (and indexer execution status) will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -6687,7 +6687,7 @@
         },
         "searchable": {
           "type": "boolean",
-          "description": "A value indicating whether the field is full-text searchable. This means it will undergo analysis such as word-breaking during indexing. If you set a searchable field to a value like \"sunny day\", internally it will be split into the individual tokens \"sunny\" and \"day\". This enables full-text searches for these terms. Fields of type Edm.String or Collection(Edm.String) are searchable by default. This property must be false for simple fields of other non-string data types, and it must be null for complex fields. Note: searchable fields consume extra space in your index since Azure Cognitive Search will store an additional tokenized version of the field value for full-text searches. If you want to save space in your index and you don't need a field to be included in searches, set searchable to false."
+          "description": "A value indicating whether the field is full-text searchable. This means it will undergo analysis such as word-breaking during indexing. If you set a searchable field to a value like \"sunny day\", internally it will be split into the individual tokens \"sunny\" and \"day\". This enables full-text searches for these terms. Fields of type Edm.String or Collection(Edm.String) are searchable by default. This property must be false for simple fields of other non-string data types, and it must be null for complex fields. Note: searchable fields consume extra space in your index to accommodate additional tokenized versions of the field value for full-text searches. If you want to save space in your index and you don't need a field to be included in searches, set searchable to false."
         },
         "filterable": {
           "type": "boolean",
@@ -6695,7 +6695,7 @@
         },
         "sortable": {
           "type": "boolean",
-          "description": "A value indicating whether to enable the field to be referenced in $orderby expressions. By default Azure Cognitive Search sorts results by score, but in many experiences users will want to sort by fields in the documents. A simple field can be sortable only if it is single-valued (it has a single value in the scope of the parent document). Simple collection fields cannot be sortable, since they are multi-valued. Simple sub-fields of complex collections are also multi-valued, and therefore cannot be sortable. This is true whether it's an immediate parent field, or an ancestor field, that's the complex collection. Complex fields cannot be sortable and the sortable property must be null for such fields. The default for sortable is true for single-valued simple fields, false for multi-valued simple fields, and null for complex fields."
+          "description": "A value indicating whether to enable the field to be referenced in $orderby expressions. By default, the search engine sorts results by score, but in many experiences users will want to sort by fields in the documents. A simple field can be sortable only if it is single-valued (it has a single value in the scope of the parent document). Simple collection fields cannot be sortable, since they are multi-valued. Simple sub-fields of complex collections are also multi-valued, and therefore cannot be sortable. This is true whether it's an immediate parent field, or an ancestor field, that's the complex collection. Complex fields cannot be sortable and the sortable property must be null for such fields. The default for sortable is true for single-valued simple fields, false for multi-valued simple fields, and null for complex fields."
         },
         "facetable": {
           "type": "boolean",
@@ -7225,7 +7225,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your data when you want full assurance that no one, not even Microsoft, can decrypt your data in Azure Cognitive Search. Once you have encrypted your data, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your data when you want full assurance that no one, not even Microsoft, can decrypt your data. Once you have encrypted your data, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -7332,11 +7332,11 @@
         "cognitiveServices": {
           "x-ms-client-name": "CognitiveServicesAccount",
           "$ref": "#/definitions/CognitiveServicesAccount",
-          "description": "Details about cognitive services to be used when running skills."
+          "description": "Details about the Azure AI service to be used when running skills."
         },
         "knowledgeStore": {
           "$ref": "#/definitions/SearchIndexerKnowledgeStore",
-          "description": "Definition of additional projections to azure blob, table, or files, of enriched data."
+          "description": "Definition of additional projections to Azure blob, table, or files, of enriched data."
         },
         "@odata.etag": {
           "x-ms-client-name": "ETag",
@@ -7345,7 +7345,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your skillset definition when you want full assurance that no one, not even Microsoft, can decrypt your skillset definition in Azure Cognitive Search. Once you have encrypted your skillset definition, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your skillset definition will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your skillset definition when you want full assurance that no one, not even Microsoft, can decrypt your skillset definition. Once you have encrypted your skillset definition, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your skillset definition will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -7366,17 +7366,17 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the cognitive service resource attached to a skillset."
+          "description": "A URI fragment specifying the type of Azure AI service resource attached to a skillset."
         },
         "description": {
           "type": "string",
-          "description": "Description of the cognitive service resource attached to a skillset."
+          "description": "Description of the Azure AI service resource attached to a skillset."
         }
       },
       "required": [
         "@odata.type"
       ],
-      "description": "Base type for describing any cognitive service resource attached to a skillset."
+      "description": "Base type for describing any Azure AI service resource attached to a skillset."
     },
     "SearchIndexerKnowledgeStore": {
       "properties": {
@@ -7511,7 +7511,7 @@
       "description": "Projection definition for what data to store in Azure Files."
     },
     "DefaultCognitiveServicesAccount": {
-      "description": "An empty object that represents the default cognitive service resource for a skillset.",
+      "description": "An empty object that represents the default Azure AI service resource for a skillset.",
       "x-ms-discriminator-value": "#Microsoft.Azure.Search.DefaultCognitiveServices",
       "allOf": [
         {
@@ -7520,7 +7520,7 @@
       ]
     },
     "CognitiveServicesAccountKey": {
-      "description": "A cognitive service resource provisioned with a key that is attached to a skillset.",
+      "description": "An Azure AI service resource provisioned with a key that is attached to a skillset.",
       "x-ms-discriminator-value": "#Microsoft.Azure.Search.CognitiveServicesByKey",
       "allOf": [
         {
@@ -7530,7 +7530,7 @@
       "properties": {
         "key": {
           "type": "string",
-          "description": "The key used to provision the cognitive service resource attached to a skillset."
+          "description": "The key used to provision the Azure AI service resource attached to a skillset."
         }
       },
       "required": [
@@ -7542,7 +7542,7 @@
       "properties": {
         "@odata.type": {
           "type": "string",
-          "description": "Identifies the concrete type of the skill."
+          "description": "A URI fragment specifying the type of skill."
         },
         "name": {
           "type": "string",
@@ -7749,7 +7749,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/KeyPhraseExtractionSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "maxKeyPhraseCount": {
           "type": "integer",
@@ -7778,7 +7778,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/OcrSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "detectOrientation": {
           "x-ms-client-name": "ShouldDetectOrientation",
@@ -7802,7 +7802,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/ImageAnalysisSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "visualFeatures": {
           "type": "array",
@@ -7904,7 +7904,7 @@
         },
         "defaultLanguageCode": {
           "$ref": "#/definitions/EntityRecognitionSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "includeTypelessEntities": {
           "type": "boolean",
@@ -7933,7 +7933,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/SentimentSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         }
       },
       "externalDocs": {
@@ -7952,7 +7952,7 @@
         "defaultLanguageCode": {
           "type": "string",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "includeOpinionMining": {
           "type": "boolean",
@@ -7981,7 +7981,7 @@
         "defaultLanguageCode": {
           "type": "string",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "minimumPrecision": {
           "type": "number",
@@ -8021,7 +8021,7 @@
         "defaultLanguageCode": {
           "type": "string",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "minimumPrecision": {
           "type": "number",
@@ -8053,7 +8053,7 @@
         "defaultLanguageCode": {
           "type": "string",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "minimumPrecision": {
           "type": "number",
@@ -8107,7 +8107,7 @@
       "properties": {
         "defaultLanguageCode": {
           "$ref": "#/definitions/SplitSkillLanguage",
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "textSplitMode": {
           "$ref": "#/definitions/TextSplitMode",
@@ -8137,7 +8137,7 @@
         "defaultLanguageCode": {
           "$ref": "#/definitions/CustomEntityLookupSkillLanguage",
           "x-nullable": true,
-          "description": "A value indicating which language code to use. Default is en."
+          "description": "A value indicating which language code to use. Default is `en`."
         },
         "entitiesDefinitionUri": {
           "type": "string",
@@ -8193,7 +8193,7 @@
         "suggestedFrom": {
           "$ref": "#/definitions/TextTranslationSkillLanguage",
           "x-nullable": true,
-          "description": "The language code to translate documents from when neither the fromLanguageCode input nor the defaultFromLanguageCode parameter are provided, and the automatic language detection is unsuccessful. Default is en."
+          "description": "The language code to translate documents from when neither the fromLanguageCode input nor the defaultFromLanguageCode parameter are provided, and the automatic language detection is unsuccessful. Default is `en`."
         }
       },
       "required": [
@@ -10401,7 +10401,7 @@
         },
         "encryptionKey": {
           "$ref": "#/definitions/SearchResourceEncryptionKey",
-          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your data when you want full assurance that no one, not even Microsoft, can decrypt your data in Azure Cognitive Search. Once you have encrypted your data, it will always remain encrypted. Azure Cognitive Search will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
+          "description": "A description of an encryption key that you create in Azure Key Vault. This key is used to provide an additional level of encryption-at-rest for your data when you want full assurance that no one, not even Microsoft, can decrypt your sensitive data. Once you have encrypted your data, it will always remain encrypted. The search service will ignore attempts to set this property to null. You can change this property as needed if you want to rotate your encryption key; Your data will be unaffected. Encryption with customer-managed keys is not available for free search services, and is only available for paid services created on or after January 1, 2019.",
           "externalDocs": {
             "url": "https://aka.ms/azure-search-encryption-with-cmk"
           },
@@ -10467,7 +10467,7 @@
         "keyVaultKeyVersion",
         "keyVaultUri"
       ],
-      "description": "A customer-managed encryption key in Azure Key Vault. Keys that you create and manage can be used to encrypt or decrypt data-at-rest in Azure Cognitive Search, such as indexes and synonym maps."
+      "description": "A customer-managed encryption key in Azure Key Vault. Keys that you create and manage can be used to encrypt or decrypt data-at-rest on your search service, such as indexes and synonym maps."
     },
     "AzureActiveDirectoryApplicationCredentials": {
       "properties": {
@@ -10629,7 +10629,7 @@
       "required": [
         "message"
       ],
-      "description": "Describes an error condition for the Azure Cognitive Search API."
+      "description": "Describes an error condition for the API."
     },
     "SemanticSettings": {
       "properties": {

--- a/specification/search/data-plane/Azure.Search/stable/2023-11-01/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/stable/2023-11-01/searchservice.json
@@ -212,7 +212,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Selects which top-level properties of the data sources to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+            "description": "Selects which top-level properties of the data sources to retrieve. Specified as a comma-separated list of JSON property names, or `*` for all properties. The default is all properties."
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"
@@ -561,7 +561,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Selects which top-level properties of the indexers to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+            "description": "Selects which top-level properties of the indexers to retrieve. Specified as a comma-separated list of JSON property names, or `*` for all properties. The default is all properties."
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"
@@ -869,7 +869,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Selects which top-level properties of the skillsets to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+            "description": "Selects which top-level properties of the skillsets to retrieve. Specified as a comma-separated list of JSON property names, or `*` for all properties. The default is all properties."
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"
@@ -1130,7 +1130,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Selects which top-level properties of the synonym maps to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+            "description": "Selects which top-level properties of the synonym maps to retrieve. Specified as a comma-separated list of JSON property names, or `*` for all properties. The default is all properties."
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"
@@ -1271,7 +1271,7 @@
             "in": "query",
             "required": false,
             "type": "string",
-            "description": "Selects which top-level properties of the index definitions to retrieve. Specified as a comma-separated list of JSON property names, or '*' for all properties. The default is all properties."
+            "description": "Selects which top-level properties of the index definitions to retrieve. Specified as a comma-separated list of JSON property names, or `*` for all properties. The default is all properties."
           },
           {
             "$ref": "#/parameters/ClientRequestIdParameter"
@@ -5738,7 +5738,7 @@
             "url": "https://learn.microsoft.com/rest/api/searchservice/Create-Data-Source"
           },
           "type": "string",
-          "description": "The connection string for the datasource. Set to '<unchanged>' if you do not want the connection string updated."
+          "description": "The connection string for the datasource. Set to `<unchanged>` (with brackets) if you don't want the connection string updated. Set to `<redacted>` if you want to remove the connection string value from the datasource."
         }
       },
       "description": "Represents credentials that can be used to connect to a datasource."
@@ -7088,7 +7088,7 @@
           "items": {
             "type": "string"
           },
-          "description": "The list of origins from which JavaScript code will be granted access to your index. Can contain a list of hosts of the form {protocol}://{fully-qualified-domain-name}[:{port#}], or a single '*' to allow all origins (not recommended)."
+          "description": "The list of origins from which JavaScript code will be granted access to your index. Can contain a list of hosts of the form {protocol}://{fully-qualified-domain-name}[:{port#}], or a single `*` to allow all origins (not recommended)."
         },
         "maxAgeInSeconds": {
           "type": "integer",
@@ -7546,7 +7546,7 @@
         },
         "name": {
           "type": "string",
-          "description": "The name of the skill which uniquely identifies it within the skillset. A skill with no name defined will be given a default name of its 1-based index in the skills array, prefixed with the character '#'."
+          "description": "The name of the skill which uniquely identifies it within the skillset. A skill with no name defined will be given a default name of its 1-based index in the skills array, prefixed with the character `#`."
         },
         "description": {
           "type": "string",
@@ -8071,7 +8071,7 @@
           "type": "string",
           "x-nullable": true,
           "maxLength": 1,
-          "description": "The character used to mask the text if the maskingMode parameter is set to replace. Default is '*'."
+          "description": "The character used to mask the text if the maskingMode parameter is set to replace. Default is `*`."
         },
         "modelVersion": {
           "type": "string",
@@ -10452,7 +10452,7 @@
         "keyVaultUri": {
           "x-ms-client-name": "vaultUri",
           "type": "string",
-          "description": "The URI of your Azure Key Vault, also referred to as DNS name, that contains the key to be used to encrypt your data at rest. An example URI might be https://my-keyvault-name.vault.azure.net."
+          "description": "The URI of your Azure Key Vault, also referred to as DNS name, that contains the key to be used to encrypt your data at rest. An example URI might be `https://my-keyvault-name.vault.azure.net`."
         },
         "accessCredentials": {
           "$ref": "#/definitions/AzureActiveDirectoryApplicationCredentials",


### PR DESCRIPTION
Removed references to "Azure Cognitive Search" per upcoming rebrand. 
Corrected references to Cognitive Services, which are now Azure AI services. 
Replaced references to "semantic search" with "semantic ranking".

These changes are for autogen data plane API reference documentation (Ignite 2023)
