### PR TITLE
Fix link to OpenAPI style guideline in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/data_plane_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/data_plane_template.md
@@ -47,13 +47,13 @@ The [Azure API Review Board](https://aka.ms/azsdk/onboarding/restapischedule) is
 ### Tooling
 
  * [Open API validation tools](https://aka.ms/swaggertools) were run on this PR. Go here to see [how to fix errors](https://aka.ms/ci-fix)
- * [Spectral Linting](https://aka.ms/style)
+ * [Spectral Linting](https://aka.ms/azapi/style)
  * [Open API Hub](https://aka.ms/openapiportal)
 
 ### Guidelines & Specifications
 
- * [Azure REST API Guidelines](https://aka.ms/guidelines)
- * [OpenAPI Style Guidelines](https://aka.ms/style)
+ * [Azure REST API Guidelines](https://aka.ms/azapi/guidelines)
+ * [OpenAPI Style Guidelines](https://aka.ms/azapi/style)
  * [Azure Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy)
 
 ### Helpful Links

--- a/.github/PULL_REQUEST_TEMPLATE/data_plane_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/data_plane_template.md
@@ -47,7 +47,7 @@ The [Azure API Review Board](https://aka.ms/azsdk/onboarding/restapischedule) is
 ### Tooling
 
  * [Open API validation tools](https://aka.ms/swaggertools) were run on this PR. Go here to see [how to fix errors](https://aka.ms/ci-fix)
- * [Spectral Linting](https://aka.ms/azapi/style)
+ * [Spectral Linting](https://github.com/Azure/azure-api-style-guide/blob/main/README.md)
  * [Open API Hub](https://aka.ms/openapiportal)
 
 ### Guidelines & Specifications


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
