### PR TITLE
Update alertsSuppressionRules.json

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/preview/2019-01-01-preview/alertsSuppressionRules.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2019-01-01-preview/alertsSuppressionRules.json
@@ -246,7 +246,7 @@
         "expirationDateUtc": {
           "type": "string",
           "format": "date-time",
-          "description": "Expiration date of the rule, if value is not provided or provided as null this field will default to the maximum allowed expiration date."
+          "description": "Expiration date of the rule, if value is not provided or provided as null there will no expiration at all"
         },
         "reason": {
           "type": "string",


### PR DESCRIPTION
fixing doc of MDC alerts suppression API.
expiry time parameter has no limitation.
previous doc was wrong, fixing now to match actual logic