### PR TITLE
Update ci-fix.md: add reference links to `Swagger PrettierCheck`

### DIFF
--- a/documentation/ci-fix.md
+++ b/documentation/ci-fix.md
@@ -39,7 +39,11 @@ npx prettier --write **/*.json
 
 Then please commit and push changes made by prettier.
 
-Reference: [prettier](https://www.npmjs.com/package/prettier).
+### Prettier reference
+
+- [`prettier` npm package](https://www.npmjs.com/package/prettier).
+- [Source: Swagger-Prettier-Check.ps1](https://github.com/Azure/azure-rest-api-specs/blob/main/eng/scripts/Swagger-Prettier-Check.ps1)
+- [Pipeline: Swagger PrettierCheck](https://dev.azure.com/azure-sdk/public/_build?definitionId=6405)
 
 ## Model Validation
 


### PR DESCRIPTION
This is a PR made by the Azure SDK Engineering System team

This PR is a companion work to the removal of obsolete openapi-alps Swagger PrettierCheck done in [openapi-alps PR 511613](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps/pullRequest/511613#1700188983)