### PR TITLE
Added x-ms-file-request-intent to File PutRangeFromUrl

### DIFF
--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2022-11-02/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2022-11-02/file.json
@@ -4863,6 +4863,9 @@
           },
           {
             "$ref": "#/parameters/SourceAllowTrailingDot"
+          },
+          {
+            "$ref": "#/parameters/FileRequestIntent"
           }
         ],
         "responses": {


### PR DESCRIPTION
This is not a new feature or a breaking change

We missed adding the header 'x-ms-file-request-intent' when we implemented Files OAuth. 
This change is to add the header to 2022-11-02 version