### PR TITLE
Revert "Add TypeSpec label for PullRequests"

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -2529,16 +2529,7 @@ configuration:
       then:
       - removeLabel:
           label: no-recent-activity
-      description:
-    - if:
-      - payloadType: Pull_Request
-      then:
-      - if:
-        - filesMatchPattern:
-            pattern: specification/.*(\.tsp|tspconfig.yaml)
-        then:
-        - addLabel:
-            label: TypeSpec
+      description: 
     - if:
       - payloadType: Issue_Comment
       - and:


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#26542 for reasons explained [here](https://github.com/Azure/azure-rest-api-specs/pull/26542#issuecomment-1831237799).