### PR TITLE
[Document Intelligence] Add client operations to analyze/classify local documents

### DIFF
--- a/specification/ai/DocumentIntelligence/client.tsp
+++ b/specification/ai/DocumentIntelligence/client.tsp
@@ -20,9 +20,13 @@ namespace ClientCustomizations;
 })
 interface DocumentIntelligenceClient {
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
-  analyzeDocument is DocumentModels.analyzeDocument;
+  analyzeDocumentFromUrl is DocumentModels.analyzeDocument;
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
-  classifyDocument is DocumentClassifiers.classifyDocument;
+  analyzeDocument is DocumentModels.analyzeDocumentFromStream;
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  classifyDocumentFromUrl is DocumentClassifiers.classifyDocument;
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  classifyDocument is DocumentClassifiers.classifyDocumentFromStream;
 }
 
 @client({


### PR DESCRIPTION
DI client has one operation in analyzing/classifying document, which content type targets to  `application/json`. But this content type doesn't fit when analyzing/classifying documents from local, it should be another operation "analyzeDocumentFromStream" in this case. 

To differentiate the two LROs in SDK, I added an operation in analyzing and classifying document. The operation names are: 
- analyzeDocument/classifyDocument -  for analyzing/classifying local docs
- analyzeDocumentFromUrl/classifyDocumentFromUrl for analyzing/classifying remote docs

so that they are consistent with the operations in old SDK - Form Recognizer.