### PR TITLE
Update readme so that the learn docs contain both the cluster teams a…

### DIFF
--- a/specification/azurestackhci/resource-manager/readme.md
+++ b/specification/azurestackhci/resource-manager/readme.md
@@ -24,6 +24,9 @@ For other options on installation see [Installing AutoRest](https://aka.ms/autor
 
 These are the global settings for the azurestackhci.
 
+Please specify both the latest Cluster and ArcVM files under the package-preview tag that is listed below (even if they are not a part of the same preview api-version). Not including both will result in docs missing from learn.
+
+
 ``` yaml
 title: AzureStackHCIClient
 description: Azure Stack HCI management service
@@ -98,6 +101,14 @@ input-file:
   - Microsoft.AzureStackHCI/preview/2023-11-01-preview/updateRuns.json
   - Microsoft.AzureStackHCI/preview/2023-11-01-preview/updateSummaries.json
   - Microsoft.AzureStackHCI/preview/2023-11-01-preview/updates.json
+  - Microsoft.AzureStackHCI/preview/2023-09-01-preview/common.json
+  - Microsoft.AzureStackHCI/preview/2023-09-01-preview/galleryImages.json
+  - Microsoft.AzureStackHCI/preview/2023-09-01-preview/logicalNetworks.json
+  - Microsoft.AzureStackHCI/preview/2023-09-01-preview/marketplaceGalleryImages.json
+  - Microsoft.AzureStackHCI/preview/2023-09-01-preview/networkInterfaces.json
+  - Microsoft.AzureStackHCI/preview/2023-09-01-preview/storageContainers.json
+  - Microsoft.AzureStackHCI/preview/2023-09-01-preview/virtualHardDisks.json
+  - Microsoft.AzureStackHCI/preview/2023-09-01-preview/virtualMachineInstances.json
 ```
 ### Tag: package-preview-2023-09
 


### PR DESCRIPTION
Since we have 2 different teams contributing to the same namespace, we need to include the resources of both teams' apis under the latest package preview tag if we want both our resources to be present on microsoft learn. 

Please note that this will have to be done every time either team releases a new api-version.

Also note that since the [docs ](https://github.com/Azure/azure-docs-rest-apis/blob/main/reference.config.yml#L915) reference the azure-rest-api-specs repo, the change will have to be made in this repo. It cannot be validated by making the change in the azure-rest-api-specs-pr repo first.

For consistency, I have also opened [this ](https://github.com/Azure/azure-rest-api-specs-pr/pull/16850/files)PR in the azure-rest-api-specs-pr repo to reflect the same. 