### PR TITLE
[TypeSpec Validation] Remove incorrect folder name exclusion

### DIFF
--- a/eng/tools/typespec-validation/src/rules/folder-structure.ts
+++ b/eng/tools/typespec-validation/src/rules/folder-structure.ts
@@ -47,10 +47,7 @@ export class FolderStructureRule implements Rule {
     }
 
     // Verify second level folder is capitalized after each '.'
-    if (
-      /(^|\. *)([a-z])/g.test(packageFolder) &&
-      !["data-plane", "resource-manager"].includes(packageFolder)
-    ) {
+    if (/(^|\. *)([a-z])/g.test(packageFolder)) {
       success = false;
       errorOutput += `Invalid folder name. Folders under specification/${folderStruct[1]} must be capitalized after each '.'\n`;
     }

--- a/eng/tools/typespec-validation/test/folder-structure.test.ts
+++ b/eng/tools/typespec-validation/test/folder-structure.test.ts
@@ -78,6 +78,23 @@ describe("folder-structure", function () {
     assert(result.errorOutput.includes("must be capitalized"));
   });
 
+  it("should fail if second level folder is resource-manager", async function () {
+    let host = new TsvTestHost();
+    host.globby = async () => {
+      return ["/foo/bar/tspconfig.yaml"];
+    };
+    host.normalizePath = () => {
+      return "/gitroot";
+    };
+
+    const result = await new FolderStructureRule().execute(
+      host,
+      "/gitroot/specification/foo/resource-manager",
+    );
+    assert(result.errorOutput);
+    assert(result.errorOutput.includes("must be capitalized"));
+  });
+
   it("should fail if Shared does not follow Management ", async function () {
     let host = new TsvTestHost();
     host.globby = async () => {

--- a/eng/tools/typespec-validation/test/folder-structure.test.ts
+++ b/eng/tools/typespec-validation/test/folder-structure.test.ts
@@ -78,6 +78,23 @@ describe("folder-structure", function () {
     assert(result.errorOutput.includes("must be capitalized"));
   });
 
+  it("should fail if second level folder is data-plane", async function () {
+    let host = new TsvTestHost();
+    host.globby = async () => {
+      return ["/foo/bar/tspconfig.yaml"];
+    };
+    host.normalizePath = () => {
+      return "/gitroot";
+    };
+
+    const result = await new FolderStructureRule().execute(
+      host,
+      "/gitroot/specification/foo/data-plane",
+    );
+    assert(result.errorOutput);
+    assert(result.errorOutput.includes("must be capitalized"));
+  });
+
   it("should fail if second level folder is resource-manager", async function () {
     let host = new TsvTestHost();
     host.globby = async () => {


### PR DESCRIPTION
- Rule was confusing a folder that is allowed to exist, with a folder that is allowed to contain TypeSpec
- Fixes #27072
