### PR TITLE
[OpenAI] [Assistants] Fix for `ThreadRun->RequiredAction->RequiredFunctionToolCall` 

### DIFF
--- a/specification/ai/OpenAI.Assistants/tools/models.tsp
+++ b/specification/ai/OpenAI.Assistants/tools/models.tsp
@@ -82,7 +82,7 @@ model RequiredFunctionToolCall extends RequiredToolCall {
   type: "function";
 
   @doc("Detailed information about the function to be executed by the tool that includes name and arguments.")
-  function: FunctionToolCall;
+  function: FunctionToolCallDetails;
 }
 
 //

--- a/specification/ai/OpenAI.Assistants/tools/models.tsp
+++ b/specification/ai/OpenAI.Assistants/tools/models.tsp
@@ -82,7 +82,7 @@ model RequiredFunctionToolCall extends RequiredToolCall {
   type: "function";
 
   @doc("Detailed information about the function to be executed by the tool that includes name and arguments.")
-  function: FunctionDefinition;
+  function: FunctionToolCall;
 }
 
 //

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
@@ -2661,7 +2661,7 @@
       "description": "A representation of a requested call to a function tool, needed by the model to continue evaluation of a run.",
       "properties": {
         "function": {
-          "$ref": "#/definitions/FunctionToolCall",
+          "$ref": "#/definitions/FunctionToolCallDetails",
           "description": "Detailed information about the function to be executed by the tool that includes name and arguments."
         }
       },

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
@@ -2661,7 +2661,7 @@
       "description": "A representation of a requested call to a function tool, needed by the model to continue evaluation of a run.",
       "properties": {
         "function": {
-          "$ref": "#/definitions/FunctionDefinition",
+          "$ref": "#/definitions/FunctionToolCall",
           "description": "Detailed information about the function to be executed by the tool that includes name and arguments."
         }
       },

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
@@ -1858,7 +1858,7 @@ components:
           description: The object type of the required tool call. Always 'function' for function tools.
         function:
           allOf:
-            - $ref: '#/components/schemas/FunctionToolCall'
+            - $ref: '#/components/schemas/FunctionToolCallDetails'
           description: Detailed information about the function to be executed by the tool that includes name and arguments.
       allOf:
         - $ref: '#/components/schemas/RequiredToolCall'
@@ -2379,6 +2379,7 @@ components:
         mapping:
           code_interpreter: '#/components/schemas/CodeInterpreterToolCall'
           retrieval: '#/components/schemas/RetrievalToolCall'
+          function: '#/components/schemas/FunctionToolCall'
       description: An abstract representation of a detailed tool call as recorded within a run step for an existing run.
     ToolDefinition:
       type: object

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
@@ -340,7 +340,7 @@ paths:
               required:
                 - file
                 - purpose
-  /files/{fileId}:
+  /files/{fileId}/{file_id}:
     delete:
       operationId: deleteFile
       description: Delete a previously uploaded file.
@@ -1858,7 +1858,7 @@ components:
           description: The object type of the required tool call. Always 'function' for function tools.
         function:
           allOf:
-            - $ref: '#/components/schemas/FunctionDefinition'
+            - $ref: '#/components/schemas/FunctionToolCall'
           description: Detailed information about the function to be executed by the tool that includes name and arguments.
       allOf:
         - $ref: '#/components/schemas/RequiredToolCall'
@@ -2379,7 +2379,6 @@ components:
         mapping:
           code_interpreter: '#/components/schemas/CodeInterpreterToolCall'
           retrieval: '#/components/schemas/RetrievalToolCall'
-          function: '#/components/schemas/FunctionToolCall'
       description: An abstract representation of a detailed tool call as recorded within a run step for an existing run.
     ToolDefinition:
       type: object

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
@@ -340,7 +340,7 @@ paths:
               required:
                 - file
                 - purpose
-  /files/{fileId}/{file_id}:
+  /files/{fileId}:
     delete:
       operationId: deleteFile
       description: Delete a previously uploaded file.


### PR DESCRIPTION
## Changes

- Change in types for field from `ThreadRun` -> `RequiredFunctionToolCall`-> `FunctionDefinition` to `ThreadRun` -> `RequiredFunctionToolCall` -> `FunctionToolCallDetails`

## Details 

The openai-openapi yaml file that ⁠[require_action](https://github.com/openai/openai-openapi/blob/97dfb59c89ce0550e9360a7d437491d556e5a65e/openapi.yaml#L7552) has a type contains a list of ⁠[RunToolCallObject](https://github.com/openai/openai-openapi/blob/97dfb59c89ce0550e9360a7d437491d556e5a65e/openapi.yaml#L7779) which specifies a structure that is actually corresponding to what we defined in our TSP as ⁠[RequiredFunctionToolCall](https://github.com/Azure/azure-rest-api-specs/blob/73d1e6522dfdedb795f46cf997921c623011caa6/specification/ai/OpenAI.Assistants/tools/models.tsp#L80).

We should use `FunctionToolCall` instead of `FunctionDefinition` to be able to access the `arguments` sent by the service to be actually able to call the function with which the assistant was configured.