### PR TITLE
[ChangedFiles-Functions.ps1] Remove unnecessary parenthesis in function call

### DIFF
--- a/eng/scripts/ChangedFiles-Functions.ps1
+++ b/eng/scripts/ChangedFiles-Functions.ps1
@@ -19,7 +19,7 @@ function Get-ChangedFiles($baseCommitish = "HEAD^", $targetCommitish = "HEAD", $
 }
 
 function Get-ChangedSwaggerFiles($changedFiles = (Get-ChangedFiles)) {
-  $changedFiles = Get-ChangedFilesUnderSpecification($changedFiles)
+  $changedFiles = Get-ChangedFilesUnderSpecification $changedFiles
 
   $changedSwaggerFiles = $changedFiles.Where({ 
     $_.EndsWith(".json")


### PR DESCRIPTION
- Fixes https://github.com/Azure/azure-rest-api-specs/pull/27341/files#r1456000098