### PR TITLE
Update guidance docs for `OAV` check

### DIFF
--- a/documentation/Semantic-and-Model-Violations-Reference.md
+++ b/documentation/Semantic-and-Model-Violations-Reference.md
@@ -850,7 +850,7 @@ This document lists the set of automated rules that can be validated against swa
 
 **Output Message**: Long running operation should return {header} in header but not being provided.
 
-**Description**: Long running operation must return `Operation-Id`, `Operation-Location`, or `azure-AsyncOperation`` header in response when this operation is annotated with x-ms-long-running-operation:true.
+**Description**: Long running operation must return `Operation-Id`, `Operation-Location`, or `azure-AsyncOperation` header in response when this operation is annotated with x-ms-long-running-operation:true.
 
 **How to fix the violation**: Adding one of these headers to the response in example or in traffic payload. Refer to this [example](https://github.com/Azure/azure-rest-api-specs/blob/5e638554b6/specification/appplatform/resource-manager/Microsoft.AppPlatform/stable/2020-07-01/examples/Apps_Update.json#L64) for the fix.
 

--- a/documentation/Semantic-and-Model-Violations-Reference.md
+++ b/documentation/Semantic-and-Model-Violations-Reference.md
@@ -850,7 +850,7 @@ This document lists the set of automated rules that can be validated against swa
 
 **Output Message**: Long running operation should return {header} in header but not being provided.
 
-**Description**: Long running operation must return location header or azure-AsyncOperation header in response when this operation is annotated with x-ms-long-running-operation:true.
+**Description**: Long running operation must return `Operation-Id`, `Operation-Location`, or `azure-AsyncOperation`` header in response when this operation is annotated with x-ms-long-running-operation:true.
 
 **How to fix the violation**: Adding one of these headers to the response in example or in traffic payload. Refer to this [example](https://github.com/Azure/azure-rest-api-specs/blob/5e638554b6/specification/appplatform/resource-manager/Microsoft.AppPlatform/stable/2020-07-01/examples/Apps_Update.json#L64) for the fix.
 


### PR DESCRIPTION
This message is a bit out of date. Need to update it to align with what `oav` is actually verifying.

