### PR TITLE
ImageAnalysis: Use property name `list` instead of `values` in some models, for Python

### DIFF
--- a/specification/ai/ImageAnalysis/models.tsp
+++ b/specification/ai/ImageAnalysis/models.tsp
@@ -82,6 +82,7 @@ The first caption always applies to the whole image.
 model DenseCaptionsResult {
   @doc("The list of image captions.")
   @minItems(1)
+  @projectedName("python", "list")
   values: Array<DenseCaption>;
 }
 
@@ -220,6 +221,7 @@ model ImageMetadata {
 model ObjectsResult {
   @doc("A list of physical object detected in an image and their location.")
   @minItems(0)
+  @projectedName("python", "list")
   values: Array<DetectedObject>;
 }
 
@@ -227,6 +229,7 @@ model ObjectsResult {
 model PeopleResult {
   @doc("A list of people detected in an image and their location.")
   @minItems(0)
+  @projectedName("python", "list")
   values: Array<DetectedPerson>;
 }
 
@@ -245,6 +248,7 @@ These regions preserve as much content as possible from the analyzed image, with
 model SmartCropsResult {
   @doc("A list of crop regions.")
   @minItems(1)
+  @projectedName("python", "list")
   values: Array<CropRegion>;
 }
 
@@ -273,6 +277,7 @@ that appear in the image.
 model TagsResult {
   @doc("A list of tags.")
   @minItems(0)
+  @projectedName("python", "list")
   values: Array<DetectedTag>;
 }
 


### PR DESCRIPTION
Use property name `list` instead of `values` in some of the models, for Python only, since the base class for all models in Python already has a property named `values` (see [ _MyMutableMapping](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/_model_base.py#L338C6-L338C24))
