### PR TITLE
[confidentialledger] Add default tag to readme.md

### DIFF
--- a/specification/confidentialledger/data-plane/readme.md
+++ b/specification/confidentialledger/data-plane/readme.md
@@ -11,6 +11,11 @@ Please look to the files `Microsoft.ConfidentialLedger/preview/2023-01-18-previe
 
 > see https://aka.ms/autorest
 
+``` yaml
+tag: package-2023-01-18-preview-identity
+openapi-type: data-plane
+```
+
 ## Configuration
 
 ### Tag: package-0.1-preview-ledger


### PR DESCRIPTION
- Should fix LintDiff error "no input files provided"

LintDiff is still failing in this PR since the **old** `readme.md` is still bugged.  But the next PR to this spec should pass.

Earlier failure: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2853494&view=logs&j=0574a2a6-2d0a-5ec6-40e4-4c6e2f70bea2&t=80c3e782-49f0-5d1c-70dd-cbee57bdd0c7&l=251