### PR TITLE
Image Analysis TypeSpec - Fix minor typo in comments (Update: remove comment sentence)

### DIFF
--- a/specification/ai/ImageAnalysis/routes.tsp
+++ b/specification/ai/ImageAnalysis/routes.tsp
@@ -32,7 +32,7 @@ alias SharedAnalyzeQuery = {
   The desired language for result generation (a two-letter language code).
   If this option is not specified, the default value 'en' is used (English).
   See https://aka.ms/cv-languages for a list of supported languages.
-  At the moment, only tags can be generated in none-English languages.
+  At the moment, only tags can be generated in non-English languages.
   """)
   @minLength(2)
   language?: string = "en";

--- a/specification/ai/ImageAnalysis/routes.tsp
+++ b/specification/ai/ImageAnalysis/routes.tsp
@@ -32,7 +32,6 @@ alias SharedAnalyzeQuery = {
   The desired language for result generation (a two-letter language code).
   If this option is not specified, the default value 'en' is used (English).
   See https://aka.ms/cv-languages for a list of supported languages.
-  At the moment, only tags can be generated in non-English languages.
   """)
   @minLength(2)
   language?: string = "en";

--- a/specification/ai/data-plane/ImageAnalysis/stable/2023-10-01/generated.json
+++ b/specification/ai/data-plane/ImageAnalysis/stable/2023-10-01/generated.json
@@ -124,7 +124,7 @@
           {
             "name": "language",
             "in": "query",
-            "description": "The desired language for result generation (a two-letter language code).\nIf this option is not specified, the default value 'en' is used (English).\nSee https://aka.ms/cv-languages for a list of supported languages.\nAt the moment, only tags can be generated in non-English languages.",
+            "description": "The desired language for result generation (a two-letter language code).\nIf this option is not specified, the default value 'en' is used (English).\nSee https://aka.ms/cv-languages for a list of supported languages.",
             "required": false,
             "type": "string",
             "default": "en",
@@ -278,7 +278,7 @@
           {
             "name": "language",
             "in": "query",
-            "description": "The desired language for result generation (a two-letter language code).\nIf this option is not specified, the default value 'en' is used (English).\nSee https://aka.ms/cv-languages for a list of supported languages.\nAt the moment, only tags can be generated in non-English languages.",
+            "description": "The desired language for result generation (a two-letter language code).\nIf this option is not specified, the default value 'en' is used (English).\nSee https://aka.ms/cv-languages for a list of supported languages.",
             "required": false,
             "type": "string",
             "default": "en",

--- a/specification/ai/data-plane/ImageAnalysis/stable/2023-10-01/generated.json
+++ b/specification/ai/data-plane/ImageAnalysis/stable/2023-10-01/generated.json
@@ -124,7 +124,7 @@
           {
             "name": "language",
             "in": "query",
-            "description": "The desired language for result generation (a two-letter language code).\nIf this option is not specified, the default value 'en' is used (English).\nSee https://aka.ms/cv-languages for a list of supported languages.\nAt the moment, only tags can be generated in none-English languages.",
+            "description": "The desired language for result generation (a two-letter language code).\nIf this option is not specified, the default value 'en' is used (English).\nSee https://aka.ms/cv-languages for a list of supported languages.\nAt the moment, only tags can be generated in non-English languages.",
             "required": false,
             "type": "string",
             "default": "en",
@@ -278,7 +278,7 @@
           {
             "name": "language",
             "in": "query",
-            "description": "The desired language for result generation (a two-letter language code).\nIf this option is not specified, the default value 'en' is used (English).\nSee https://aka.ms/cv-languages for a list of supported languages.\nAt the moment, only tags can be generated in none-English languages.",
+            "description": "The desired language for result generation (a two-letter language code).\nIf this option is not specified, the default value 'en' is used (English).\nSee https://aka.ms/cv-languages for a list of supported languages.\nAt the moment, only tags can be generated in non-English languages.",
             "required": false,
             "type": "string",
             "default": "en",


### PR DESCRIPTION
This was called out by @kristapratico in PR code-review of the emitted Python SDK. Thank you Krista! Of course, this applies to all emitted SDK, so I would like to fix this in the TypeSpec file.
