### PR TITLE
doc, mgmt, java, add a default readme.java.md in samplereadme

### DIFF
--- a/documentation/samplefiles/readme.java.md
+++ b/documentation/samplefiles/readme.java.md
@@ -1,0 +1,7 @@
+## Java
+
+These settings apply only when `--java` is specified on the command line.
+
+``` yaml $(java)
+client-flattened-annotation-target: disabled
+```

--- a/documentation/samplefiles/samplereadme.md
+++ b/documentation/samplefiles/samplereadme.md
@@ -76,3 +76,7 @@ See configuration in [readme.typescript.md](./readme.typescript.md)
 ## CSharp
 
 See configuration in [readme.csharp.md](./readme.csharp.md)
+
+## Java
+
+See configuration in [readme.java.md](./readme.java.md)


### PR DESCRIPTION
We'd expect `x-ms-client-flatten` be disabled in new services (typespec would avoid doing the client flatten -- this condition would be valid for all languages).

This be same effect for Java, as such in python
https://github.com/Azure/azure-rest-api-specs/blob/999f9e8e9166c587ecc99011821e5a6c7fbb78dc/documentation/samplefiles/readme.python.md?plain=1#L20-L23

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
