### PR TITLE
update datadog swagger examples to fix parameter name mismatch issue

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/stable/2023-08-01/extensions.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/stable/2023-08-01/extensions.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2023-08-01",
+    "version": "2024-01-01",
     "title": "AzureStackHCI",
     "description": "Azure Stack HCI management service"
   },

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/stable/2023-08-01/extensions.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/stable/2023-08-01/extensions.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2024-01-01",
+    "version": "2023-08-01",
     "title": "AzureStackHCI",
     "description": "Azure Stack HCI management service"
   },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/ApiKeys_SetDefaultKey.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/ApiKeys_SetDefaultKey.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "key": "1111111111111111aaaaaaaaaaaaaaaa"
     }
   },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/MarketplaceAgreements_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/MarketplaceAgreements_Create.json
@@ -2,7 +2,7 @@
   "parameters": {
     "api-version": "2020-02-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
-    "requestBody": {
+    "body": {
       "properties": {
         "accepted": true
       }

--- a/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/Monitors_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/Monitors_Create.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "name": "myMonitor",
       "sku": {
         "name": "free_Monthly"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/Monitors_Update.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/Monitors_Update.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "properties": {
         "monitoringStatus": "Enabled"
       },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/SingleSignOnConfigurations_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/SingleSignOnConfigurations_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "configurationName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "singleSignOnState": "Enable",
         "enterpriseAppId": "00000000-0000-0000-0000-000000000000"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/TagRules_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/preview/2020-02-01-preview/examples/TagRules_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "ruleSetName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "logRules": {
           "sendAadLogs": false,

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/ApiKeys_SetDefaultKey.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/ApiKeys_SetDefaultKey.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "key": "1111111111111111aaaaaaaaaaaaaaaa"
     }
   },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/MarketplaceAgreements_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/MarketplaceAgreements_Create.json
@@ -2,7 +2,7 @@
   "parameters": {
     "api-version": "2021-03-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
-    "requestBody": {
+    "body": {
       "properties": {
         "accepted": true
       }

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/Monitors_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/Monitors_Create.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "name": "myMonitor",
       "sku": {
         "name": "free_Monthly"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/Monitors_Update.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/Monitors_Update.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "properties": {
         "monitoringStatus": "Enabled"
       },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/SingleSignOnConfigurations_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/SingleSignOnConfigurations_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "configurationName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "singleSignOnState": "Enable",
         "enterpriseAppId": "00000000-0000-0000-0000-000000000000"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/TagRules_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2021-03-01/examples/TagRules_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "ruleSetName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "logRules": {
           "sendAadLogs": false,

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/ApiKeys_SetDefaultKey.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/ApiKeys_SetDefaultKey.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "key": "1111111111111111aaaaaaaaaaaaaaaa"
     }
   },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/MarketplaceAgreements_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/MarketplaceAgreements_Create.json
@@ -2,7 +2,7 @@
   "parameters": {
     "api-version": "2022-06-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
-    "requestBody": {
+    "body": {
       "properties": {
         "accepted": true
       }

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/Monitors_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/Monitors_Create.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "name": "myMonitor",
       "sku": {
         "name": "free_Monthly"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/Monitors_Update.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/Monitors_Update.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "properties": {
         "monitoringStatus": "Enabled"
       },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/SingleSignOnConfigurations_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/SingleSignOnConfigurations_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "configurationName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "singleSignOnState": "Enable",
         "enterpriseAppId": "00000000-0000-0000-0000-000000000000"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/TagRules_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-06-01/examples/TagRules_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "ruleSetName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "logRules": {
           "sendAadLogs": false,

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/ApiKeys_SetDefaultKey.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/ApiKeys_SetDefaultKey.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "key": "1111111111111111aaaaaaaaaaaaaaaa"
     }
   },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/MarketplaceAgreements_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/MarketplaceAgreements_Create.json
@@ -2,7 +2,7 @@
   "parameters": {
     "api-version": "2022-08-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
-    "requestBody": {
+    "body": {
       "properties": {
         "accepted": true
       }

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/Monitors_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/Monitors_Create.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "name": "myMonitor",
       "sku": {
         "name": "free_Monthly"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/Monitors_Update.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/Monitors_Update.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "properties": {
         "monitoringStatus": "Enabled"
       },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/SingleSignOnConfigurations_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/SingleSignOnConfigurations_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "configurationName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "singleSignOnState": "Enable",
         "enterpriseAppId": "00000000-0000-0000-0000-000000000000"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/TagRules_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2022-08-01/examples/TagRules_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "ruleSetName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "logRules": {
           "sendAadLogs": false,

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/ApiKeys_SetDefaultKey.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/ApiKeys_SetDefaultKey.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "key": "1111111111111111aaaaaaaaaaaaaaaa"
     }
   },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/MarketplaceAgreements_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/MarketplaceAgreements_Create.json
@@ -2,7 +2,7 @@
   "parameters": {
     "api-version": "2023-01-01",
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
-    "requestBody": {
+    "body": {
       "properties": {
         "accepted": true
       }

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/MonitoredSubscriptions_CreateorUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/MonitoredSubscriptions_CreateorUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "configurationName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "operation": "AddBegin",
         "monitoredSubscriptionList": [

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/MonitoredSubscriptions_Update.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/MonitoredSubscriptions_Update.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "configurationName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "operation": "AddComplete",
         "monitoredSubscriptionList": [

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/Monitors_Create.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/Monitors_Create.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "name": "myMonitor",
       "sku": {
         "name": "free_Monthly"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/Monitors_Update.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/Monitors_Update.json
@@ -4,7 +4,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
-    "requestBody": {
+    "body": {
       "properties": {
         "monitoringStatus": "Enabled"
       },

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/SingleSignOnConfigurations_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/SingleSignOnConfigurations_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "configurationName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "singleSignOnState": "Enable",
         "enterpriseAppId": "00000000-0000-0000-0000-000000000000"

--- a/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/TagRules_CreateOrUpdate.json
+++ b/specification/datadog/resource-manager/Microsoft.Datadog/stable/2023-01-01/examples/TagRules_CreateOrUpdate.json
@@ -5,7 +5,7 @@
     "resourceGroupName": "myResourceGroup",
     "monitorName": "myMonitor",
     "ruleSetName": "default",
-    "requestBody": {
+    "body": {
       "properties": {
         "logRules": {
           "sendAadLogs": false,


### PR DESCRIPTION
customer met an issue https://github.com/Azure/azure-sdk-for-js/issues/27930 when using sdk samples which are generated by swagger examples.
It is because the parameter name mismatch. So I create a pr to fix this.

@vikotha could you help review this pr? thanks