### PR TITLE
[Stream Analytics] Add body parameters for stop streaming job operation for scheduled stop function.

### DIFF
--- a/specification/streamanalytics/resource-manager/Microsoft.StreamAnalytics/preview/2017-04-01-preview/examples/StreamingJob_Stop_Scheduled.json
+++ b/specification/streamanalytics/resource-manager/Microsoft.StreamAnalytics/preview/2017-04-01-preview/examples/StreamingJob_Stop_Scheduled.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2017-04-01-preview",
+    "subscriptionId": "56b5e0a9-b645-407d-99b0-c64f86013e3d",
+    "resourceGroupName": "sjrg",
+    "jobName": "sjName",
+    "stopJobParameters": {
+      "outputStopTime": "2012-12-12T12:12:12Z"
+    }
+  },
+  "responses": {
+    "200": {},
+    "202": {}
+  }
+}

--- a/specification/streamanalytics/resource-manager/Microsoft.StreamAnalytics/preview/2017-04-01-preview/streamingjobs.json
+++ b/specification/streamanalytics/resource-manager/Microsoft.StreamAnalytics/preview/2017-04-01-preview/streamingjobs.json
@@ -458,6 +458,15 @@
         },
         "parameters": [
           {
+            "name": "stopJobParameters",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/StopStreamingJobParameters"
+            },
+            "description": "Parameters applicable to a stop streaming job operation."
+          },
+          {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
           },
           {
@@ -719,6 +728,17 @@
           "type": "string",
           "format": "date-time",
           "description": "Value is either an ISO-8601 formatted time stamp that indicates the starting point of the output event stream, or null to indicate that the output event stream will start whenever the streaming job is started. This property must have a value if outputStartMode is set to CustomTime."
+        }
+      }
+    },
+    "StopStreamingJobParameters": {
+      "type": "object",
+      "description": "Parameters supplied to the Stop Streaming Job operation.",
+      "properties": {
+        "outputStopTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Value is either an ISO-8601 formatted time stamp that indicates the scheduled stopping point of the output event stream, or null to indicate that the output event stream will stop immediately."
         }
       }
     },

--- a/specification/streamanalytics/resource-manager/Microsoft.StreamAnalytics/preview/2021-10-01-preview/examples/StreamingJob_Stop_Scheduled.json
+++ b/specification/streamanalytics/resource-manager/Microsoft.StreamAnalytics/preview/2021-10-01-preview/examples/StreamingJob_Stop_Scheduled.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2021-10-01-preview",
+    "subscriptionId": "56b5e0a9-b645-407d-99b0-c64f86013e3d",
+    "resourceGroupName": "sjrg6936",
+    "jobName": "sj59",
+    "stopJobParameters": {
+      "outputStopTime": "2012-12-12T12:12:12Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/56b5e0a9-b645-407d-99b0-c64f86013e3d/resourceGroups/sjrg/providers/Microsoft.StreamAnalytics/streamingjobs/sjName/OperationResults/0cc50cef-de8c-48d4-b60b-7750cbaf4f76?api-version=2021-10-01-preview"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/56b5e0a9-b645-407d-99b0-c64f86013e3d/resourceGroups/sjrg/providers/Microsoft.StreamAnalytics/streamingjobs/sjName/OperationResults/0cc50cef-de8c-48d4-b60b-7750cbaf4f76?api-version=2021-10-01-preview"
+      }
+    }
+  }
+}

--- a/specification/streamanalytics/resource-manager/Microsoft.StreamAnalytics/preview/2021-10-01-preview/streamingjobs.json
+++ b/specification/streamanalytics/resource-manager/Microsoft.StreamAnalytics/preview/2021-10-01-preview/streamingjobs.json
@@ -497,6 +497,15 @@
         },
         "parameters": [
           {
+            "name": "stopJobParameters",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/StopStreamingJobParameters"
+            },
+            "description": "Parameters applicable to a stop streaming job operation."
+          },
+          {
             "$ref": "../../common/v1/definitions.json#/parameters/ApiVersionParameter"
           },
           {
@@ -913,6 +922,17 @@
           "type": "string",
           "format": "date-time",
           "description": "Value is either an ISO-8601 formatted time stamp that indicates the starting point of the output event stream, or null to indicate that the output event stream will start whenever the streaming job is started. This property must have a value if outputStartMode is set to CustomTime."
+        }
+      }
+    },
+    "StopStreamingJobParameters": {
+      "type": "object",
+      "description": "Parameters supplied to the Stop Streaming Job operation.",
+      "properties": {
+        "outputStopTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Value is either an ISO-8601 formatted time stamp that indicates the scheduled stopping point of the output event stream, or null to indicate that the output event stream will stop immediately."
         }
       }
     },


### PR DESCRIPTION
Add body parameters as the following for stop streaming job operation for scheduled stop function.
    "stopJobParameters": {
      "outputStopTime": "<a time stamp>"
    }

The changes involved versions: 2017-04-01-preview and 2021-10-01-preview.