### PR TITLE
Fix incorrect tag name in comment.

### DIFF
--- a/specification/contosowidgetmanager/data-plane/readme.md
+++ b/specification/contosowidgetmanager/data-plane/readme.md
@@ -19,7 +19,7 @@ tag: package-2022-11-01-preview
 
 ### Tag: package-2022-11-01-preview
 
-These settings apply only when `--tag=package--2022-11-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2022-11-01-preview` is specified on the command line.
 
 ```yaml $(tag) == 'package-2022-11-01-preview'
 input-file:


### PR DESCRIPTION
Change to template readme to fix tag name in comments.