### PR TITLE
Azure OpenAI: change ChatMessageImageUrl.url to be a string rather than url (base64 support)

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/client/custom_visibility.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/client/custom_visibility.tsp
@@ -31,30 +31,21 @@ namespace Azure.OpenAI;
 @@access(AudioTranslation, Access.public, "java");
 @@access(AudioTranslationOptions, Access.public, "java");
 
-@@access(AzureCognitiveSearchIndexFieldMappingOptions,
-  Access.public
-);
+@@access(AzureCognitiveSearchIndexFieldMappingOptions, Access.public);
 @@usage(AzureCognitiveSearchIndexFieldMappingOptions, Usage.input);
 
 @@access(AzureCognitiveSearchQueryType, Access.public);
 @@usage(AzureCognitiveSearchQueryType, Usage.input);
 
-@@access(AzureCognitiveSearchChatExtensionConfiguration,
-  Access.public
-);
-@@usage(AzureCognitiveSearchChatExtensionConfiguration,
-  Usage.input
-);
+@@access(AzureCognitiveSearchChatExtensionConfiguration, Access.public);
+@@usage(AzureCognitiveSearchChatExtensionConfiguration, Usage.input);
 
 // .NET maps the input bifurcation of URL vs. image data via distinct parameterization; it should hide the combined
 // string-based container used on the wire and plumb the relevant information through the parent content item.
 @@access(ChatMessageImageUrl, Access.internal, "csharp");
 
 // Remap "model" nomenclature to "DeploymentName" in appropriate containers; comments should clarify the dual use
-@@projectedName(ImageGenerationOptions.`model`,
-  "csharp",
-  "DeploymentName"
-);
+@@projectedName(ImageGenerationOptions.`model`, "csharp", "DeploymentName");
 
 @@projectedName(ChatResponseMessage.context,
   "csharp",
@@ -63,29 +54,20 @@ namespace Azure.OpenAI;
 
 @@projectedName(AudioTranscriptionFormat.json, "csharp", "Simple");
 
-@@projectedName(AudioTranscriptionFormat.verbose_json,
-  "csharp",
-  "Verbose"
-);
+@@projectedName(AudioTranscriptionFormat.verbose_json, "csharp", "Verbose");
 
-@@projectedName(AudioTranscriptionFormat.text,
-  "csharp",
-  "InternalPlainText"
-);
+@@projectedName(AudioTranscriptionFormat.text, "csharp", "InternalPlainText");
 
 @@projectedName(AudioTranslationFormat.json, "csharp", "Simple");
 
-@@projectedName(AudioTranslationFormat.verbose_json,
-  "csharp",
-  "Verbose"
-);
+@@projectedName(AudioTranslationFormat.verbose_json, "csharp", "Verbose");
 
-@@projectedName(AudioTranslationFormat.text,
-  "csharp",
-  "InternalPlainText"
-);
+@@projectedName(AudioTranslationFormat.text, "csharp", "InternalPlainText");
 
 // .NET maps the input bifurcation of URL vs. image data via distinct parameterization; it should hide the combined
 // string-based container used on the wire and plumb the relevant information through the parent content item.
 @@projectedName(ChatMessageImageUrl, "csharp", "InternalChatMessageImageUrl");
-@@projectedName(ChatMessageImageContentItem.imageUrl, "csharp", "InternalImageUrlOrData");
+@@projectedName(ChatMessageImageContentItem.imageUrl,
+  "csharp",
+  "InternalImageUrlOrData"
+);

--- a/specification/cognitiveservices/OpenAI.Inference/client/custom_visibility.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/client/custom_visibility.tsp
@@ -3,77 +3,89 @@ import "../main.tsp";
 
 using Azure.ClientGenerator.Core;
 
+#suppress "@azure-tools/typespec-azure-core/casing-style" "OpenAI is a case-sensitive name"
+namespace Azure.OpenAI;
+
 // Azure-specific Chat Completions with extensions should be handled by clients as a conditional selection within the
 // shared Chat Completions route, with the selection gated by the presence or non-presence of additional child
 // configuration options on the request payload options model.
-@@access(Azure.OpenAI.getChatCompletionsWithAzureExtensions, Access.internal);
+@@access(getChatCompletionsWithAzureExtensions, Access.internal);
 
 // In C#, the functionality provided by the `response_format` property used in image generations is handled by unique
 // method signatures for the different response types (i.e. blob URL versus base64 methods).
-@@access(Azure.OpenAI.ImageGenerationResponseFormat, Access.internal, "csharp");
+@@access(ImageGenerationResponseFormat, Access.internal, "csharp");
 
 // Some models from routes with suppressed visibility are still desired for custom public surface.
-@@access(Azure.OpenAI.ImageGenerationOptions, Access.public);
-@@usage(Azure.OpenAI.ImageGenerationOptions, Usage.input | Usage.output);
-@@access(Azure.OpenAI.ImageSize, Access.public);
-@@usage(Azure.OpenAI.ImageGenerations, Usage.input | Usage.output);
+@@access(ImageGenerationOptions, Access.public);
+@@usage(ImageGenerationOptions, Usage.input | Usage.output);
+@@access(ImageSize, Access.public);
+@@usage(ImageGenerations, Usage.input | Usage.output);
 
 // The purpose of this enum is to identify the type of a given result. In C#, this is redundant because we have
 // strongly-typed classes for each possible result.
-@@access(Azure.OpenAI.AudioTaskLabel, Access.internal, "csharp");
+@@access(AudioTaskLabel, Access.internal, "csharp");
 
 // Java will need to have those models expose in public surface.
-@@access(Azure.OpenAI.AudioTranscription, Access.public, "java");
-@@access(Azure.OpenAI.AudioTranscriptionOptions, Access.public, "java");
-@@access(Azure.OpenAI.AudioTranslation, Access.public, "java");
-@@access(Azure.OpenAI.AudioTranslationOptions, Access.public, "java");
+@@access(AudioTranscription, Access.public, "java");
+@@access(AudioTranscriptionOptions, Access.public, "java");
+@@access(AudioTranslation, Access.public, "java");
+@@access(AudioTranslationOptions, Access.public, "java");
 
-@@access(Azure.OpenAI.AzureCognitiveSearchIndexFieldMappingOptions,
+@@access(AzureCognitiveSearchIndexFieldMappingOptions,
   Access.public
 );
-@@usage(Azure.OpenAI.AzureCognitiveSearchIndexFieldMappingOptions, Usage.input);
+@@usage(AzureCognitiveSearchIndexFieldMappingOptions, Usage.input);
 
-@@access(Azure.OpenAI.AzureCognitiveSearchQueryType, Access.public);
-@@usage(Azure.OpenAI.AzureCognitiveSearchQueryType, Usage.input);
+@@access(AzureCognitiveSearchQueryType, Access.public);
+@@usage(AzureCognitiveSearchQueryType, Usage.input);
 
-@@access(Azure.OpenAI.AzureCognitiveSearchChatExtensionConfiguration,
+@@access(AzureCognitiveSearchChatExtensionConfiguration,
   Access.public
 );
-@@usage(Azure.OpenAI.AzureCognitiveSearchChatExtensionConfiguration,
+@@usage(AzureCognitiveSearchChatExtensionConfiguration,
   Usage.input
 );
 
+// .NET maps the input bifurcation of URL vs. image data via distinct parameterization; it should hide the combined
+// string-based container used on the wire and plumb the relevant information through the parent content item.
+@@access(ChatMessageImageUrl, Access.internal, "csharp");
+
 // Remap "model" nomenclature to "DeploymentName" in appropriate containers; comments should clarify the dual use
-@@projectedName(Azure.OpenAI.ImageGenerationOptions.`model`,
+@@projectedName(ImageGenerationOptions.`model`,
   "csharp",
   "DeploymentName"
 );
 
-@@projectedName(Azure.OpenAI.ChatResponseMessage.context,
+@@projectedName(ChatResponseMessage.context,
   "csharp",
   "AzureExtensionsContext"
 );
 
-@@projectedName(Azure.OpenAI.AudioTranscriptionFormat.json, "csharp", "Simple");
+@@projectedName(AudioTranscriptionFormat.json, "csharp", "Simple");
 
-@@projectedName(Azure.OpenAI.AudioTranscriptionFormat.verbose_json,
+@@projectedName(AudioTranscriptionFormat.verbose_json,
   "csharp",
   "Verbose"
 );
 
-@@projectedName(Azure.OpenAI.AudioTranscriptionFormat.text,
+@@projectedName(AudioTranscriptionFormat.text,
   "csharp",
   "InternalPlainText"
 );
 
-@@projectedName(Azure.OpenAI.AudioTranslationFormat.json, "csharp", "Simple");
+@@projectedName(AudioTranslationFormat.json, "csharp", "Simple");
 
-@@projectedName(Azure.OpenAI.AudioTranslationFormat.verbose_json,
+@@projectedName(AudioTranslationFormat.verbose_json,
   "csharp",
   "Verbose"
 );
 
-@@projectedName(Azure.OpenAI.AudioTranslationFormat.text,
+@@projectedName(AudioTranslationFormat.text,
   "csharp",
   "InternalPlainText"
 );
+
+// .NET maps the input bifurcation of URL vs. image data via distinct parameterization; it should hide the combined
+// string-based container used on the wire and plumb the relevant information through the parent content item.
+@@projectedName(ChatMessageImageUrl, "csharp", "InternalChatMessageImageUrl");
+@@projectedName(ChatMessageImageContentItem.imageUrl, "csharp", "InternalImageUrlOrData");

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_messages.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_messages.tsp
@@ -64,11 +64,11 @@ model ChatMessageImageContentItem extends ChatMessageContentItem {
   imageUrl: ChatMessageImageUrl;
 }
 
-@doc("An internet location from which the model may retrieve an image.")
+@doc("A representation of the image data in a chat message content item.")
 @added(ServiceApiVersions.v2023_12_01_Preview)
 model ChatMessageImageUrl {
-  @doc("The URL of the image.")
-  url: url;
+  @doc("The URL or base64-encoded binary data of the image.")
+  url: string;
 
   @doc("""
   The evaluation quality setting to use, which controls relative prioritization of speed, token consumption, and


### PR DESCRIPTION
In our original specification of `ChatMessageImageUrl`'s `url` field (matching the structure of [OpenAI's image_url schema component](https://github.com/openai/openai-openapi/blob/f4a2833d00e92c4b1cb531d437da88a03de997d8/openapi.yaml#L5354)), we intuitively described it as a `url` type.

Trouble arises because `url` supports base64-encoded data URLs in addition to the standard format, while several language projections directly infer things like `URI` as the language type.

Pending further discussion on whether we can generalize tooling support for "url" to include data, this change simply loosens the type to be a plain `string` such that languages can transparently support either format.