### PR TITLE
HCRP: Generate SDK for Machines PUT / PATCH

### DIFF
--- a/specification/hybridcompute/resource-manager/readme.csharp.md
+++ b/specification/hybridcompute/resource-manager/readme.csharp.md
@@ -17,6 +17,4 @@ csharp:
 directive:
   - remove-operation: 
     - Machines_Reconnect
-    - Machines_CreateOrUpdate
-    - Machines_Update
 ```

--- a/specification/hybridcompute/resource-manager/readme.go.md
+++ b/specification/hybridcompute/resource-manager/readme.go.md
@@ -11,8 +11,6 @@ go:
   directive:
   - remove-operation: 
     - Machines_Reconnect
-    - Machines_CreateOrUpdate
-    - Machines_Update
 ```
 
 ``` yaml $(go) && $(track2)

--- a/specification/hybridcompute/resource-manager/readme.java.md
+++ b/specification/hybridcompute/resource-manager/readme.java.md
@@ -14,8 +14,6 @@ output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-hybridcompute
 directive:
   - remove-operation: 
     - Machines_Reconnect
-    - Machines_CreateOrUpdate
-    - Machines_Update
 ```
 
 ## Java multi-api

--- a/specification/hybridcompute/resource-manager/readme.python.md
+++ b/specification/hybridcompute/resource-manager/readme.python.md
@@ -22,8 +22,6 @@ output-folder: $(python-sdks-folder)/hybridcompute/azure-mgmt-hybridcompute/azur
 directive:
   - remove-operation: 
     - Machines_Reconnect
-    - Machines_CreateOrUpdate
-    - Machines_Update
 ```
 
 ``` yaml $(python)

--- a/specification/hybridcompute/resource-manager/readme.ruby.md
+++ b/specification/hybridcompute/resource-manager/readme.ruby.md
@@ -9,6 +9,4 @@ azure-arm: true
 directive:
   - remove-operation: 
     - Machines_Reconnect
-    - Machines_CreateOrUpdate
-    - Machines_Update
 ```

--- a/specification/hybridcompute/resource-manager/readme.typescript.md
+++ b/specification/hybridcompute/resource-manager/readme.typescript.md
@@ -13,8 +13,6 @@ typescript:
 directive:
   - remove-operation:
     - Machines_Reconnect
-    - Machines_CreateOrUpdate
-    - Machines_Update
 ```
 
 ``` yaml $(typescript) && !$(profile-content)


### PR DESCRIPTION
## Generate SDK for Machines PUT and PATCH

With the introduction of child resource to HCRP Machines, we need the ability to create Machines from ARM, if the user is creating a VMInstance of a particular kind (VMWare, AVS, SCVMM, HCI, etc.). Also, we need to update the Identity to SystemAssigned and public key property.
We need to generate the code for PUT and PATCH for Machines.

We are removing the blacklist for these operations from the `readme.md` so that the generated sdks for each of the programming languages contain these operations.
