### PR TITLE
[OpenAI-Assistant] Rename some method and model names.

### DIFF
--- a/specification/ai/OpenAI.Assistants/README.md
+++ b/specification/ai/OpenAI.Assistants/README.md
@@ -2,4 +2,4 @@ title: OpenAIAssistants
 clear-output-folder: false
 guessResourceKey: true
 isAzureSpec: true
-namespace: azure.openai.assistants
+namespace: azure.ai.openai.assistants

--- a/specification/ai/OpenAI.Assistants/assistants/models.tsp
+++ b/specification/ai/OpenAI.Assistants/assistants/models.tsp
@@ -7,7 +7,7 @@ namespace Azure.AI.OpenAI.Assistants;
 using TypeSpec.Versioning;
 
 @doc("Represents an assistant that can call the model and use tools.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model Assistant {
   @doc("The identifier, which can be referenced in API endpoints.")
   id: string;
@@ -46,7 +46,7 @@ model Assistant {
 }
 
 @doc("The request details to use when creating a new assistant.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model AssistantCreationOptions {
   @doc("The ID of the model to use.")
   `model`: string;
@@ -75,7 +75,7 @@ model AssistantCreationOptions {
 }
 
 @doc("The request details to use when modifying an existing assistant.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model UpdateAssistantOptions {
   @doc("The ID of the model to use.")
   `model`?: string;
@@ -104,7 +104,7 @@ model UpdateAssistantOptions {
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "https://github.com/Azure/autorest.csharp/issues/4041"
 @doc("The status of an assistant deletion operation.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model AssistantDeletionStatus {
   ...DeletionStatus;
 
@@ -113,7 +113,7 @@ model AssistantDeletionStatus {
 }
 
 @doc("Information about a file attached to an assistant, as used by tools that can read files.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model AssistantFile {
   @doc("The identifier, which can be referenced in API endpoints.")
   id: string;
@@ -133,7 +133,7 @@ model AssistantFile {
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "https://github.com/Azure/autorest.csharp/issues/4041"
 @doc("The status of an assistant file deletion operation.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model AssistantFileDeletionStatus {
   ...DeletionStatus;
 

--- a/specification/ai/OpenAI.Assistants/assistants/models.tsp
+++ b/specification/ai/OpenAI.Assistants/assistants/models.tsp
@@ -76,7 +76,7 @@ model AssistantCreationOptions {
 
 @doc("The request details to use when modifying an existing assistant.")
 @added(ServiceApiVersions.v2023_02_15_preview)
-model AssistantModificationOptions {
+model UpdateAssistantOptions {
   @doc("The ID of the model to use.")
   `model`?: string;
 

--- a/specification/ai/OpenAI.Assistants/assistants/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/assistants/routes.tsp
@@ -64,9 +64,9 @@ op getAssistant(@path assistantId: string): Assistant;
 @post
 @route("/assistants/{assistantId}")
 @added(ServiceApiVersions.v2023_02_15_preview)
-op modifyAssistant(
+op updateAssistant(
   @path assistantId: string,
-  @body modificationOptions: AssistantModificationOptions,
+  @body updateAssistantOptions: UpdateAssistantOptions,
 ): Assistant;
 
 /**

--- a/specification/ai/OpenAI.Assistants/assistants/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/assistants/routes.tsp
@@ -18,7 +18,7 @@ namespace Azure.AI.OpenAI.Assistants;
 #suppress "@azure-tools/typespec-azure-core/no-operation-id" "non-standard operations"
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 @route("/assistants")
 op createAssistant(...AssistantCreationOptions): Assistant;
 
@@ -32,7 +32,7 @@ op createAssistant(...AssistantCreationOptions): Assistant;
 #suppress "@azure-tools/typespec-azure-core/no-operation-id" "non-standard operations"
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @get
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 @route("/assistants")
 op listAssistants(...OpenAIListRequestOptions): OpenAIPageableListOf<Assistant>;
 
@@ -48,7 +48,7 @@ op listAssistants(...OpenAIListRequestOptions): OpenAIPageableListOf<Assistant>;
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "mirrored API name parity"
 @get
 @route("/assistants/{assistantId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op getAssistant(@path assistantId: string): Assistant;
 
 /**
@@ -63,7 +63,7 @@ op getAssistant(@path assistantId: string): Assistant;
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
 @route("/assistants/{assistantId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op updateAssistant(
   @path assistantId: string,
   @body updateAssistantOptions: UpdateAssistantOptions,
@@ -80,7 +80,7 @@ op updateAssistant(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @delete
 @route("/assistants/{assistantId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op deleteAssistant(@path assistantId: string): AssistantDeletionStatus;
 
 /**
@@ -95,7 +95,7 @@ op deleteAssistant(@path assistantId: string): AssistantDeletionStatus;
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
 @route("assistants/{assistantId}/files")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op createAssistantFile(
   @path assistantId: string,
   @projectedName("json", "file_id") fileId: string,
@@ -113,7 +113,7 @@ op createAssistantFile(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @get
 @route("assistants/{assistantId}/files")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op listAssistantFiles(
   @path assistantId: string,
   ...OpenAIListRequestOptions,
@@ -132,7 +132,7 @@ op listAssistantFiles(
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "mirrored API name parity"
 @get
 @route("assistants/{assistantId}/files/{fileId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op getAssistantFile(
   @path assistantId: string,
   @path fileId: string,
@@ -151,7 +151,7 @@ op getAssistantFile(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @delete
 @route("assistants/{assistantId}/files/{fileId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op deleteAssistantFile(
   @path assistantId: string,
   @path fileId: string,

--- a/specification/ai/OpenAI.Assistants/client.tsp
+++ b/specification/ai/OpenAI.Assistants/client.tsp
@@ -154,7 +154,6 @@ namespace Azure.AI.OpenAI.Assistants;
   "OverrideInstructions"
 );
 @@projectedName(CreateAndRunThreadOptions.tools, "csharp", "OverrideTools");
-@@projectedName(createFile, "csharp", "UploadFile");
 // From https://platform.openai.com/docs/assistants/how-it-works
 // "Note that deleting an AssistantFile doesn’t delete the original File object, it simply deletes the association
 // between that File and the Assistant."

--- a/specification/ai/OpenAI.Assistants/common/models.tsp
+++ b/specification/ai/OpenAI.Assistants/common/models.tsp
@@ -7,7 +7,7 @@ using TypeSpec.Versioning;
 namespace Azure.AI.OpenAI.Assistants;
 
 @doc("The possible values for roles attributed to messages in a thread.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 enum MessageRole {
   @doc("The role representing the end-user.")
   user: "user",

--- a/specification/ai/OpenAI.Assistants/files/models.tsp
+++ b/specification/ai/OpenAI.Assistants/files/models.tsp
@@ -6,7 +6,7 @@ using TypeSpec.Versioning;
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "OpenAI is a case-sensitive name"
 @doc("Represents an assistant that can call the model and use tools.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model OpenAIFile {
   @doc("The object type, which is always 'file'.")
   object: "file";
@@ -30,7 +30,7 @@ model OpenAIFile {
 }
 
 @doc("The possible values denoting the intended usage of a file.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 enum FilePurpose {
   @doc("Indicates a file is used for fine tuning input.")
   fineTune: "fine-tune",
@@ -46,7 +46,7 @@ enum FilePurpose {
 }
 
 @doc("The response data from a file list operation.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model FileListResponse {
   @doc("The object type, which is always 'list'.")
   object: "list";
@@ -57,7 +57,7 @@ model FileListResponse {
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "https://github.com/Azure/autorest.csharp/issues/4041"
 @doc("A status response from a file deletion operation.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model FileDeletionStatus {
   ...DeletionStatus;
 

--- a/specification/ai/OpenAI.Assistants/files/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/files/routes.tsp
@@ -20,7 +20,7 @@ namespace Azure.AI.OpenAI.Assistants;
 #suppress "@azure-tools/typespec-azure-core/no-operation-id" "non-standard operations"
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @get
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 @route("/files")
 op listFiles(@query purpose?: FilePurpose): FileListResponse;
 
@@ -38,7 +38,7 @@ op listFiles(@query purpose?: FilePurpose): FileListResponse;
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 #suppress "@azure-tools/typespec-azure-core/byos" "mirrored API"
 @post
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 @route("/files")
 op uploadFile(
   @header contentType: "multipart/form-data",

--- a/specification/ai/OpenAI.Assistants/files/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/files/routes.tsp
@@ -40,7 +40,7 @@ op listFiles(@query purpose?: FilePurpose): FileListResponse;
 @post
 @added(ServiceApiVersions.v2023_02_15_preview)
 @route("/files")
-op createFile(
+op uploadFile(
   @header contentType: "multipart/form-data",
   @projectedName("csharp", "Data") file: bytes,
   purpose: FilePurpose,
@@ -75,7 +75,7 @@ op deleteFile(
 @get
 @route("/files/{fileId}")
 @doc("Returns information about a specific file. Does not retrieve file content.")
-op retrieveFile(
+op getFile(
   @doc("The ID of the file to retrieve.")
   @path
   @projectedName("json", "file_id")

--- a/specification/ai/OpenAI.Assistants/main.tsp
+++ b/specification/ai/OpenAI.Assistants/main.tsp
@@ -42,5 +42,5 @@ namespace Azure.AI.OpenAI.Assistants;
 enum ServiceApiVersions {
   @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   @doc("The initial, beta version of assistants associated with OpenAI's 11/06/23 model releases.")
-  v2023_02_15_preview: "2024-02-15-preview",
+  v2024_02_15_preview: "2024-02-15-preview",
 }

--- a/specification/ai/OpenAI.Assistants/messages/models.tsp
+++ b/specification/ai/OpenAI.Assistants/messages/models.tsp
@@ -5,7 +5,7 @@ namespace Azure.AI.OpenAI.Assistants;
 using TypeSpec.Versioning;
 
 @doc("A single message within an assistant thread, as provided during that thread's creation for its initial state.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model ThreadInitializationMessage {
   @doc("The role associated with the assistant thread message. Currently, only 'user' is supported when providing initial messages to a new thread.")
   role: MessageRole;
@@ -24,7 +24,7 @@ model ThreadInitializationMessage {
 }
 
 @doc("A single, existing message within an assistant thread.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model ThreadMessage {
   @doc("The identifier, which can be referenced in API endpoints.")
   id: string;
@@ -69,14 +69,14 @@ model ThreadMessage {
 
 @discriminator("type")
 @doc("An abstract representation of a single item of thread message content.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageContent {
   @doc("The object type.")
   type: string;
 }
 
 @doc("A representation of a textual item of thread message content.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageTextContent extends MessageContent {
   @doc("The object type, which is always 'text'.")
   type: "text";
@@ -86,7 +86,7 @@ model MessageTextContent extends MessageContent {
 }
 
 @doc("A representation of image file content in a thread message.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageImageFileContent extends MessageContent {
   @doc("The object type, which is always 'image_file'.")
   type: "image_file";
@@ -99,7 +99,7 @@ model MessageImageFileContent extends MessageContent {
 // Text content details
 
 @doc("The text and associated annotations for a single item of assistant thread message content.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageTextDetails {
   @doc("The text data.")
   value: string;
@@ -112,7 +112,7 @@ model MessageTextDetails {
 
 @discriminator("type")
 @doc("An abstract representation of an annotation to text thread message content.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageTextAnnotation {
   @doc("The object type.")
   type: string;
@@ -132,7 +132,7 @@ model MessageTextAnnotation {
 // File citation annotation + details
 
 @doc("A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the 'retrieval' tool to search files.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageFileCitationTextAnnotation extends MessageTextAnnotation {
   @doc("The object type, which is always 'file_citation'.")
   type: "file_citation";
@@ -146,7 +146,7 @@ model MessageFileCitationTextAnnotation extends MessageTextAnnotation {
 }
 
 @doc("A representation of a file-based text citation, as used in a file-based annotation of text thread message content.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageTextFileCitationDetails {
   @projectedName("json", "file_id")
   @doc("The ID of the file associated with this citation.")
@@ -159,7 +159,7 @@ model MessageTextFileCitationDetails {
 // File path annotation + details
 
 @doc("A citation within the message that points to a file located at a specific path.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageFilePathTextAnnotation extends MessageTextAnnotation {
   @doc("The object type, which is always 'file_path'.")
   type: "file_path";
@@ -170,7 +170,7 @@ model MessageFilePathTextAnnotation extends MessageTextAnnotation {
 }
 
 @doc("An encapsulation of an image file ID, as used by message image content.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageFilePathDetails {
   @doc("The ID of the specific file that the citation is from.")
   @projectedName("json", "file_id")
@@ -180,7 +180,7 @@ model MessageFilePathDetails {
 // Image file content details
 
 @doc("An image reference, as represented in thread message content.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageImageFileDetails {
   @projectedName("json", "file_id")
   @doc("The ID for the file associated with this image.")
@@ -188,7 +188,7 @@ model MessageImageFileDetails {
 }
 
 @doc("An encapsulation of an image file ID, as used by message image content.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageImageFileIdDetails {
   @doc("The ID of the specific image file.")
   @projectedName("json", "file_id")
@@ -198,7 +198,7 @@ model MessageImageFileIdDetails {
 // Assistant message file representation, used for message "list files" route responses
 
 @doc("Information about a file attached to an assistant thread message.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model MessageFile {
   @doc("The identifier, which can be referenced in API endpoints.")
   id: string;

--- a/specification/ai/OpenAI.Assistants/messages/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/messages/routes.tsp
@@ -28,7 +28,7 @@ namespace Azure.AI.OpenAI.Assistants;
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
 @route("/threads/{threadId}/messages")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op createMessage(
   @path threadId: string,
   role: MessageRole,
@@ -49,7 +49,7 @@ op createMessage(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @get
 @route("/threads/{threadId}/messages")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op listMessages(
   @path threadId: string,
   ...OpenAIListRequestOptions,
@@ -68,7 +68,7 @@ op listMessages(
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "mirrored API name parity"
 @get
 @route("/threads/{threadId}/messages/{messageId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op getMessage(@path threadId: string, @path messageId: string): ThreadMessage;
 
 /**
@@ -83,7 +83,7 @@ op getMessage(@path threadId: string, @path messageId: string): ThreadMessage;
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
 @route("/threads/{threadId}/messages/{messageId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op updateMessage(
   @path threadId: string,
   @path messageId: string,
@@ -103,7 +103,7 @@ op updateMessage(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @get
 @route("/threads/{threadId}/messages/{messageId}/files")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op listMessageFiles(
   @path threadId: string,
   @path messageId: string,
@@ -124,7 +124,7 @@ op listMessageFiles(
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "mirrored API name parity"
 @get
 @route("/threads/{threadId}/messages/{messageId}/files/{fileId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op getMessageFile(
   @path threadId: string,
   @path messageId: string,

--- a/specification/ai/OpenAI.Assistants/messages/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/messages/routes.tsp
@@ -84,7 +84,7 @@ op getMessage(@path threadId: string, @path messageId: string): ThreadMessage;
 @post
 @route("/threads/{threadId}/messages/{messageId}")
 @added(ServiceApiVersions.v2023_02_15_preview)
-op modifyMessage(
+op updateMessage(
   @path threadId: string,
   @path messageId: string,
   ...OptionalNullableMetadata,

--- a/specification/ai/OpenAI.Assistants/run_steps/models.tsp
+++ b/specification/ai/OpenAI.Assistants/run_steps/models.tsp
@@ -6,7 +6,7 @@ namespace Azure.AI.OpenAI.Assistants;
 using TypeSpec.Versioning;
 
 @doc("Detailed information about a single step of an assistant thread run.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RunStep {
   @doc("The identifier, which can be referenced in API endpoints.")
   id: string;
@@ -74,7 +74,7 @@ model RunStep {
 }
 
 @doc("The possible types of run steps.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 enum RunStepType {
   @doc("Represents a run step to create a message.")
   messageCreation: "message_creation",
@@ -85,14 +85,14 @@ enum RunStepType {
 
 @discriminator("type")
 @doc("An abstract representation of the details for a run step.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RunStepDetails {
   @doc("The object type.")
   type: RunStepType;
 }
 
 @doc("The detailed information associated with a message creation run step.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RunStepMessageCreationDetails extends RunStepDetails {
   @doc("The object type, which is always 'message_creation'.")
   type: RunStepType.messageCreation;
@@ -103,7 +103,7 @@ model RunStepMessageCreationDetails extends RunStepDetails {
 }
 
 @doc("The detailed information associated with a run step calling tools.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RunStepToolCallDetails extends RunStepDetails {
   @doc("The object type, which is always 'tool_calls'.")
   type: RunStepType.toolCalls;
@@ -114,7 +114,7 @@ model RunStepToolCallDetails extends RunStepDetails {
 }
 
 @doc("The details of a message created as a part of a run step.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RunStepMessageCreationReference {
   @projectedName("json", "message_id")
   @doc("The ID of the message created by this run step.")
@@ -122,7 +122,7 @@ model RunStepMessageCreationReference {
 }
 
 @doc("Possible values for the status of a run step.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 enum RunStepStatus {
   @doc("Represents a run step still in progress.")
   inProgress: "in_progress",
@@ -141,7 +141,7 @@ enum RunStepStatus {
 }
 
 @doc("Possible error code values attributable to a failed run step.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 enum RunStepErrorCode {
   @doc("Represents a server error.")
   serverError: "server_error",
@@ -151,7 +151,7 @@ enum RunStepErrorCode {
 }
 
 @doc("The error information associated with a failed run step.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RunStepError {
   @doc("The error code for this error.")
   code: RunStepErrorCode;

--- a/specification/ai/OpenAI.Assistants/run_steps/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/run_steps/routes.tsp
@@ -23,7 +23,7 @@ namespace Azure.AI.OpenAI.Assistants;
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "mirrored API name parity"
 @get
 @route("/threads/{threadId}/runs/{runId}/steps/{stepId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op getRunStep(
   @path threadId: string,
   @path runId: string,
@@ -43,7 +43,7 @@ op getRunStep(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @get
 @route("/threads/{threadId}/runs/{runId}/steps")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op listRunSteps(
   @path threadId: string,
   @path runId: string,

--- a/specification/ai/OpenAI.Assistants/runs/models.tsp
+++ b/specification/ai/OpenAI.Assistants/runs/models.tsp
@@ -8,7 +8,7 @@ namespace Azure.AI.OpenAI.Assistants;
 using TypeSpec.Versioning;
 
 @doc("Data representing a single evaluation run of an assistant thread.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model ThreadRun {
   @doc("The identifier, which can be referenced in API endpoints.")
   id: string;
@@ -97,7 +97,7 @@ model ThreadRun {
 }
 
 @doc("The details of an error as encountered by an assistant thread run.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RunError {
   @doc("The status for the error.")
   code: string;
@@ -107,7 +107,7 @@ model RunError {
 }
 
 @doc("Possible values for the status of an assistant thread run.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 enum RunStatus {
   @doc("Represents a run that is queued to start.")
   queued: "queued",
@@ -136,14 +136,14 @@ enum RunStatus {
 
 @discriminator("type")
 @doc("An abstract representation of a required action for an assistant thread run to continue.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RequiredAction {
   @doc("The object type.")
   type: string;
 }
 
 @doc("The details for required tool calls that must be submitted for an assistant thread run to continue.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model SubmitToolOutputsAction extends RequiredAction {
   @doc("The object type, which is always 'submit_tool_outputs'.")
   type: "submit_tool_outputs";
@@ -154,7 +154,7 @@ model SubmitToolOutputsAction extends RequiredAction {
 }
 
 @doc("The details describing tools that should be called to submit tool outputs.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model SubmitToolOutputsDetails {
   @projectedName("json", "tool_calls")
   @doc("The list of tool calls that must be resolved for the assistant thread run to continue.")
@@ -162,7 +162,7 @@ model SubmitToolOutputsDetails {
 }
 
 @doc("The details used when creating and immediately running a new assistant thread.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model CreateAndRunThreadOptions {
   @projectedName("json", "assistant_id")
   @doc("The ID of the assistant for which the thread should be created.")

--- a/specification/ai/OpenAI.Assistants/runs/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/runs/routes.tsp
@@ -27,7 +27,7 @@ namespace Azure.AI.OpenAI.Assistants;
 @post
 @route("/threads/{threadId}/runs")
 @doc("Creates a new run for an assistant thread.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op createRun(
   @path threadId: string,
   @projectedName("json", "assistant_id") assistantId: string,
@@ -49,7 +49,7 @@ op createRun(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @get
 @route("/threads/{threadId}/runs")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op listRuns(
   @path threadId: string,
   ...OpenAIListRequestOptions,
@@ -68,7 +68,7 @@ op listRuns(
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "mirrored API name parity"
 @get
 @route("/threads/{threadId}/runs/{runId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op getRun(@path threadId: string, @path runId: string): ThreadRun;
 
 /**
@@ -83,7 +83,7 @@ op getRun(@path threadId: string, @path runId: string): ThreadRun;
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
 @route("/threads/{threadId}/runs/{runId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op updateRun(
   @path threadId: string,
   @path runId: string,
@@ -103,7 +103,7 @@ op updateRun(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
 @route("/threads/{threadId}/runs/{runId}/submit_tool_outputs")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op submitToolOutputsToRun(
   @path threadId: string,
   @path runId: string,
@@ -122,7 +122,7 @@ op submitToolOutputsToRun(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
 @route("/threads/{threadId}/runs/{runId}/cancel")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op cancelRun(@path threadId: string, @path runId: string): ThreadRun;
 
 /**
@@ -136,5 +136,5 @@ op cancelRun(@path threadId: string, @path runId: string): ThreadRun;
 @post
 @route("/threads/runs")
 @doc("Creates a new assistant thread and immediately starts a run using that new thread.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op createThreadAndRun(...CreateAndRunThreadOptions): ThreadRun;

--- a/specification/ai/OpenAI.Assistants/runs/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/runs/routes.tsp
@@ -84,7 +84,7 @@ op getRun(@path threadId: string, @path runId: string): ThreadRun;
 @post
 @route("/threads/{threadId}/runs/{runId}")
 @added(ServiceApiVersions.v2023_02_15_preview)
-op modifyRun(
+op updateRun(
   @path threadId: string,
   @path runId: string,
   ...OptionalNullableMetadata,

--- a/specification/ai/OpenAI.Assistants/threads/models.tsp
+++ b/specification/ai/OpenAI.Assistants/threads/models.tsp
@@ -7,7 +7,7 @@ using TypeSpec.Versioning;
 namespace Azure.AI.OpenAI.Assistants;
 
 @doc("Information about a single thread associated with an assistant.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model AssistantThread {
   @doc("The identifier, which can be referenced in API endpoints.")
   id: string;
@@ -24,7 +24,7 @@ model AssistantThread {
 }
 
 @doc("The details used to create a new assistant thread.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model AssistantThreadCreationOptions {
   @doc("The initial messages to associate with the new thread.")
   messages?: ThreadInitializationMessage[];
@@ -34,7 +34,7 @@ model AssistantThreadCreationOptions {
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "https://github.com/Azure/autorest.csharp/issues/4041"
 @doc("The status of a thread deletion operation.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model ThreadDeletionStatus {
   ...DeletionStatus;
 

--- a/specification/ai/OpenAI.Assistants/threads/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/threads/routes.tsp
@@ -51,7 +51,7 @@ op getThread(@path threadId: string): AssistantThread;
 @post
 @route("/threads/{threadId}")
 @added(ServiceApiVersions.v2023_02_15_preview)
-op modifyThread(
+op updateThread(
   @path threadId: string,
   ...OptionalNullableMetadata,
 ): AssistantThread;

--- a/specification/ai/OpenAI.Assistants/threads/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/threads/routes.tsp
@@ -18,7 +18,7 @@ namespace Azure.AI.OpenAI.Assistants;
 #suppress "@azure-tools/typespec-azure-core/no-operation-id" "non-standard operations"
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 @route("/threads")
 op createThread(...AssistantThreadCreationOptions): AssistantThread;
 
@@ -36,7 +36,7 @@ op createThread(...AssistantThreadCreationOptions): AssistantThread;
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "mirrored API name parity"
 @get
 @route("/threads/{threadId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op getThread(@path threadId: string): AssistantThread;
 
 /**
@@ -50,7 +50,7 @@ op getThread(@path threadId: string): AssistantThread;
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
 @route("/threads/{threadId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op updateThread(
   @path threadId: string,
   ...OptionalNullableMetadata,
@@ -67,5 +67,5 @@ op updateThread(
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @delete
 @route("/threads/{threadId}")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 op deleteThread(@path threadId: string): ThreadDeletionStatus;

--- a/specification/ai/OpenAI.Assistants/tools/models.tsp
+++ b/specification/ai/OpenAI.Assistants/tools/models.tsp
@@ -12,28 +12,28 @@ namespace Azure.AI.OpenAI.Assistants;
 
 @doc("An abstract representation of an input tool definition that an assistant can use.")
 @discriminator("type")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model ToolDefinition {
   @doc("The object type.")
   type: string;
 }
 
 @doc("The input definition information for a code interpreter tool as used to configure an assistant.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model CodeInterpreterToolDefinition extends ToolDefinition {
   @doc("The object type, which is always 'code_interpreter'.")
   type: "code_interpreter";
 }
 
 @doc("The input definition information for a retrieval tool as used to configure an assistant.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RetrievalToolDefinition extends ToolDefinition {
   @doc("The object type, which is always 'retrieval'.")
   type: "retrieval";
 }
 
 @doc("The input definition information for a function tool as used to configure an assistant.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model FunctionToolDefinition extends ToolDefinition {
   @doc("The object type, which is always 'function'.")
   type: "function";
@@ -45,7 +45,7 @@ model FunctionToolDefinition extends ToolDefinition {
 // Definition details: Functions
 
 @doc("The input definition information for a function.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model FunctionDefinition {
   @doc("The name of the function to be called.")
   name: string;
@@ -67,7 +67,7 @@ model FunctionDefinition {
 An abstract representation a tool call, issued by the model in evaluation of a configured tool definition, that must
 be fulfilled and have its outputs submitted before the model can continue.
 """)
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model ToolCall {
   @doc("The object type.")
   type: string;
@@ -80,7 +80,7 @@ model ToolCall {
 A tool call to a code interpreter tool, issued by the model in evaluation of a configured code interpreter tool, that
 represents submitted output needed or already fulfilled by the tool for the model to continue.
 """)
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model CodeInterpreterToolCall extends ToolCall {
   @doc("The object type, which is always 'code_interpreter'.")
   type: "code_interpreter";
@@ -94,7 +94,7 @@ model CodeInterpreterToolCall extends ToolCall {
 A tool call to a retrieval tool, issued by the model in evaluation of a configured retrieval tool, that represents
 submitted output needed or already fulfilled by the tool for the model to continue.
 """)
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model RetrievalToolCall extends ToolCall {
   @doc("The object type, which is always 'retrieval'.")
   type: "retrieval";
@@ -107,7 +107,7 @@ model RetrievalToolCall extends ToolCall {
 A tool call to a function tool, issued by the model in evaluation of a configured function tool, that represents
 given function inputs and submitted function outputs needed or already fulfilled by the tool for the model to continue.
 """)
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model FunctionToolCall extends ToolCall {
   @doc("The object type, which is always 'function'.")
   type: "function";
@@ -119,7 +119,7 @@ model FunctionToolCall extends ToolCall {
 // Call details: Code Interpreter
 
 @doc("The detailed information about a code interpreter invocation by the model.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model CodeInterpreterToolCallDetails {
   @doc("The input provided by the model to the code interpreter tool.")
   input: string;
@@ -130,14 +130,14 @@ model CodeInterpreterToolCallDetails {
 
 @discriminator("type")
 @doc("An abstract representation of an emitted output from a code interpreter tool.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model CodeInterpreterToolCallOutput {
   @doc("The object type.")
   type: string;
 }
 
 @doc("A representation of a log output emitted by a code interpreter tool in response to a tool call by the model.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model CodeInterpreterLogOutput extends CodeInterpreterToolCallOutput {
   @doc("The object type, which is always 'logs'.")
   type: "logs";
@@ -147,7 +147,7 @@ model CodeInterpreterLogOutput extends CodeInterpreterToolCallOutput {
 }
 
 @doc("A representation of an image output emitted by a code interpreter tool in response to a tool call by the model.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model CodeInterpreterImageOutput extends CodeInterpreterToolCallOutput {
   @doc("The object type, which is always 'image'.")
   type: "image";
@@ -157,7 +157,7 @@ model CodeInterpreterImageOutput extends CodeInterpreterToolCallOutput {
 }
 
 @doc("An image reference emitted by a code interpreter tool in response to a tool call by the model.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model CodeInterpreterImageReference {
   @projectedName("json", "file_id")
   @doc("The ID of the file associated with this image.")
@@ -167,7 +167,7 @@ model CodeInterpreterImageReference {
 // Call details: Functions
 
 @doc("The detailed information about the function called by the model.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model FunctionToolCallDetails {
   @doc("The name of the function.")
   name: string;
@@ -185,7 +185,7 @@ model FunctionToolCallDetails {
 //
 
 @doc("The data provided during a tool outputs submission to resolve pending tool calls and allow the model to continue.")
-@added(ServiceApiVersions.v2023_02_15_preview)
+@added(ServiceApiVersions.v2024_02_15_preview)
 model ToolOutput {
   @doc("The ID of the tool call being resolved, as provided in the tool calls of a required action from a run.")
   @projectedName("json", "tool_call_id")


### PR DESCRIPTION
- Renames to 
  - `get*` instead of `retrieve*`,  [NEED A DISCUSSION]
  - `uploadFile` instead of `createFile`
  -  use `update` instead of `modify`
- `ServiceApiVersion` value should be `v2024_02_15_preview` instead of `v2023_02_15_preview`