### PR TITLE
[TypeSpec Scripts] Add base and target commit params

### DIFF
--- a/eng/scripts/Get-TypeSpec-Folders.ps1
+++ b/eng/scripts/Get-TypeSpec-Folders.ps1
@@ -1,6 +1,8 @@
 [CmdletBinding()]
 param (
-  [switch]$CheckAll = $false
+  [switch]$CheckAll = $false,
+  [string]$BaseCommitish = "HEAD^",
+  [string]$TargetCommitish = "HEAD"
 )
 Set-StrictMode -Version 3
 
@@ -13,7 +15,7 @@ if ($CheckAll) {
   $changedFiles = $checkAllPath
 }
 else {
-  $changedFiles = @(Get-ChangedFiles -diffFilter "")
+  $changedFiles = @(Get-ChangedFiles -baseCommitish $BaseCommitish -targetCommitish $TargetCommitish -diffFilter "")
   $coreChangedFiles = Get-ChangedCoreFiles $changedFiles
 
   if ($Env:BUILD_REPOSITORY_NAME -eq 'azure/azure-rest-api-specs' -and $coreChangedFiles) {

--- a/eng/scripts/Validate-TypeSpec.ps1
+++ b/eng/scripts/Validate-TypeSpec.ps1
@@ -1,12 +1,14 @@
 [CmdletBinding()]
 param (
   [switch]$CheckAll = $false,
-  [switch]$GitClean = $false
+  [switch]$GitClean = $false,
+  [string]$BaseCommitish = "HEAD^",
+  [string]$TargetCommitish = "HEAD"
 )
 
 . $PSScriptRoot/Logging-Functions.ps1
 
-$typespecFolders = &"$PSScriptRoot/Get-TypeSpec-Folders.ps1" -CheckAll:$CheckAll
+$typespecFolders = &"$PSScriptRoot/Get-TypeSpec-Folders.ps1" -BaseCommitish:$BaseCommitish -TargetCommitish:$TargetCommitish -CheckAll:$CheckAll
 
 $typespecFoldersWithFailures = @()
 if ($typespecFolders) {


### PR DESCRIPTION
- Plumb parameters from Get-ChangedFiles
- Enables validating between arbitrary commits
- Used by branch typespec-next
