### PR TITLE
Disable new `arm-common-types-version` rule ahead of rollout

### DIFF
--- a/specification/communitytraining/Community.Management/tspconfig.yaml
+++ b/specification/communitytraining/Community.Management/tspconfig.yaml
@@ -9,3 +9,5 @@ options:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"

--- a/specification/containerservice/Fleet.Management/tspconfig.yaml
+++ b/specification/containerservice/Fleet.Management/tspconfig.yaml
@@ -3,6 +3,8 @@ emit:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"
 options:
   '@azure-tools/typespec-autorest':
     azure-resource-provider-folder: "resource-manager"

--- a/specification/containerstorage/ContainerStorage.Management/tspconfig.yaml
+++ b/specification/containerstorage/ContainerStorage.Management/tspconfig.yaml
@@ -3,6 +3,8 @@ emit:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"
 options:
   '@azure-tools/typespec-autorest':
     azure-resource-provider-folder: "resource-manager"

--- a/specification/devopsinfrastructure/Microsoft.DevOpsInfrastructure/tspconfig.yaml
+++ b/specification/devopsinfrastructure/Microsoft.DevOpsInfrastructure/tspconfig.yaml
@@ -1,6 +1,8 @@
 linter:
   extends:
     - '@azure-tools/typespec-azure-resource-manager/all'
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"
 emit:
   - '@azure-tools/typespec-autorest'
 options:

--- a/specification/iotoperationsdataprocessor/IoTOperationsDataProcessor.Management/tspconfig.yaml
+++ b/specification/iotoperationsdataprocessor/IoTOperationsDataProcessor.Management/tspconfig.yaml
@@ -9,3 +9,5 @@ options:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"

--- a/specification/iotoperationsmq/IoTOperationsMQ.Management/tspconfig.yaml
+++ b/specification/iotoperationsmq/IoTOperationsMQ.Management/tspconfig.yaml
@@ -9,3 +9,5 @@ options:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"

--- a/specification/iotoperationsorchestrator/IoTOperationsOrchestrator.Management/tspconfig.yaml
+++ b/specification/iotoperationsorchestrator/IoTOperationsOrchestrator.Management/tspconfig.yaml
@@ -9,3 +9,5 @@ options:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"

--- a/specification/liftrastronomer/Astronomer.Astro.Management/tspconfig.yaml
+++ b/specification/liftrastronomer/Astronomer.Astro.Management/tspconfig.yaml
@@ -4,6 +4,8 @@ emit:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"
 options:
   "@azure-tools/typespec-autorest":
     emitter-output-dir: "{project-root}/.."

--- a/specification/mpcnetworkfunction/MpcNetworkFunction.Management/tspconfig.yaml
+++ b/specification/mpcnetworkfunction/MpcNetworkFunction.Management/tspconfig.yaml
@@ -3,6 +3,8 @@ emit:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"
 options:
   "@azure-tools/typespec-autorest":
     azure-resource-provider-folder: "resource-manager"

--- a/specification/networkanalytics/NetworkAnalytics.Management/tspconfig.yaml
+++ b/specification/networkanalytics/NetworkAnalytics.Management/tspconfig.yaml
@@ -3,6 +3,8 @@ emit:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"
 options:
   '@azure-tools/typespec-autorest':
     emitter-output-dir: "{project-root}/.."

--- a/specification/playwrighttesting/PlaywrightTesting.Management/tspconfig.yaml
+++ b/specification/playwrighttesting/PlaywrightTesting.Management/tspconfig.yaml
@@ -4,6 +4,8 @@ emit:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"
 parameters:
   "service-directory-name":
     default: "playwrighttesting"

--- a/specification/servicenetworking/ServiceNetworking.Management/tspconfig.yaml
+++ b/specification/servicenetworking/ServiceNetworking.Management/tspconfig.yaml
@@ -3,6 +3,8 @@ emit:
 linter:
   extends:
     - "@azure-tools/typespec-azure-resource-manager/all"
+  disable:
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"
 options:
   "@azure-tools/typespec-autorest":
     azure-resource-provider-folder: "resource-manager"

--- a/specification/sphere/Sphere.Management/tspconfig.yaml
+++ b/specification/sphere/Sphere.Management/tspconfig.yaml
@@ -5,6 +5,7 @@ linter:
     - "@azure-tools/typespec-azure-resource-manager/all"
   disable:
     "@azure-tools/typespec-azure-core/composition-over-inheritance": "New rule"
+    "@azure-tools/typespec-azure-resource-manager/arm-common-types-version": "New rule"
 options:
   '@azure-tools/typespec-autorest':
     emitter-output-dir: "{project-root}/.."


### PR DESCRIPTION
This PR preemptively disables the new `@azure-tools/typespec-azure-resource-manager/arm-common-types-version` rule before it gets rolled out in an upcoming release of the `@azure-tools/typespec-azure-resource-manager` library.

This rule checks to see if the new `@armCommonTypesVersion` decorator (see https://github.com/Azure/typespec-azure/pull/3768/) has been applied to the service namespace or to one of the version enum values that represent service versions.  If not found, a warning is raised.

We're disabling this rule in advance for all existing ARM specs so that CI jobs are not disrupted until the specs have been updated to use the appropriate `common-types` version.

Please let me know if I should make an equivalent PR to any other repo that might be affected by this change!