### PR TITLE
[TypeSpec Validation] Refactor TsvHost

### DIFF
--- a/eng/tools/TypeSpecValidation/src/index.ts
+++ b/eng/tools/TypeSpecValidation/src/index.ts
@@ -21,7 +21,7 @@ export async function main() {
 
   const host = new TsvRunnerHost();
 
-  let rules = [
+  const rules = [
     new FolderStructureRule(),
     new NpmPrefixRule(),
     new LinterRulesetRule(),

--- a/eng/tools/TypeSpecValidation/src/index.ts
+++ b/eng/tools/TypeSpecValidation/src/index.ts
@@ -19,6 +19,8 @@ export async function main() {
   const folder = parsedArgs.positionals[0];
   console.log("Running TypeSpecValidation on folder:", folder);
 
+  const host = new TsvRunnerHost();
+
   let rules = [
     new FolderStructureRule(),
     new NpmPrefixRule(),
@@ -31,7 +33,7 @@ export async function main() {
   for (let i = 0; i < rules.length; i++) {
     const rule = rules[i];
     console.log("\nExecuting rule: " + rule.name);
-    const result = await rule.execute(TsvRunnerHost, folder);
+    const result = await rule.execute(host, folder);
     if (result.stdOutput) console.log(result.stdOutput);
     if (!result.success) {
       success = false;

--- a/eng/tools/TypeSpecValidation/src/tsv-host.ts
+++ b/eng/tools/TypeSpecValidation/src/tsv-host.ts
@@ -1,7 +1,6 @@
 export interface TsvHost {
   checkFileExists(file: string): Promise<boolean>;
   gitOperation(folder: string): IGitOperation;
-  readTspConfig(folder: string): Promise<string>;
   runCmd(cmd: string, cwd: string): Promise<[Error | null, string, string]>;
 }
 

--- a/eng/tools/TypeSpecValidation/src/tsv-host.ts
+++ b/eng/tools/TypeSpecValidation/src/tsv-host.ts
@@ -1,8 +1,8 @@
 export interface TsvHost {
-  gitOperation(folder: string): IGitOperation;
-  runCmd(cmd: string, cwd: string): Promise<[Error | null, string, string]>;
   checkFileExists(file: string): Promise<boolean>;
-  // TODO: Other functions that need mocks
+  gitOperation(folder: string): IGitOperation;
+  readTspConfig(folder: string): Promise<string>;
+  runCmd(cmd: string, cwd: string): Promise<[Error | null, string, string]>;
 }
 
 export interface IGitOperation {

--- a/eng/tools/TypeSpecValidation/src/tsv-runner-host.ts
+++ b/eng/tools/TypeSpecValidation/src/tsv-runner-host.ts
@@ -1,5 +1,3 @@
-import { join } from "path";
-import { readFile } from "fs/promises";
 import { IGitOperation, TsvHost } from "./tsv-host.js";
 import { simpleGit } from "simple-git";
 import { runCmd, checkFileExists } from "./utils.js";
@@ -11,10 +9,6 @@ export class TsvRunnerHost implements TsvHost {
 
   gitOperation(folder: string): IGitOperation {
     return simpleGit(folder);
-  }
-
-  readTspConfig(folder: string): Promise<string> {
-    return readFile(join(folder, "tspconfig.yaml"), "utf-8");
   }
 
   runCmd(cmd: string, cwd: string): Promise<[Error | null, string, string]> {

--- a/eng/tools/TypeSpecValidation/src/tsv-runner-host.ts
+++ b/eng/tools/TypeSpecValidation/src/tsv-runner-host.ts
@@ -1,10 +1,23 @@
-import { TsvHost } from "./tsv-host.js";
+import { join } from "path";
+import { readFile } from "fs/promises";
+import { IGitOperation, TsvHost } from "./tsv-host.js";
 import { simpleGit } from "simple-git";
 import { runCmd, checkFileExists } from "./utils.js";
 
-export const TsvRunnerHost: TsvHost = {
-  gitOperation: simpleGit,
-  runCmd: runCmd,
-  checkFileExists: checkFileExists,
-  // TODO: Other functions that need mocks
-};
+export class TsvRunnerHost implements TsvHost {
+  checkFileExists(file: string): Promise<boolean> {
+    return checkFileExists(file);
+  }
+
+  gitOperation(folder: string): IGitOperation {
+    return simpleGit(folder);
+  }
+
+  readTspConfig(folder: string): Promise<string> {
+    return readFile(join(folder, "tspconfig.yaml"), "utf-8");
+  }
+
+  runCmd(cmd: string, cwd: string): Promise<[Error | null, string, string]> {
+    return runCmd(cmd, cwd);
+  }
+}

--- a/eng/tools/TypeSpecValidation/test/compile.test.ts
+++ b/eng/tools/TypeSpecValidation/test/compile.test.ts
@@ -3,12 +3,8 @@ import { TsvTestHost } from "./tsv-test-host.js";
 import { strict as assert } from "node:assert";
 describe("compile", function () {
   it("should succeed if project can compile", async function () {
-    let host = new TsvTestHost();
-    host.runCmd = async (_cmd: string, _cwd: string) => [null, "success", "success"];
-
-    const result = await new CompileRule().execute(host, TsvTestHost.folder);
+    const result = await new CompileRule().execute(new TsvTestHost(), TsvTestHost.folder);
 
     assert(result.success);
-    assert(result.stdOutput === "successsuccess");
   });
 });

--- a/eng/tools/TypeSpecValidation/test/compile.test.ts
+++ b/eng/tools/TypeSpecValidation/test/compile.test.ts
@@ -1,14 +1,13 @@
-// import { error } from "node:console";
 import { CompileRule } from "../src/rules/compile.js";
-import { TsvTestHostGenerator } from "./tsv-test-host.js";
+import { TsvTestHost } from "./tsv-test-host.js";
 import { strict as assert } from "node:assert";
-describe("#Compile", function () {
-  it("Should fail if project cannot compile.", async function () {
-    let compileRule = new CompileRule();
-    let TsvTestHost = TsvTestHostGenerator({
-      runCmd: Promise.resolve([null, "success", "success"]),
-    });
-    const result = await compileRule.execute(TsvTestHost, "mockFolder");
+describe("compile", function () {
+  it("should succeed if project can compile", async function () {
+    let host = new TsvTestHost();
+    host.runCmd = async (_cmd: string, _cwd: string) => [null, "success", "success"];
+
+    const result = await new CompileRule().execute(host, TsvTestHost.folder);
+
     assert(result.success);
     assert(result.stdOutput === "successsuccess");
   });

--- a/eng/tools/TypeSpecValidation/test/folder-structure.test.ts
+++ b/eng/tools/TypeSpecValidation/test/folder-structure.test.ts
@@ -1,5 +1,0 @@
-describe("#FolderStructure", function () {
-  it("Should fail if directory name does not conform.", async function () {
-    // TODO: Folder structure rule unit test
-  });
-});

--- a/eng/tools/TypeSpecValidation/test/git-diff.test.ts
+++ b/eng/tools/TypeSpecValidation/test/git-diff.test.ts
@@ -1,12 +1,11 @@
 import { GitDiffRule } from "../src/rules/git-diff.js";
-import { DefaultTsvTestHost } from "./tsv-test-host.js";
+import { TsvTestHost } from "./tsv-test-host.js";
 import { strict as assert } from "node:assert";
 
-describe("#GitDiff", function () {
-  it("Should fail if git diff produces output.", async function () {
-    let gitDiffRule = new GitDiffRule();
-    const result = await gitDiffRule.execute(DefaultTsvTestHost, "mockFolder");
-    assert(result.errorOutput);
-    assert(result.errorOutput.length !== 0);
+describe("git-diff", function () {
+  it("should succeed if git diff produces no output", async function () {
+    const result = await new GitDiffRule().execute(new TsvTestHost(), TsvTestHost.folder);
+
+    assert(result.success);
   });
 });

--- a/eng/tools/TypeSpecValidation/test/tsv-test-host.ts
+++ b/eng/tools/TypeSpecValidation/test/tsv-test-host.ts
@@ -33,20 +33,4 @@ export class TsvTestHost implements TsvHost {
   async checkFileExists(_file: string): Promise<boolean> {
     return true;
   }
-
-  async readTspConfig(_folder: string): Promise<string> {
-    return `
-emit:
-  - "@azure-tools/typespec-autorest"
-linter:
-  extends:
-    - "@azure-tools/typespec-azure-core/all"
-options:
-  "@azure-tools/typespec-autorest":
-    azure-resource-provider-folder: "data-plane"
-    emitter-output-dir: "{project-root}/.."
-    examples-directory: "examples"
-    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
-`;
-  }
 }

--- a/eng/tools/TypeSpecValidation/test/tsv-test-host.ts
+++ b/eng/tools/TypeSpecValidation/test/tsv-test-host.ts
@@ -1,57 +1,52 @@
-import { TsvHost } from "../src/tsv-host.js";
+import { IGitOperation, TsvHost } from "../src/tsv-host.js";
 
-export function TsvTestHostGenerator(fnReturnSub: { [key: string]: Object }) {
-  let tsvTestHost = Object.assign({}, DefaultTsvTestHost); // Needs deep copy
-  for (let key in fnReturnSub) {
-    let typedKey = key as keyof TsvHost;
-    if (fnReturnSub[typedKey]) {
-      tsvTestHost = {
-        ...tsvTestHost,
-        [typedKey]: () => {
-          return fnReturnSub[typedKey];
-        },
-      };
-    } else {
-      tsvTestHost = {
-        ...tsvTestHost,
-        [typedKey]: () => {},
-      };
-    }
+export class TsvTestHost implements TsvHost {
+  static get folder() {
+    return "specification/foo/Foo";
   }
-  return tsvTestHost;
-}
 
-export const DefaultTsvTestHost: TsvHost = {
-  gitOperation: (folder: string) => {
+  gitOperation(_folder: string): IGitOperation {
     return {
       status: () => {
         return Promise.resolve({
-          modified: [`${folder}\n`],
-          isClean: () => {
-            return false;
-          },
+          modified: [],
+          isClean: () => true,
         });
       },
       diff: () => {
-        return Promise.resolve("diff");
+        return Promise.resolve("");
       },
       revparse: () => {
         return Promise.resolve("");
       },
     };
-  },
+  }
 
-  runCmd: async (cmd: string, cwd: string) => {
+  async runCmd(cmd: string, cwd: string): Promise<[Error | null, string, string]> {
     let err = null;
     let stdout = `default ${cmd} at ${cwd}`;
     let stderr = "";
 
     return [err, stdout, stderr];
-  },
+  }
 
-  checkFileExists: async (file: string) => {
-    console.log(`file ${file} exists`);
+  async checkFileExists(_file: string): Promise<boolean> {
     return true;
-  },
-  // TODO: Other functions that need mocks
-};
+  }
+
+  async readTspConfig(_folder: string): Promise<string> {
+    return `
+emit:
+  - "@azure-tools/typespec-autorest"
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-core/all"
+options:
+  "@azure-tools/typespec-autorest":
+    azure-resource-provider-folder: "data-plane"
+    emitter-output-dir: "{project-root}/.."
+    examples-directory: "examples"
+    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
+`;
+  }
+}


### PR DESCRIPTION
- Export TsvRunnerHost and TsvTestHost as classes rather than consts
- Change test names to lower-case for consistency with typespec repo
- Delete incomplete FolderStructure rule
- TsvRunnerHost.gitOperation should succeed by default
