### PR TITLE
[CDN][2023-05-01] Add x-ms-enum extension to fix Pandora SDK const conflict

### DIFF
--- a/specification/cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/cdn.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/cdn.json
@@ -3742,7 +3742,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleRemoteAddressConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "RemoteAddressMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -3789,7 +3793,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleRequestMethodConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "RequestMethodMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -3827,7 +3835,11 @@
               "DELETE",
               "OPTIONS",
               "TRACE"
-            ]
+            ],
+            "x-ms-enum": {
+              "name": "RequestMethodMatchValue",
+              "modelAsString": true
+            }
           }
         }
       }
@@ -3843,7 +3855,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleQueryStringConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "QueryStringMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -3897,7 +3913,11 @@
           "type": "string",
           "enum": [
             "DeliveryRulePostArgsConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "PostArgsMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "selector": {
           "description": "Name of PostArg to be matched",
@@ -3955,7 +3975,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleRequestUriConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "RequestUriMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4009,7 +4033,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleRequestHeaderConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "RequestHeaderMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "selector": {
           "description": "Name of Header to be matched",
@@ -4067,7 +4095,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleRequestBodyConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "RequestBodyMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4121,7 +4153,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleRequestSchemeConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "RequestSchemeMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4150,7 +4186,11 @@
             "enum": [
               "HTTP",
               "HTTPS"
-            ]
+            ],
+            "x-ms-enum": {
+              "name": "RequestSchemeMatchValue",
+              "modelAsString": true
+            }
           }
         }
       }
@@ -4166,7 +4206,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleUrlPathMatchConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "UrlPathMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4221,7 +4265,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleUrlFileExtensionMatchConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "UrlFileExtensionMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4275,7 +4323,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleUrlFilenameConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "UrlFileNameMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4329,7 +4381,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleHttpVersionConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "HttpVersionMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4374,7 +4430,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleCookiesConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "CookiesMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "selector": {
           "description": "Name of Cookies to be matched",
@@ -4432,7 +4492,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleIsDeviceConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "IsDeviceMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4458,7 +4522,11 @@
             "enum": [
               "Mobile",
               "Desktop"
-            ]
+            ],
+            "x-ms-enum": {
+              "name": "IsDeviceMatchValue",
+              "modelAsString": true
+            }
           }
         },
         "transforms": {
@@ -4482,7 +4550,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleSocketAddrConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "SocketAddrMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4529,7 +4601,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleClientPortConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "ClientPortMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4584,7 +4660,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleServerPortConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "ServerPortMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4639,7 +4719,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleHostNameConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "HostNameMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4694,7 +4778,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleSslProtocolConditionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "SslProtocolMatchConditionParametersType",
+            "modelAsString": true
+          }
         },
         "operator": {
           "description": "Describes operator to be matched",
@@ -4785,7 +4873,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleUrlRedirectActionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "UrlRedirectActionParametersParametersType",
+            "modelAsString": true
+          }
         },
         "redirectType": {
           "description": "The redirect type the rule will use when redirecting traffic.",
@@ -4860,7 +4952,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleUrlSigningActionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "UrlSigningActionParametersType",
+            "modelAsString": true
+          }
         },
         "algorithm": {
           "description": "Algorithm to use for URL signing",
@@ -4940,7 +5036,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleOriginGroupOverrideActionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "OriginGroupOverrideActionParametersType",
+            "modelAsString": true
+          }
         },
         "originGroup": {
           "description": "defines the OriginGroup that would override the DefaultOriginGroup.",
@@ -4979,7 +5079,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleUrlRewriteActionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "UrlRewriteActionParametersType",
+            "modelAsString": true
+          }
         },
         "sourcePattern": {
           "description": "define a request URI pattern that identifies the type of requests that may be rewritten. If value is blank, all strings are matched.",
@@ -5043,7 +5147,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleHeaderActionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "HeaderActionParametersType",
+            "modelAsString": true
+          }
         },
         "headerAction": {
           "description": "Action to perform",
@@ -5098,7 +5206,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleCacheExpirationActionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "CacheExpirationActionParametersType",
+            "modelAsString": true
+          }
         },
         "cacheBehavior": {
           "description": "Caching behavior for the requests",
@@ -5160,7 +5272,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "CacheKeyQueryStringActionParametersType",
+            "modelAsString": true
+          }
         },
         "queryStringBehavior": {
           "description": "Caching behavior for the requests",
@@ -5213,7 +5329,11 @@
           "type": "string",
           "enum": [
             "DeliveryRuleRouteConfigurationOverrideActionParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "RouteConfigurationOverrideActionParametersType",
+            "modelAsString": true
+          }
         },
         "originGroupOverride": {
           "description": "A reference to the origin group override configuration. Leave empty to use the default origin group on route.",
@@ -5572,7 +5692,11 @@
           "type": "string",
           "enum": [
             "KeyVaultSigningKeyParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "KeyVaultSigningKeyParametersType",
+            "modelAsString": true
+          }
         },
         "subscriptionId": {
           "description": "Subscription Id of the user's Key Vault containing the secret",
@@ -6214,7 +6338,11 @@
           "type": "string",
           "enum": [
             "CdnCertificateSourceParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "CdnCertificateSourceParametersType",
+            "modelAsString": true
+          }
         },
         "certificateType": {
           "description": "Type of certificate used",
@@ -6264,7 +6392,11 @@
           "type": "string",
           "enum": [
             "KeyVaultCertificateSourceParameters"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "KeyVaultCertificateSourceParametersType",
+            "modelAsString": true
+          }
         },
         "subscriptionId": {
           "description": "Subscription Id of the user's Key Vault containing the SSL certificate",

--- a/specification/cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/cdn.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/stable/2023-05-01/cdn.json
@@ -4838,7 +4838,7 @@
             "RouteConfigurationOverride"
           ],
           "x-ms-enum": {
-            "name": "DeliveryRuleAction",
+            "name": "DeliveryRuleActionName",
             "modelAsString": true
           }
         }


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request 

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/029a11fd-eaf9-4865-9d77-a16b5ea5eb26)

[1] [ARM review queue] (for **merge** queues, see [4])  
The PRs are processed by time opened, ascending. Your PR may show up on 2nd or later page. 
If you addressed Step 1 from the diagram and your PR is not showing up in the queue, ensure the label `ARMChangesRequested` 
is removed from your PR. This should cause the label `WaitForARMFeedback` to be added.  
[2] https://aka.ms/azsdk/support/specreview-channel  
[3] [List of SDK breaking changes approvers] in pinned Teams announcement  
[4] [public repo merge queue], [private repo merge queue] (for **ARM review** queue, [1])

If you need further help with anything, see `Getting help` section below.

## Purpose of this PR

What's the purpose of this PR? Check all that apply. This is **mandatory**!

  - [ ] New API version. (Such PR should have been generated with [OpenAPI Hub](https://aka.ms/openapihub)).
  - [ ] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
  - [ ] Update existing version to fix swagger quality issues in S360.
  - [x] Other, please clarify:
    Our existing swagger definition does not follow the best practice of polymorphism to define class inheritance hierarchy, a hard-coded property (typeName) with a single ENUM value is in a lot of places for deserialization purpose. It will break the Hashicorp Pandora SDK generation which will impact Terraform integration for Azure Front Door Standard/Premium service, as Golang does not support ENUM naturally. It will use string constants instead. In our case, with so many ENUMs with the same name “typeName”, it will complain about name conflict when generating Golang SDK: https://github.com/hashicorp/pandora/issues/2831. Azure SDK Track2 for Golang does not have the problem as they did some workaround to add prefixes when the name is conflicting, which is not recommended by Pandora team. This PR aims to add x-ms-enum extension to fix Pandora SDK const conflict. This is introduced as a workaround and we will fix the swagger in next stable version.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood 
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including
  [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and
  [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md) (estimated time: 4 hours).  
  I understand this is required before I can proceed to Step 2, "ARM Review", for this PR.

### Breaking changes review (Step 1)

- If the automation determines you have breaking changes, i.e. Step 1 from the diagram applies to you,
  you must follow the [breaking changes process].  
  **IMPORTANT** This applies even if:
  - The tool fails while it shouldn't, e.g. due to runtime exception, or incorrect detection of breaking changes.
  - You believe there is no need for you to request breaking change approval, for any reason. 
    Such claims must be reviewed, and the process is the same.

### ARM API changes review (Step 2)

- If this PR is in purview of ARM review then automation will add the `ARMReview` label.
- If you want to force ARM review, add the label yourself.
- Proceed according to the diagram at the top of this comment.

## Viewing API changes

For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 

## Suppressing failures

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
[Swagger-Suppression-Process](https://aka.ms/azsdk/pr-suppressions) 
to get approval.

## Getting help

- For general PR approval workflow, see the diagram at the top of this comment.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
  and https://aka.ms/ci-fix.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.

[ARM review queue]: https://github.com/search?q=org%3AAzure+is%3Apr+is%3Aopen+label%3AWaitForARMFeedback+-label%3AIDCDevDiv++draft%3Afalse+sort%3Acreated-asc+&type=pullrequests
[List of SDK breaking changes approvers]: https://teams.microsoft.com/l/message/19:0351f5f9404446e4b4fd4eaf2c27448d@thread.skype/1689115217750?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1689115217750&teamName=Azure%20SDK&channelName=API%20Spec%20Review&createdTime=1689115217750
[public repo merge queue]: https://github.com/Azure/azure-rest-api-specs/pulls?q=is%3Aopen+is%3Apr+label%3AMergeRequested+draft%3Afalse+sort%3Acreated-asc
[private repo merge queue]: https://github.com/Azure/azure-rest-api-specs-pr/pulls?q=is%3Aopen+is%3Apr+label%3AMergeRequested+-label%3AApproved-OkToMerge+draft%3Afalse+sort%3Acreated-asc
[breaking changes process]: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-core-pm-and-design/trusted-platform-pm-karimb/service-lifecycle-and-actions-team/service-lifecycle-actions-team/apex/media/launchingproductbreakingchanges#breaking-change-process-1
