### PR TITLE
Create a new tag for Maps Ref Docs

### DIFF
--- a/specification/maps/data-plane/readme.md
+++ b/specification/maps/data-plane/readme.md
@@ -49,7 +49,7 @@ directive:
 
 These settings apply only when `--tag=package-stable-2023-07-01` is specified on the command line.
 
-```yaml $(tag) == 'package-preview-2023-07-01'
+```yaml $(tag) == 'package-stable-2023-07-01'
 input-file:
   - Common/stable/2023-07-01/common.json
   - Creator/stable/2023-07-01/alias.json

--- a/specification/maps/data-plane/readme.md
+++ b/specification/maps/data-plane/readme.md
@@ -27,7 +27,7 @@ These are the global settings for MapsClient.
 ``` yaml
 title: MapsClient
 openapi-type: data-plane
-tag: package-preview-2.0
+tag: package-stable-2023-07-01
 ```
 
 ### Suppression
@@ -44,6 +44,33 @@ directive:
     reason: The reason for this suppression is the API is already released and introducing new LRO properties will not function and are not supported today and will only be developed for the next version of this API.
 ``` 
 
+
+### Tag: package-stable-2023-07-01
+
+These settings apply only when `--tag=package-stable-2023-07-01` is specified on the command line.
+
+```yaml $(tag) == 'package-preview-2023-07-01'
+input-file:
+  - Common/stable/2023-07-01/common.json
+  - Creator/stable/2023-07-01/alias.json
+  - Creator/stable/2023-07-01/dataset.json
+  - Creator/stable/2023-07-01/dwgconversion.json
+  - Creator/stable/2023-07-01/features.json
+  - Creator/stable/2023-07-01/featurestate.json
+  - Creator/stable/2023-07-01/mapconfiguration.json
+  - Creator/stable/2023-07-01/style.json
+  - Creator/stable/2023-07-01/tileset.json
+  - Microsoft.Maps/Data/preview/2.0/data.json
+  - DataRegistry/stable/2023-06-01/dataregistry.json
+  - Geolocation/preview/1.0/geolocation.json
+  - Render/stable/2022-08-01/render.json
+  - Route/preview/1.0/route.json
+  - Search/stable/2023-06-01/search.json
+  - Spatial/stable/2022-08-01/spatial.json
+  - Timezone/preview/1.0/timezone.json
+  - Traffic/preview/1.0/traffic.json
+  - Weather/stable/1.1/weather.json
+```
 
 ### Tag: package-preview-2.0
 


### PR DESCRIPTION
Update Maps readme.md to create a new tag for REST API Ref Docs.

Replaces #26708
