### PR TITLE
[TypeSpec Validation] Trigger "all" pipeline when TypeSpec dev package is published

### DIFF
--- a/eng/pipelines/typespec-validation-all.yml
+++ b/eng/pipelines/typespec-validation-all.yml
@@ -21,13 +21,20 @@ pr:
 
 resources:
   pipelines:
-  - pipeline: test
-    source: mikeharder.AzurePipelineTests
-    project: playground
+  - pipeline: typespec
+    source: typespec - CI
+    project: internal
     trigger:
       branches:
         include:
-        - test-fast
+        - main
+  - pipeline: typespec-azure
+    source: typespec-azure - CI
+    project: internal
+    trigger:
+      branches:
+        include:
+        - main
 
 jobs:
 - job: Validate_All_Specs

--- a/eng/pipelines/typespec-validation-all.yml
+++ b/eng/pipelines/typespec-validation-all.yml
@@ -19,6 +19,16 @@ pr:
     - eng
     - specification/common-types
 
+resources:
+  pipelines:
+  - pipeline: test
+    source: mikeharder.AzurePipelineTests
+    project: playground
+    trigger:
+      branches:
+        include:
+        - test-fast
+
 jobs:
 - job: Validate_All_Specs
 


### PR DESCRIPTION
- Triggers on completion of any build from pipelines "typespec[-azure] - CI"
- This usually correlates with the release of a new dev package, but if no new package is released, it's harmless
