### PR TITLE
update parameter value in kusto swagger examples

### DIFF
--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2023-08-15/examples/KustoClustersCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2023-08-15/examples/KustoClustersCreateOrUpdate.json
@@ -27,8 +27,8 @@
         "languageExtensions": {
           "value": [
             {
-              "languageExtensionImageName": "Python3_10_8",
-              "languageExtensionCustomImageName": "customImage8"
+              "languageExtensionName": "PYTHON",
+              "languageExtensionImageName": "Python3_10_8"
             },
             {
               "languageExtensionName": "R",
@@ -68,8 +68,8 @@
           "languageExtensions": {
             "value": [
               {
-                "languageExtensionImageName": "Python3_10_8",
-                "languageExtensionCustomImageName": "customImage8"
+                "languageExtensionName": "PYTHON",
+                "languageExtensionImageName": "Python3_10_8"
               },
               {
                 "languageExtensionName": "R",
@@ -120,8 +120,8 @@
           "languageExtensions": {
             "value": [
               {
-                "languageExtensionImageName": "Python3_10_8",
-                "languageExtensionCustomImageName": "customImage8"
+                "languageExtensionName": "PYTHON",
+                "languageExtensionImageName": "Python3_10_8"
               },
               {
                 "languageExtensionName": "R",

--- a/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2023-08-15/examples/KustoClustersCreateOrUpdate.json
+++ b/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2023-08-15/examples/KustoClustersCreateOrUpdate.json
@@ -27,8 +27,7 @@
         "languageExtensions": {
           "value": [
             {
-              "languageExtensionName": "PYTHON",
-              "languageExtensionImageName": "Python_Custom_Image",
+              "languageExtensionImageName": "Python3_10_8",
               "languageExtensionCustomImageName": "customImage8"
             },
             {
@@ -69,8 +68,7 @@
           "languageExtensions": {
             "value": [
               {
-                "languageExtensionName": "PYTHON",
-                "languageExtensionImageName": "Python_Custom_Image",
+                "languageExtensionImageName": "Python3_10_8",
                 "languageExtensionCustomImageName": "customImage8"
               },
               {
@@ -122,8 +120,7 @@
           "languageExtensions": {
             "value": [
               {
-                "languageExtensionName": "PYTHON",
-                "languageExtensionImageName": "Python_Custom_Image",
+                "languageExtensionImageName": "Python3_10_8",
                 "languageExtensionCustomImageName": "customImage8"
               },
               {


### PR DESCRIPTION
customer met an issue https://github.com/Azure/azure-sdk-for-js/issues/27928 when using sdk samples which are generated by swagger examples.
It is because the parameter value is not correct. But after I fixed this , I tried to add a test case to test it, but I met a error on languageExtensionCustomImageName. I don't know what the custom image is, and don't know how to create it. So I remove languageExtensionCustomImageName and use Python3_10_8 stead of Python_Custom_Image. 

@michaelshikh07, could you help review this pr? thanks