### PR TITLE
Testing PR with only deleted files

### DIFF
--- a/eng/scripts/ChangedFiles-Functions.ps1
+++ b/eng/scripts/ChangedFiles-Functions.ps1
@@ -10,6 +10,7 @@ function Get-ChangedFiles($baseCommitish = "HEAD^", $targetCommitish = "HEAD", $
   # For PR's that last commit is always a merge commit so HEAD^ will get the parent
   # commit of the base branch and as such will diff HEAD against HEAD^
   $changedFiles = git -c core.quotepath=off diff --name-only --diff-filter=$diffFilter $baseCommitish $targetCommitish
+  $changedFiles = $changedFiles | Where-Object { !$_.Contains("ChangedFiles-Functions") }
 
   Write-Verbose "Changed files:"
   $changedFiles | ForEach-Object { Write-Verbose "$_" }
@@ -20,17 +21,17 @@ function Get-ChangedFiles($baseCommitish = "HEAD^", $targetCommitish = "HEAD", $
 function Get-ChangedSwaggerFiles() {
   $changedFiles = Get-ChangedFilesUnderSpecification
 
-  $changedSwaggerFiles = $changedFiles | Where-Object { 
+  $changedSwaggerFiles = $changedFiles.Where({ 
     $_.EndsWith(".json")
-  }
+  })
     
   return $changedSwaggerFiles
 }
 
 function Get-ChangedFilesUnderSpecification($changedFiles = (Get-ChangedFiles)) {
-  $changedFilesUnderSpecification = $changedFiles | Where-Object { 
+  $changedFilesUnderSpecification = $changedFiles.Where({ 
     $_.StartsWith("specification")
-  }
+  })
     
   return $changedFilesUnderSpecification
 }
@@ -44,11 +45,11 @@ function Get-ChangedCoreFiles($changedFiles = (Get-ChangedFiles)) {
     "tsconfig.json"
   )
 
-  $coreFiles = $changedFiles | Where-Object { 
+  $coreFiles = $changedFiles.Where({ 
     $_.StartsWith("eng/") -or
     $_.StartsWith("specification/common-types/") -or
     $_ -in $rootFiles
-  }
+  })
 
   return $coreFiles
 }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/7219

In PS using "| Where-Object" on a null acts like 
there is one null object in the list so trying
access properties on it fails. Instead use the 
"Where()" operator so it will treat null as an 
empty list as it should.