### PR TITLE
[TypeSpecValidation] Include text of git diff if any changes

### DIFF
--- a/eng/tools/typespec-validation/src/rules/compile.ts
+++ b/eng/tools/typespec-validation/src/rules/compile.ts
@@ -50,7 +50,7 @@ export class CompileRule implements Rule {
       if (!gitDiffResult.success) {
         success = false;
         errorOutput += gitDiffResult.errorOutput;
-        errorOutput += `\nFiles have been changed after \`tsp compile\`. Run \`tsp compile\` and ensure all files are included in the branch.`;
+        errorOutput += `\nFiles have been changed after \`tsp compile\`. Run \`tsp compile\` and ensure all files are included in your change.`;
       }
     }
     return {

--- a/eng/tools/typespec-validation/src/rules/compile.ts
+++ b/eng/tools/typespec-validation/src/rules/compile.ts
@@ -50,7 +50,7 @@ export class CompileRule implements Rule {
       if (!gitDiffResult.success) {
         success = false;
         errorOutput += gitDiffResult.errorOutput;
-        errorOutput += `\nFiles has been gerenate/changed after tsp compile, please run \`tsp compile\` and ensure all files are included in the branch.`;
+        errorOutput += `\nFiles have been changed after \`tsp compile\`. Run \`tsp compile\` and ensure all files are included in the branch.`;
       }
     }
     return {

--- a/eng/tools/typespec-validation/src/rules/format.ts
+++ b/eng/tools/typespec-validation/src/rules/format.ts
@@ -39,7 +39,7 @@ export class FormatRule implements Rule {
       if (!gitDiffResult.success) {
         success = false;
         errorOutput += gitDiffResult.errorOutput;
-        errorOutput += `\nFiles have been changed after \`tsp format\`. Run \`tsp format\` and ensure all files are included in the branch.`;
+        errorOutput += `\nFiles have been changed after \`tsp format\`. Run \`tsp format\` and ensure all files are included in your change.`;
       }
     }
 

--- a/eng/tools/typespec-validation/src/rules/format.ts
+++ b/eng/tools/typespec-validation/src/rules/format.ts
@@ -39,7 +39,7 @@ export class FormatRule implements Rule {
       if (!gitDiffResult.success) {
         success = false;
         errorOutput += gitDiffResult.errorOutput;
-        errorOutput += `\nFiles has been gerenate/changed after tsp format, please run \`tsp format\` and ensure all files are included in the branch.`;
+        errorOutput += `\nFiles have been changed after \`tsp format\`. Run \`tsp format\` and ensure all files are included in the branch.`;
       }
     }
 

--- a/eng/tools/typespec-validation/src/utils.ts
+++ b/eng/tools/typespec-validation/src/utils.ts
@@ -46,8 +46,8 @@ export async function gitDiffTopSpecFolder(host: TsvHost, folder: string) {
 
   if (!gitStatus.isClean()) {
     success = false;
-    errorOutput = `Files generated: ${gitStatus.not_added}\n`;
-    errorOutput += `Files modified: ${gitStatus.modified}`;
+    errorOutput = JSON.stringify(await git.status());
+    errorOutput += await git.diff();
   }
 
   return {

--- a/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
+++ b/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
@@ -1,6 +1,5 @@
 {
   "swagger": "2.0",
-
   "info": {
     "title": "Contoso Widget Manager",
     "version": "2022-11-01-preview",

--- a/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
+++ b/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
@@ -1,5 +1,6 @@
 {
   "swagger": "2.0",
+
   "info": {
     "title": "Contoso Widget Manager",
     "version": "2022-11-01-preview",


### PR DESCRIPTION
- Fixes #28526 
- Introduced in #27801

## Before
```
Running git diff on folder /home/mharder/specs-mh/specification/contosowidgetmanager
Rule Compile failed
Files generated:
Files modified: specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
Files has been gerenate/changed after tsp compile, please run `tsp compile` and ensure all files are included in the branch.
```

## After
```
Running git diff on folder /home/mharder/specs-mh/specification/contosowidgetmanager
Rule Compile failed
{"not_added":[],"conflicted":[],"created":[],"deleted":[],"modified":["specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json"],"renamed":[],"files":[{"path":"specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json","index":" ","working_dir":"M"}],"staged":[],"ahead":0,"behind":0,"current":"tsv-git-diff","tracking":"origin/tsv-git-diff","detached":false}diff --git a/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json b/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
index a2ed5f24b1..58c33188c1 100644
--- a/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
+++ b/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
@@ -1,6 +1,5 @@
 {
   "swagger": "2.0",
-
   "info": {
     "title": "Contoso Widget Manager",
     "version": "2022-11-01-preview",

Files have been changed after `tsp compile`. Run `tsp compile` and ensure all files are included in your change.
```