### PR TITLE
`storage`: ensuring the constant names are unique

### DIFF
--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2023-04-01/storage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2023-04-01/storage.json
@@ -4263,7 +4263,7 @@
             "Disabled"
           ],
           "x-ms-enum": {
-            "name": "PublicNetworkAccess",
+            "name": "PublicNetworkAccessLegacy",
             "modelAsString": true
           },
           "description": "Allow or disallow public network access to Storage Account. Value is optional but if passed in, must be 'Enabled' or 'Disabled'."


### PR DESCRIPTION
There's two different constants defined for `PublicNetworkAccess`, both contain `Enabled` and `Disabled` but only one contains `SecuredByPerimeter` - therefore these are different constants and need unique names
