### PR TITLE
Remove Generation of Java Tests and Samples

### DIFF
--- a/specification/devcenter/DevCenter/tspconfig.yaml
+++ b/specification/devcenter/DevCenter/tspconfig.yaml
@@ -32,6 +32,5 @@ options:
   "@azure-tools/typespec-java":
     package-dir: "azure-developer-devcenter"
     namespace: com.azure.developer.devcenter
-    examples-directory: "examples"
     partial-update: true
     flavor: azure


### PR DESCRIPTION
Disabling generation for java tests and samples as they make the java build break due to the mismatch with operations that have been customized directly in Java repo. 