### PR TITLE
OpenAI Assistants: fix required_action function representation

### DIFF
--- a/specification/ai/OpenAI.Assistants/client.tsp
+++ b/specification/ai/OpenAI.Assistants/client.tsp
@@ -69,27 +69,29 @@ namespace Azure.AI.OpenAI.Assistants;
   "InternalDetails"
 );
 
-// RequiredFunctionToolCall, FunctionToolCall: include name/arguments directly
+// RequiredFunctionToolCall, RunStepFunctionToolCall: include name/arguments/output directly
 
-@@access(FunctionToolCallDetails, Access.internal);
-@@projectedName(FunctionToolCallDetails,
+@@access(RunStepFunctionToolCallDetails, Access.internal);
+@@projectedName(RunStepFunctionToolCallDetails,
   "csharp",
-  "InternalFunctionToolCallDetails"
+  "InternalRunStepFunctionToolCallDetails"
 );
-@@projectedName(RequiredFunctionToolCall.function,
+@@projectedName(RequiredFunctionToolCall.function, "csharp", "InternalDetails");
+@@access(RequiredFunctionToolCallDetails, Access.internal);
+@@projectedName(RequiredFunctionToolCallDetails,
   "csharp",
-  "InternalFunctionDefinition"
+  "InternalRequiredFunctionToolCallDetails"
 );
-@@projectedName(FunctionToolCall.function, "csharp", "InternalDetails");
+@@projectedName(RunStepFunctionToolCall.function, "csharp", "InternalDetails");
 
-// CodeInterpreterToolCall: include input/outputs directly
+// RunStepCodeInterpreterToolCall: include input/outputs directly
 
-@@access(CodeInterpreterToolCallDetails, Access.internal);
-@@projectedName(CodeInterpreterToolCallDetails,
+@@access(RunStepCodeInterpreterToolCallDetails, Access.internal);
+@@projectedName(RunStepCodeInterpreterToolCallDetails,
   "csharp",
   "InternalCodeInterpreterToolCallDetails"
 );
-@@projectedName(CodeInterpreterToolCall.codeInterpreter,
+@@projectedName(RunStepCodeInterpreterToolCall.codeInterpreter,
   "csharp",
   "InternalDetails"
 );

--- a/specification/ai/OpenAI.Assistants/run_steps/models.tsp
+++ b/specification/ai/OpenAI.Assistants/run_steps/models.tsp
@@ -110,7 +110,7 @@ model RunStepToolCallDetails extends RunStepDetails {
 
   @projectedName("json", "tool_calls")
   @doc("A list of tool call details for this run step.")
-  toolCalls: ToolCall[];
+  toolCalls: RunStepToolCall[];
 }
 
 @doc("The details of a message created as a part of a run step.")

--- a/specification/ai/OpenAI.Assistants/tools/models.tsp
+++ b/specification/ai/OpenAI.Assistants/tools/models.tsp
@@ -82,7 +82,17 @@ model RequiredFunctionToolCall extends RequiredToolCall {
   type: "function";
 
   @doc("Detailed information about the function to be executed by the tool that includes name and arguments.")
-  function: FunctionDefinition;
+  function: RequiredFunctionToolCallDetails;
+}
+
+@added(ServiceApiVersions.v2024_02_15_preview)
+@doc("The detailed information for a function invocation, as provided by a required action invoking a function tool, that includes the name of and arguments to the function.")
+model RequiredFunctionToolCallDetails {
+  @doc("The name of the function.")
+  name: string;
+
+  @doc("The arguments to use when invoking the named function, as provided by the model.")
+  arguments: string;
 }
 
 //
@@ -92,7 +102,7 @@ model RequiredFunctionToolCall extends RequiredToolCall {
 @discriminator("type")
 @doc("An abstract representation of a detailed tool call as recorded within a run step for an existing run.")
 @added(ServiceApiVersions.v2024_02_15_preview)
-model ToolCall {
+model RunStepToolCall {
   @doc("The object type.")
   type: string;
 
@@ -105,13 +115,13 @@ A record of a call to a code interpreter tool, issued by the model in evaluation
 represents inputs and outputs consumed and emitted by the code interpreter.
 """)
 @added(ServiceApiVersions.v2024_02_15_preview)
-model CodeInterpreterToolCall extends ToolCall {
+model RunStepCodeInterpreterToolCall extends RunStepToolCall {
   @doc("The object type, which is always 'code_interpreter'.")
   type: "code_interpreter";
 
   @projectedName("json", "code_interpreter")
   @doc("The details of the tool call to the code interpreter tool.")
-  codeInterpreter: CodeInterpreterToolCallDetails;
+  codeInterpreter: RunStepCodeInterpreterToolCallDetails;
 }
 
 @doc("""
@@ -119,7 +129,7 @@ A record of a call to a retrieval tool, issued by the model in evaluation of a d
 executed retrieval actions.
 """)
 @added(ServiceApiVersions.v2024_02_15_preview)
-model RetrievalToolCall extends ToolCall {
+model RunStepRetrievalToolCall extends RunStepToolCall {
   @doc("The object type, which is always 'retrieval'.")
   type: "retrieval";
 
@@ -132,37 +142,38 @@ A record of a call to a function tool, issued by the model in evaluation of a de
 and output consumed and emitted by the specified function.
 """)
 @added(ServiceApiVersions.v2024_02_15_preview)
-model FunctionToolCall extends ToolCall {
+model RunStepFunctionToolCall extends RunStepToolCall {
   @doc("The object type, which is always 'function'.")
   type: "function";
 
   @doc("The detailed information about the function called by the model.")
-  function: FunctionToolCallDetails;
+  function: RunStepFunctionToolCallDetails;
 }
 
 // Call details: Code Interpreter
 
 @doc("The detailed information about a code interpreter invocation by the model.")
 @added(ServiceApiVersions.v2024_02_15_preview)
-model CodeInterpreterToolCallDetails {
+model RunStepCodeInterpreterToolCallDetails {
   @doc("The input provided by the model to the code interpreter tool.")
   input: string;
 
   @doc("The outputs produced by the code interpreter tool back to the model in response to the tool call.")
-  outputs: CodeInterpreterToolCallOutput[];
+  outputs: RunStepCodeInterpreterToolCallOutput[];
 }
 
 @discriminator("type")
 @doc("An abstract representation of an emitted output from a code interpreter tool.")
 @added(ServiceApiVersions.v2024_02_15_preview)
-model CodeInterpreterToolCallOutput {
+model RunStepCodeInterpreterToolCallOutput {
   @doc("The object type.")
   type: string;
 }
 
 @doc("A representation of a log output emitted by a code interpreter tool in response to a tool call by the model.")
 @added(ServiceApiVersions.v2024_02_15_preview)
-model CodeInterpreterLogOutput extends CodeInterpreterToolCallOutput {
+model RunStepCodeInterpreterLogOutput
+  extends RunStepCodeInterpreterToolCallOutput {
   @doc("The object type, which is always 'logs'.")
   type: "logs";
 
@@ -172,17 +183,18 @@ model CodeInterpreterLogOutput extends CodeInterpreterToolCallOutput {
 
 @doc("A representation of an image output emitted by a code interpreter tool in response to a tool call by the model.")
 @added(ServiceApiVersions.v2024_02_15_preview)
-model CodeInterpreterImageOutput extends CodeInterpreterToolCallOutput {
+model RunStepCodeInterpreterImageOutput
+  extends RunStepCodeInterpreterToolCallOutput {
   @doc("The object type, which is always 'image'.")
   type: "image";
 
   @doc("Referential information for the image associated with this output.")
-  image: CodeInterpreterImageReference;
+  image: RunStepCodeInterpreterImageReference;
 }
 
 @doc("An image reference emitted by a code interpreter tool in response to a tool call by the model.")
 @added(ServiceApiVersions.v2024_02_15_preview)
-model CodeInterpreterImageReference {
+model RunStepCodeInterpreterImageReference {
   @projectedName("json", "file_id")
   @doc("The ID of the file associated with this image.")
   fileId: string;
@@ -192,7 +204,7 @@ model CodeInterpreterImageReference {
 
 @doc("The detailed information about the function called by the model.")
 @added(ServiceApiVersions.v2024_02_15_preview)
-model FunctionToolCallDetails {
+model RunStepFunctionToolCallDetails {
   @doc("The name of the function.")
   name: string;
 

--- a/specification/ai/OpenAI.Assistants/tools/models.tsp
+++ b/specification/ai/OpenAI.Assistants/tools/models.tsp
@@ -91,7 +91,7 @@ model RequiredFunctionToolCallDetails {
   @doc("The name of the function.")
   name: string;
 
-  @doc("The arguments to use when invoking the named function, as provided by the model.")
+  @doc("The arguments to use when invoking the named function, as provided by the model. Arguments are presented as a JSON document that should be validated and parsed for evaluation.")
   arguments: string;
 }
 

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
@@ -2534,7 +2534,7 @@
         },
         "arguments": {
           "type": "string",
-          "description": "The arguments to use when invoking the named function, as provided by the model."
+          "description": "The arguments to use when invoking the named function, as provided by the model. Arguments are presented as a JSON document that should be validated and parsed for evaluation."
         }
       },
       "required": [

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
@@ -1943,114 +1943,6 @@
         }
       }
     },
-    "CodeInterpreterImageOutput": {
-      "type": "object",
-      "description": "A representation of an image output emitted by a code interpreter tool in response to a tool call by the model.",
-      "properties": {
-        "image": {
-          "$ref": "#/definitions/CodeInterpreterImageReference",
-          "description": "Referential information for the image associated with this output."
-        }
-      },
-      "required": [
-        "image"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/CodeInterpreterToolCallOutput"
-        }
-      ],
-      "x-ms-discriminator-value": "image"
-    },
-    "CodeInterpreterImageReference": {
-      "type": "object",
-      "description": "An image reference emitted by a code interpreter tool in response to a tool call by the model.",
-      "properties": {
-        "file_id": {
-          "type": "string",
-          "description": "The ID of the file associated with this image.",
-          "x-ms-client-name": "fileId"
-        }
-      },
-      "required": [
-        "file_id"
-      ]
-    },
-    "CodeInterpreterLogOutput": {
-      "type": "object",
-      "description": "A representation of a log output emitted by a code interpreter tool in response to a tool call by the model.",
-      "properties": {
-        "logs": {
-          "type": "string",
-          "description": "The serialized log output emitted by the code interpreter."
-        }
-      },
-      "required": [
-        "logs"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/CodeInterpreterToolCallOutput"
-        }
-      ],
-      "x-ms-discriminator-value": "logs"
-    },
-    "CodeInterpreterToolCall": {
-      "type": "object",
-      "description": "A record of a call to a code interpreter tool, issued by the model in evaluation of a defined tool, that\nrepresents inputs and outputs consumed and emitted by the code interpreter.",
-      "properties": {
-        "code_interpreter": {
-          "$ref": "#/definitions/CodeInterpreterToolCallDetails",
-          "description": "The details of the tool call to the code interpreter tool.",
-          "x-ms-client-name": "codeInterpreter"
-        }
-      },
-      "required": [
-        "code_interpreter"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ToolCall"
-        }
-      ],
-      "x-ms-discriminator-value": "code_interpreter"
-    },
-    "CodeInterpreterToolCallDetails": {
-      "type": "object",
-      "description": "The detailed information about a code interpreter invocation by the model.",
-      "properties": {
-        "input": {
-          "type": "string",
-          "description": "The input provided by the model to the code interpreter tool."
-        },
-        "outputs": {
-          "type": "array",
-          "description": "The outputs produced by the code interpreter tool back to the model in response to the tool call.",
-          "items": {
-            "$ref": "#/definitions/CodeInterpreterToolCallOutput"
-          },
-          "x-ms-identifiers": []
-        }
-      },
-      "required": [
-        "input",
-        "outputs"
-      ]
-    },
-    "CodeInterpreterToolCallOutput": {
-      "type": "object",
-      "description": "An abstract representation of an emitted output from a code interpreter tool.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "The object type."
-        }
-      },
-      "discriminator": "type",
-      "required": [
-        "type"
-      ]
-    },
     "CodeInterpreterToolDefinition": {
       "type": "object",
       "description": "The input definition information for a code interpreter tool as used to configure an assistant.",
@@ -2261,49 +2153,6 @@
       "required": [
         "name",
         "parameters"
-      ]
-    },
-    "FunctionToolCall": {
-      "type": "object",
-      "description": "A record of a call to a function tool, issued by the model in evaluation of a defined tool, that represents the inputs\nand output consumed and emitted by the specified function.",
-      "properties": {
-        "function": {
-          "$ref": "#/definitions/FunctionToolCallDetails",
-          "description": "The detailed information about the function called by the model."
-        }
-      },
-      "required": [
-        "function"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ToolCall"
-        }
-      ],
-      "x-ms-discriminator-value": "function"
-    },
-    "FunctionToolCallDetails": {
-      "type": "object",
-      "description": "The detailed information about the function called by the model.",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the function."
-        },
-        "arguments": {
-          "type": "string",
-          "description": "The arguments that the model requires are provided to the named function."
-        },
-        "output": {
-          "type": "string",
-          "description": "The output of the function, only populated for function calls that have already have had their outputs submitted.",
-          "x-nullable": true
-        }
-      },
-      "required": [
-        "name",
-        "arguments",
-        "output"
       ]
     },
     "FunctionToolDefinition": {
@@ -2661,7 +2510,7 @@
       "description": "A representation of a requested call to a function tool, needed by the model to continue evaluation of a run.",
       "properties": {
         "function": {
-          "$ref": "#/definitions/FunctionDefinition",
+          "$ref": "#/definitions/RequiredFunctionToolCallDetails",
           "description": "Detailed information about the function to be executed by the tool that includes name and arguments."
         }
       },
@@ -2674,6 +2523,24 @@
         }
       ],
       "x-ms-discriminator-value": "function"
+    },
+    "RequiredFunctionToolCallDetails": {
+      "type": "object",
+      "description": "The detailed information for a function invocation, as provided by a required action invoking a function tool, that includes the name of and arguments to the function.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The arguments to use when invoking the named function, as provided by the model."
+        }
+      },
+      "required": [
+        "name",
+        "arguments"
+      ]
     },
     "RequiredToolCall": {
       "type": "object",
@@ -2693,28 +2560,6 @@
         "type",
         "id"
       ]
-    },
-    "RetrievalToolCall": {
-      "type": "object",
-      "description": "A record of a call to a retrieval tool, issued by the model in evaluation of a defined tool, that represents\nexecuted retrieval actions.",
-      "properties": {
-        "retrieval": {
-          "type": "object",
-          "description": "The key/value pairs produced by the retrieval tool.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "required": [
-        "retrieval"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ToolCall"
-        }
-      ],
-      "x-ms-discriminator-value": "retrieval"
     },
     "RetrievalToolDefinition": {
       "type": "object",
@@ -2922,6 +2767,114 @@
         "metadata"
       ]
     },
+    "RunStepCodeInterpreterImageOutput": {
+      "type": "object",
+      "description": "A representation of an image output emitted by a code interpreter tool in response to a tool call by the model.",
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/RunStepCodeInterpreterImageReference",
+          "description": "Referential information for the image associated with this output."
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/RunStepCodeInterpreterToolCallOutput"
+        }
+      ],
+      "x-ms-discriminator-value": "image"
+    },
+    "RunStepCodeInterpreterImageReference": {
+      "type": "object",
+      "description": "An image reference emitted by a code interpreter tool in response to a tool call by the model.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The ID of the file associated with this image.",
+          "x-ms-client-name": "fileId"
+        }
+      },
+      "required": [
+        "file_id"
+      ]
+    },
+    "RunStepCodeInterpreterLogOutput": {
+      "type": "object",
+      "description": "A representation of a log output emitted by a code interpreter tool in response to a tool call by the model.",
+      "properties": {
+        "logs": {
+          "type": "string",
+          "description": "The serialized log output emitted by the code interpreter."
+        }
+      },
+      "required": [
+        "logs"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/RunStepCodeInterpreterToolCallOutput"
+        }
+      ],
+      "x-ms-discriminator-value": "logs"
+    },
+    "RunStepCodeInterpreterToolCall": {
+      "type": "object",
+      "description": "A record of a call to a code interpreter tool, issued by the model in evaluation of a defined tool, that\nrepresents inputs and outputs consumed and emitted by the code interpreter.",
+      "properties": {
+        "code_interpreter": {
+          "$ref": "#/definitions/RunStepCodeInterpreterToolCallDetails",
+          "description": "The details of the tool call to the code interpreter tool.",
+          "x-ms-client-name": "codeInterpreter"
+        }
+      },
+      "required": [
+        "code_interpreter"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "code_interpreter"
+    },
+    "RunStepCodeInterpreterToolCallDetails": {
+      "type": "object",
+      "description": "The detailed information about a code interpreter invocation by the model.",
+      "properties": {
+        "input": {
+          "type": "string",
+          "description": "The input provided by the model to the code interpreter tool."
+        },
+        "outputs": {
+          "type": "array",
+          "description": "The outputs produced by the code interpreter tool back to the model in response to the tool call.",
+          "items": {
+            "$ref": "#/definitions/RunStepCodeInterpreterToolCallOutput"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "input",
+        "outputs"
+      ]
+    },
+    "RunStepCodeInterpreterToolCallOutput": {
+      "type": "object",
+      "description": "An abstract representation of an emitted output from a code interpreter tool.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
     "RunStepDetails": {
       "type": "object",
       "description": "An abstract representation of the details for a run step.",
@@ -2978,6 +2931,49 @@
         ]
       }
     },
+    "RunStepFunctionToolCall": {
+      "type": "object",
+      "description": "A record of a call to a function tool, issued by the model in evaluation of a defined tool, that represents the inputs\nand output consumed and emitted by the specified function.",
+      "properties": {
+        "function": {
+          "$ref": "#/definitions/RunStepFunctionToolCallDetails",
+          "description": "The detailed information about the function called by the model."
+        }
+      },
+      "required": [
+        "function"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "function"
+    },
+    "RunStepFunctionToolCallDetails": {
+      "type": "object",
+      "description": "The detailed information about the function called by the model.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The arguments that the model requires are provided to the named function."
+        },
+        "output": {
+          "type": "string",
+          "description": "The output of the function, only populated for function calls that have already have had their outputs submitted.",
+          "x-nullable": true
+        }
+      },
+      "required": [
+        "name",
+        "arguments",
+        "output"
+      ]
+    },
     "RunStepMessageCreationDetails": {
       "type": "object",
       "description": "The detailed information associated with a message creation run step.",
@@ -3011,6 +3007,28 @@
       "required": [
         "message_id"
       ]
+    },
+    "RunStepRetrievalToolCall": {
+      "type": "object",
+      "description": "A record of a call to a retrieval tool, issued by the model in evaluation of a defined tool, that represents\nexecuted retrieval actions.",
+      "properties": {
+        "retrieval": {
+          "type": "object",
+          "description": "The key/value pairs produced by the retrieval tool.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "retrieval"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "retrieval"
     },
     "RunStepStatus": {
       "type": "string",
@@ -3054,6 +3072,25 @@
         ]
       }
     },
+    "RunStepToolCall": {
+      "type": "object",
+      "description": "An abstract representation of a detailed tool call as recorded within a run step for an existing run.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the tool call. This ID must be referenced when you submit tool outputs."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type",
+        "id"
+      ]
+    },
     "RunStepToolCallDetails": {
       "type": "object",
       "description": "The detailed information associated with a run step calling tools.",
@@ -3062,7 +3099,7 @@
           "type": "array",
           "description": "A list of tool call details for this run step.",
           "items": {
-            "$ref": "#/definitions/ToolCall"
+            "$ref": "#/definitions/RunStepToolCall"
           },
           "x-ms-client-name": "toolCalls"
         }
@@ -3429,25 +3466,6 @@
         "cancelled_at",
         "failed_at",
         "metadata"
-      ]
-    },
-    "ToolCall": {
-      "type": "object",
-      "description": "An abstract representation of a detailed tool call as recorded within a run step for an existing run.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "The object type."
-        },
-        "id": {
-          "type": "string",
-          "description": "The ID of the tool call. This ID must be referenced when you submit tool outputs."
-        }
-      },
-      "discriminator": "type",
-      "required": [
-        "type",
-        "id"
       ]
     },
     "ToolDefinition": {

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
@@ -1743,7 +1743,7 @@ components:
           description: The name of the function.
         arguments:
           type: string
-          description: The arguments to use when invoking the named function, as provided by the model.
+          description: The arguments to use when invoking the named function, as provided by the model. Arguments are presented as a JSON document that should be validated and parsed for evaluation.
       description: The detailed information for a function invocation, as provided by a required action invoking a function tool, that includes the name of and arguments to the function.
     RequiredToolCall:
       type: object

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
@@ -1304,99 +1304,6 @@ components:
           nullable: true
           description: A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.
       description: The details used to create a new assistant thread.
-    CodeInterpreterImageOutput:
-      type: object
-      required:
-        - type
-        - image
-      properties:
-        type:
-          type: string
-          enum:
-            - image
-          description: The object type, which is always 'image'.
-        image:
-          allOf:
-            - $ref: '#/components/schemas/CodeInterpreterImageReference'
-          description: Referential information for the image associated with this output.
-      allOf:
-        - $ref: '#/components/schemas/CodeInterpreterToolCallOutput'
-      description: A representation of an image output emitted by a code interpreter tool in response to a tool call by the model.
-    CodeInterpreterImageReference:
-      type: object
-      required:
-        - file_id
-      properties:
-        file_id:
-          type: string
-          description: The ID of the file associated with this image.
-      description: An image reference emitted by a code interpreter tool in response to a tool call by the model.
-    CodeInterpreterLogOutput:
-      type: object
-      required:
-        - type
-        - logs
-      properties:
-        type:
-          type: string
-          enum:
-            - logs
-          description: The object type, which is always 'logs'.
-        logs:
-          type: string
-          description: The serialized log output emitted by the code interpreter.
-      allOf:
-        - $ref: '#/components/schemas/CodeInterpreterToolCallOutput'
-      description: A representation of a log output emitted by a code interpreter tool in response to a tool call by the model.
-    CodeInterpreterToolCall:
-      type: object
-      required:
-        - type
-        - code_interpreter
-      properties:
-        type:
-          type: string
-          enum:
-            - code_interpreter
-          description: The object type, which is always 'code_interpreter'.
-        code_interpreter:
-          allOf:
-            - $ref: '#/components/schemas/CodeInterpreterToolCallDetails'
-          description: The details of the tool call to the code interpreter tool.
-      allOf:
-        - $ref: '#/components/schemas/ToolCall'
-      description: |-
-        A record of a call to a code interpreter tool, issued by the model in evaluation of a defined tool, that
-        represents inputs and outputs consumed and emitted by the code interpreter.
-    CodeInterpreterToolCallDetails:
-      type: object
-      required:
-        - input
-        - outputs
-      properties:
-        input:
-          type: string
-          description: The input provided by the model to the code interpreter tool.
-        outputs:
-          type: array
-          items:
-            $ref: '#/components/schemas/CodeInterpreterToolCallOutput'
-          description: The outputs produced by the code interpreter tool back to the model in response to the tool call.
-      description: The detailed information about a code interpreter invocation by the model.
-    CodeInterpreterToolCallOutput:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          description: The object type.
-      discriminator:
-        propertyName: type
-        mapping:
-          logs: '#/components/schemas/CodeInterpreterLogOutput'
-          image: '#/components/schemas/CodeInterpreterImageOutput'
-      description: An abstract representation of an emitted output from a code interpreter tool.
     CodeInterpreterToolDefinition:
       type: object
       required:
@@ -1534,44 +1441,6 @@ components:
         parameters:
           description: The parameters the functions accepts, described as a JSON Schema object.
       description: The input definition information for a function.
-    FunctionToolCall:
-      type: object
-      required:
-        - type
-        - function
-      properties:
-        type:
-          type: string
-          enum:
-            - function
-          description: The object type, which is always 'function'.
-        function:
-          allOf:
-            - $ref: '#/components/schemas/FunctionToolCallDetails'
-          description: The detailed information about the function called by the model.
-      allOf:
-        - $ref: '#/components/schemas/ToolCall'
-      description: |-
-        A record of a call to a function tool, issued by the model in evaluation of a defined tool, that represents the inputs
-        and output consumed and emitted by the specified function.
-    FunctionToolCallDetails:
-      type: object
-      required:
-        - name
-        - arguments
-        - output
-      properties:
-        name:
-          type: string
-          description: The name of the function.
-        arguments:
-          type: string
-          description: The arguments that the model requires are provided to the named function.
-        output:
-          type: string
-          nullable: true
-          description: The output of the function, only populated for function calls that have already have had their outputs submitted.
-      description: The detailed information about the function called by the model.
     FunctionToolDefinition:
       type: object
       required:
@@ -1858,11 +1727,24 @@ components:
           description: The object type of the required tool call. Always 'function' for function tools.
         function:
           allOf:
-            - $ref: '#/components/schemas/FunctionDefinition'
+            - $ref: '#/components/schemas/RequiredFunctionToolCallDetails'
           description: Detailed information about the function to be executed by the tool that includes name and arguments.
       allOf:
         - $ref: '#/components/schemas/RequiredToolCall'
       description: A representation of a requested call to a function tool, needed by the model to continue evaluation of a run.
+    RequiredFunctionToolCallDetails:
+      type: object
+      required:
+        - name
+        - arguments
+      properties:
+        name:
+          type: string
+          description: The name of the function.
+        arguments:
+          type: string
+          description: The arguments to use when invoking the named function, as provided by the model.
+      description: The detailed information for a function invocation, as provided by a required action invoking a function tool, that includes the name of and arguments to the function.
     RequiredToolCall:
       type: object
       required:
@@ -1880,27 +1762,6 @@ components:
         mapping:
           function: '#/components/schemas/RequiredFunctionToolCall'
       description: An abstract representation a a tool invocation needed by the model to continue a run.
-    RetrievalToolCall:
-      type: object
-      required:
-        - type
-        - retrieval
-      properties:
-        type:
-          type: string
-          enum:
-            - retrieval
-          description: The object type, which is always 'retrieval'.
-        retrieval:
-          type: object
-          additionalProperties:
-            type: string
-          description: The key/value pairs produced by the retrieval tool.
-      allOf:
-        - $ref: '#/components/schemas/ToolCall'
-      description: |-
-        A record of a call to a retrieval tool, issued by the model in evaluation of a defined tool, that represents
-        executed retrieval actions.
     RetrievalToolDefinition:
       type: object
       required:
@@ -2024,6 +1885,99 @@ components:
           nullable: true
           description: A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.
       description: Detailed information about a single step of an assistant thread run.
+    RunStepCodeInterpreterImageOutput:
+      type: object
+      required:
+        - type
+        - image
+      properties:
+        type:
+          type: string
+          enum:
+            - image
+          description: The object type, which is always 'image'.
+        image:
+          allOf:
+            - $ref: '#/components/schemas/RunStepCodeInterpreterImageReference'
+          description: Referential information for the image associated with this output.
+      allOf:
+        - $ref: '#/components/schemas/RunStepCodeInterpreterToolCallOutput'
+      description: A representation of an image output emitted by a code interpreter tool in response to a tool call by the model.
+    RunStepCodeInterpreterImageReference:
+      type: object
+      required:
+        - file_id
+      properties:
+        file_id:
+          type: string
+          description: The ID of the file associated with this image.
+      description: An image reference emitted by a code interpreter tool in response to a tool call by the model.
+    RunStepCodeInterpreterLogOutput:
+      type: object
+      required:
+        - type
+        - logs
+      properties:
+        type:
+          type: string
+          enum:
+            - logs
+          description: The object type, which is always 'logs'.
+        logs:
+          type: string
+          description: The serialized log output emitted by the code interpreter.
+      allOf:
+        - $ref: '#/components/schemas/RunStepCodeInterpreterToolCallOutput'
+      description: A representation of a log output emitted by a code interpreter tool in response to a tool call by the model.
+    RunStepCodeInterpreterToolCall:
+      type: object
+      required:
+        - type
+        - code_interpreter
+      properties:
+        type:
+          type: string
+          enum:
+            - code_interpreter
+          description: The object type, which is always 'code_interpreter'.
+        code_interpreter:
+          allOf:
+            - $ref: '#/components/schemas/RunStepCodeInterpreterToolCallDetails'
+          description: The details of the tool call to the code interpreter tool.
+      allOf:
+        - $ref: '#/components/schemas/RunStepToolCall'
+      description: |-
+        A record of a call to a code interpreter tool, issued by the model in evaluation of a defined tool, that
+        represents inputs and outputs consumed and emitted by the code interpreter.
+    RunStepCodeInterpreterToolCallDetails:
+      type: object
+      required:
+        - input
+        - outputs
+      properties:
+        input:
+          type: string
+          description: The input provided by the model to the code interpreter tool.
+        outputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/RunStepCodeInterpreterToolCallOutput'
+          description: The outputs produced by the code interpreter tool back to the model in response to the tool call.
+      description: The detailed information about a code interpreter invocation by the model.
+    RunStepCodeInterpreterToolCallOutput:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: The object type.
+      discriminator:
+        propertyName: type
+        mapping:
+          logs: '#/components/schemas/RunStepCodeInterpreterLogOutput'
+          image: '#/components/schemas/RunStepCodeInterpreterImageOutput'
+      description: An abstract representation of an emitted output from a code interpreter tool.
     RunStepDetails:
       type: object
       required:
@@ -2059,6 +2013,44 @@ components:
         - server_error
         - rate_limit_exceeded
       description: Possible error code values attributable to a failed run step.
+    RunStepFunctionToolCall:
+      type: object
+      required:
+        - type
+        - function
+      properties:
+        type:
+          type: string
+          enum:
+            - function
+          description: The object type, which is always 'function'.
+        function:
+          allOf:
+            - $ref: '#/components/schemas/RunStepFunctionToolCallDetails'
+          description: The detailed information about the function called by the model.
+      allOf:
+        - $ref: '#/components/schemas/RunStepToolCall'
+      description: |-
+        A record of a call to a function tool, issued by the model in evaluation of a defined tool, that represents the inputs
+        and output consumed and emitted by the specified function.
+    RunStepFunctionToolCallDetails:
+      type: object
+      required:
+        - name
+        - arguments
+        - output
+      properties:
+        name:
+          type: string
+          description: The name of the function.
+        arguments:
+          type: string
+          description: The arguments that the model requires are provided to the named function.
+        output:
+          type: string
+          nullable: true
+          description: The output of the function, only populated for function calls that have already have had their outputs submitted.
+      description: The detailed information about the function called by the model.
     RunStepMessageCreationDetails:
       type: object
       required:
@@ -2086,6 +2078,27 @@ components:
           type: string
           description: The ID of the message created by this run step.
       description: The details of a message created as a part of a run step.
+    RunStepRetrievalToolCall:
+      type: object
+      required:
+        - type
+        - retrieval
+      properties:
+        type:
+          type: string
+          enum:
+            - retrieval
+          description: The object type, which is always 'retrieval'.
+        retrieval:
+          type: object
+          additionalProperties:
+            type: string
+          description: The key/value pairs produced by the retrieval tool.
+      allOf:
+        - $ref: '#/components/schemas/RunStepToolCall'
+      description: |-
+        A record of a call to a retrieval tool, issued by the model in evaluation of a defined tool, that represents
+        executed retrieval actions.
     RunStepStatus:
       type: string
       enum:
@@ -2095,6 +2108,25 @@ components:
         - completed
         - expired
       description: Possible values for the status of a run step.
+    RunStepToolCall:
+      type: object
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          description: The object type.
+        id:
+          type: string
+          description: The ID of the tool call. This ID must be referenced when you submit tool outputs.
+      discriminator:
+        propertyName: type
+        mapping:
+          code_interpreter: '#/components/schemas/RunStepCodeInterpreterToolCall'
+          retrieval: '#/components/schemas/RunStepRetrievalToolCall'
+          function: '#/components/schemas/RunStepFunctionToolCall'
+      description: An abstract representation of a detailed tool call as recorded within a run step for an existing run.
     RunStepToolCallDetails:
       type: object
       required:
@@ -2109,7 +2141,7 @@ components:
         tool_calls:
           type: array
           items:
-            $ref: '#/components/schemas/ToolCall'
+            $ref: '#/components/schemas/RunStepToolCall'
           description: A list of tool call details for this run step.
       allOf:
         - $ref: '#/components/schemas/RunStepDetails'
@@ -2362,25 +2394,6 @@ components:
           nullable: true
           description: A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.
       description: Data representing a single evaluation run of an assistant thread.
-    ToolCall:
-      type: object
-      required:
-        - type
-        - id
-      properties:
-        type:
-          type: string
-          description: The object type.
-        id:
-          type: string
-          description: The ID of the tool call. This ID must be referenced when you submit tool outputs.
-      discriminator:
-        propertyName: type
-        mapping:
-          code_interpreter: '#/components/schemas/CodeInterpreterToolCall'
-          retrieval: '#/components/schemas/RetrievalToolCall'
-          function: '#/components/schemas/FunctionToolCall'
-      description: An abstract representation of a detailed tool call as recorded within a run step for an existing run.
     ToolDefinition:
       type: object
       required:


### PR DESCRIPTION
Full credit and many thanks to #27632 for finding this sneaky mismatch!

Problem summary: the spec currently inappropriately reuses a `FunctionDefinition` model for information about a function within a `required_action` -- this model has required `name` and `parameter` properties, while the matching anonymous model in [OpenAI's RunToolCallObject.function](https://github.com/openai/openai-openapi/blob/97dfb59c89ce0550e9360a7d437491d556e5a65e/openapi.yaml#L7789) instead has required `name` and **`arguments`** properties.

Fundamentally, this spec doesn't yet have a model that matches `RunToolCallObject.function` -- the closest is `FunctionToolCallDetails`, as used in the above PR, but that's already a direct "almost but not quite the same" match to [OpenAI's RunStepDetailsToolCallsFunctionObject.function](https://github.com/openai/openai-openapi/blob/97dfb59c89ce0550e9360a7d437491d556e5a65e/openapi.yaml#L8504) anonymous model, which has `name`, `arguments`, *and* an additional, required `output`.

Functionally, all this change does is add a new `RequiredFunctionToolCallDetails` model (to match the `name`/`arguments` pair) and then substitute it where the inappropriate use of `FunctionDefinition` was in `RequiredFunctionToolCall`.

Given the way this highlights how confusing the small but important model differences are, I also pushed a naming consistency prefix of 'RunStep' on all of the models exclusively used in run step representations; this makes for longer names but also establishes a much less ambiguous split between the models used in required_action and the models used in run steps. These are purely superficial naming updates to the existing types likely better consolidated by a consuming library layer.
