### PR TITLE
[ADF] Add ability to filter PipelineRuns by `TriggeredByName`

### DIFF
--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/datafactory.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/datafactory.json
@@ -6458,11 +6458,11 @@
       "description": "Query filter option for listing runs.",
       "type": "object",
       "properties": {
-        "operand": {
-          "description": "Parameter name to be used for filter. The allowed operands to query pipeline runs are PipelineName, RunStart, RunEnd and Status; to query activity runs are ActivityName, ActivityRunStart, ActivityRunEnd, ActivityType and Status, and to query trigger runs are TriggerName, TriggerRunTimestamp and Status.",
+          "description": "Parameter name to be used for filter. The allowed operands to query pipeline runs are PipelineName, TriggeredByName, LatestOnly, RunGroupId, RunStart, RunEnd and Status; to query activity runs are ActivityName, ActivityRunStart, ActivityRunEnd, ActivityType and Status, and to query trigger runs are TriggerName, TriggerRunTimestamp and Status.",
           "type": "string",
           "enum": [
             "PipelineName",
+            "TriggeredByName",
             "Status",
             "RunStart",
             "RunEnd",


### PR DESCRIPTION
Also expanded list of valid filters for PipelineRuns with `LatestOnly` and `RunGroupId` based on what API returned as possible values(it also listed `SandboxId`, but since that seems very undocumented thing, I decided to not add it here).