### PR TITLE
[OpenAI] Remove usage.input for visibility.

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/client/custom_visibility.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/client/custom_visibility.tsp
@@ -11,7 +11,7 @@ using Azure.ClientGenerator.Core;
 @@access(Azure.OpenAI.ImageGenerationOptions, Access.public);
 @@usage(Azure.OpenAI.ImageGenerationOptions, Usage.input | Usage.output);
 @@access(Azure.OpenAI.ImageSize, Access.public);
-@@usage(Azure.OpenAI.ImageGenerations, Usage.input | Usage.output);
+@@usage(Azure.OpenAI.ImageGenerations, Usage.output);
 
 // The purpose of this enum is to identify the type of a given result. In C#, this is redundant because we have
 // strongly-typed classes for each possible result.


### PR DESCRIPTION
`ImageGeneration` is an output model that does not need to be Usage.Input.

With Usage.Input, the ImageGeneration model and its properties models will generate public constructor and setters that allows user to be able to set the properties.


Java changes: https://github.com/Azure/azure-sdk-for-java/pull/38975/commits/8c69476acbce589d61866a4b22d367251b4c6be3