### PR TITLE
documentintelligence, java, sync tspconfig with java repo

### DIFF
--- a/specification/ai/DocumentIntelligence/tspconfig.yaml
+++ b/specification/ai/DocumentIntelligence/tspconfig.yaml
@@ -28,6 +28,15 @@ options:
     namespace: "com.azure.ai.documentintelligence"
     enable-sync-stack: true
     custom-types-subpackage: "implementation.models"
+    polling:
+      buildDocumentModel:
+        final-type: com.azure.ai.documentintelligence.models.DocumentModelDetails
+      buildClassifier:
+        final-type: com.azure.ai.documentintelligence.models.DocumentClassifierDetails
+      composeModel:
+        final-type: com.azure.ai.documentintelligence.models.DocumentModelDetails
+      copyModelTo:
+        final-type: com.azure.ai.documentintelligence.models.DocumentModelDetails
   # Uncomment this line and add "@azure-tools/typespec-csharp" to your package.json to generate C# code
   # "@azure-tools/typespec-csharp": true
   # Uncomment this line and add "@azure-tools/typespec-ts" to your package.json to generate Typescript code


### PR DESCRIPTION
Java tsp-location https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/documentintelligence/azure-ai-documentintelligence/tsp-location.yaml

The tspconfig.yaml it points to is not on main https://github.com/Azure/azure-rest-api-specs/blob/a4879111ce38cd0350ced6278936ba36580218f9/specification/ai/DocumentIntelligence/tspconfig.yaml

Sync its content to main.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
