### PR TITLE
update duration properties with "x-ms-format" : "duration-constant"

### DIFF
--- a/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/preview/2023-12-01-preview/managedapplication.json
+++ b/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/preview/2023-12-01-preview/managedapplication.json
@@ -1827,10 +1827,12 @@
     },
     "HealthCheckStableDuration": {
       "type": "string",
+      "x-ms-format" : "duration-constant",
       "description": "The amount of time that the application or cluster must remain healthy before the upgrade proceeds to the next upgrade domain. It is interpreted as a string representing an ISO 8601 duration with following format \"hh:mm:ss.fff\"."
     },
     "HealthCheckWaitDuration": {
       "type": "string",
+      "x-ms-format" : "duration-constant",
       "description": "The amount of time to wait after completing an upgrade domain before applying health policies. It is interpreted as a string representing an ISO 8601 duration with following format \"hh:mm:ss.fff\"."
     },
     "ManagedIdentity": {

--- a/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/preview/2023-12-01-preview/managedapplication.json
+++ b/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/preview/2023-12-01-preview/managedapplication.json
@@ -1827,12 +1827,12 @@
     },
     "HealthCheckStableDuration": {
       "type": "string",
-      "x-ms-format" : "duration-constant",
+      "x-ms-format": "duration-constant",
       "description": "The amount of time that the application or cluster must remain healthy before the upgrade proceeds to the next upgrade domain. It is interpreted as a string representing an ISO 8601 duration with following format \"hh:mm:ss.fff\"."
     },
     "HealthCheckWaitDuration": {
       "type": "string",
-      "x-ms-format" : "duration-constant",
+      "x-ms-format": "duration-constant",
       "description": "The amount of time to wait after completing an upgrade domain before applying health policies. It is interpreted as a string representing an ISO 8601 duration with following format \"hh:mm:ss.fff\"."
     },
     "ManagedIdentity": {

--- a/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/preview/2023-12-01-preview/managedcluster.json
+++ b/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/preview/2023-12-01-preview/managedcluster.json
@@ -992,12 +992,12 @@
       "properties": {
         "healthCheckWaitDuration": {
           "type": "string",
-          "x-ms-format" : "duration-constant",
+          "x-ms-format": "duration-constant",
           "description": "The length of time to wait after completing an upgrade domain before performing health checks. The duration can be in either hh:mm:ss or in d.hh:mm:ss.ms format."
         },
         "healthCheckStableDuration": {
           "type": "string",
-          "x-ms-format" : "duration-constant",
+          "x-ms-format": "duration-constant",
           "description": "The amount of time that the application or cluster must remain healthy before the upgrade proceeds to the next upgrade domain. The duration can be in either hh:mm:ss or in d.hh:mm:ss.ms format."
         },
         "healthCheckRetryTimeout": {

--- a/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/preview/2023-12-01-preview/managedcluster.json
+++ b/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabric/preview/2023-12-01-preview/managedcluster.json
@@ -992,10 +992,12 @@
       "properties": {
         "healthCheckWaitDuration": {
           "type": "string",
+          "x-ms-format" : "duration-constant",
           "description": "The length of time to wait after completing an upgrade domain before performing health checks. The duration can be in either hh:mm:ss or in d.hh:mm:ss.ms format."
         },
         "healthCheckStableDuration": {
           "type": "string",
+          "x-ms-format" : "duration-constant",
           "description": "The amount of time that the application or cluster must remain healthy before the upgrade proceeds to the next upgrade domain. The duration can be in either hh:mm:ss or in d.hh:mm:ss.ms format."
         },
         "healthCheckRetryTimeout": {


### PR DESCRIPTION
Adding "x-ms-format" : "duration-constant" to duration properties because .Net sdk generation is broken.

<img width="1912" alt="Screenshot 2024-01-05 183620 (1)" src="https://github.com/Azure/azure-rest-api-specs/assets/111312378/890b6b16-88f1-4d39-9c93-81b7099b0e41">


<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
