### PR TITLE
Convert scripts to use "npm exec" instead of "npx"

### DIFF
--- a/eng/scripts/Swagger-Prettier-Check.ps1
+++ b/eng/scripts/Swagger-Prettier-Check.ps1
@@ -11,8 +11,8 @@ $repoPath = Resolve-Path "$PSScriptRoot/../.."
 $pathsWithErrors = @()
 
 if ($CheckAll) {
-  LogInfo "npx --no -- prettier --check $repoPath/specification/**/*.json --log-level warn"
-  npx --no -- prettier --check $repoPath/specification/**/*.json --log-level warn
+  LogInfo "npm exec --no -- prettier --check $repoPath/specification/**/*.json --log-level warn"
+  npm exec --no -- prettier --check $repoPath/specification/**/*.json --log-level warn
   if ($LASTEXITCODE) {
     $pathsWithErrors += "$repoPath/specification/**/*.json"
   }
@@ -25,8 +25,8 @@ else
   }
   else {
     foreach ($file in $filesToCheck) {
-      LogInfo "npx --no -- prettier --check $repoPath/$file --log-level warn"
-      npx --no -- prettier --check $repoPath/$file --log-level warn
+      LogInfo "npm exec --no -- prettier --check $repoPath/$file --log-level warn"
+      npm exec --no -- prettier --check $repoPath/$file --log-level warn
       if ($LASTEXITCODE) {
         $pathsWithErrors += $file
       }

--- a/eng/scripts/Validate-TypeSpec.ps1
+++ b/eng/scripts/Validate-TypeSpec.ps1
@@ -13,8 +13,8 @@ if ($typespecFolders) {
   $typespecFolders = $typespecFolders.Split('',[System.StringSplitOptions]::RemoveEmptyEntries)
   foreach ($typespecFolder in $typespecFolders) {
     LogGroupStart "Validating $typespecFolder"
-    LogInfo "npm exec --no tsv $typespecFolder"
-    npm exec --no tsv $typespecFolder 2>&1 | Write-Host
+    LogInfo "npm exec --no -- tsv $typespecFolder"
+    npm exec --no -- tsv $typespecFolder 2>&1 | Write-Host
     if ($LASTEXITCODE) {
       $typespecFoldersWithFailures += $typespecFolder
       $errorString = "TypeSpec Validation failed for project $typespecFolder run the following command locally to validate."

--- a/eng/scripts/Validate-TypeSpec.ps1
+++ b/eng/scripts/Validate-TypeSpec.ps1
@@ -13,8 +13,8 @@ if ($typespecFolders) {
   $typespecFolders = $typespecFolders.Split('',[System.StringSplitOptions]::RemoveEmptyEntries)
   foreach ($typespecFolder in $typespecFolders) {
     LogGroupStart "Validating $typespecFolder"
-    LogInfo "npx --no tsv $typespecFolder"
-    npx --no tsv $typespecFolder 2>&1 | Write-Host
+    LogInfo "npm exec --no tsv $typespecFolder"
+    npm exec --no tsv $typespecFolder 2>&1 | Write-Host
     if ($LASTEXITCODE) {
       $typespecFoldersWithFailures += $typespecFolder
       $errorString = "TypeSpec Validation failed for project $typespecFolder run the following command locally to validate."

--- a/eng/tools/typespec-validation/src/rules/compile.ts
+++ b/eng/tools/typespec-validation/src/rules/compile.ts
@@ -14,7 +14,7 @@ export class CompileRule implements Rule {
 
     if (await host.checkFileExists(path.join(folder, "main.tsp"))) {
       let [err, stdout, stderr] = await host.runCmd(
-        `npx --no tsp compile . --warn-as-error`,
+        `npm exec --no -- tsp compile . --warn-as-error`,
         folder,
       );
       if (
@@ -33,7 +33,7 @@ export class CompileRule implements Rule {
     }
     if (await host.checkFileExists(path.join(folder, "client.tsp"))) {
       let [err, stdout, stderr] = await host.runCmd(
-        `npx --no tsp compile client.tsp --no-emit --warn-as-error`,
+        `npm exec --no -- tsp compile client.tsp --no-emit --warn-as-error`,
         folder,
       );
       if (err) {

--- a/eng/tools/typespec-validation/src/rules/format.ts
+++ b/eng/tools/typespec-validation/src/rules/format.ts
@@ -9,7 +9,10 @@ export class FormatRule implements Rule {
   async execute(host: TsvHost, folder: string): Promise<RuleResult> {
     // Format parent folder to include shared files
 
-    let [err, stdOutput, errorOutput] = await host.runCmd(`npx tsp format "../**/*.tsp"`, folder);
+    let [err, stdOutput, errorOutput] = await host.runCmd(
+      `npm exec --no -- tsp format "../**/*.tsp"`,
+      folder,
+    );
     // Failing on both err and errorOutput because of known bug in tsp format where it returns 0 on failed formatting
     // https://github.com/microsoft/typespec/issues/2323
     let success = !err && !errorOutput;


### PR DESCRIPTION
- Devs should use "npx" for brevity
- Scripts should use "npm exec --no --" for predictability and consistency
- Not expected to cause any behavioral changes, just fixing proactively
