### PR TITLE
Added private IP prefix length to network interface resource.

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/examples/NetworkInterfaceCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/examples/NetworkInterfaceCreate.json
@@ -19,6 +19,12 @@
                 "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
               }
             }
+          },
+          {
+            "name": "ipconfig2",
+            "properties": {
+              "privateIPAddressPrefixLength": 28
+            }
           }
         ]
       },
@@ -48,6 +54,21 @@
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
                 },
                 "primary": true,
+                "privateIPAddressVersion": "IPv4"
+              }
+            },
+            {
+              "name": "ipconfig2",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig2",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "172.20.2.16/28",
+                "privateIPAddressPrefixLength": 28,
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                },
+                "primary": false,
                 "privateIPAddressVersion": "IPv4"
               }
             }
@@ -86,6 +107,21 @@
                   "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
                 },
                 "primary": true,
+                "privateIPAddressVersion": "IPv4"
+              }
+            },
+            {
+              "name": "ipconfig2",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig2",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "172.20.2.16/28",
+                "privateIPAddressPrefixLength": 28,
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                },
+                "primary": false,
                 "privateIPAddressVersion": "IPv4"
               }
             }

--- a/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/examples/NetworkInterfaceGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/examples/NetworkInterfaceGet.json
@@ -30,6 +30,21 @@
                 "primary": true,
                 "privateIPAddressVersion": "IPv4"
               }
+            },
+            {
+              "name": "ipconfig2",
+              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig2",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "172.20.2.16/28",
+                "privateIPAddressPrefixLength": 28,
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                },
+                "primary": false,
+                "privateIPAddressVersion": "IPv4"
+              }
             }
           ],
           "dnsSettings": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/examples/NetworkInterfaceList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/examples/NetworkInterfaceList.json
@@ -76,6 +76,21 @@
                     "primary": true,
                     "privateIPAddressVersion": "IPv4"
                   }
+                },
+                {
+                  "name": "ipconfig2",
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/test-nic/ipConfigurations/ipconfig2",
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "privateIPAddress": "172.20.2.16/28",
+                    "privateIPAddressPrefixLength": 28,
+                    "privateIPAllocationMethod": "Dynamic",
+                    "subnet": {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/rg1-vnet/subnets/default"
+                    },
+                    "primary": false,
+                    "privateIPAddressVersion": "IPv4"
+                  }
                 }
               ],
               "dnsSettings": {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkInterface.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2023-11-01/networkInterface.json
@@ -962,7 +962,15 @@
         },
         "privateIPAddress": {
           "type": "string",
-          "description": "Private IP address of the IP configuration."
+          "description": "Private IP address of the IP configuration. It can be a single IP address or a CIDR block in the format <address>/<prefix-length>."
+        },
+        "privateIPAddressPrefixLength": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "maximum": 128,
+          "x-nullable": true,
+          "description": "The private IP address prefix length. If specified and the allocation method is dynamic, the service will allocate a CIDR block instead of a single IP address."
         },
         "privateIPAllocationMethod": {
           "$ref": "./network.json#/definitions/IPAllocationMethod",


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request 

This PR adds the `privateIPAddressPrefixLength` property to `networkInterfaces` resource, to upcoming Microsoft.Network API version 2023-11-01. The property allows customers to allocate a CIDR such as 10.0.0.16/28, instead of just a single IP address, in a network interface, subject to other validations. The new property is optional and can be absent or null on input. It won't be present in the output (response) if the customer is not using the feature. It shouldn't be a breaking change.

## Purpose of this PR

What's the purpose of this PR? Check the specific option that applies. This is **mandatory**!

  - [ ] New resource provider.
  - [X] New API version for an existing resource provider. (If API spec is not defined in TypeSpec, the PR should have been generated using [OpenAPI Hub](https://aka.ms/openapihub)).
  - [ ] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Other, please clarify:
    - _edit this with your clarification_

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood 
and followed the instructions by checking all the boxes:

- [X] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [X] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including
  [ARM resource provider contract](https://github.com/Azure/azure-resource-manager-rpc) and
  [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md) (estimated time: 4 hours).  
  I understand this is required before I can proceed to the diagram Step 2, "ARM API changes review", for this PR.
