### PR TITLE
Fix order of tags that differ when generated from `main.tsp` vs `client.tsp` (due to `--no-emit-fix`)

### DIFF
--- a/specification/communication/data-plane/Messages/stable/2024-02-01/communicationservicesmessages.json
+++ b/specification/communication/data-plane/Messages/stable/2024-02-01/communicationservicesmessages.json
@@ -63,13 +63,13 @@
   },
   "tags": [
     {
-      "name": "Stream"
+      "name": "Template"
     },
     {
       "name": "Notifications"
     },
     {
-      "name": "Template"
+      "name": "Stream"
     }
   ],
   "paths": {


### PR DESCRIPTION
Not sure how the original PR passed the TypeSpecValidation ci step but it is now failing 

Update: We determined the issue is only in `typespec-next`, and the root cause is related to a bug where `compile --no-emit` was actually emitting.