### PR TITLE
fix(healthinsights): add @lroResult

### DIFF
--- a/specification/ai/HealthInsights/HealthInsights.OncoPhenotype/model.oncophenotype.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.OncoPhenotype/model.oncophenotype.tsp
@@ -1,6 +1,7 @@
 import "../HealthInsights.Common/model.common.request.tsp";
 import "../HealthInsights.Common/model.common.response.tsp";
 import "../HealthInsights.Common/model.common.shared.tsp";
+import "@azure-tools/typespec-azure-core";
 
 using TypeSpec.Rest;
 
@@ -21,6 +22,7 @@ model OncoPhenotypeResult {
 
   @doc("The inference results for the Onco Phenotype request.")
   @visibility("read")
+  @Azure.Core.lroResult
   results?: OncoPhenotypeResults;
 }
 

--- a/specification/ai/HealthInsights/HealthInsights.OncoPhenotype/model.oncophenotype.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.OncoPhenotype/model.oncophenotype.tsp
@@ -4,6 +4,7 @@ import "../HealthInsights.Common/model.common.shared.tsp";
 import "@azure-tools/typespec-azure-core";
 
 using TypeSpec.Rest;
+using Azure.Core;
 
 namespace AzureHealthInsights;
 
@@ -22,7 +23,7 @@ model OncoPhenotypeResult {
 
   @doc("The inference results for the Onco Phenotype request.")
   @visibility("read")
-  @Azure.Core.lroResult
+  @lroResult
   results?: OncoPhenotypeResults;
 }
 

--- a/specification/ai/HealthInsights/HealthInsights.TrialMatcher/model.trialmatcher.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.TrialMatcher/model.trialmatcher.tsp
@@ -4,6 +4,7 @@ import "../HealthInsights.Common/model.common.shared.tsp";
 import "@azure-tools/typespec-azure-core";
 
 using TypeSpec.Rest;
+using Azure.Core;
 
 namespace AzureHealthInsights;
 
@@ -35,7 +36,7 @@ model TrialMatcherResult {
 
   @doc("The inference results for the Trial Matcher request.")
   @visibility("read")
-  @Azure.Core.lroResult
+  @lroResult
   results?: TrialMatcherResults;
 }
 

--- a/specification/ai/HealthInsights/HealthInsights.TrialMatcher/model.trialmatcher.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.TrialMatcher/model.trialmatcher.tsp
@@ -1,6 +1,7 @@
 import "../HealthInsights.Common/model.common.request.tsp";
 import "../HealthInsights.Common/model.common.response.tsp";
 import "../HealthInsights.Common/model.common.shared.tsp";
+import "@azure-tools/typespec-azure-core";
 
 using TypeSpec.Rest;
 
@@ -34,6 +35,7 @@ model TrialMatcherResult {
 
   @doc("The inference results for the Trial Matcher request.")
   @visibility("read")
+  @Azure.Core.lroResult
   results?: TrialMatcherResults;
 }
 


### PR DESCRIPTION
# Data Plane API - Pull Request
Add `@lroResult` to identify the final results of LRO operations, because:
- otherwise, the `LroMetadata.finalResult` will be null under tsp `0.51.0`
- `results` are the actual return value we want for the LRO operations, not the envelope result.

Let's take `Azure.Health.Insights.ClinicalMatching` as an example. `public virtual Operation<TrialMatcherResult> MatchTrials` will be changed to `public virtual Operation MatchTrials`, if we just upgrade to Typespec `0.51.0`. The return value is lost, because `LroMetadata.finalResult` is null.

![image](https://github.com/Azure/azure-rest-api-specs/assets/4516/c4070e4d-0a88-4367-b500-17a23e17d763)

---

If we add `@lroResult` (like what we do in this PR), the change is like follows:
![image](https://github.com/Azure/azure-rest-api-specs/assets/4516/bc5fb72c-7050-48cb-a0bd-5d19a83038e1)

The return type is changed from `TrialMatcherResult` to `TrialMatcherResults`.
- [TrialMatcherResult](https://github.com/Azure/azure-rest-api-specs/blob/e62b17a09302b9bacca3504135091d1a71eeaebf/specification/ai/HealthInsights/HealthInsights.TrialMatcher/model.trialmatcher.tsp#L32-L38) is the status monitor model, e.g. the envelope model. That's not what we should return in SDK.
- [TrialMatcherResults](https://github.com/Azure/azure-rest-api-specs/blob/e62b17a09302b9bacca3504135091d1a71eeaebf/specification/ai/HealthInsights/HealthInsights.TrialMatcher/model.trialmatcher.tsp#L41-L50) is actually [TrialMatcherResult.results](https://github.com/Azure/azure-rest-api-specs/blob/e62b17a09302b9bacca3504135091d1a71eeaebf/specification/ai/HealthInsights/HealthInsights.TrialMatcher/model.trialmatcher.tsp#L37), that's the return type we want in SDK

## API Info: The Basics
Most of the information about your service should be captured in the issue that serves as your [*API Spec engagement record*](https://aka.ms/azsdk/onboarding/restapischedule).

* Link to API Spec engagement record issue:

Is this review for (select one):

- [ ] a private preview
- [x] a public preview
- [ ] GA release

### Change Scope

<sup>This section will help us focus on the specific parts of your API that are new or have been modified. <br/>Please share a link to the design document for the new APIs, a link to the previous API Spec document (if applicable), and the root paths that have been updated. </sup>
* Design Document:
* Previous API Spec Doc:
* Updated paths:

### Viewing API changes

For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 

### Suppressing failures

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
[Swagger-Suppression-Process](https://aka.ms/pr-suppressions) 
to get approval.

## ❔Got questions? Need additional info?? We are here to help!

<details>
  <summary> Contact us!</summary>

The [Azure API Review Board](https://aka.ms/azsdk/onboarding/restapischedule) is dedicated to helping you create amazing APIs. You can read about our mission and learn more about our process on our [wiki](https://aka.ms/azsdk/onboarding/restapischedule).
* 💬 [Teams Channel](https://teams.microsoft.com/l/channel/19%3a3ebb18fded0e47938f998e196a52952f%40thread.tacv2/General?groupId=1a10b50c-e870-4fe0-8483-bf5542a8d2d8&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
* 💌 [email](mailto://azureapirbcore@microsoft.com)

</details>

<details>
  <summary>Click here for links to tools, specs, guidelines & other good stuff</summary>

### Tooling

 * [Open API validation tools](https://aka.ms/swaggertools) were run on this PR. Go here to see [how to fix errors](https://aka.ms/ci-fix)
 * [Spectral Linting](https://github.com/Azure/azure-api-style-guide/blob/main/README.md)
 * [Open API Hub](https://aka.ms/openapiportal)

### Guidelines & Specifications

 * [Azure REST API Guidelines](https://aka.ms/azapi/guidelines)
 * [OpenAPI Style Guidelines](https://aka.ms/azapi/style)
 * [Azure Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy)

### Helpful Links

 * [Azure DevTools Wiki](https://aka.ms/azapi)

</details>

<details>
  <summary>Checks stuck in `queued` state?</summary>
If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.  
</details>
