### PR TITLE
OpenAI assistants: The file ID is just a string, not an object.

### DIFF
--- a/specification/ai/OpenAI.Assistants/client.tsp
+++ b/specification/ai/OpenAI.Assistants/client.tsp
@@ -131,16 +131,11 @@ namespace Azure.AI.OpenAI.Assistants;
 // base64) are better accomplished via another approach at the client layer.
 
 @@access(MessageImageFileDetails, Access.internal);
-@@access(MessageImageFileIdDetails, Access.internal);
 @@projectedName(MessageImageFileDetails,
   "csharp",
   "InternalMessageImageFileDetails"
 );
 @@projectedName(MessageImageFileContent.imageFile, "csharp", "InternalDetails");
-@@projectedName(MessageImageFileIdDetails,
-  "csharp",
-  "InternalMessageImageFileIdDetails"
-);
 @@projectedName(MessageImageFileDetails.fileId, "csharp", "InternalDetails");
 
 // Several of the content item types are not intended to be used as input

--- a/specification/ai/OpenAI.Assistants/files/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/files/routes.tsp
@@ -83,7 +83,7 @@ op getFile(
 ): OpenAIFile;
 
 @get
-@route("/files/content/{fileId}")
+@route("/files/{fileId}/content")
 @doc("Returns information about a specific file. Does not retrieve file content.")
 op getFileContent(
   @doc("The ID of the file to retrieve.")

--- a/specification/ai/OpenAI.Assistants/files/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/files/routes.tsp
@@ -81,3 +81,13 @@ op getFile(
   @encodedName("application/json", "file_id")
   fileId: string,
 ): OpenAIFile;
+
+@get
+@route("/files/content/{fileId}")
+@doc("Returns information about a specific file. Does not retrieve file content.")
+op getFileContent(
+  @doc("The ID of the file to retrieve.")
+  @path
+  @encodedName("application/json", "file_id")
+  fileId: string,
+): bytes;

--- a/specification/ai/OpenAI.Assistants/files/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/files/routes.tsp
@@ -82,6 +82,8 @@ op getFile(
   fileId: string,
 ): OpenAIFile;
 
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+#suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @get
 @route("/files/{fileId}/content")
 @doc("Returns information about a specific file. Does not retrieve file content.")

--- a/specification/ai/OpenAI.Assistants/messages/models.tsp
+++ b/specification/ai/OpenAI.Assistants/messages/models.tsp
@@ -184,14 +184,6 @@ model MessageTextFilePathDetails {
 model MessageImageFileDetails {
   @encodedName("application/json", "file_id")
   @doc("The ID for the file associated with this image.")
-  fileId: MessageImageFileIdDetails;
-}
-
-@doc("An encapsulation of an image file ID, as used by message image content.")
-@added(ServiceApiVersions.v2024_02_15_preview)
-model MessageImageFileIdDetails {
-  @doc("The ID of the specific image file.")
-  @encodedName("application/json", "file_id")
   fileId: string;
 }
 

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-02-15-preview/assistants_generated.json
@@ -641,6 +641,30 @@
         }
       }
     },
+    "/files/{fileId}/content": {
+      "get": {
+        "operationId": "GetFileContent",
+        "description": "Returns information about a specific file. Does not retrieve file content.",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The ID of the file to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "string",
+              "format": "byte"
+            }
+          }
+        }
+      }
+    },
     "/threads": {
       "post": {
         "operationId": "CreateThread",
@@ -2250,22 +2274,8 @@
       "description": "An image reference, as represented in thread message content.",
       "properties": {
         "file_id": {
-          "$ref": "#/definitions/MessageImageFileIdDetails",
-          "description": "The ID for the file associated with this image.",
-          "x-ms-client-name": "fileId"
-        }
-      },
-      "required": [
-        "file_id"
-      ]
-    },
-    "MessageImageFileIdDetails": {
-      "type": "object",
-      "description": "An encapsulation of an image file ID, as used by message image content.",
-      "properties": {
-        "file_id": {
           "type": "string",
-          "description": "The ID of the specific image file.",
+          "description": "The ID for the file associated with this image.",
           "x-ms-client-name": "fileId"
         }
       },

--- a/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
+++ b/specification/ai/data-plane/OpenAI.Assistants/OpenApiV3/2024-02-15-preview/assistants_generated.yaml
@@ -375,6 +375,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAIFile'
+  /files/{fileId}/content:
+    get:
+      operationId: getFileContent
+      description: Returns information about a specific file. Does not retrieve file content.
+      parameters:
+        - name: fileId
+          in: path
+          required: true
+          description: The ID of the file to retrieve.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
   /threads:
     post:
       operationId: createThread
@@ -1527,19 +1546,9 @@ components:
         - file_id
       properties:
         file_id:
-          allOf:
-            - $ref: '#/components/schemas/MessageImageFileIdDetails'
+          type: string
           description: The ID for the file associated with this image.
       description: An image reference, as represented in thread message content.
-    MessageImageFileIdDetails:
-      type: object
-      required:
-        - file_id
-      properties:
-        file_id:
-          type: string
-          description: The ID of the specific image file.
-      description: An encapsulation of an image file ID, as used by message image content.
     MessageRole:
       type: string
       enum:


### PR DESCRIPTION
- MessageImageFileDetails.FileID is just a string, not an object that contains a string. 
- Adding in a function so we can also GetFileContents (needed to download files generated as part of an assistants run)