### PR TITLE
Synapse: fixing the casing for `recoverableSqlpools` to be consistent as `recoverableSqlPools`

### DIFF
--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -9,9 +9,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
         "name": "recoverableSqlpools-1235",
-        "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+        "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
         "properties": {
           "edition": "Standard",
           "serviceLevelObjective": "S0",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -10,9 +10,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
             "name": "recoverableSqlpools-1235",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Standard",
               "serviceLevelObjective": "S0",
@@ -21,9 +21,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-9231",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-9231",
             "name": "recoverableSqlpools-9231",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Premium",
               "serviceLevelObjective": "P1",
@@ -32,9 +32,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-0342",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-0342",
             "name": "recoverableSqlpools-0342",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Basic",
               "serviceLevelObjective": "Basic",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/sqlServer.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2019-06-01-preview/sqlServer.json
@@ -845,13 +845,13 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/recoverableSqlpools": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/recoverableSqlPools": {
       "get": {
         "tags": [
           "WorkspaceManagedSqlServer",
-          "recoverableSqlpools"
+          "RecoverableSqlPools"
         ],
-        "operationId": "WorkspaceManagedSqlServerRecoverableSqlpools_List",
+        "operationId": "WorkspaceManagedSqlServerRecoverableSqlPools_List",
         "summary": "Get list of recoverable sql pools for the server.",
         "description": "Get list of recoverable sql pools for workspace managed sql server.",
         "parameters": [

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -9,9 +9,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
         "name": "recoverableSqlpools-1235",
-        "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+        "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
         "properties": {
           "edition": "Standard",
           "serviceLevelObjective": "S0",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-04-01-preview/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -10,9 +10,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
             "name": "recoverableSqlpools-1235",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Standard",
               "serviceLevelObjective": "S0",
@@ -21,9 +21,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-9231",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-9231",
             "name": "recoverableSqlpools-9231",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Premium",
               "serviceLevelObjective": "P1",
@@ -32,9 +32,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-0342",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-0342",
             "name": "recoverableSqlpools-0342",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Basic",
               "serviceLevelObjective": "Basic",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -9,9 +9,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
         "name": "recoverableSqlpools-1235",
-        "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+        "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
         "properties": {
           "edition": "Standard",
           "serviceLevelObjective": "S0",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/preview/2021-06-01-preview/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -10,9 +10,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
             "name": "recoverableSqlpools-1235",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Standard",
               "serviceLevelObjective": "S0",
@@ -21,9 +21,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-9231",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-9231",
             "name": "recoverableSqlpools-9231",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Premium",
               "serviceLevelObjective": "P1",
@@ -32,9 +32,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-0342",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-0342",
             "name": "recoverableSqlpools-0342",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Basic",
               "serviceLevelObjective": "Basic",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -9,9 +9,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
         "name": "recoverableSqlpools-1235",
-        "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+        "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
         "properties": {
           "edition": "Standard",
           "serviceLevelObjective": "S0",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2020-12-01/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -10,9 +10,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
             "name": "recoverableSqlpools-1235",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Standard",
               "serviceLevelObjective": "S0",
@@ -21,9 +21,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-9231",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-9231",
             "name": "recoverableSqlpools-9231",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Premium",
               "serviceLevelObjective": "P1",
@@ -32,9 +32,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-0342",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-0342",
             "name": "recoverableSqlpools-0342",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Basic",
               "serviceLevelObjective": "Basic",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -9,9 +9,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
         "name": "recoverableSqlpools-1235",
-        "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+        "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
         "properties": {
           "edition": "Standard",
           "serviceLevelObjective": "S0",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-03-01/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -10,9 +10,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
             "name": "recoverableSqlpools-1235",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Standard",
               "serviceLevelObjective": "S0",
@@ -21,9 +21,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-9231",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-9231",
             "name": "recoverableSqlpools-9231",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Premium",
               "serviceLevelObjective": "P1",
@@ -32,9 +32,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-0342",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-0342",
             "name": "recoverableSqlpools-0342",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Basic",
               "serviceLevelObjective": "Basic",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -9,9 +9,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
         "name": "recoverableSqlpools-1235",
-        "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+        "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
         "properties": {
           "edition": "Standard",
           "serviceLevelObjective": "S0",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-05-01/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -10,9 +10,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
             "name": "recoverableSqlpools-1235",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Standard",
               "serviceLevelObjective": "S0",
@@ -21,9 +21,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-9231",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-9231",
             "name": "recoverableSqlpools-9231",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Premium",
               "serviceLevelObjective": "P1",
@@ -32,9 +32,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-0342",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-0342",
             "name": "recoverableSqlpools-0342",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Basic",
               "serviceLevelObjective": "Basic",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/GetWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -9,9 +9,9 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
         "name": "recoverableSqlpools-1235",
-        "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+        "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
         "properties": {
           "edition": "Standard",
           "serviceLevelObjective": "S0",

--- a/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
+++ b/specification/synapse/resource-manager/Microsoft.Synapse/stable/2021-06-01/examples/ListWorkspaceManagedSqlServerRecoverableSqlPool.json
@@ -10,9 +10,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-1235",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-1235",
             "name": "recoverableSqlpools-1235",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Standard",
               "serviceLevelObjective": "S0",
@@ -21,9 +21,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-9231",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-9231",
             "name": "recoverableSqlpools-9231",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Premium",
               "serviceLevelObjective": "P1",
@@ -32,9 +32,9 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlpools/recoverableSqlpools-0342",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/wsg-7398/providers/Microsoft.Synapse/workspaces/testWorkspace/recoverableSqlPools/recoverableSqlpools-0342",
             "name": "recoverableSqlpools-0342",
-            "type": "Microsoft.Synapse/workspaces/recoverableSqlpools",
+            "type": "Microsoft.Synapse/workspaces/recoverableSqlPools",
             "properties": {
               "edition": "Basic",
               "serviceLevelObjective": "Basic",


### PR DESCRIPTION
Both instances exist in the `synapse` directory, however Resource ID segments are supposed to be camelCased, as such these should be normalized to `recoverableSqlPools`.

This fixes a data inconsistency tracked in https://github.com/hashicorp/pandora/issues/1508
