### PR TITLE
fix readme file

### DIFF
--- a/specification/chaos/resource-manager/readme.md
+++ b/specification/chaos/resource-manager/readme.md
@@ -28,9 +28,60 @@ These are the global settings for the chaos.
 title: ChaosManagementClient
 description: Chaos Management Client
 openapi-type: arm
-tag: package-preview-2023-10
+tag: package-2023-11
 ```
 
+### Tag: package-2023-11
+
+These settings apply only when `--tag=package-2023-11` is specified on the command line.
+
+```yaml $(tag) == 'package-2023-11'
+input-file:
+  - Microsoft.Chaos/stable/2023-11-01/capabilities.json
+  - Microsoft.Chaos/stable/2023-11-01/capabilityTypes.json
+  - Microsoft.Chaos/stable/2023-11-01/experiments.json
+  - Microsoft.Chaos/stable/2023-11-01/operationStatuses.json
+  - Microsoft.Chaos/stable/2023-11-01/operations.json
+  - Microsoft.Chaos/stable/2023-11-01/targetTypes.json
+  - Microsoft.Chaos/stable/2023-11-01/targets.json
+directive:
+  - from: swagger-document
+    where: "$.definitions.action"
+    transform: >
+      $["x-ms-client-name"] = "ChaosExperimentAction";
+  - from: swagger-document
+    where: "$.definitions.branch"
+    transform: >
+      $["x-ms-client-name"] = "ChaosExperimentBranch";
+  - from: swagger-document
+    where: "$.definitions.step"
+    transform: >
+      $["x-ms-client-name"] = "ChaosExperimentStep";
+  - from: swagger-document
+    where: "$.definitions.filter"
+    transform: >
+      $["x-ms-client-name"] = "ChaosTargetFilter";
+  - from: swagger-document
+    where: "$.definitions.simpleFilter"
+    transform: >
+      $["x-ms-client-name"] = "ChaosTargetSimpleFilter";
+  - from: swagger-document
+    where: "$.definitions.simpleFilterParameters"
+    transform: >
+      $["x-ms-client-name"] = "ChaosTargetSimpleFilterParameters";
+  - from: swagger-document
+    where: "$.definitions.selector"
+    transform: >
+      $["x-ms-client-name"] = "ChaosTargetSelector";
+  - from: swagger-document
+    where: "$.definitions.listSelector"
+    transform: >
+      $["x-ms-client-name"] = "ChaosTargetListSelector";
+  - from: swagger-document
+    where: "$.definitions.querySelector"
+    transform: >
+      $["x-ms-client-name"] = "ChaosTargetQuerySelector";
+```
 
 ### Tag: package-preview-2023-10
 
@@ -83,6 +134,7 @@ directive:
     transform: >
       $["x-ms-client-name"] = "ChaosTargetQuerySelector";
 ```
+
 ### Tag: package-preview-2023-09
 
 These settings apply only when `--tag=package-preview-2023-09` is specified on the command line.


### PR DESCRIPTION
we had a merge issue for branch dev-chaos-Microsoft.Chaos-2023-11-01 where we had to revert changes to readme file. now that dev-chaos-Microsoft.Chaos-2023-11-01 is merged in. I need to add back the change to readme file.

original PR here: https://github.com/Azure/azure-rest-api-specs/pull/26255