### PR TITLE
Azure OpenAI: 2023-12-01-preview TypeSpec fix for ChatMessageImageContentItem

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_messages.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_messages.tsp
@@ -62,12 +62,6 @@ model ChatMessageImageContentItem extends ChatMessageContentItem {
   @doc("An internet location, which must be accessible to the model,from which the image may be retrieved.")
   @projectedName("json", "image_url")
   imageUrl: ChatMessageImageUrl;
-
-  @doc("""
-  The evaluation quality setting to use, which controls relative prioritization of speed, token consumption, and
-  accuracy.
-  """)
-  detail?: ChatMessageImageDetailLevel;
 }
 
 @doc("An internet location from which the model may retrieve an image.")
@@ -75,6 +69,12 @@ model ChatMessageImageContentItem extends ChatMessageContentItem {
 model ChatMessageImageUrl {
   @doc("The URL of the image.")
   url: url;
+
+  @doc("""
+  The evaluation quality setting to use, which controls relative prioritization of speed, token consumption, and
+  accuracy.
+  """)
+  detail?: ChatMessageImageDetailLevel;
 }
 
 @discriminator("role")


### PR DESCRIPTION
The `gpt-4-vision-preview` variant of the /chat/completions API accepts a broader structure for the `content` property that includes a new capability to include `image_url` items. OpenAI [does not yet document everything thoroughly](https://platform.openai.com/docs/guides/vision) but [their spec](https://github.com/openai/openai-openapi/blob/master/openapi.yaml#L5618) as well as [ours for Azure OpenAI](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-12-01-preview/inference.json#L1516) make it clear that we have a subtle but important bug in what we just merged for the .tsp representation: `detail` is one level higher than it should be.

This very small patch just adjusts the level to match the spec.

Credit and sincere thanks to @extraes for catching this proactively, per this .NET repo comment!
https://github.com/Azure/azure-sdk-for-net/pull/40078#issuecomment-1841688168