### PR TITLE
APC: Make SimSwap date result optional

### DIFF
--- a/specification/programmableconnectivity/Azure.ProgrammableConnectivity/apis/simswap.tsp
+++ b/specification/programmableconnectivity/Azure.ProgrammableConnectivity/apis/simswap.tsp
@@ -65,7 +65,7 @@ model SimSwapVerificationContent {
 @doc("Response with SimSwap date")
 model SimSwapRetrievalResult {
   @doc("Datetime of most recent swap for SIM")
-  date: utcDateTime;
+  date?: utcDateTime;
 }
 
 @doc("Response verifying SimSwap in period")

--- a/specification/programmableconnectivity/data-plane/Azure.ProgrammableConnectivity/preview/2024-02-09-preview/openapi.json
+++ b/specification/programmableconnectivity/data-plane/Azure.ProgrammableConnectivity/preview/2024-02-09-preview/openapi.json
@@ -942,10 +942,7 @@
           "format": "date-time",
           "description": "Datetime of most recent swap for SIM"
         }
-      },
-      "required": [
-        "date"
-      ]
+      }
     },
     "SimSwapVerificationContent": {
       "type": "object",


### PR DESCRIPTION
# Data Plane API - Pull Request

Minor change to reflect that APC may now return a null value for the field `date` in a SIM Swap retrieval.

This change has been implemented in APC before it goes into public preview on 23rd February, so this PR just makes the API specification match the deployed code.