### PR TITLE
[TypeSpec Validation] Revert "trigger on only specification/<service-family> (#26276)"

### DIFF
--- a/eng/scripts/Get-TypeSpec-Folders.ps1
+++ b/eng/scripts/Get-TypeSpec-Folders.ps1
@@ -28,7 +28,7 @@ else {
 $typespecFolders = @()
 $skippedTypespecFolders = @()
 foreach ($file in $changedFiles) {
-  if ($file -match 'specification(\/[^\/]*\/)+') {
+  if ($file -match 'specification(\/[^\/]*\/)*') {
     $path = "$repoPath/$($matches[0])"
     if (Test-Path $path) {   
       Write-Verbose "Checking for tspconfig files under $path"


### PR DESCRIPTION
- Commit broke "CheckAll" switch, causing it to validate no specs rather than all specs
- Reverts commit 5faae69471b14fd729e19052bc84859bb12bbdeb
- Reverts PR #26276
