### PR TITLE
Fix for `put-operation-response-codes` and `post-operation-response-codes` rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,5 @@ External Contributors can read [Getting Started with OpenAPI Specifications](htt
 
 ---
 _This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments._
+
+remove


### PR DESCRIPTION
Follow-up for https://github.com/Azure/typespec-azure/pull/369