### PR TITLE
[ACS JobRouter][GA] Change discriminators to enum instead of string for all polymorphic base class

### DIFF
--- a/specification/communication/Communication.JobRouter/client.tsp
+++ b/specification/communication/Communication.JobRouter/client.tsp
@@ -22,6 +22,7 @@ interface JobRouterAdministrationRestClient {
 
   getDistributionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getDistributionPolicy;
 
+  @access(Access.internal, "csharp")
   listDistributionPolicies is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listDistributionPolicies;
 
   deleteDistributionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteDistributionPolicy;
@@ -32,6 +33,7 @@ interface JobRouterAdministrationRestClient {
 
   getClassificationPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getClassificationPolicy;
 
+  @access(Access.internal, "csharp")
   listClassificationPolicies is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listClassificationPolicies;
 
   deleteClassificationPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteClassificationPolicy;
@@ -42,6 +44,7 @@ interface JobRouterAdministrationRestClient {
 
   getExceptionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getExceptionPolicy;
 
+  @access(Access.internal, "csharp")
   listExceptionPolicies is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listExceptionPolicies;
 
   deleteExceptionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteExceptionPolicy;
@@ -52,6 +55,7 @@ interface JobRouterAdministrationRestClient {
 
   getQueue is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getQueue;
 
+  @access(Access.internal, "csharp")
   listQueues is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listQueues;
 
   deleteQueue is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteQueue;
@@ -90,6 +94,7 @@ interface JobRouterRestClient {
   @access(Access.internal, "java")
   close is AzureCommunicationRoutingService.JobRouterOperations.close;
 
+  @access(Access.internal, "csharp")
   listJobs is AzureCommunicationRoutingService.JobRouterOperations.listJobs;
 
   #suppress "@azure-tools/typespec-azure-core/no-explicit-routes-resource-ops" "Need to revist how to correctly define singletons https://github.com/Azure/azure-rest-api-specs/issues/25605#issuecomment-1736265997"
@@ -118,5 +123,6 @@ interface JobRouterRestClient {
 
   deleteWorker is AzureCommunicationRoutingService.JobRouterOperations.deleteWorker;
 
+  @access(Access.internal, "csharp")
   listWorkers is AzureCommunicationRoutingService.JobRouterOperations.listWorkers;
 }

--- a/specification/communication/Communication.JobRouter/client.tsp
+++ b/specification/communication/Communication.JobRouter/client.tsp
@@ -23,7 +23,6 @@ interface JobRouterAdministrationRestClient {
   getDistributionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getDistributionPolicy;
 
   @access(Access.internal, "csharp")
-  @projectedName("csharp", "listDistributionPoliciesInternal")
   listDistributionPolicies is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listDistributionPolicies;
 
   deleteDistributionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteDistributionPolicy;
@@ -35,7 +34,6 @@ interface JobRouterAdministrationRestClient {
   getClassificationPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getClassificationPolicy;
 
   @access(Access.internal, "csharp")
-  @projectedName("csharp", "listClassificationPoliciesInternal")
   listClassificationPolicies is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listClassificationPolicies;
 
   deleteClassificationPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteClassificationPolicy;
@@ -47,7 +45,6 @@ interface JobRouterAdministrationRestClient {
   getExceptionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getExceptionPolicy;
 
   @access(Access.internal, "csharp")
-  @projectedName("csharp", "listExceptionPoliciesInternal")
   listExceptionPolicies is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listExceptionPolicies;
 
   deleteExceptionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteExceptionPolicy;
@@ -59,7 +56,6 @@ interface JobRouterAdministrationRestClient {
   getQueue is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getQueue;
 
   @access(Access.internal, "csharp")
-  @projectedName("csharp", "listQueuesInternal")
   listQueues is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listQueues;
 
   deleteQueue is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteQueue;
@@ -99,7 +95,6 @@ interface JobRouterRestClient {
   close is AzureCommunicationRoutingService.JobRouterOperations.close;
 
   @access(Access.internal, "csharp")
-  @projectedName("csharp", "listJobsInternal")
   listJobs is AzureCommunicationRoutingService.JobRouterOperations.listJobs;
 
   #suppress "@azure-tools/typespec-azure-core/no-explicit-routes-resource-ops" "Need to revist how to correctly define singletons https://github.com/Azure/azure-rest-api-specs/issues/25605#issuecomment-1736265997"
@@ -129,6 +124,5 @@ interface JobRouterRestClient {
   deleteWorker is AzureCommunicationRoutingService.JobRouterOperations.deleteWorker;
 
   @access(Access.internal, "csharp")
-  @projectedName("csharp", "listWorkersInternal")
   listWorkers is AzureCommunicationRoutingService.JobRouterOperations.listWorkers;
 }

--- a/specification/communication/Communication.JobRouter/client.tsp
+++ b/specification/communication/Communication.JobRouter/client.tsp
@@ -23,6 +23,7 @@ interface JobRouterAdministrationRestClient {
   getDistributionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getDistributionPolicy;
 
   @access(Access.internal, "csharp")
+  @projectedName("csharp", "listDistributionPoliciesInternal")
   listDistributionPolicies is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listDistributionPolicies;
 
   deleteDistributionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteDistributionPolicy;
@@ -34,6 +35,7 @@ interface JobRouterAdministrationRestClient {
   getClassificationPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getClassificationPolicy;
 
   @access(Access.internal, "csharp")
+  @projectedName("csharp", "listClassificationPoliciesInternal")
   listClassificationPolicies is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listClassificationPolicies;
 
   deleteClassificationPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteClassificationPolicy;
@@ -45,6 +47,7 @@ interface JobRouterAdministrationRestClient {
   getExceptionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getExceptionPolicy;
 
   @access(Access.internal, "csharp")
+  @projectedName("csharp", "listExceptionPoliciesInternal")
   listExceptionPolicies is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listExceptionPolicies;
 
   deleteExceptionPolicy is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteExceptionPolicy;
@@ -56,6 +59,7 @@ interface JobRouterAdministrationRestClient {
   getQueue is AzureCommunicationRoutingService.JobRouterAdministrationOperations.getQueue;
 
   @access(Access.internal, "csharp")
+  @projectedName("csharp", "listQueuesInternal")
   listQueues is AzureCommunicationRoutingService.JobRouterAdministrationOperations.listQueues;
 
   deleteQueue is AzureCommunicationRoutingService.JobRouterAdministrationOperations.deleteQueue;
@@ -95,6 +99,7 @@ interface JobRouterRestClient {
   close is AzureCommunicationRoutingService.JobRouterOperations.close;
 
   @access(Access.internal, "csharp")
+  @projectedName("csharp", "listJobsInternal")
   listJobs is AzureCommunicationRoutingService.JobRouterOperations.listJobs;
 
   #suppress "@azure-tools/typespec-azure-core/no-explicit-routes-resource-ops" "Need to revist how to correctly define singletons https://github.com/Azure/azure-rest-api-specs/issues/25605#issuecomment-1736265997"
@@ -124,5 +129,6 @@ interface JobRouterRestClient {
   deleteWorker is AzureCommunicationRoutingService.JobRouterOperations.deleteWorker;
 
   @access(Access.internal, "csharp")
+  @projectedName("csharp", "listWorkersInternal")
   listWorkers is AzureCommunicationRoutingService.JobRouterOperations.listWorkers;
 }

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_CreateClassificationPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_CreateClassificationPolicy.json
@@ -12,7 +12,7 @@
         {
           "kind": "conditional",
           "condition": {
-            "kind": "expression-rule",
+            "kind": "expression",
             "language": "powerFx",
             "expression": "1 = 1"
           },
@@ -26,7 +26,7 @@
         }
       ],
       "prioritizationRule": {
-        "kind": "static-rule",
+        "kind": "static",
         "value": "2"
       }
     }

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_CreateClassificationPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_CreateClassificationPolicy.json
@@ -41,7 +41,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -55,7 +55,7 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [],
@@ -71,7 +71,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -85,7 +85,7 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [],

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_GetClassificationPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_GetClassificationPolicy.json
@@ -16,7 +16,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -30,12 +30,12 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [
           {
-            "kind": "pass-through",
+            "kind": "passThrough",
             "key": "language",
             "labelOperator": "equal"
           }

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_ListClassificationPoliciesWithPageSize.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_ListClassificationPoliciesWithPageSize.json
@@ -16,16 +16,16 @@
             "fallbackQueueId": "MainQueue",
             "queueSelectorAttachments": [
               {
-                "kind": "rule-engine",
+                "kind": "ruleEngine",
                 "rule": {
-                  "kind": "expression-rule",
+                  "kind": "expression",
                   "language": "powerFx",
                   "expression": "If(job.Escalated = true, \"SecondaryQueue\", \"MainQueue\")"
                 }
               }
             ],
             "prioritizationRule": {
-              "kind": "static-rule",
+              "kind": "static",
               "value": "2"
             },
             "workerSelectorAttachments": [],
@@ -37,16 +37,16 @@
             "fallbackQueueId": "MainQueue",
             "queueSelectorAttachments": [
               {
-                "kind": "rule-engine",
+                "kind": "ruleEngine",
                 "rule": {
-                  "kind": "expression-rule",
+                  "kind": "expression",
                   "language": "powerFx",
                   "expression": "If(job.VIP = true, \"VIPQueue\", \"MainQueue\")"
                 }
               }
             ],
             "prioritizationRule": {
-              "kind": "static-rule",
+              "kind": "static",
               "value": "1"
             },
             "workerSelectorAttachments": [],

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_UpdateClassificationPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/ClassificationPolicies_UpdateClassificationPolicy.json
@@ -19,7 +19,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -33,7 +33,7 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [],
@@ -49,7 +49,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -63,7 +63,7 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [],

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/DistributionPolicies_CreateDistributionPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/DistributionPolicies_CreateDistributionPolicy.json
@@ -7,7 +7,7 @@
     "distributionPolicyId": "d9033d56-659c-437a-b5b7-4f3b14301dd4",
     "resource": {
       "mode": {
-        "kind": "longest-idle",
+        "kind": "longestIdle",
         "minConcurrentOffers": 1,
         "maxConcurrentOffers": 5,
         "bypassSelectors": false
@@ -23,7 +23,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false
@@ -37,7 +37,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/DistributionPolicies_GetDistributionPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/DistributionPolicies_GetDistributionPolicy.json
@@ -13,7 +13,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/DistributionPolicies_ListDistributionPoliciesWithPageSize.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/DistributionPolicies_ListDistributionPoliciesWithPageSize.json
@@ -15,7 +15,7 @@
             "name": "Secondary",
             "offerExpiresAfterSeconds": 300,
             "mode": {
-              "kind": "round-robin",
+              "kind": "roundRobin",
               "minConcurrentOffers": 1,
               "maxConcurrentOffers": 2,
               "bypassSelectors": false
@@ -27,7 +27,7 @@
             "name": "Main",
             "offerExpiresAfterSeconds": 300,
             "mode": {
-              "kind": "longest-idle",
+              "kind": "longestIdle",
               "minConcurrentOffers": 1,
               "maxConcurrentOffers": 5,
               "bypassSelectors": false

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/DistributionPolicies_UpdateDistributionPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/DistributionPolicies_UpdateDistributionPolicy.json
@@ -7,7 +7,7 @@
     "distributionPolicyId": "d9033d56-659c-437a-b5b7-4f3b14301dd4",
     "resource": {
       "mode": {
-        "kind": "longest-idle",
+        "kind": "longestIdle",
         "minConcurrentOffers": 1,
         "maxConcurrentOffers": 5,
         "bypassSelectors": false
@@ -23,7 +23,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false
@@ -37,7 +37,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/ExceptionPolicies_CreateExceptionPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/ExceptionPolicies_CreateExceptionPolicy.json
@@ -20,7 +20,7 @@
             }
           ],
           "trigger": {
-            "kind": "wait-time",
+            "kind": "waitTime",
             "thresholdSeconds": 20
           }
         }
@@ -36,7 +36,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [
@@ -62,7 +62,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/ExceptionPolicies_GetExceptionPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/ExceptionPolicies_GetExceptionPolicy.json
@@ -15,7 +15,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/ExceptionPolicies_ListExceptionPoliciesWithPageSize.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/ExceptionPolicies_ListExceptionPoliciesWithPageSize.json
@@ -17,7 +17,7 @@
               {
                 "id": "MaxWaitTimeExceeded",
                 "trigger": {
-                  "kind": "wait-time",
+                  "kind": "waitTime",
                   "thresholdSeconds": 20
                 },
                 "actions": [
@@ -41,7 +41,7 @@
               {
                 "id": "MaxWaitTimeExceeded",
                 "trigger": {
-                  "kind": "wait-time",
+                  "kind": "waitTime",
                   "thresholdSeconds": 50
                 },
                 "actions": [

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/ExceptionPolicies_UpdateExceptionPolicy.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/ExceptionPolicies_UpdateExceptionPolicy.json
@@ -20,7 +20,7 @@
             }
           ],
           "trigger": {
-            "kind": "wait-time",
+            "kind": "waitTime",
             "thresholdSeconds": 20
           }
         }
@@ -36,7 +36,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [
@@ -62,7 +62,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_CreateJob.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_CreateJob.json
@@ -19,7 +19,7 @@
       ],
       "labels": {},
       "matchingMode": {
-        "kind": "queue-and-match"
+        "kind": "queueAndMatch"
       }
     }
   },
@@ -48,7 +48,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }
@@ -77,7 +77,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_CreateScheduledJob.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_CreateScheduledJob.json
@@ -19,7 +19,7 @@
       ],
       "labels": {},
       "matchingMode": {
-        "kind": "schedule-and-suspend",
+        "kind": "scheduleAndSuspend",
         "scheduleAt": "2023-05-26T23:22:12.0774222+00:00"
       }
     }
@@ -49,7 +49,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "schedule-and-suspend",
+          "kind": "scheduleAndSuspend",
           "scheduleAt": "2023-05-26T23:22:12.0774222+00:00"
         },
         "scheduledAt": null,
@@ -80,7 +80,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "schedule-and-suspend",
+          "kind": "scheduleAndSuspend",
           "scheduleAt": "2023-05-26T23:22:12.0774222+00:00"
         },
         "scheduledAt": null,

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_GetJob.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_GetJob.json
@@ -31,7 +31,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_GetJobsWithPageSize.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_GetJobsWithPageSize.json
@@ -27,7 +27,7 @@
             "assignments": {},
             "notes": [],
             "matchingMode": {
-              "kind": "queue-and-match"
+              "kind": "queueAndMatch"
             },
             "etag": "etag"
           },
@@ -45,7 +45,7 @@
             "assignments": {},
             "notes": [],
             "matchingMode": {
-              "kind": "queue-and-match"
+              "kind": "queueAndMatch"
             },
             "etag": "etag"
           }

--- a/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_UpdateJob.json
+++ b/specification/communication/Communication.JobRouter/examples/2023-11-01/Jobs_UpdateJob.json
@@ -34,7 +34,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }
@@ -63,7 +63,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }

--- a/specification/communication/Communication.JobRouter/models.tsp
+++ b/specification/communication/Communication.JobRouter/models.tsp
@@ -224,6 +224,105 @@ enum ExpressionRouterRuleLanguage {
   powerFx,
 }
 
+@doc("Supported matching mode types")
+enum JobMatchingModeKind {
+  @doc("Discriminator value for QueueAndMatchMode.")
+  queueAndMatch,
+
+  @doc("Discriminator value for ScheduleAndSuspendMode.")
+  scheduleAndSuspend,
+
+  @doc("Discriminator value for SuspendMode.")
+  suspend,
+}
+
+@doc("Supported router rule types")
+enum RouterRuleKind {
+  @doc("Discriminator value for DirectMapRouterRule.")
+  directMap,
+
+  @doc("Discriminator value for ExpressionRouterRule.")
+  expression,
+
+  @doc("Discriminator value for FunctionRouterRule.")
+  function,
+
+  @doc("Discriminator value for StaticRouterRule.")
+  static,
+
+  @doc("Discriminator value for WebhookRouterRule.")
+  webhook,
+}
+
+@doc("Supported distribution mode types")
+enum DistributionModeKind {
+  @doc("Discriminator value for BestWorkerMode.")
+  bestWorker,
+
+  @doc("Discriminator value for LongestIdleMode.")
+  longestIdle,
+
+  @doc("Discriminator value for RoundRobinMode.")
+  roundRobin,
+}
+
+@doc("Supported exception trigger types")
+enum ExceptionTriggerKind {
+  @doc("Discriminator value for QueueLengthExceptionTrigger.")
+  queueLength,
+
+  @doc("Discriminator value for WaitTimeExceptionTrigger.")
+  waitTime,
+}
+
+@doc("Supported exception action types")
+enum ExceptionActionKind {
+  @doc("Discriminator value for CancelExceptionAction.")
+  cancel,
+
+  @doc("Discriminator value for ManualReclassifyExceptionAction.")
+  manualReclassify,
+
+  @doc("Discriminator value for ReclassifyExceptionAction.")
+  reclassify,
+}
+
+@doc("Supported queue selector attachment types")
+enum QueueSelectorAttachmentKind {
+  @doc("Discriminator value for ConditionalQueueSelectorAttachment.")
+  conditional,
+
+  @doc("Discriminator value for PassThroughQueueSelectorAttachment.")
+  passThrough,
+
+  @doc("Discriminator value for RuleEngineQueueSelectorAttachment.")
+  ruleEngine,
+
+  @doc("Discriminator value for StaticQueueSelectorAttachment.")
+  static,
+
+  @doc("Discriminator value for WeightedAllocationQueueSelectorAttachment.")
+  weightedAllocation,
+}
+
+@doc("Supported worker selector attachment types")
+enum WorkerSelectorAttachmentKind {
+  @doc("Discriminator value for ConditionalWorkerSelectorAttachment.")
+  conditional,
+
+  @doc("Discriminator value for PassThroughWorkerSelectorAttachment.")
+  passThrough,
+
+  @doc("Discriminator value for RuleEngineWorkerSelectorAttachment.")
+  ruleEngine,
+
+  @doc("Discriminator value for StaticWorkerSelectorAttachment.")
+  static,
+
+  @doc("Discriminator value for WeightedAllocationWorkerSelectorAttachment.")
+  weightedAllocation,
+}
+
 @resource("routing/classificationPolicies")
 @doc("A container for the rules that govern how jobs are classified.")
 model ClassificationPolicy {
@@ -261,7 +360,7 @@ WebhookRule: A rule providing a binding to a webserver following OAuth2.0 authen
 @discriminator("kind")
 model RouterRule {
   @doc("The type discriminator describing a sub-type of RouterRule")
-  kind: string;
+  kind: RouterRuleKind;
 }
 
 @resource("routing/distributionPolicies")
@@ -297,7 +396,7 @@ model DistributionMode {
   bypassSelectors?: boolean = false;
 
   @doc("The type discriminator describing a sub-type of DistributionMode")
-  kind: string;
+  kind: DistributionModeKind;
 }
 
 @resource("routing/exceptionPolicies")
@@ -333,7 +432,7 @@ model ExceptionRule {
 @discriminator("kind")
 model ExceptionTrigger {
   @doc("The type discriminator describing a sub-type of ExceptionTrigger")
-  kind: string;
+  kind: ExceptionTriggerKind;
 }
 
 @doc("A note attached to a job.")
@@ -469,7 +568,7 @@ SuspendMode: Used when matching workers to a job needs to be suspended.
 @discriminator("kind")
 model JobMatchingMode {
   @doc("The type discriminator describing a sub-type of JobMatchingMode")
-  kind: string;
+  kind: JobMatchingModeKind;
 }
 
 @doc("Describes a matching mode used for scheduling jobs to be queued at a future time. At the specified time, matching worker to a job will not start automatically.")
@@ -478,19 +577,19 @@ model ScheduleAndSuspendMode extends JobMatchingMode {
   scheduleAt: utcDateTime;
 
   @doc("The type discriminator describing ScheduleAndSuspendMode")
-  kind: "schedule-and-suspend";
+  kind: JobMatchingModeKind.scheduleAndSuspend;
 }
 
 @doc("Describes a matching mode where matching worker to a job is automatically started after job is queued successfully.")
 model QueueAndMatchMode extends JobMatchingMode {
   @doc("The type discriminator describing QueueAndMatchMode")
-  kind: "queue-and-match";
+  kind: JobMatchingModeKind.queueAndMatch;
 }
 
 @doc("Describes a matching mode where matching worker to a job is suspended.")
 model SuspendMode extends JobMatchingMode {
   @doc("The type discriminator describing SuspendMode")
-  kind: "suspend";
+  kind: JobMatchingModeKind.suspend;
 }
 
 @access(Access.public, "python")
@@ -719,7 +818,7 @@ model BestWorkerMode extends DistributionMode {
   scoringRuleOptions?: ScoringRuleOptions;
 
   @doc("The type discriminator describing a sub-type of Mode")
-  kind: "best-worker";
+  kind: DistributionModeKind.bestWorker;
 }
 
 @doc("Encapsulates all options that can be passed as parameters for scoring rule with BestWorkerMode")
@@ -749,7 +848,7 @@ model CancelExceptionAction extends ExceptionAction {
   dispositionCode?: string;
 
   @doc("The type discriminator describing a sub-type of ExceptionAction")
-  kind: "cancel";
+  kind: ExceptionActionKind.cancel;
 }
 
 @doc("The action to take when the exception is triggered")
@@ -759,7 +858,7 @@ model ExceptionAction {
   id?: string;
 
   @doc("The type discriminator describing a sub-type of ExceptionAction")
-  kind: string;
+  kind: ExceptionActionKind;
 }
 
 @doc("Describes a set of queue selectors that will be attached if the given condition resolves to true")
@@ -771,7 +870,7 @@ model ConditionalQueueSelectorAttachment extends QueueSelectorAttachment {
   queueSelectors: RouterQueueSelector[];
 
   @doc("The type discriminator describing the type of queue selector attachment")
-  kind: "conditional";
+  kind: QueueSelectorAttachmentKind.conditional;
 }
 
 @doc("Describes a condition that must be met against a set of labels for queue selection")
@@ -791,7 +890,7 @@ model RouterQueueSelector {
 @discriminator("kind")
 model QueueSelectorAttachment {
   @doc("The type discriminator describing a sub-type of QueueSelectorAttachment")
-  kind: string;
+  kind: QueueSelectorAttachmentKind;
 }
 
 @doc("Describes a set of worker selectors that will be attached if the given condition resolves to true")
@@ -803,20 +902,20 @@ model ConditionalWorkerSelectorAttachment extends WorkerSelectorAttachment {
   workerSelectors: RouterWorkerSelector[];
 
   @doc("The type discriminator describing the type of worker selector attachment")
-  kind: "conditional";
+  kind: WorkerSelectorAttachmentKind.conditional;
 }
 
 @doc("An attachment which attaches worker selectors to a job")
 @discriminator("kind")
 model WorkerSelectorAttachment {
   @doc("The type discriminator describing a sub-type of WorkerSelectorAttachment")
-  kind: string;
+  kind: WorkerSelectorAttachmentKind;
 }
 
 @doc("A rule that return the same labels as the input labels.")
 model DirectMapRouterRule extends RouterRule {
   @doc("The type discriminator describing a sub-type of Rule")
-  kind: "direct-map-rule";
+  kind: RouterRuleKind.directMap;
 }
 
 @doc("A rule providing inline expression rules.")
@@ -828,7 +927,7 @@ model ExpressionRouterRule extends RouterRule {
   expression: string;
 
   @doc("The type discriminator describing a sub-type of Rule")
-  kind: "expression-rule";
+  kind: RouterRuleKind.expression;
 }
 
 @doc("A rule providing a binding to an HTTP Triggered Azure Function.")
@@ -840,7 +939,7 @@ model FunctionRouterRule extends RouterRule {
   credential?: FunctionRouterRuleCredential;
 
   @doc("The type discriminator describing a sub-type of Rule")
-  kind: "azure-function-rule";
+  kind: RouterRuleKind.function;
 }
 
 @doc("Credentials used to access Azure function rule")
@@ -858,7 +957,7 @@ model FunctionRouterRuleCredential {
 @doc("Jobs are directed to the worker who has been idle longest.")
 model LongestIdleMode extends DistributionMode {
   @doc("The type discriminator describing a sub-type of Mode")
-  kind: "longest-idle";
+  kind: DistributionModeKind.longestIdle;
 }
 
 @doc("An action that manually reclassifies a job by providing the queue, priority and worker selectors.")
@@ -873,7 +972,7 @@ model ManualReclassifyExceptionAction extends ExceptionAction {
   workerSelectors?: RouterWorkerSelector[];
 
   @doc("The type discriminator describing a sub-type of ExceptionAction")
-  kind: "manual-reclassify";
+  kind: ExceptionActionKind.manualReclassify;
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "This is standard naming convention for OAuth."
@@ -895,7 +994,7 @@ model PassThroughQueueSelectorAttachment extends QueueSelectorAttachment {
   labelOperator: LabelOperator;
 
   @doc("The type discriminator describing the type of queue selector attachment")
-  kind: "pass-through";
+  kind: QueueSelectorAttachmentKind.passThrough;
 }
 
 @doc("Attaches a worker selector where the value is passed through from the job label with the same key")
@@ -910,7 +1009,7 @@ model PassThroughWorkerSelectorAttachment extends WorkerSelectorAttachment {
   expiresAfterSeconds?: float64;
 
   @doc("The type discriminator describing the type of worker selector attachment")
-  kind: "pass-through";
+  kind: WorkerSelectorAttachmentKind.passThrough;
 }
 
 @doc("Trigger for an exception action on exceeding queue length")
@@ -919,7 +1018,7 @@ model QueueLengthExceptionTrigger extends ExceptionTrigger {
   threshold: int32;
 
   @doc("The type discriminator describing a sub-type of ExceptionTrigger")
-  kind: "queue-length";
+  kind: ExceptionTriggerKind.queueLength;
 }
 
 @doc("Contains the weight percentage and queue selectors to be applied if selected for weighted distributions.")
@@ -941,13 +1040,13 @@ model ReclassifyExceptionAction extends ExceptionAction {
   labelsToUpsert?: Record<unknown>;
 
   @doc("The type discriminator describing a sub-type of ExceptionAction")
-  kind: "reclassify";
+  kind: ExceptionActionKind.reclassify;
 }
 
 @doc("Jobs are distributed in order to workers, starting with the worker that is after the last worker to receive a job.")
 model RoundRobinMode extends DistributionMode {
   @doc("The type discriminator describing a sub-type of Mode")
-  kind: "round-robin";
+  kind: DistributionModeKind.roundRobin;
 }
 
 @doc("Attaches queue selectors to a job when the RouterRule is resolved")
@@ -956,7 +1055,7 @@ model RuleEngineQueueSelectorAttachment extends QueueSelectorAttachment {
   rule: RouterRule;
 
   @doc("The type discriminator describing the type of queue selector attachment")
-  kind: "rule-engine";
+  kind: QueueSelectorAttachmentKind.ruleEngine;
 }
 
 @doc("Attaches worker selectors to a job when a RouterRule is resolved")
@@ -965,7 +1064,7 @@ model RuleEngineWorkerSelectorAttachment extends WorkerSelectorAttachment {
   rule: RouterRule;
 
   @doc("The type discriminator describing the type of worker selector attachment")
-  kind: "rule-engine";
+  kind: WorkerSelectorAttachmentKind.ruleEngine;
 }
 
 @doc("Describes a queue selector that will be attached to the job")
@@ -974,7 +1073,7 @@ model StaticQueueSelectorAttachment extends QueueSelectorAttachment {
   queueSelector: RouterQueueSelector;
 
   @doc("The type discriminator describing the type of queue selector attachment")
-  kind: "static";
+  kind: QueueSelectorAttachmentKind.static;
 }
 
 @doc("A rule providing static rules that always return the same result, regardless of input.")
@@ -984,7 +1083,7 @@ model StaticRouterRule extends RouterRule {
   value?: unknown;
 
   @doc("The type discriminator describing a sub-type of Rule")
-  kind: "static-rule";
+  kind: RouterRuleKind.static;
 }
 
 @doc("Describes a worker selector that will be attached to the job")
@@ -993,7 +1092,7 @@ model StaticWorkerSelectorAttachment extends WorkerSelectorAttachment {
   workerSelector: RouterWorkerSelector;
 
   @doc("The type discriminator describing the type of worker selector attachment")
-  kind: "static";
+  kind: WorkerSelectorAttachmentKind.static;
 }
 
 @doc("Trigger for an exception action on exceeding wait time")
@@ -1002,7 +1101,7 @@ model WaitTimeExceptionTrigger extends ExceptionTrigger {
   thresholdSeconds: float64;
 
   @doc("The type discriminator describing a sub-type of ExceptionTrigger")
-  kind: "wait-time";
+  kind: ExceptionTriggerKind.waitTime;
 }
 
 @doc("A rule providing a binding to an external web server.")
@@ -1017,7 +1116,7 @@ model WebhookRouterRule extends RouterRule {
   webhookUri?: url;
 
   @doc("The type discriminator describing a sub-type of Rule")
-  kind: "webhook-rule";
+  kind: RouterRuleKind.webhook;
 }
 
 @doc("Describes multiple sets of queue selectors, of which one will be selected and attached according to a weighting")
@@ -1027,7 +1126,7 @@ model WeightedAllocationQueueSelectorAttachment
   allocations: QueueWeightedAllocation[];
 
   @doc("The type discriminator describing the type of queue selector attachment")
-  kind: "weighted-allocation-queue-selector";
+  kind: QueueSelectorAttachmentKind.weightedAllocation;
 }
 
 @doc("Describes multiple sets of worker selectors, of which one will be selected and attached according to a weighting")
@@ -1037,7 +1136,7 @@ model WeightedAllocationWorkerSelectorAttachment
   allocations: WorkerWeightedAllocation[];
 
   @doc("The type discriminator describing the type of worker selector attachment")
-  kind: "weighted-allocation-worker-selector";
+  kind: WorkerSelectorAttachmentKind.weightedAllocation;
 }
 
 @doc("Contains the weight percentage and worker selectors to be applied if selected for weighted distributions.")

--- a/specification/communication/Communication.JobRouter/tspconfig.yaml
+++ b/specification/communication/Communication.JobRouter/tspconfig.yaml
@@ -43,6 +43,7 @@ options:
     package-version: 1.0.0
   "@azure-tools/typespec-java":
     emitter-output-dir: "{java-sdk-folder}/sdk/{service-directory-name}/azure-communication-jobrouter"
+    package-dir: "azure-communication-jobrouter"
     namespace: com.azure.communication.jobrouter
     partial-update: true
   "@azure-tools/typespec-ts":

--- a/specification/communication/Communication.JobRouter/tspconfig.yaml
+++ b/specification/communication/Communication.JobRouter/tspconfig.yaml
@@ -47,7 +47,7 @@ options:
     partial-update: true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{js-sdk-folder}/sdk/{service-directory-name}/communication-job-router-rest"
-    package-dir: "communication-job-router"
+    package-dir: "communication-job-router-rest"
     packageDetails:
       name: "@azure-rest/communication-job-router"
       description: "Azure client library for Azure Communication Job Router services"

--- a/specification/communication/data-plane/JobRouter/readme.md
+++ b/specification/communication/data-plane/JobRouter/readme.md
@@ -37,6 +37,20 @@ suppressions:
     reason: eTag should be an allowed format
 directive:
   - suppress: INVALID_TYPE
+
+  - suppress: OAV131 # DISCRIMINATOR_NOT_REQUIRED
+    where:
+    - $.definitions.DistributionModeCreateOrUpdate
+    - $.definitions.JobMatchingModeCreateOrUpdate
+    - $.definitions.RouterRuleCreateOrUpdate
+    reason: TypeSpec generates optional discriminators (Azure/typespec-azure#3833)
+
+  - suppress: OAV132 # INVALID_DISCRIMINATOR_TYPE
+    where:
+    - $.definitions.DistributionModeCreateOrUpdate
+    - $.definitions.JobMatchingModeCreateOrUpdate
+    - $.definitions.RouterRuleCreateOrUpdate
+    reason: False positive if discriminator is optional $ref (Azure/oav#1018)
 ```
 
 ### Tag: package-jobrouter-2023-11-01

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/communicationservicejobrouter.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/communicationservicejobrouter.json
@@ -2241,7 +2241,7 @@
           "$ref": "#/definitions/DistributionMode"
         }
       ],
-      "x-ms-discriminator-value": "best-worker"
+      "x-ms-discriminator-value": "bestWorker"
     },
     "BestWorkerModeCreateOrUpdate": {
       "type": "object",
@@ -2261,7 +2261,7 @@
           "$ref": "#/definitions/DistributionModeCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "best-worker"
+      "x-ms-discriminator-value": "bestWorker"
     },
     "CancelExceptionAction": {
       "type": "object",
@@ -2499,7 +2499,7 @@
           "$ref": "#/definitions/RouterRule"
         }
       ],
-      "x-ms-discriminator-value": "direct-map-rule"
+      "x-ms-discriminator-value": "directMap"
     },
     "DirectMapRouterRuleCreateOrUpdate": {
       "type": "object",
@@ -2509,7 +2509,7 @@
           "$ref": "#/definitions/RouterRuleCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "direct-map-rule"
+      "x-ms-discriminator-value": "directMap"
     },
     "DistributionMode": {
       "type": "object",
@@ -2533,7 +2533,7 @@
           "default": false
         },
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/DistributionModeKind",
           "description": "The type discriminator describing a sub-type of DistributionMode"
         }
       },
@@ -2564,11 +2564,41 @@
           "default": false
         },
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/DistributionModeKind",
           "description": "The type discriminator describing a sub-type of DistributionMode"
         }
       },
       "discriminator": "kind"
+    },
+    "DistributionModeKind": {
+      "type": "string",
+      "description": "Supported distribution mode types",
+      "enum": [
+        "bestWorker",
+        "longestIdle",
+        "roundRobin"
+      ],
+      "x-ms-enum": {
+        "name": "DistributionModeKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "bestWorker",
+            "value": "bestWorker",
+            "description": "Discriminator value for BestWorkerMode."
+          },
+          {
+            "name": "longestIdle",
+            "value": "longestIdle",
+            "description": "Discriminator value for LongestIdleMode."
+          },
+          {
+            "name": "roundRobin",
+            "value": "roundRobin",
+            "description": "Discriminator value for RoundRobinMode."
+          }
+        ]
+      }
     },
     "DistributionPolicy": {
       "type": "object",
@@ -2631,7 +2661,7 @@
           "description": "Unique Id of the exception action"
         },
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/ExceptionActionKind",
           "description": "The type discriminator describing a sub-type of ExceptionAction"
         }
       },
@@ -2639,6 +2669,36 @@
       "required": [
         "kind"
       ]
+    },
+    "ExceptionActionKind": {
+      "type": "string",
+      "description": "Supported exception action types",
+      "enum": [
+        "cancel",
+        "manualReclassify",
+        "reclassify"
+      ],
+      "x-ms-enum": {
+        "name": "ExceptionActionKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "cancel",
+            "value": "cancel",
+            "description": "Discriminator value for CancelExceptionAction."
+          },
+          {
+            "name": "manualReclassify",
+            "value": "manualReclassify",
+            "description": "Discriminator value for ManualReclassifyExceptionAction."
+          },
+          {
+            "name": "reclassify",
+            "value": "reclassify",
+            "description": "Discriminator value for ReclassifyExceptionAction."
+          }
+        ]
+      }
     },
     "ExceptionPolicy": {
       "type": "object",
@@ -2719,7 +2779,7 @@
       "description": "The trigger for this exception rule",
       "properties": {
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/ExceptionTriggerKind",
           "description": "The type discriminator describing a sub-type of ExceptionTrigger"
         }
       },
@@ -2727,6 +2787,30 @@
       "required": [
         "kind"
       ]
+    },
+    "ExceptionTriggerKind": {
+      "type": "string",
+      "description": "Supported exception trigger types",
+      "enum": [
+        "queueLength",
+        "waitTime"
+      ],
+      "x-ms-enum": {
+        "name": "ExceptionTriggerKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "queueLength",
+            "value": "queueLength",
+            "description": "Discriminator value for QueueLengthExceptionTrigger."
+          },
+          {
+            "name": "waitTime",
+            "value": "waitTime",
+            "description": "Discriminator value for WaitTimeExceptionTrigger."
+          }
+        ]
+      }
     },
     "ExpressionRouterRule": {
       "type": "object",
@@ -2749,7 +2833,7 @@
           "$ref": "#/definitions/RouterRule"
         }
       ],
-      "x-ms-discriminator-value": "expression-rule"
+      "x-ms-discriminator-value": "expression"
     },
     "ExpressionRouterRuleCreateOrUpdate": {
       "type": "object",
@@ -2769,7 +2853,7 @@
           "$ref": "#/definitions/RouterRuleCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "expression-rule"
+      "x-ms-discriminator-value": "expression"
     },
     "ExpressionRouterRuleLanguage": {
       "type": "string",
@@ -2811,7 +2895,7 @@
           "$ref": "#/definitions/RouterRule"
         }
       ],
-      "x-ms-discriminator-value": "azure-function-rule"
+      "x-ms-discriminator-value": "function"
     },
     "FunctionRouterRuleCreateOrUpdate": {
       "type": "object",
@@ -2832,7 +2916,7 @@
           "$ref": "#/definitions/RouterRuleCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "azure-function-rule"
+      "x-ms-discriminator-value": "function"
     },
     "FunctionRouterRuleCredential": {
       "type": "object",
@@ -2857,7 +2941,7 @@
       "description": "A matching mode of one of the following types:\nQueueAndMatchMode: Used when matching worker to a job is required to be done right after job is queued.\nScheduleAndSuspendMode: Used for scheduling jobs to be queued at a future time. At specified time, matching of a worker to the job will not start automatically.\nSuspendMode: Used when matching workers to a job needs to be suspended.",
       "properties": {
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/JobMatchingModeKind",
           "description": "The type discriminator describing a sub-type of JobMatchingMode"
         }
       },
@@ -2871,11 +2955,41 @@
       "description": "A matching mode of one of the following types:\nQueueAndMatchMode: Used when matching worker to a job is required to be done right after job is queued.\nScheduleAndSuspendMode: Used for scheduling jobs to be queued at a future time. At specified time, matching of a worker to the job will not start automatically.\nSuspendMode: Used when matching workers to a job needs to be suspended.",
       "properties": {
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/JobMatchingModeKind",
           "description": "The type discriminator describing a sub-type of JobMatchingMode"
         }
       },
       "discriminator": "kind"
+    },
+    "JobMatchingModeKind": {
+      "type": "string",
+      "description": "Supported matching mode types",
+      "enum": [
+        "queueAndMatch",
+        "scheduleAndSuspend",
+        "suspend"
+      ],
+      "x-ms-enum": {
+        "name": "JobMatchingModeKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "queueAndMatch",
+            "value": "queueAndMatch",
+            "description": "Discriminator value for QueueAndMatchMode."
+          },
+          {
+            "name": "scheduleAndSuspend",
+            "value": "scheduleAndSuspend",
+            "description": "Discriminator value for ScheduleAndSuspendMode."
+          },
+          {
+            "name": "suspend",
+            "value": "suspend",
+            "description": "Discriminator value for SuspendMode."
+          }
+        ]
+      }
     },
     "LabelOperator": {
       "type": "string",
@@ -2933,7 +3047,7 @@
           "$ref": "#/definitions/DistributionMode"
         }
       ],
-      "x-ms-discriminator-value": "longest-idle"
+      "x-ms-discriminator-value": "longestIdle"
     },
     "LongestIdleModeCreateOrUpdate": {
       "type": "object",
@@ -2943,7 +3057,7 @@
           "$ref": "#/definitions/DistributionModeCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "longest-idle"
+      "x-ms-discriminator-value": "longestIdle"
     },
     "ManualReclassifyExceptionAction": {
       "type": "object",
@@ -2972,7 +3086,7 @@
           "$ref": "#/definitions/ExceptionAction"
         }
       ],
-      "x-ms-discriminator-value": "manual-reclassify"
+      "x-ms-discriminator-value": "manualReclassify"
     },
     "OAuth2WebhookClientCredential": {
       "type": "object",
@@ -3136,7 +3250,7 @@
           "$ref": "#/definitions/QueueSelectorAttachment"
         }
       ],
-      "x-ms-discriminator-value": "pass-through"
+      "x-ms-discriminator-value": "passThrough"
     },
     "PassThroughWorkerSelectorAttachment": {
       "type": "object",
@@ -3165,7 +3279,7 @@
           "$ref": "#/definitions/WorkerSelectorAttachment"
         }
       ],
-      "x-ms-discriminator-value": "pass-through"
+      "x-ms-discriminator-value": "passThrough"
     },
     "QueueAndMatchMode": {
       "type": "object",
@@ -3175,7 +3289,7 @@
           "$ref": "#/definitions/JobMatchingMode"
         }
       ],
-      "x-ms-discriminator-value": "queue-and-match"
+      "x-ms-discriminator-value": "queueAndMatch"
     },
     "QueueAndMatchModeCreateOrUpdate": {
       "type": "object",
@@ -3185,7 +3299,7 @@
           "$ref": "#/definitions/JobMatchingModeCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "queue-and-match"
+      "x-ms-discriminator-value": "queueAndMatch"
     },
     "QueueLengthExceptionTrigger": {
       "type": "object",
@@ -3205,14 +3319,14 @@
           "$ref": "#/definitions/ExceptionTrigger"
         }
       ],
-      "x-ms-discriminator-value": "queue-length"
+      "x-ms-discriminator-value": "queueLength"
     },
     "QueueSelectorAttachment": {
       "type": "object",
       "description": "An attachment of queue selectors to resolve a queue to a job from a classification policy",
       "properties": {
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/QueueSelectorAttachmentKind",
           "description": "The type discriminator describing a sub-type of QueueSelectorAttachment"
         }
       },
@@ -3220,6 +3334,48 @@
       "required": [
         "kind"
       ]
+    },
+    "QueueSelectorAttachmentKind": {
+      "type": "string",
+      "description": "Supported queue selector attachment types",
+      "enum": [
+        "conditional",
+        "passThrough",
+        "ruleEngine",
+        "static",
+        "weightedAllocation"
+      ],
+      "x-ms-enum": {
+        "name": "QueueSelectorAttachmentKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "conditional",
+            "value": "conditional",
+            "description": "Discriminator value for ConditionalQueueSelectorAttachment."
+          },
+          {
+            "name": "passThrough",
+            "value": "passThrough",
+            "description": "Discriminator value for PassThroughQueueSelectorAttachment."
+          },
+          {
+            "name": "ruleEngine",
+            "value": "ruleEngine",
+            "description": "Discriminator value for RuleEngineQueueSelectorAttachment."
+          },
+          {
+            "name": "static",
+            "value": "static",
+            "description": "Discriminator value for StaticQueueSelectorAttachment."
+          },
+          {
+            "name": "weightedAllocation",
+            "value": "weightedAllocation",
+            "description": "Discriminator value for WeightedAllocationQueueSelectorAttachment."
+          }
+        ]
+      }
     },
     "QueueWeightedAllocation": {
       "type": "object",
@@ -3281,7 +3437,7 @@
           "$ref": "#/definitions/DistributionMode"
         }
       ],
-      "x-ms-discriminator-value": "round-robin"
+      "x-ms-discriminator-value": "roundRobin"
     },
     "RoundRobinModeCreateOrUpdate": {
       "type": "object",
@@ -3291,7 +3447,7 @@
           "$ref": "#/definitions/DistributionModeCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "round-robin"
+      "x-ms-discriminator-value": "roundRobin"
     },
     "RouterChannel": {
       "type": "object",
@@ -3812,7 +3968,7 @@
       "description": "A rule of one of the following types:\nStaticRule:  A rule providing static rules that always return the same result, regardless of input.\nDirectMapRule:  A rule that return the same labels as the input labels.\nExpressionRule: A rule providing inline expression rules.\nFunctionRule: A rule providing a binding to an HTTP Triggered Azure Function.\nWebhookRule: A rule providing a binding to a webserver following OAuth2.0 authentication protocol.",
       "properties": {
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/RouterRuleKind",
           "description": "The type discriminator describing a sub-type of RouterRule"
         }
       },
@@ -3826,11 +3982,53 @@
       "description": "A rule of one of the following types:\nStaticRule:  A rule providing static rules that always return the same result, regardless of input.\nDirectMapRule:  A rule that return the same labels as the input labels.\nExpressionRule: A rule providing inline expression rules.\nFunctionRule: A rule providing a binding to an HTTP Triggered Azure Function.\nWebhookRule: A rule providing a binding to a webserver following OAuth2.0 authentication protocol.",
       "properties": {
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/RouterRuleKind",
           "description": "The type discriminator describing a sub-type of RouterRule"
         }
       },
       "discriminator": "kind"
+    },
+    "RouterRuleKind": {
+      "type": "string",
+      "description": "Supported router rule types",
+      "enum": [
+        "directMap",
+        "expression",
+        "function",
+        "static",
+        "webhook"
+      ],
+      "x-ms-enum": {
+        "name": "RouterRuleKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "directMap",
+            "value": "directMap",
+            "description": "Discriminator value for DirectMapRouterRule."
+          },
+          {
+            "name": "expression",
+            "value": "expression",
+            "description": "Discriminator value for ExpressionRouterRule."
+          },
+          {
+            "name": "function",
+            "value": "function",
+            "description": "Discriminator value for FunctionRouterRule."
+          },
+          {
+            "name": "static",
+            "value": "static",
+            "description": "Discriminator value for StaticRouterRule."
+          },
+          {
+            "name": "webhook",
+            "value": "webhook",
+            "description": "Discriminator value for WebhookRouterRule."
+          }
+        ]
+      }
     },
     "RouterWorker": {
       "type": "object",
@@ -4097,7 +4295,7 @@
           "$ref": "#/definitions/QueueSelectorAttachment"
         }
       ],
-      "x-ms-discriminator-value": "rule-engine"
+      "x-ms-discriminator-value": "ruleEngine"
     },
     "RuleEngineWorkerSelectorAttachment": {
       "type": "object",
@@ -4116,7 +4314,7 @@
           "$ref": "#/definitions/WorkerSelectorAttachment"
         }
       ],
-      "x-ms-discriminator-value": "rule-engine"
+      "x-ms-discriminator-value": "ruleEngine"
     },
     "ScheduleAndSuspendMode": {
       "type": "object",
@@ -4136,7 +4334,7 @@
           "$ref": "#/definitions/JobMatchingMode"
         }
       ],
-      "x-ms-discriminator-value": "schedule-and-suspend"
+      "x-ms-discriminator-value": "scheduleAndSuspend"
     },
     "ScheduleAndSuspendModeCreateOrUpdate": {
       "type": "object",
@@ -4153,7 +4351,7 @@
           "$ref": "#/definitions/JobMatchingModeCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "schedule-and-suspend"
+      "x-ms-discriminator-value": "scheduleAndSuspend"
     },
     "ScoringRuleOptions": {
       "type": "object",
@@ -4244,7 +4442,7 @@
           "$ref": "#/definitions/RouterRule"
         }
       ],
-      "x-ms-discriminator-value": "static-rule"
+      "x-ms-discriminator-value": "static"
     },
     "StaticRouterRuleCreateOrUpdate": {
       "type": "object",
@@ -4259,7 +4457,7 @@
           "$ref": "#/definitions/RouterRuleCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "static-rule"
+      "x-ms-discriminator-value": "static"
     },
     "StaticWorkerSelectorAttachment": {
       "type": "object",
@@ -4347,7 +4545,7 @@
           "$ref": "#/definitions/ExceptionTrigger"
         }
       ],
-      "x-ms-discriminator-value": "wait-time"
+      "x-ms-discriminator-value": "waitTime"
     },
     "WebhookRouterRule": {
       "type": "object",
@@ -4373,7 +4571,7 @@
           "$ref": "#/definitions/RouterRule"
         }
       ],
-      "x-ms-discriminator-value": "webhook-rule"
+      "x-ms-discriminator-value": "webhook"
     },
     "WebhookRouterRuleCreateOrUpdate": {
       "type": "object",
@@ -4399,7 +4597,7 @@
           "$ref": "#/definitions/RouterRuleCreateOrUpdate"
         }
       ],
-      "x-ms-discriminator-value": "webhook-rule"
+      "x-ms-discriminator-value": "webhook"
     },
     "WeightedAllocationQueueSelectorAttachment": {
       "type": "object",
@@ -4422,7 +4620,7 @@
           "$ref": "#/definitions/QueueSelectorAttachment"
         }
       ],
-      "x-ms-discriminator-value": "weighted-allocation-queue-selector"
+      "x-ms-discriminator-value": "weightedAllocation"
     },
     "WeightedAllocationWorkerSelectorAttachment": {
       "type": "object",
@@ -4445,14 +4643,14 @@
           "$ref": "#/definitions/WorkerSelectorAttachment"
         }
       ],
-      "x-ms-discriminator-value": "weighted-allocation-worker-selector"
+      "x-ms-discriminator-value": "weightedAllocation"
     },
     "WorkerSelectorAttachment": {
       "type": "object",
       "description": "An attachment which attaches worker selectors to a job",
       "properties": {
         "kind": {
-          "type": "string",
+          "$ref": "#/definitions/WorkerSelectorAttachmentKind",
           "description": "The type discriminator describing a sub-type of WorkerSelectorAttachment"
         }
       },
@@ -4460,6 +4658,48 @@
       "required": [
         "kind"
       ]
+    },
+    "WorkerSelectorAttachmentKind": {
+      "type": "string",
+      "description": "Supported worker selector attachment types",
+      "enum": [
+        "conditional",
+        "passThrough",
+        "ruleEngine",
+        "static",
+        "weightedAllocation"
+      ],
+      "x-ms-enum": {
+        "name": "WorkerSelectorAttachmentKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "conditional",
+            "value": "conditional",
+            "description": "Discriminator value for ConditionalWorkerSelectorAttachment."
+          },
+          {
+            "name": "passThrough",
+            "value": "passThrough",
+            "description": "Discriminator value for PassThroughWorkerSelectorAttachment."
+          },
+          {
+            "name": "ruleEngine",
+            "value": "ruleEngine",
+            "description": "Discriminator value for RuleEngineWorkerSelectorAttachment."
+          },
+          {
+            "name": "static",
+            "value": "static",
+            "description": "Discriminator value for StaticWorkerSelectorAttachment."
+          },
+          {
+            "name": "weightedAllocation",
+            "value": "weightedAllocation",
+            "description": "Discriminator value for WeightedAllocationWorkerSelectorAttachment."
+          }
+        ]
+      }
     },
     "WorkerWeightedAllocation": {
       "type": "object",

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_CreateClassificationPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_CreateClassificationPolicy.json
@@ -12,7 +12,7 @@
         {
           "kind": "conditional",
           "condition": {
-            "kind": "expression-rule",
+            "kind": "expression",
             "language": "powerFx",
             "expression": "1 = 1"
           },
@@ -26,7 +26,7 @@
         }
       ],
       "prioritizationRule": {
-        "kind": "static-rule",
+        "kind": "static",
         "value": "2"
       }
     }

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_CreateClassificationPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_CreateClassificationPolicy.json
@@ -41,7 +41,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -55,7 +55,7 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [],
@@ -71,7 +71,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -85,7 +85,7 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [],

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_GetClassificationPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_GetClassificationPolicy.json
@@ -16,7 +16,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -30,12 +30,12 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [
           {
-            "kind": "pass-through",
+            "kind": "passThrough",
             "key": "language",
             "labelOperator": "equal"
           }

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_ListClassificationPoliciesWithPageSize.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_ListClassificationPoliciesWithPageSize.json
@@ -16,16 +16,16 @@
             "fallbackQueueId": "MainQueue",
             "queueSelectorAttachments": [
               {
-                "kind": "rule-engine",
+                "kind": "ruleEngine",
                 "rule": {
-                  "kind": "expression-rule",
+                  "kind": "expression",
                   "language": "powerFx",
                   "expression": "If(job.Escalated = true, \"SecondaryQueue\", \"MainQueue\")"
                 }
               }
             ],
             "prioritizationRule": {
-              "kind": "static-rule",
+              "kind": "static",
               "value": "2"
             },
             "workerSelectorAttachments": [],
@@ -37,16 +37,16 @@
             "fallbackQueueId": "MainQueue",
             "queueSelectorAttachments": [
               {
-                "kind": "rule-engine",
+                "kind": "ruleEngine",
                 "rule": {
-                  "kind": "expression-rule",
+                  "kind": "expression",
                   "language": "powerFx",
                   "expression": "If(job.VIP = true, \"VIPQueue\", \"MainQueue\")"
                 }
               }
             ],
             "prioritizationRule": {
-              "kind": "static-rule",
+              "kind": "static",
               "value": "1"
             },
             "workerSelectorAttachments": [],

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_UpdateClassificationPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ClassificationPolicies_UpdateClassificationPolicy.json
@@ -19,7 +19,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -33,7 +33,7 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [],
@@ -49,7 +49,7 @@
           {
             "kind": "conditional",
             "condition": {
-              "kind": "expression-rule",
+              "kind": "expression",
               "language": "powerFx",
               "expression": "1 = 1"
             },
@@ -63,7 +63,7 @@
           }
         ],
         "prioritizationRule": {
-          "kind": "static-rule",
+          "kind": "static",
           "value": "2"
         },
         "workerSelectorAttachments": [],

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/DistributionPolicies_CreateDistributionPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/DistributionPolicies_CreateDistributionPolicy.json
@@ -7,7 +7,7 @@
     "distributionPolicyId": "d9033d56-659c-437a-b5b7-4f3b14301dd4",
     "resource": {
       "mode": {
-        "kind": "longest-idle",
+        "kind": "longestIdle",
         "minConcurrentOffers": 1,
         "maxConcurrentOffers": 5,
         "bypassSelectors": false
@@ -23,7 +23,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false
@@ -37,7 +37,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/DistributionPolicies_GetDistributionPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/DistributionPolicies_GetDistributionPolicy.json
@@ -13,7 +13,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/DistributionPolicies_ListDistributionPoliciesWithPageSize.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/DistributionPolicies_ListDistributionPoliciesWithPageSize.json
@@ -15,7 +15,7 @@
             "name": "Secondary",
             "offerExpiresAfterSeconds": 300,
             "mode": {
-              "kind": "round-robin",
+              "kind": "roundRobin",
               "minConcurrentOffers": 1,
               "maxConcurrentOffers": 2,
               "bypassSelectors": false
@@ -27,7 +27,7 @@
             "name": "Main",
             "offerExpiresAfterSeconds": 300,
             "mode": {
-              "kind": "longest-idle",
+              "kind": "longestIdle",
               "minConcurrentOffers": 1,
               "maxConcurrentOffers": 5,
               "bypassSelectors": false

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/DistributionPolicies_UpdateDistributionPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/DistributionPolicies_UpdateDistributionPolicy.json
@@ -7,7 +7,7 @@
     "distributionPolicyId": "d9033d56-659c-437a-b5b7-4f3b14301dd4",
     "resource": {
       "mode": {
-        "kind": "longest-idle",
+        "kind": "longestIdle",
         "minConcurrentOffers": 1,
         "maxConcurrentOffers": 5,
         "bypassSelectors": false
@@ -23,7 +23,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false
@@ -37,7 +37,7 @@
         "name": "Main",
         "offerExpiresAfterSeconds": 300,
         "mode": {
-          "kind": "longest-idle",
+          "kind": "longestIdle",
           "minConcurrentOffers": 1,
           "maxConcurrentOffers": 5,
           "bypassSelectors": false

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ExceptionPolicies_CreateExceptionPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ExceptionPolicies_CreateExceptionPolicy.json
@@ -20,7 +20,7 @@
             }
           ],
           "trigger": {
-            "kind": "wait-time",
+            "kind": "waitTime",
             "thresholdSeconds": 20
           }
         }
@@ -36,7 +36,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [
@@ -62,7 +62,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ExceptionPolicies_GetExceptionPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ExceptionPolicies_GetExceptionPolicy.json
@@ -15,7 +15,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ExceptionPolicies_ListExceptionPoliciesWithPageSize.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ExceptionPolicies_ListExceptionPoliciesWithPageSize.json
@@ -17,7 +17,7 @@
               {
                 "id": "MaxWaitTimeExceeded",
                 "trigger": {
-                  "kind": "wait-time",
+                  "kind": "waitTime",
                   "thresholdSeconds": 20
                 },
                 "actions": [
@@ -41,7 +41,7 @@
               {
                 "id": "MaxWaitTimeExceeded",
                 "trigger": {
-                  "kind": "wait-time",
+                  "kind": "waitTime",
                   "thresholdSeconds": 50
                 },
                 "actions": [

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ExceptionPolicies_UpdateExceptionPolicy.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/ExceptionPolicies_UpdateExceptionPolicy.json
@@ -20,7 +20,7 @@
             }
           ],
           "trigger": {
-            "kind": "wait-time",
+            "kind": "waitTime",
             "thresholdSeconds": 20
           }
         }
@@ -36,7 +36,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [
@@ -62,7 +62,7 @@
           {
             "id": "MaxWaitTimeExceeded",
             "trigger": {
-              "kind": "wait-time",
+              "kind": "waitTime",
               "thresholdSeconds": 20
             },
             "actions": [

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_CreateJob.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_CreateJob.json
@@ -19,7 +19,7 @@
       ],
       "labels": {},
       "matchingMode": {
-        "kind": "queue-and-match"
+        "kind": "queueAndMatch"
       }
     }
   },
@@ -48,7 +48,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }
@@ -77,7 +77,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_CreateScheduledJob.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_CreateScheduledJob.json
@@ -19,7 +19,7 @@
       ],
       "labels": {},
       "matchingMode": {
-        "kind": "schedule-and-suspend",
+        "kind": "scheduleAndSuspend",
         "scheduleAt": "2023-05-26T23:22:12.0774222+00:00"
       }
     }
@@ -49,7 +49,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "schedule-and-suspend",
+          "kind": "scheduleAndSuspend",
           "scheduleAt": "2023-05-26T23:22:12.0774222+00:00"
         },
         "scheduledAt": null,
@@ -80,7 +80,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "schedule-and-suspend",
+          "kind": "scheduleAndSuspend",
           "scheduleAt": "2023-05-26T23:22:12.0774222+00:00"
         },
         "scheduledAt": null,

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_GetJob.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_GetJob.json
@@ -31,7 +31,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_GetJobsWithPageSize.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_GetJobsWithPageSize.json
@@ -27,7 +27,7 @@
             "assignments": {},
             "notes": [],
             "matchingMode": {
-              "kind": "queue-and-match"
+              "kind": "queueAndMatch"
             },
             "etag": "etag"
           },
@@ -45,7 +45,7 @@
             "assignments": {},
             "notes": [],
             "matchingMode": {
-              "kind": "queue-and-match"
+              "kind": "queueAndMatch"
             },
             "etag": "etag"
           }

--- a/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_UpdateJob.json
+++ b/specification/communication/data-plane/JobRouter/stable/2023-11-01/examples/Jobs_UpdateJob.json
@@ -34,7 +34,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }
@@ -63,7 +63,7 @@
         "assignments": {},
         "notes": [],
         "matchingMode": {
-          "kind": "queue-and-match"
+          "kind": "queueAndMatch"
         },
         "etag": "etag"
       }


### PR DESCRIPTION
Based on reviews from https://github.com/Azure/azure-sdk/issues/6852

It was recommended for the discriminator property used in polymorphic classes to be exposed as extensible enums. This introduces the following enums in the spec which are now used as discriminator type instead of `str`

This is also the recommended representation of discriminators [Teams post (internal)](https://teams.microsoft.com/l/message/19:906c1efbbec54dc8949ac736633e6bdf@thread.skype/1699578609898?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1663361364981&teamName=Azure%20SDK&channelName=TypeSpec%20Discussion%20%F0%9F%90%AE&createdTime=1699578609898)

`JobMatchingModeKind` (used for `JobMatchingMode.kind`)
`RouterRuleKind` (used for `RouterRule.kind`)
`DistributionModeKind` (used for `DistributionMode.kind`)
`ExceptionTriggerKind` (used for `ExceptionTrigger.kind`)
`ExceptionActionKind` (used for `ExceptionAction.kind`)
`QueueSelectorAttachmentKind` (used for `QueueSelectorAttachment.kind`)
`WorkerSelectorAttachmentKind` (used for `WorkerSelectorAttachment.kind`)

Other changes:-
- Update examples
- Correction of config value for typespec-ts [Link](https://github.com/Azure/azure-rest-api-specs/pull/25763/files#r1388979352)
- Misc. SDK customizations

Previous PR: https://github.com/Azure/azure-rest-api-specs/pull/25763

Breaking Change: [Workitem](https://msazure.visualstudio.com/One/_workitems/edit/25798283)