### PR TITLE
remove the save-inputs in jobrouters

### DIFF
--- a/specification/communication/Communication.JobRouter/tspconfig.yaml
+++ b/specification/communication/Communication.JobRouter/tspconfig.yaml
@@ -34,7 +34,6 @@ options:
     emitter-output-dir: "{csharp-sdk-folder}/sdk/{service-directory-name}/{namespace}/src"
     namespace: Azure.Communication.JobRouter
     package-dir: "Azure.Communication.JobRouter"
-    save-inputs: true
   "@azure-tools/typespec-python":
     package-pprint-name: "\"Communication JobRouter\""
     emitter-output-dir: "{python-sdk-folder}/sdk/{service-directory-name}/{package-name}"


### PR DESCRIPTION
The `save-inputs` option should only be used as debugging purpose of the generator, we should never specify this in azure-rest-api-specs.

This PR removes it.
