### PR TITLE
Revert "remove suppression"

### DIFF
--- a/specification/appplatform/resource-manager/readme.md
+++ b/specification/appplatform/resource-manager/readme.md
@@ -57,6 +57,8 @@ directive:
 suppressions:
   - code: LroPostReturn
     reason: start,stop,flushDNSsetting api do not have return body in async operation
+  - code: PostResponseCodes
+    reason: start,stop,flushDNSSetting API do not have return body
 ```
 
 


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#26976

Long-running POST operations must have responses with 202 and default return codes. They must also have a 200 return code if only if the final response is intended to have a schema, if not the 200 return code must not be specified. They also must not have other response codes.