### PR TITLE
Fix regression to KeyRotationPolicyAction from 7.4

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.5-preview.1/keys.json
@@ -2205,7 +2205,7 @@
             "Notify"
           ],
           "x-ms-enum": {
-            "name": "ActionType",
+            "name": "KeyRotationPolicyAction",
             "modelAsString": false,
             "values": [
               {

--- a/specification/keyvault/data-plane/readme.md
+++ b/specification/keyvault/data-plane/readme.md
@@ -218,6 +218,7 @@ These transforms apply to any generator.
 directive:
 # Rename models back to what they were before 7.4 for autorest-based code generators.
 # Generated names were disambiguated for generators not using autorest but still processing x-ms-enum.name.
+# See https://github.com/Azure/azure-rest-api-specs/pull/22435 for details.
 - from: certificates.json
   where: $.definitions.Action
   transform: $.properties.action_type["x-ms-enum"].name = "ActionType";


### PR DESCRIPTION
We renamed via `x-ms-enum.name` `LifetimeActionsType` to `KeyRotationPolicyAction` in #22435 for external partners, only to be changed back to `ActionType` via autorest transform that should end up in the Azure SDKs. This was to disambiguate to instances of `ActionType` across `keys.json` and `certificates.json`.
