### PR TITLE
[DocumentIntelligence] Rename base64Source to bytesSource in Python

### DIFF
--- a/specification/ai/DocumentIntelligence/client.tsp
+++ b/specification/ai/DocumentIntelligence/client.tsp
@@ -94,3 +94,6 @@ interface DocumentIntelligenceAdministrationClient {
 @@usage(ComposeDocumentModelRequest, Usage.input, "csharp");
 @@usage(ComponentDocumentModelDetails, Usage.input, "csharp");
 @@usage(CopyAuthorization, Usage.input | Usage.output, "csharp");
+
+@@projectedName(AnalyzeDocumentRequest.base64Source, "python", "bytesSource");
+@@projectedName(ClassifyDocumentRequest.base64Source, "python", "bytesSource");

--- a/specification/ai/DocumentIntelligence/models.tsp
+++ b/specification/ai/DocumentIntelligence/models.tsp
@@ -315,6 +315,7 @@ model AnalyzeDocumentRequest {
   Base64 encoding of the document to analyze.  Either urlSource or base64Source
   must be specified.
   """)
+  @projectedName("python", "bytesSource")
   base64Source?: bytes;
 }
 
@@ -1364,6 +1365,7 @@ model ClassifyDocumentRequest {
   Base64 encoding of the document to classify.  Either urlSource or base64Source
   must be specified.
   """)
+  @projectedName("python", "bytesSource")
   base64Source?: bytes;
 }
 

--- a/specification/ai/DocumentIntelligence/models.tsp
+++ b/specification/ai/DocumentIntelligence/models.tsp
@@ -315,7 +315,6 @@ model AnalyzeDocumentRequest {
   Base64 encoding of the document to analyze.  Either urlSource or base64Source
   must be specified.
   """)
-  @projectedName("python", "bytesSource")
   base64Source?: bytes;
 }
 
@@ -1365,7 +1364,6 @@ model ClassifyDocumentRequest {
   Base64 encoding of the document to classify.  Either urlSource or base64Source
   must be specified.
   """)
-  @projectedName("python", "bytesSource")
   base64Source?: bytes;
 }
 


### PR DESCRIPTION
Rename property `base64Source` as Python sdk will encode the input into base64 encoded bytes, the input from customer should just be bytes.