### PR TITLE
[TypeSpec Requirement] Cache github queries, set job display name, remove incorrect step condition

### DIFF
--- a/eng/pipelines/typespec-requirement.yml
+++ b/eng/pipelines/typespec-requirement.yml
@@ -2,6 +2,7 @@ trigger: none
 
 jobs:
 - job: TypeSpec_Requirement
+  displayName: TypeSpec Requirement
   pool:
     name: azsdk-pool-mms-ubuntu-2204-general
     vmImage: ubuntu-22.04

--- a/eng/pipelines/typespec-requirement.yml
+++ b/eng/pipelines/typespec-requirement.yml
@@ -11,4 +11,3 @@ jobs:
       $(Build.SourcesDirectory)/eng/scripts/TypeSpec-Requirement.ps1
     displayName: TypeSpec Requirement
     ignoreLASTEXITCODE: true
-    condition: succeededOrFailed()

--- a/eng/scripts/TypeSpec-Requirement.ps1
+++ b/eng/scripts/TypeSpec-Requirement.ps1
@@ -18,6 +18,7 @@ if (!$filesToCheck) {
   LogInfo "No OpenAPI files found to check"
 }
 else {
+  # Cache responses to GitHub web requests, for efficiency and to prevent rate limiting
   $responseCache = @{}
 
   # Example: specification/foo/resource-manager/Microsoft.Foo/stable/2023-01-01/Foo.json

--- a/eng/scripts/TypeSpec-Requirement.ps1
+++ b/eng/scripts/TypeSpec-Requirement.ps1
@@ -40,7 +40,6 @@ else {
     # Example: specification/foo/resource-manager/Microsoft.Foo
     $pathToServiceName = ($file -split '/')[0..3] -join '/'
 
-    # ToDo: Fetch main and query local git repo to prevent issues with rate limiting
     $urlToStableFolder = "https://github.com/Azure/azure-rest-api-specs/tree/main/$pathToServiceName/stable"
 
     LogInfo "  Checking $urlToStableFolder"

--- a/eng/scripts/TypeSpec-Requirement.ps1
+++ b/eng/scripts/TypeSpec-Requirement.ps1
@@ -18,6 +18,8 @@ if (!$filesToCheck) {
   LogInfo "No OpenAPI files found to check"
 }
 else {
+  $responseCache = @{}
+
   # Example: specification/foo/resource-manager/Microsoft.Foo/stable/2023-01-01/Foo.json
   # - Forward slashes on both Linux and Windows
   foreach ($file in $filesToCheck) {
@@ -27,10 +29,6 @@ else {
 
     if ($null -ne ${jsonContent}?["info"]?["x-typespec-generated"]) {
       LogInfo "  OpenAPI was generated from TypeSpec (contains '/info/x-typespec-generated')"
-
-      # ToDo: Verify spec folder includes *.tsp and tspconfig.yaml, to prevent spec authors committing
-      # openapi generated from TypeSpec, without also including the TypeSpec sources.
-
       # Skip further checks, since spec is already using TypeSpec
       continue
     }
@@ -44,23 +42,37 @@ else {
     # ToDo: Fetch main and query local git repo to prevent issues with rate limiting
     $urlToStableFolder = "https://github.com/Azure/azure-rest-api-specs/tree/main/$pathToServiceName/stable"
 
-    try {
-      $response = Invoke-WebRequest -Uri $urlToStableFolder -Method Head -SkipHttpErrorCheck
-      if ($response.StatusCode -eq 200) {
-        LogInfo "  Branch 'main' contains path '$pathToServiceName/stable', so spec already exists and is not required to use TypeSpec"
+    LogInfo "  Checking $urlToStableFolder"
+
+    $responseStatus = $responseCache[$urlToStableFolder];
+    if ($null -ne $responseStatus) {
+      LogInfo "    Found in cache"
+    }
+    else {
+      LogInfo "    Not found in cache, making web request"
+      try {
+        $response = Invoke-WebRequest -Uri $urlToStableFolder -Method Head -SkipHttpErrorCheck
+        $responseStatus = $response.StatusCode
+        $responseCache[$urlToStableFolder] = $responseStatus
       }
-      elseif ($response.StatusCode -eq 404) {
-        LogInfo "  Branch 'main' does not contain path '$pathToServiceName/stable', so spec is new and must use TypeSpec"
-        $pathsWithErrors += $file
-      }
-      else {
-        LogError "Unexpected response from ${urlToStableFolder}: ${response.StatusCode}"
+      catch {
+        LogError "  Exception making web request to ${urlToStableFolder}: $_"
         LogJobFailure
         exit 1
       }
     }
-    catch {
-      LogError "  Exception making web request to ${urlToStableFolder}: $_"
+
+    LogInfo "    Status: $responseStatus"
+
+    if ($responseStatus -eq 200) {
+      LogInfo "  Branch 'main' contains path '$pathToServiceName/stable', so spec already exists and is not required to use TypeSpec"
+    }
+    elseif ($response.StatusCode -eq 404) {
+      LogInfo "  Branch 'main' does not contain path '$pathToServiceName/stable', so spec is new and must use TypeSpec"
+      $pathsWithErrors += $file
+    }
+    else {
+      LogError "Unexpected response from ${urlToStableFolder}: ${response.StatusCode}"
       LogJobFailure
       exit 1
     }


### PR DESCRIPTION
- Fixes #27256 
- Cache github queries
- Set job display name
- Remove incorrect step condition

Example:
```
$ pwsh eng/scripts/TypeSpec-Requirement.ps1
Checking specification/chaos/resource-manager/Microsoft.Chaos/stable/2023-11-01/operationStatuses.json
  OpenAPI was not generated from TypeSpec (missing '/info/x-typespec-generated')
  Checking https://github.com/Azure/azure-rest-api-specs/tree/main/specification/chaos/resource-manager/Microsoft.Chaos/stable
    Not found in cache, making web request
    Status: 200
  Branch 'main' contains path 'specification/chaos/resource-manager/Microsoft.Chaos/stable', so spec already exists and is not required to use TypeSpec
Checking specification/chaos/resource-manager/Microsoft.Chaos/stable/2024-01-01/capabilities.json
  OpenAPI was not generated from TypeSpec (missing '/info/x-typespec-generated')
  Checking https://github.com/Azure/azure-rest-api-specs/tree/main/specification/chaos/resource-manager/Microsoft.Chaos/stable
    Found in cache
    Status: 200
  Branch 'main' contains path 'specification/chaos/resource-manager/Microsoft.Chaos/stable', so spec already exists and is not required to use TypeSpec
Checking specification/chaos/resource-manager/Microsoft.Chaos/stable/2024-01-01/capabilityTypes.json
  OpenAPI was not generated from TypeSpec (missing '/info/x-typespec-generated')
  Checking https://github.com/Azure/azure-rest-api-specs/tree/main/specification/chaos/resource-manager/Microsoft.Chaos/stable
    Found in cache
    Status: 200
  Branch 'main' contains path 'specification/chaos/resource-manager/Microsoft.Chaos/stable', so spec already exists and is not required to use TypeSpec
```