### PR TITLE
Azure OpenAI: align to removal of "finish_details" for gpt-4-vision-preview

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
@@ -236,15 +236,6 @@ model ChatChoice {
   @projectedName("json", "finish_reason")
   finishReason: CompletionsFinishReason | null;
 
-  // Note: this property is currently speculative via observation and not yet documented anywhere.
-  @doc("""
-  The reason the model stopped generating tokens, together with any applicable details.
-  This structured representation replaces 'finish_reason' for some models.
-  """)
-  @added(ServiceApiVersions.v2023_12_01_Preview)
-  @projectedName("json", "finish_details")
-  finishDetails?: ChatFinishDetails;
-
   @doc("The delta message content for a streaming response.")
   @projectedName("json", "delta")
   @projectedName("csharp", "InternalStreamingDeltaMessage")

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-12-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-12-01-preview/generated.json
@@ -1586,11 +1586,6 @@
           "x-nullable": true,
           "x-ms-client-name": "finishReason"
         },
-        "finish_details": {
-          "$ref": "#/definitions/ChatFinishDetails",
-          "description": "The reason the model stopped generating tokens, together with any applicable details.\nThis structured representation replaces 'finish_reason' for some models.",
-          "x-ms-client-name": "finishDetails"
-        },
         "delta": {
           "$ref": "#/definitions/ChatResponseMessage",
           "description": "The delta message content for a streaming response."
@@ -1864,20 +1859,6 @@
     "ChatCompletionsToolDefinition": {
       "type": "object",
       "description": "An abstract representation of a tool that can be used by the model to improve a chat completions response.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "The object type."
-        }
-      },
-      "discriminator": "type",
-      "required": [
-        "type"
-      ]
-    },
-    "ChatFinishDetails": {
-      "type": "object",
-      "description": "An abstract representation of structured information about why a chat completions response terminated.",
       "properties": {
         "type": {
           "type": "string",
@@ -3085,16 +3066,6 @@
         ]
       }
     },
-    "MaxTokensFinishDetails": {
-      "type": "object",
-      "description": "A structured representation of a stop reason that signifies a token limit was reached before the model could naturally\ncomplete.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/ChatFinishDetails"
-        }
-      ],
-      "x-ms-discriminator-value": "max_tokens"
-    },
     "OnYourDataApiKeyAuthenticationOptions": {
       "type": "object",
       "description": "The authentication options for Azure OpenAI On Your Data when using an API key.",
@@ -3461,25 +3432,6 @@
           }
         }
       }
-    },
-    "StopFinishDetails": {
-      "type": "object",
-      "description": "A structured representation of a stop reason that signifies natural termination by the model.",
-      "properties": {
-        "stop": {
-          "type": "string",
-          "description": "The token sequence that the model terminated with."
-        }
-      },
-      "required": [
-        "stop"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ChatFinishDetails"
-        }
-      ],
-      "x-ms-discriminator-value": "stop"
     }
   },
   "parameters": {


### PR DESCRIPTION
At release and until recently, `gpt-4-vision-preview` provided a response body value named `finish_details` in lieu of the conventional `finish_reason`. We included this in our specification based on observation but it's now removed in favor of alignment with the older structure.

This change simply removes the temporary addition. It's a breaking change to spec, but it reflects an actual hard breaking change to the preview/beta model behavior.