### PR TITLE
Revert ROUNDTRIP Rules

### DIFF
--- a/documentation/api-scenario/references/ErrorCodeReference.md
+++ b/documentation/api-scenario/references/ErrorCodeReference.md
@@ -91,3 +91,31 @@ Example:
    }
 }
 ```
+
+## ROUNDTRIP_INCONSISTENT_PROPERTY
+
+**Error message** The property's value in the response is different from what was set in the request. Path: {}. Request: {}. Response: {}
+
+Example: The sku in request parameters is `default`, but actual return is `standard`.
+
+```diff
+{
+   "parameters":{
+      "properties":{
+         "name":"myService",
+         "SKU":"default"
+      }
+   },
+   "responses":{
+      "200":{
+         "properties":{
+            "name":"myService",
++            "SKU":"standard"
+-            "SKU":"default"
+
+         }
+      }
+   }
+}
+
+```


### PR DESCRIPTION
Revert https://github.com/Azure/azure-rest-api-specs/pull/25609 for the following reasons:
1. [Azure Terraform](https://learn.microsoft.com/en-us/azure/developer/terraform/overview) requires that onboarded APIs must comply with the roundtrip rules.  
2. These rules are not described in any other alternative places.
3. These rules are still existing in [oav](https://github.com/Azure/oav/blob/develop/lib/armValidator/roundTripValidator.ts) 