### PR TITLE
Update for `lro-location-header` and `arm-resource-name-pattern` rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-REMOVE
 # Azure REST API Specifications
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+REMOVE
 # Azure REST API Specifications
 
 ## Description

--- a/specification/devopsinfrastructure/Microsoft.DevOpsInfrastructure/main.tsp
+++ b/specification/devopsinfrastructure/Microsoft.DevOpsInfrastructure/main.tsp
@@ -353,6 +353,7 @@ model ResourceDetailsObject is ProxyResource<ResourceDetailsObjectProperties> {
   @segment("resources")
   @visibility("read")
   @path
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: string;
 }
 
@@ -510,6 +511,7 @@ model ResourceSku is ProxyResource<ResourceSkuProperties> {
   @segment("skus")
   @visibility("read")
   @path
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: string;
 }
 

--- a/specification/networkanalytics/NetworkAnalytics.Management/main.tsp
+++ b/specification/networkanalytics/NetworkAnalytics.Management/main.tsp
@@ -464,6 +464,7 @@ model DataProductsCatalog is ProxyResource<DataProductsCatalogProperties> {
   @key("dataProductsCatalogName")
   @segment("dataProductsCatalogs")
   @path
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: string;
 }
 

--- a/specification/playwrighttesting/PlaywrightTesting.Management/main.tsp
+++ b/specification/playwrighttesting/PlaywrightTesting.Management/main.tsp
@@ -112,6 +112,7 @@ model Quota is ProxyResource<QuotaProperties> {
   @key("quotaName")
   @path
   @segment("quotas")
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: QuotaNames;
 }
 
@@ -151,6 +152,7 @@ model AccountQuota is ProxyResource<AccountQuotaProperties> {
   @key("quotaName")
   @path
   @segment("quotas")
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: QuotaNames;
 }
 

--- a/specification/sphere/Sphere.Management/certificate.tsp
+++ b/specification/sphere/Sphere.Management/certificate.tsp
@@ -24,6 +24,7 @@ model Certificate is ProxyResource<CertificateProperties> {
   @key("serialNumber")
   @segment("certificates")
   @visibility("read")
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: string;
 }
 

--- a/specification/sphere/Sphere.Management/deployment.tsp
+++ b/specification/sphere/Sphere.Management/deployment.tsp
@@ -24,6 +24,7 @@ model Deployment is ProxyResource<DeploymentProperties> {
   @key("deploymentName")
   @segment("deployments")
   @visibility("read")
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: string;
 }
 

--- a/specification/sphere/Sphere.Management/device.tsp
+++ b/specification/sphere/Sphere.Management/device.tsp
@@ -44,6 +44,7 @@ interface Devices {
    * Update a Device. Use '.unassigned' or '.default' for the device group and product names to move a device to the catalog level.
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/retry-after" "Existing API"
+  #suppress "@azure-tools/typespec-azure-resource-manager/lro-location-header" "Existing API"
   @parameterVisibility("read")
   update is ArmCustomPatchAsync<Device, DeviceUpdate, LroHeaders = {}>;
 

--- a/specification/sphere/Sphere.Management/image.tsp
+++ b/specification/sphere/Sphere.Management/image.tsp
@@ -24,6 +24,7 @@ model Image is ProxyResource<ImageProperties> {
   @key("imageName")
   @segment("images")
   @visibility("read")
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: string;
 }
 

--- a/specification/vmware/Microsoft.AVS/models.tsp
+++ b/specification/vmware/Microsoft.AVS/models.tsp
@@ -1212,6 +1212,7 @@ model WorkloadNetwork is ProxyResource<WorkloadNetworkProperties> {
   @key("workloadNetworkName")
   @path
   @segment("workloadNetworks")
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: string;
 }
 
@@ -2186,6 +2187,7 @@ model IscsiPath is ProxyResource<IscsiPathProperties> {
   @key("iscsiPathName")
   @path
   @segment("iscsiPaths")
+  @pattern("^[a-zA-Z0-9-]{3,24}$")
   name: string;
 }
 


### PR DESCRIPTION
For resolving the name patterns, rather than add suppressions (which will likely never be removed) I instead added the pattern decorator. If it's wrong, that will bubble up as a bug fix later on. 