### PR TITLE
add KIND to 2024-02-02preview

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-02-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-02-02-preview/managedClusters.json
@@ -5477,6 +5477,10 @@
           "description": "Properties of a managed cluster.",
           "$ref": "#/definitions/ManagedClusterProperties",
           "x-ms-client-flatten": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is primarily used to expose different UI experiences in the portal for different kinds"
         }
       },
       "allOf": [


### PR DESCRIPTION
add KIND to 2024-02-02preview

PRD Link: [https://microsoft.sharepoint.com/:w:/r/teams/azurecontainercompute/_layouts/15/Doc.aspx?sourcedoc={BCE16B46-5383-484E-81B0-143A3BECF24F}&file=DevX - AKS Application Mode PRD.docx&action=default&mobileredirect=true&cid=e6fba65f-a795-4efd-a234-197674c787fe](https://microsoft.sharepoint.com/:w:/r/teams/azurecontainercompute/_layouts/15/Doc.aspx?sourcedoc=%7BBCE16B46-5383-484E-81B0-143A3BECF24F%7D&file=DevX%20-%20AKS%20Application%20Mode%20PRD.docx&action=default&mobileredirect=true&cid=e6fba65f-a795-4efd-a234-197674c787fe) 

API review Doc : https://dev.azure.com/msazure/CloudNativeCompute/_wiki/wikis/CloudNativeCompute.wiki/642084/AppsReady-Kind-API 

for any existing API versions except of new 2024-02-02-preview API, there is no Kind property in MC, so there is no behavior change for all these existing API versions

for 2024-02-02-preview API, if no explicit Kind provided or Kind and SKU.Name matches in input body, MC put has no behavior change. MC put will fail with BadRequest only explicit Kind and SKU.Name doesn't match.
