### PR TITLE
Azure OpenAI: add structured representation for On Your Data response 'metadata' (including 'chunking')

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/azure_chat_extensions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/azure_chat_extensions.tsp
@@ -87,9 +87,21 @@ model AzureChatExtensionDataSourceResponseCitation {
   @doc("The file path of the citation.")
   filepath?: string;
 
+  @doc("Additional metadata related to this citation.")
+  metadata?: AzureChatExtensionDataSourceResponseCitationMetadata;
+
   #suppress "@azure-tools/typespec-azure-core/casing-style" "OpenAI uses wire-format snake_casing"
   @doc("The chunk ID of the citation.")
   chunk_id?: string;
+}
+
+@added(ServiceApiVersions.v2024_02_15_Preview)
+@doc("""
+A representation of additional metadata information for an On Your Data response citation.
+""")
+model AzureChatExtensionDataSourceResponseCitationMetadata {
+  @doc("Additional information about chunking operations related to this citation.")
+  chunking: string;
 }
 
 @added(ServiceApiVersions.v2024_02_15_Preview)

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-02-15-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-02-15-preview/generated.json
@@ -1128,6 +1128,10 @@
           "type": "string",
           "description": "The file path of the citation."
         },
+        "metadata": {
+          "$ref": "#/definitions/AzureChatExtensionDataSourceResponseCitationMetadata",
+          "description": "Additional metadata related to this citation."
+        },
         "chunk_id": {
           "type": "string",
           "description": "The chunk ID of the citation."
@@ -1135,6 +1139,19 @@
       },
       "required": [
         "content"
+      ]
+    },
+    "AzureChatExtensionDataSourceResponseCitationMetadata": {
+      "type": "object",
+      "description": "A representation of additional metadata information for an On Your Data response citation.",
+      "properties": {
+        "chunking": {
+          "type": "string",
+          "description": "Additional information about chunking operations related to this citation."
+        }
+      },
+      "required": [
+        "chunking"
       ]
     },
     "AzureChatExtensionType": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-02-15-preview/inference.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-02-15-preview/inference.json
@@ -4612,12 +4612,28 @@
             "type": "string",
             "description": "The file path of the citation."
           },
+          "metadata": {
+            "$ref": "#/components/schemas/citationMetadata"
+          },
           "chunk_id": {
             "type": "string",
             "description": "The chunk ID of the citation."
           }
         },
         "description": "citation information for a chat completions response message."
+      },
+      "citationMetadata": {
+        "type": "object",
+        "description": "Additional metadata related to a citation.",
+        "properties": {
+          "chunking": {
+            "type": "string",
+            "description": "Information about the chunking operations related to a citation."
+          }
+        },
+        "required": [
+          "chunking"
+        ]
       },
       "chatCompletionMessageToolCall": {
         "type": "object",

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-02-15-preview/inference.yaml
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-02-15-preview/inference.yaml
@@ -3066,10 +3066,25 @@ components:
         filepath:
           type: string
           description: The file path of the citation.
+        metadata:
+          type:
+            $ref: '#/components/schemas/citationMetadata'
+          description: Additional metadata information for this citation.
         chunk_id:
           type: string
           description: The chunk ID of the citation.
       description: citation information for a chat completions response message.
+      required:
+        - content
+    citationMetadata:
+      type: object
+      description: Additional metadata information for a citation.
+      properties:
+        chunking:
+          type: string
+          description: Information about the chunking operations related to a citation.
+      required:
+        - chunking
     chatCompletionMessageToolCall:
       type: object
       properties:


### PR DESCRIPTION
`2024-02-15-preview` features a new, structured representation of On Your Data response citations that dramatically improves usability. It appears to currently lack structured representation of `metadata`, however, which still features on the raw response but does surface in the deconstructed object model for the schema.

This change adds said structured representation. It's intentionally a retroactive descriptive patch to the existing API version.