### PR TITLE
turn the MRW feature off explicitly for communication jobrouter

### DIFF
--- a/specification/communication/Communication.JobRouter/tspconfig.yaml
+++ b/specification/communication/Communication.JobRouter/tspconfig.yaml
@@ -34,6 +34,7 @@ options:
     emitter-output-dir: "{csharp-sdk-folder}/sdk/{service-directory-name}/{namespace}/src"
     namespace: Azure.Communication.JobRouter
     package-dir: "Azure.Communication.JobRouter"
+    use-model-reader-writer: false # temporarily add this config to turn this off, because turning this on will require a refreshment on the test cases
   "@azure-tools/typespec-python":
     package-pprint-name: "\"Communication JobRouter\""
     emitter-output-dir: "{python-sdk-folder}/sdk/{service-directory-name}/{package-name}"


### PR DESCRIPTION
C# SDK is enabling the MRW feature for all DPG libraries, but this RP needs some more modifications and test recordings to be updaated.
This PR disables this feature temporarily and we will enable this again after the things for other RPs are consolidated in azure-sdk-for-net later.
