### PR TITLE
Azure OpenAI: fix object representation of response_format

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
@@ -16,16 +16,33 @@ using TypeSpec.Versioning;
 namespace Azure.OpenAI;
 
 @added(ServiceApiVersions.v2023_12_01_Preview)
-@doc("The valid response formats Chat Completions can provide. Used to enable JSON mode.")
-enum ChatCompletionsResponseFormat {
-  @doc("Use the default, plain text response format.")
-  text: "text",
+@doc("""
+An abstract representation of a response format configuration usable by Chat Completions. Can be used to enable JSON
+mode.
+""")
+@discriminator("type")
+model ChatCompletionsResponseFormat {
+  @doc("The discriminated type for the response format.")
+  type: string;
+}
 
-  @doc("""
-  Use a response format that guarantees emission of a valid JSON object. Only structure is guaranteed and contents must
-  still be validated.
-  """)
-  jsonObject: "json_object",
+@doc("""
+The standard Chat Completions response format that can freely generate text and is not guaranteed to produce response
+content that adheres to a specific schema.
+""")
+@added(ServiceApiVersions.v2023_12_01_Preview)
+model ChatCompletionsTextResponseFormat extends ChatCompletionsResponseFormat {
+  @doc("The discriminated object type, which is always 'text' for this format.")
+  type: "text";
+}
+
+@doc("""
+A response format for Chat Completions that restricts responses to emitting valid JSON objects.
+""")
+@added(ServiceApiVersions.v2023_12_01_Preview)
+model ChatCompletionsJsonResponseFormat extends ChatCompletionsResponseFormat {
+  @doc("The discriminated object type, which is always 'json_object' for this format.")
+  type: "json_object";
 }
 
 @doc("""

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-12-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-12-01-preview/generated.json
@@ -1696,6 +1696,16 @@
       ],
       "x-ms-discriminator-value": "function"
     },
+    "ChatCompletionsJsonResponseFormat": {
+      "type": "object",
+      "description": "A response format for Chat Completions that restricts responses to emitting valid JSON objects.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatCompletionsResponseFormat"
+        }
+      ],
+      "x-ms-discriminator-value": "json_object"
+    },
     "ChatCompletionsOptions": {
       "type": "object",
       "description": "The configuration information for a chat completions request.\nCompletions support a wide variety of tasks and generate text that continues from or \"completes\"\nprovided prompt data.",
@@ -1810,28 +1820,28 @@
       ]
     },
     "ChatCompletionsResponseFormat": {
-      "type": "string",
-      "description": "The valid response formats Chat Completions can provide. Used to enable JSON mode.",
-      "enum": [
-        "text",
-        "json_object"
+      "type": "object",
+      "description": "An abstract representation of a response format configuration usable by Chat Completions. Can be used to enable JSON\nmode.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The discriminated type for the response format."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "ChatCompletionsTextResponseFormat": {
+      "type": "object",
+      "description": "The standard Chat Completions response format that can freely generate text and is not guaranteed to produce responses\nfollowing a specific schema.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatCompletionsResponseFormat"
+        }
       ],
-      "x-ms-enum": {
-        "name": "ChatCompletionsResponseFormat",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "text",
-            "value": "text",
-            "description": "Use the default, plain text response format."
-          },
-          {
-            "name": "jsonObject",
-            "value": "json_object",
-            "description": "Use a response format that guarantees emission of a valid JSON object. Only structure is guaranteed and contents must\nstill be validated."
-          }
-        ]
-      }
+      "x-ms-discriminator-value": "text"
     },
     "ChatCompletionsToolCall": {
       "type": "object",

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-12-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-12-01-preview/generated.json
@@ -1835,7 +1835,7 @@
     },
     "ChatCompletionsTextResponseFormat": {
       "type": "object",
-      "description": "The standard Chat Completions response format that can freely generate text and is not guaranteed to produce responses\nfollowing a specific schema.",
+      "description": "The standard Chat Completions response format that can freely generate text and is not guaranteed to produce response\ncontent that adheres to a specific schema.",
       "allOf": [
         {
           "$ref": "#/definitions/ChatCompletionsResponseFormat"


### PR DESCRIPTION
Reference: https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format

`response_format` has valid values of `{ "type": "text" }` and `{ "type": "json_object" }`. I unwittingly simplified this to an effective `"text" | "json_object"` in our TypeSpec, which ultimately leads to request errors when attempting to set the type.

This change addresses the problem by consistently aligning with the discriminated type pattern: `ChatCompletionsResponseFormat` is an "abstract" model with a `@discriminator` for `type` while `ChatCompletionsTextResponseFormat` and `ChatCompletionsJsonResponseFormat` are extended types. It's a bit odd to have no additional data *beyond* the discriminator itself set in that manner, but this is the right way to get emission to cooperate and also retains the proper flexibility if configurable response formats are introduced in the future.