### PR TITLE
Update workflow-bot comment.yml: update guidance for publishing to public repo; add support for new breaking changes labels

### DIFF
--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -80,21 +80,21 @@
 - rule:
     type: label
     label: Approved-BreakingChange
-    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
+    booleanFilterExpression: "!(ARMSignedOff||WaitForARMFeedback||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit||)&&ARMReview"
     onLabeledAddLabels:
         - WaitForARMFeedback
 
 - rule:
     type: label
     label: BreakingChange-Approved-*
-    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
+    booleanFilterExpression: "!(ARMSignedOff||WaitForARMFeedback||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
     onLabeledAddLabels:
         - WaitForARMFeedback
 
 - rule:
     type: label
     label: Versioning-Approved-*
-    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
+    booleanFilterExpression: "!(ARMSignedOff||WaitForARMFeedback||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
     onLabeledAddLabels:
         - WaitForARMFeedback
 

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -13,9 +13,7 @@
       If this PR is targeting `main` branch, then it cannot be merged, as `azure-rest-api-specs-pr` repo `main` branch 
       is mirrored from `azure-rest-api-specs` `main`` branch. <br/>
       If you want to publish the PR to the public repo (`Azure/azure-rest-api-specs`) `main` branch, 
-      please use [OpenAPIHub Publish PR](${openapiHub}/tools/publishpullrequest?pr=${owner}/${repo}/${PRNumber}&to=${to}).
-      </li><li>
-      For further guidance see [Spec Repos](https://eng.ms/docs/products/azure-developer-experience/design/api-specs-pr/api-repos).
+      follow the guidance given in the [spec repos article](https://eng.ms/docs/products/azure-developer-experience/design/api-specs-pr/api-repos).
       </li>
 
 - rule:
@@ -82,6 +80,20 @@
 - rule:
     type: label
     label: Approved-BreakingChange
+    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
+    onLabeledAddLabels:
+        - WaitForARMFeedback
+
+- rule:
+    type: label
+    label: BreakingChange-Approved-*
+    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
+    onLabeledAddLabels:
+        - WaitForARMFeedback
+
+- rule:
+    type: label
+    label: Versioning-Approved-*
     booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
     onLabeledAddLabels:
         - WaitForARMFeedback


### PR DESCRIPTION
This PR contributes to:
- https://github.com/Azure/azure-sdk-tools/issues/6374 

And requires logic from the following PR:
- [Pull Request 532621](https://devdiv.visualstudio.com/DevDiv/_git/openapi-alps/pullrequest/532621): Add support to workflow bot for matching labels by prefix.