### PR TITLE
Update @body to @bodyRoot and fix issue with misuse of traits

### DIFF
--- a/specification/ai/DocumentIntelligence/routes.tsp
+++ b/specification/ai/DocumentIntelligence/routes.tsp
@@ -115,7 +115,7 @@ model AnalyzeFromStreamRequestParams {
     | "application/vnd.openxmlformats-officedocument.presentationml.presentation";
 
   @doc("Input content.")
-  @body
+  @bodyRoot
   input: bytes;
 }
 
@@ -169,7 +169,7 @@ interface DocumentModels {
       contentType: "application/json";
 
       @doc("Analyze request parameters.")
-      @body
+      @bodyRoot
       analyzeRequest?: AnalyzeDocumentRequest;
     },
     AnalyzeResultOperation
@@ -186,7 +186,7 @@ interface DocumentModels {
   buildModel is DocumentIntelligenceLongRunningOperation<
     {
       @doc("Build request parameters.")
-      @body
+      @bodyRoot
       buildRequest: BuildDocumentModelRequest;
     },
     DocumentModelBuildOperationDetails
@@ -200,7 +200,7 @@ interface DocumentModels {
   composeModel is DocumentIntelligenceLongRunningOperation<
     {
       @doc("Compose request parameters.")
-      @body
+      @bodyRoot
       composeRequest: ComposeDocumentModelRequest;
     },
     DocumentModelComposeOperationDetails
@@ -216,7 +216,7 @@ interface DocumentModels {
   authorizeModelCopy is DocumentIntelligenceOperation<
     {
       @doc("Authorize copy request parameters.")
-      @body
+      @bodyRoot
       authorizeCopyRequest: AuthorizeCopyRequest;
     },
     CopyAuthorization
@@ -236,7 +236,7 @@ interface DocumentModels {
       modelId: string;
 
       @doc("Copy to request parameters.")
-      @body
+      @bodyRoot
       copyToRequest: CopyAuthorization;
     },
     DocumentModelCopyToOperationDetails
@@ -290,7 +290,7 @@ interface DocumentClassifiers {
   buildClassifier is DocumentIntelligenceLongRunningOperation<
     {
       @doc("Build request parameters.")
-      @body
+      @bodyRoot
       buildRequest: BuildDocumentClassifierRequest;
     },
     DocumentClassifierBuildOperationDetails
@@ -335,7 +335,7 @@ interface DocumentClassifiers {
       contentType: "application/json";
 
       @doc("Classify request parameters.")
-      @body
+      @bodyRoot
       classifyRequest: ClassifyDocumentRequest;
     },
     AnalyzeResultOperation

--- a/specification/ai/HealthInsights/HealthInsights.Common/primitives.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.Common/primitives.tsp
@@ -33,7 +33,7 @@ alias ServiceTraits = NoRepeatableRequests &
   QueryParametersTrait<Azure.Core.ExpandQueryParameter>;
 
 model HealthInsightsErrorResponse is Azure.Core.Foundations.ErrorResponse {
-  ...RequestIdResponseHeaderTrait;
+  ...RequestIdResponseHeader;
 }
 
 alias HealthInsightsOperations = ResourceOperations<

--- a/specification/ai/ImageAnalysis/routes.tsp
+++ b/specification/ai/ImageAnalysis/routes.tsp
@@ -82,7 +82,7 @@ op analyzeFromImageData is Azure.Core.RpcOperation<
     contentType: "application/octet-stream";
 
     @doc("The image to be analyzed")
-    @body
+    @bodyRoot
     imageData: bytes;
 
     ...SharedAnalyzeQuery;
@@ -101,7 +101,7 @@ op analyzeFromUrl is Azure.Core.RpcOperation<
     contentType: "application/json";
 
     @doc("The image to be analyzed")
-    @body
+    @bodyRoot
     imageUrl: ImageUrl;
 
     ...SharedAnalyzeQuery;

--- a/specification/ai/OpenAI.Assistants/runs/routes.tsp
+++ b/specification/ai/OpenAI.Assistants/runs/routes.tsp
@@ -28,7 +28,7 @@ namespace Azure.AI.OpenAI.Assistants;
 @added(ServiceApiVersions.v2024_02_15_preview)
 op createRun(
   @path threadId: string,
-  @body createRunOptions: CreateRunOptions,
+  @bodyRoot createRunOptions: CreateRunOptions,
 ): ThreadRun;
 
 /**

--- a/specification/apicenter/ApiCenter.Management/main.tsp
+++ b/specification/apicenter/ApiCenter.Management/main.tsp
@@ -175,7 +175,7 @@ op ArmResourceCreateOrReplaceSync<
   ...ResourceInstanceParameters<TResource, TBaseParameters>,
 
   @doc("Resource create parameters.")
-  @body
+  @bodyRoot
   resource: TResource,
 ): ArmResourceUpdatedResponseWithEtag<TResource> | ArmResourceCreatedSyncResponseWithEtag<TResource> | ErrorResponse;
 

--- a/specification/applicationinsights/ApplicationInsights.LiveMetrics/models.tsp
+++ b/specification/applicationinsights/ApplicationInsights.LiveMetrics/models.tsp
@@ -48,7 +48,7 @@ model IsSubscribedOperationRequestParameters {
   configurationEtag?: eTag;
 
   @doc("Data contract between Application Insights client SDK and Live Metrics. /QuickPulseService.svc/ping uses this as a backup source of machine name, instance name and invariant version.")
-  @body
+  @bodyRoot
   monitoringDataPoint?: MonitoringDataPoint;
 }
 
@@ -95,7 +95,7 @@ model PublishOperationRequestParameters {
 
   #suppress "@azure-tools/typespec-azure-core/request-body-problem" "Need to follow the existing SDK contract."
   @doc("Data contract between the client and Live Metrics. /QuickPulseService.svc/ping uses this as a backup source of machine name, instance name and invariant version.")
-  @body
+  @bodyRoot
   monitoringDataPoints?: MonitoringDataPoint[];
 }
 

--- a/specification/azurelargeinstance/AzureLargeInstance.Management/AzureLargeInstance.tsp
+++ b/specification/azurelargeinstance/AzureLargeInstance.Management/AzureLargeInstance.tsp
@@ -63,7 +63,7 @@ operations returns various properties of each Azure Large Instance.
     AzureLargeInstance,
     {
       /** When set to 'active', this parameter empowers the server with the ability to forcefully terminate and halt any existing processes that may be running on the server */
-      @body forceParameter?: ForceState;
+      @bodyRoot forceParameter?: ForceState;
     },
     OperationStatusResult
   >;

--- a/specification/batch/Azure.Batch/routes.tsp
+++ b/specification/batch/Azure.Batch/routes.tsp
@@ -1343,7 +1343,7 @@ primary task; subtasks are then terminated asynchronously in the background.
       @path
       taskId: string;
     },
-    DataServiceResponseHeaders
+    NoContentResponse & DataServiceResponseHeaders
   >;
 
   @summary("""
@@ -1371,7 +1371,7 @@ will fail if the Job has completed (or is terminating or deleting).
       @path
       taskId: string;
     },
-    DataServiceResponseHeaders
+    NoContentResponse & DataServiceResponseHeaders
   >;
 
   @summary("Deletes the specified Task file from the Compute Node where the Task ran.")

--- a/specification/batch/Azure.Batch/routes.tsp
+++ b/specification/batch/Azure.Batch/routes.tsp
@@ -227,7 +227,7 @@ to Microsoft Support engineers.
   @clientName("createPoolInternal", "java")
   createPool is BatchOps.CreateOperation<
     {
-      @body
+      @bodyRoot
       @doc("The Pool to be created.")
       pool: BatchPoolCreateContent;
     },
@@ -329,7 +329,7 @@ a StartTask element, then the Pool keeps the existing StartTask.
   updatePool is BatchOps.UpdateOperation<
     BatchPoolHeaders & {
       @doc("The pool properties to update.")
-      @body
+      @bodyRoot
       pool: BatchPoolUpdateContent;
     },
     RequestSuccesResponseHeaders
@@ -363,7 +363,7 @@ more than once every 30 seconds.
     BatchPoolHeaders &
       MinimalMetadata & {
         @doc("The options to use for enabling automatic scaling.")
-        @body
+        @bodyRoot
         content: BatchPoolEnableAutoScaleContent;
       },
     RequestSuccesResponseHeaders
@@ -384,7 +384,7 @@ scaling enabled in order to evaluate a formula.
       poolId: string;
 
       @doc("The options to use for evaluating the automatic scaling formula.")
-      @body
+      @bodyRoot
       content: BatchPoolEvaluateAutoScaleContent;
     },
     AutoScaleRun & RequestSuccesResponseHeaders
@@ -406,7 +406,7 @@ Nodes, use the Pool remove Compute Nodes API instead.
     BatchPoolHeaders &
       MinimalMetadata & {
         @doc("The options to use for resizing the pool.")
-        @body
+        @bodyRoot
         content: BatchPoolResizeContent;
       },
     AcceptedProcessingResponseHeaders
@@ -444,7 +444,7 @@ with this request, then the Batch service will remove the existing StartTask.
       poolId: string;
 
       @doc("The options to use for replacing properties on the pool.")
-      @body
+      @bodyRoot
       pool: BatchPoolReplaceContent;
     },
     NoContentSuccesResponseHeaders
@@ -462,7 +462,7 @@ Each request may remove up to 100 nodes.
     BatchPoolHeaders &
       MinimalMetadata & {
         @doc("The options to use for removing the node.")
-        @body
+        @bodyRoot
         content: BatchNodeRemoveContent;
       },
     AcceptedProcessingResponseHeaders
@@ -569,7 +569,7 @@ element, then the Job keeps the existing constraints.
       jobId: string;
 
       @doc("The options to use for updating the Job.")
-      @body
+      @bodyRoot
       job: BatchJobUpdateContent;
     },
     RequestSuccesResponseHeaders
@@ -590,7 +590,7 @@ with this request, then the Batch service will remove the existing constraints.
       jobId: string;
 
       @doc("A job with updated properties")
-      @body
+      @bodyRoot
       job: BatchJob;
     },
     RequestSuccesResponseHeaders
@@ -617,7 +617,7 @@ the request fails with status code 409.
         jobId: string;
 
         @doc("The options to use for disabling the Job.")
-        @body
+        @bodyRoot
         content: BatchJobDisableContent;
       },
     AcceptedProcessingResponseHeaders
@@ -662,7 +662,7 @@ Tasks cannot be added and any remaining active Tasks will not be scheduled.
         jobId: string;
 
         @doc("The options to use for terminating the Job.")
-        @body
+        @bodyRoot
         parameters?: BatchJobTerminateContent;
       },
     AcceptedProcessingResponseHeaders
@@ -685,7 +685,7 @@ engineers.
   createJob is BatchOps.CreateOperation<
     {
       @doc("The Job to be created.")
-      @body
+      @bodyRoot
       job: BatchJobCreateContent;
     },
     {}
@@ -821,7 +821,7 @@ up to date. If you need exact task counts, use a list query.
   createCertificate is BatchOps.CreateOperation<
     {
       @doc("The Certificate to be created.")
-      @body
+      @bodyRoot
       certificate: BatchCertificate;
     },
     {}
@@ -1011,7 +1011,7 @@ running Jobs are unaffected.
       jobScheduleId: string;
 
       @doc("The options to use for updating the Job Schedule.")
-      @body
+      @bodyRoot
       jobSchedule: BatchJobScheduleUpdateContent;
     },
     RequestSuccesResponseHeaders
@@ -1034,7 +1034,7 @@ running Jobs are unaffected.
       jobScheduleId: string;
 
       @doc("A Job Schedule with updated properties")
-      @body
+      @bodyRoot
       jobSchedule: BatchJobSchedule;
     },
     RequestSuccesResponseHeaders
@@ -1086,7 +1086,7 @@ running Jobs are unaffected.
   createJobSchedule is BatchOps.CreateOperation<
     {
       @doc("The Job Schedule to be created.")
-      @body
+      @bodyRoot
       jobSchedule: BatchJobScheduleCreateContent;
     },
     {}
@@ -1138,7 +1138,7 @@ the Batch service and left in whatever state it was in at that time.
       jobId: string;
 
       @doc("The Task to be created.")
-      @body
+      @bodyRoot
       task: BatchTaskCreateContent;
     },
     {}
@@ -1209,7 +1209,7 @@ service and left in whatever state it was in at that time.
       jobId: string;
 
       @doc("The Tasks to be added.")
-      @body
+      @bodyRoot
       taskCollection: BatchTaskGroup;
     },
     BatchTaskAddCollectionResult
@@ -1291,7 +1291,7 @@ information about subtasks.
       taskId: string;
 
       @doc("The Task to update.")
-      @body
+      @bodyRoot
       task: BatchTask;
     },
     RequestSuccesResponseHeaders
@@ -1414,7 +1414,7 @@ format is bytes=startRange-endRange.
       @header("content-type")
       contentType: "application/octet-stream";
 
-      @body
+      @bodyRoot
       @doc("A response containing the file content.")
       file: bytes;
     }
@@ -1478,7 +1478,7 @@ running state.
       nodeId: string;
 
       @doc("The options to use for creating the user.")
-      @body
+      @bodyRoot
       user: BatchNodeUserCreateContent;
     },
     {}
@@ -1538,7 +1538,7 @@ Account on a Compute Node only when it is in the idle or running state.
       userName: string;
 
       @doc("The options to use for updating the user.")
-      @body
+      @bodyRoot
       content: BatchNodeUserUpdateContent;
     },
     RequestSuccesResponseHeaders
@@ -1583,7 +1583,7 @@ Account on a Compute Node only when it is in the idle or running state.
       nodeId: string;
 
       @doc("The options to use for rebooting the Compute Node.")
-      @body
+      @bodyRoot
       parameters?: BatchNodeRebootContent;
     },
     AcceptedProcessingResponseHeaders
@@ -1608,7 +1608,7 @@ cloud service configuration property.
       nodeId: string;
 
       @doc("The options to use for reimaging the Compute Node.")
-      @body
+      @bodyRoot
       parameters?: BatchNodeReimageContent;
     },
     AcceptedProcessingResponseHeaders
@@ -1632,7 +1632,7 @@ scheduling state is enabled.
       nodeId: string;
 
       @doc("The options to use for disabling scheduling on the Compute Node.")
-      @body
+      @bodyRoot
       parameters?: BatchNodeDisableSchedulingContent;
     },
     RequestSuccesResponseHeaders
@@ -1708,7 +1708,7 @@ Protocol file.
       @header("content-type")
       contentType: "application/octet-stream";
 
-      @body
+      @bodyRoot
       @doc("A response containing the file content.")
       file: bytes;
     }
@@ -1740,7 +1740,7 @@ Protocol file.
       nodeId: string;
 
       @doc("The Azure Batch service log files upload options.")
-      @body
+      @bodyRoot
       content: UploadBatchServiceLogsContent;
     },
     UploadBatchServiceLogsResult
@@ -1868,7 +1868,7 @@ format is bytes=startRange-endRange.
       @header("content-type")
       contentType: "application/octet-stream";
 
-      @body
+      @bodyRoot
       @doc("A response containing the file content.")
       file: bytes;
     }

--- a/specification/carbon/Carbon.Management/main.tsp
+++ b/specification/carbon/Carbon.Management/main.tsp
@@ -458,7 +458,7 @@ interface CarbonService {
   listCarbonEmissionReports(
     ...ApiVersionParameter,
 
-    @body
+    @bodyRoot
     @doc("Query parameters")
     queryParameters: QueryFilter,
   ): CarbonEmissionDataListResult | ErrorResponse;

--- a/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/multivariate/models.tsp
@@ -410,5 +410,9 @@ model ResponseError {
   @doc("Error code.")
   msErrorCode?: string;
 
-  ...ErrorResponse;
+  @doc("Error code.")
+  code: string;
+
+  @doc("Message that explains the error that the service reported.")
+  message: string;
 }

--- a/specification/cognitiveservices/AnomalyDetector/multivariate/routes.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/multivariate/routes.tsp
@@ -57,7 +57,7 @@ op trainMultivariateModel is MultivariateServiceAction<
   // TParams
   {
     @doc("Model information.")
-    @body
+    @bodyRoot
     modelInfo: ModelInfo;
   },
   // TResponse
@@ -68,7 +68,7 @@ op trainMultivariateModel is MultivariateServiceAction<
     @header
     location: string;
 
-    @body result: AnomalyDetectionModel;
+    @bodyRoot result: AnomalyDetectionModel;
   }
 >;
 
@@ -143,7 +143,7 @@ op detectMultivariateBatchAnomaly(
   modelId: string,
 
   @doc("Request of multivariate anomaly detection.")
-  @body
+  @bodyRoot
   options: MultivariateBatchDetectionOptions,
 ): {
   @statusCode statusCode: 202;
@@ -156,7 +156,7 @@ op detectMultivariateBatchAnomaly(
   @header("Operation-Location")
   operationLocation: string;
 
-  @body result: MultivariateDetectionResult;
+  @bodyRoot result: MultivariateDetectionResult;
 } | ResponseError;
 
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Does not fit any standard operation pattern"
@@ -177,6 +177,6 @@ op detectMultivariateLastAnomaly(
   modelId: string,
 
   @doc("Request of the last detection.")
-  @body
+  @bodyRoot
   options: MultivariateLastDetectionOptions,
 ): MultivariateLastDetectionResult | ResponseError;

--- a/specification/cognitiveservices/AnomalyDetector/univariate/routes.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/univariate/routes.tsp
@@ -29,7 +29,7 @@ op detectUnivariateEntireSeries is UnivariateServiceAction<
   // TParams
   {
     @doc("Method of univariate anomaly detection.")
-    @body
+    @bodyRoot
     options: UnivariateDetectionOptions;
   },
   // TResponse
@@ -48,7 +48,7 @@ op detectUnivariateLastPoint is UnivariateServiceAction<
   // TParams
   {
     @doc("Method of univariate anomaly detection.")
-    @body
+    @bodyRoot
     options: UnivariateDetectionOptions;
   },
   // TResponse
@@ -64,7 +64,7 @@ op detectUnivariateChangePoint is UnivariateServiceAction<
   // TParams
   {
     @doc("Method of univariate anomaly detection.")
-    @body
+    @bodyRoot
     options: UnivariateChangePointDetectionOptions;
   },
   // TResponse

--- a/specification/cognitiveservices/ContentSafety/routes.tsp
+++ b/specification/cognitiveservices/ContentSafety/routes.tsp
@@ -20,7 +20,7 @@ interface TextOperations {
   @post
   analyzeText is Azure.Core.RpcOperation<
     {
-      @body
+      @bodyRoot
       @doc("The text analysis request.")
       @clientName("options", "csharp")
       @clientName("options", "python")
@@ -37,7 +37,7 @@ interface TextOperations {
   @post
   detectTextJailbreak is Azure.Core.RpcOperation<
     {
-      @body
+      @bodyRoot
       @doc("The text jailbreak analysis request.")
       @clientName("options", "csharp")
       @clientName("options", "python")
@@ -54,7 +54,7 @@ interface TextOperations {
   @post
   detectTextProtectedMaterial is Azure.Core.RpcOperation<
     {
-      @body
+      @bodyRoot
       @doc("The text protected material analysis request.")
       @clientName("options", "csharp")
       @clientName("options", "python")
@@ -71,7 +71,7 @@ interface TextOperations {
   @post
   detectTextPromptInjectionOptions is Azure.Core.RpcOperation<
     {
-      @body
+      @bodyRoot
       @doc("The text prompt injection attacks analysis request.")
       @clientName("options", "csharp")
       @clientName("options", "python")
@@ -90,7 +90,7 @@ interface ImageOperations {
   analyzeImage is Azure.Core.RpcOperation<
     {
       @doc("The image analysis request.")
-      @body
+      @bodyRoot
       @clientName("options", "csharp")
       @clientName("options", "python")
       @clientName("options", "java")
@@ -130,7 +130,7 @@ interface TextBlocklists {
     TextBlocklist,
     {
       @doc("Options for adding or updating blocklist items.")
-      @body
+      @bodyRoot
       @clientName("options", "csharp")
       @clientName("options", "python")
       @clientName("options", "java")
@@ -145,7 +145,7 @@ interface TextBlocklists {
     TextBlocklist,
     {
       @doc("Options for removing blocklist items.")
-      @body
+      @bodyRoot
       @clientName("options", "csharp")
       @clientName("options", "python")
       @clientName("options", "java")
@@ -174,7 +174,7 @@ interface TextGroundednessDetectionOperations {
   @post
   detectGroundednessOptions is Azure.Core.RpcOperation<
     {
-      @body
+      @bodyRoot
       @doc("The text groundedness detection request.")
       @clientName("options", "csharp")
       @clientName("options", "python")

--- a/specification/cognitiveservices/OpenAI.Inference/models/audio/audio_speech.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/audio/audio_speech.tsp
@@ -87,6 +87,6 @@ model SpeechGenerationResponse {
   contentType: "application/octet-stream";
 
   @doc("The generated audio, generated in the requested audio output format.")
-  @body
+  @bodyRoot
   audio: bytes;
 }

--- a/specification/cognitiveservices/OpenAI.Inference/models/audio/common.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/audio/common.tsp
@@ -20,6 +20,6 @@ union AudioTaskLabel {
 
 alias AudioTextResponse = {
   @doc("Representation of the response data of audio text.")
-  @body
+  @bodyRoot
   body: string;
 };

--- a/specification/communication/Communication.JobRouter/models.tsp
+++ b/specification/communication/Communication.JobRouter/models.tsp
@@ -1244,7 +1244,7 @@ model ReclassifyJobResult {}
 @doc("OK Response payload from reclassifying a job.")
 model ReclassifyJobResultWithOkResponse {
   @doc("Response payload from reclassifying a job.")
-  @body
+  @bodyRoot
   body: ReclassifyJobResult;
 
   @doc("Status code.")
@@ -1260,7 +1260,7 @@ model CloseJobResult {}
 @doc("Response payload from closing a job synchronously.")
 model CloseJobResultWithOkResponse {
   @doc("Response after closing a job.")
-  @body
+  @bodyRoot
   body: CloseJobResult;
 
   @doc("Status code.")
@@ -1276,7 +1276,7 @@ model CancelJobResult {}
 @doc("OK Response payload from cancelling a job.")
 model CancelJobResultWithOkResponse {
   @doc("Response after cancelling a job.")
-  @body
+  @bodyRoot
   body: CancelJobResult;
 
   @doc("Status code.")
@@ -1292,7 +1292,7 @@ model CompleteJobResult {}
 @doc("OK Response payload from completing a job.")
 model CompleteJobResultWithOkResponse {
   @doc("Response after completing a job.")
-  @body
+  @bodyRoot
   body: CompleteJobResult;
 
   @doc("Status code.")
@@ -1308,7 +1308,7 @@ model DeclineJobOfferResult {}
 @doc("OK Response payload from declining a job.")
 model DeclineJobOfferResultWithOkResponse {
   @doc("Response payload from declining a job.")
-  @body
+  @bodyRoot
   body: DeclineJobOfferResult;
 
   @doc("Status code.")

--- a/specification/communication/Communication.JobRouter/routes.tsp
+++ b/specification/communication/Communication.JobRouter/routes.tsp
@@ -120,7 +120,7 @@ interface JobRouterOperations {
     RouterJob,
     {
       @doc("Request object for reclassifying a job.")
-      @body
+      @bodyRoot
       options?: ReclassifyJobOptions;
     },
     ReclassifyJobResultWithOkResponse
@@ -133,7 +133,7 @@ interface JobRouterOperations {
     RouterJob,
     {
       @doc("Request model for cancelling job.")
-      @body
+      @bodyRoot
       options?: CancelJobOptions;
     },
     CancelJobResultWithOkResponse
@@ -146,7 +146,7 @@ interface JobRouterOperations {
     RouterJobAssignment,
     {
       @doc("Request model for completing job.")
-      @body
+      @bodyRoot
       options?: CompleteJobOptions;
     },
     CompleteJobResultWithOkResponse
@@ -159,7 +159,7 @@ interface JobRouterOperations {
     RouterJobAssignment,
     {
       @doc("Request model for closing job.")
-      @body
+      @bodyRoot
       options?: CloseJobOptions;
     },
     CloseJobResultWithOkResponse
@@ -190,7 +190,7 @@ interface JobRouterOperations {
     RouterJobAssignment,
     {
       @doc("Request body for unassign route.")
-      @body
+      @bodyRoot
       options?: UnassignJobOptions;
     },
     UnassignJobResult
@@ -208,7 +208,7 @@ interface JobRouterOperations {
     RouterJobOffer,
     {
       @doc("Request model for declining offer.")
-      @body
+      @bodyRoot
       options?: DeclineJobOfferOptions;
     },
     DeclineJobOfferResultWithOkResponse

--- a/specification/communication/Communication.Messages/models.tsp
+++ b/specification/communication/Communication.Messages/models.tsp
@@ -334,7 +334,7 @@ model MessageDataStream {
   @bodyIgnore
   id: string;
 
-  @bodyRoot
+  @body
   @doc("The stream body.")
   body: bytes;
 

--- a/specification/communication/Communication.Messages/models.tsp
+++ b/specification/communication/Communication.Messages/models.tsp
@@ -331,6 +331,7 @@ model MessageDataStream {
   @visibility("read")
   @doc("The stream ID.")
   @clientName("mediaId", "java")
+  @bodyIgnore
   id: string;
 
   @bodyRoot

--- a/specification/communication/Communication.Messages/models.tsp
+++ b/specification/communication/Communication.Messages/models.tsp
@@ -333,7 +333,7 @@ model MessageDataStream {
   @clientName("mediaId", "java")
   id: string;
 
-  @body
+  @bodyRoot
   @doc("The stream body.")
   body: bytes;
 

--- a/specification/communication/Communication.Messages/models.tsp
+++ b/specification/communication/Communication.Messages/models.tsp
@@ -324,16 +324,8 @@ model CommunicationChannel {
   channelId: uuid;
 }
 
-@resource("messages/streams")
 @doc("A data stream.")
 model MessageDataStream {
-  @key
-  @visibility("read")
-  @doc("The stream ID.")
-  @clientName("mediaId", "java")
-  @bodyIgnore
-  id: string;
-
   @body
   @doc("The stream body.")
   body: bytes;

--- a/specification/communication/Communication.Messages/models.tsp
+++ b/specification/communication/Communication.Messages/models.tsp
@@ -324,8 +324,15 @@ model CommunicationChannel {
   channelId: uuid;
 }
 
+@resource("messages/streams")
 @doc("A data stream.")
 model MessageDataStream {
+  @key
+  @visibility("none") // this model is only used as a parameter
+  @doc("The stream ID.")
+  @clientName("mediaId", "java")
+  id: string;
+
   @body
   @doc("The stream body.")
   body: bytes;

--- a/specification/communication/Communication.Messages/routes.tsp
+++ b/specification/communication/Communication.Messages/routes.tsp
@@ -41,9 +41,7 @@ interface NotificationMessagesOperations {
 }
 
 interface StreamOperations {
-  #suppress "@azure-tools/typespec-azure-core/rpc-operation-request-body" "BUG https://github.com/Azure/typespec-azure/issues/684"
   @tag("Stream")
   @doc("Download the Media payload from a User to Business message.")
-  @route("messages/streams")
-  getMedia is RpcOperation<{}, MessageDataStream>;
+  getMedia is Operations.ResourceRead<MessageDataStream>;
 }

--- a/specification/communication/Communication.Messages/routes.tsp
+++ b/specification/communication/Communication.Messages/routes.tsp
@@ -41,7 +41,9 @@ interface NotificationMessagesOperations {
 }
 
 interface StreamOperations {
+  #suppress "@azure-tools/typespec-azure-core/rpc-operation-request-body" "BUG https://github.com/Azure/typespec-azure/issues/684"
   @tag("Stream")
   @doc("Download the Media payload from a User to Business message.")
-  getMedia is Operations.ResourceRead<MessageDataStream>;
+  @route("messages/streams")
+  getMedia is RpcOperation<{}, MessageDataStream>;
 }

--- a/specification/confidentialledger/Microsoft.CodeTransparency/models.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/models.tsp
@@ -43,7 +43,7 @@ model CoseEntry {
   contentType: "application/cose";
 
   @doc("A raw CoseSign1 signature")
-  @body
+  @bodyRoot
   body: bytes;
 }
 
@@ -54,7 +54,7 @@ model RawEntry {
   contentType: "application/cbor";
 
   @doc("A raw CBOR content")
-  @body
+  @bodyRoot
   body: bytes;
 }
 

--- a/specification/containerservice/Fleet.Management/helpers.tsp
+++ b/specification/containerservice/Fleet.Management/helpers.tsp
@@ -77,7 +77,7 @@ op FleetCustomPatchSync<
   ...ResourceInstanceParameters<TResource, TBaseParameters>,
 
   @doc("The resource properties to be updated.")
-  @body
+  @bodyRoot
   parameters?: TPatchModel, //prevents api breaking change. properties -> parameters
 ): ArmResponse<TResource> | ErrorResponse;
 
@@ -100,7 +100,7 @@ op FleetArmResourceCreateOrUpdateAsync<
   ...ResourceInstanceParameters<TResource, TBaseParameters>,
 
   @doc("Resource create parameters.")
-  @body
+  @bodyRoot
   parameters: TResource, //prevent api breaking change. resource -> parameters
 ): ArmResponse<TResource> | ArmCreatedResponse<TResource> | ErrorResponse;
 

--- a/specification/devcenter/DevCenter/DevBox/routes.tsp
+++ b/specification/devcenter/DevCenter/DevBox/routes.tsp
@@ -135,13 +135,7 @@ interface DevBoxes {
   startDevBox is StandardResourceOperations.LongRunningResourceAction<
     DevBox,
     {},
-    {
-      @statusCode
-      statusCode: 202;
-
-      @bodyRoot
-      body: OperationStatus;
-    }
+    never
   >;
 
   @doc("Stops a Dev Box")
@@ -154,13 +148,7 @@ interface DevBoxes {
       @query
       hibernate?: boolean;
     },
-    {
-      @statusCode
-      statusCode: 202;
-
-      @bodyRoot
-      body: OperationStatus;
-    }
+    never
   >;
 
   @doc("Restarts a Dev Box")
@@ -169,13 +157,7 @@ interface DevBoxes {
   restartDevBox is StandardResourceOperations.LongRunningResourceAction<
     DevBox,
     {},
-    {
-      @statusCode
-      statusCode: 202;
-
-      @bodyRoot
-      body: OperationStatus;
-    }
+    never
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "can not be represeted by using stand operations"

--- a/specification/devcenter/DevCenter/DevBox/routes.tsp
+++ b/specification/devcenter/DevCenter/DevBox/routes.tsp
@@ -76,7 +76,7 @@ interface DevBoxes {
       devBoxName: string;
 
       @doc("Represents the body request of a Dev Box creation. Dev Box Pool name is required. Optionally set the owner of the Dev Box as local administrator")
-      @body
+      @bodyRoot
       body: DevBox;
     },
     DevBox | {
@@ -89,7 +89,7 @@ interface DevBoxes {
       @header("Operation-Location")
       operationLocation: string;
 
-      @body body?: DevBox;
+      @bodyRoot body?: DevBox;
     }
   >;
 
@@ -123,7 +123,7 @@ interface DevBoxes {
       @header("Operation-Location")
       operationLocation: string;
 
-      @body body: OperationStatus;
+      @bodyRoot body: OperationStatus;
     } | {
       @statusCode statusCode: 204;
     }
@@ -139,7 +139,7 @@ interface DevBoxes {
       @statusCode
       statusCode: 202;
 
-      @body
+      @bodyRoot
       body: OperationStatus;
     }
   >;
@@ -158,7 +158,7 @@ interface DevBoxes {
       @statusCode
       statusCode: 202;
 
-      @body
+      @bodyRoot
       body: OperationStatus;
     }
   >;
@@ -173,7 +173,7 @@ interface DevBoxes {
       @statusCode
       statusCode: 202;
 
-      @body
+      @bodyRoot
       body: OperationStatus;
     }
   >;

--- a/specification/devcenter/DevCenter/Environments/routes.tsp
+++ b/specification/devcenter/DevCenter/Environments/routes.tsp
@@ -69,7 +69,7 @@ interface Environments {
       environmentName: string;
 
       @doc("Represents an environment.")
-      @body
+      @bodyRoot
       body: Environment;
     },
     {
@@ -80,7 +80,7 @@ interface Environments {
       @header("Operation-Location")
       operationLocation: string;
 
-      @body body: Environment;
+      @bodyRoot body: Environment;
     }
   >;
 
@@ -108,7 +108,7 @@ interface Environments {
       @statusCode
       statusCode: 202;
 
-      @body body: OperationStatus;
+      @bodyRoot body: OperationStatus;
 
       @header("Location")
       location: string;

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/stable/2023-04-01/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/stable/2023-04-01/devcenter.json
@@ -1118,7 +1118,26 @@
           "202": {
             "description": "The request has been accepted for processing, but processing has not yet completed.",
             "schema": {
-              "$ref": "#/definitions/OperationStatus"
+              "type": "object",
+              "description": "Provides status details for long running operations.",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The unique ID of the operation."
+                },
+                "status": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.OperationState",
+                  "description": "The status of the operation"
+                },
+                "error": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.Error",
+                  "description": "Error object that describes the error when status is \"Failed\"."
+                }
+              },
+              "required": [
+                "id",
+                "status"
+              ]
             },
             "headers": {
               "Operation-Location": {
@@ -1199,7 +1218,26 @@
           "202": {
             "description": "The request has been accepted for processing, but processing has not yet completed.",
             "schema": {
-              "$ref": "#/definitions/OperationStatus"
+              "type": "object",
+              "description": "Provides status details for long running operations.",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The unique ID of the operation."
+                },
+                "status": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.OperationState",
+                  "description": "The status of the operation"
+                },
+                "error": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.Error",
+                  "description": "Error object that describes the error when status is \"Failed\"."
+                }
+              },
+              "required": [
+                "id",
+                "status"
+              ]
             },
             "headers": {
               "Operation-Location": {
@@ -1273,7 +1311,26 @@
           "202": {
             "description": "The request has been accepted for processing, but processing has not yet completed.",
             "schema": {
-              "$ref": "#/definitions/OperationStatus"
+              "type": "object",
+              "description": "Provides status details for long running operations.",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The unique ID of the operation."
+                },
+                "status": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.OperationState",
+                  "description": "The status of the operation"
+                },
+                "error": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.Error",
+                  "description": "Error object that describes the error when status is \"Failed\"."
+                }
+              },
+              "required": [
+                "id",
+                "status"
+              ]
             },
             "headers": {
               "Operation-Location": {
@@ -2123,6 +2180,48 @@
           "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
           "description": "Inner error."
         }
+      }
+    },
+    "Azure.Core.Foundations.OperationState": {
+      "type": "string",
+      "description": "Enum describing allowed operation states.",
+      "enum": [
+        "NotStarted",
+        "Running",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "OperationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "The operation has not started."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The operation is in progress."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The operation has completed successfully."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The operation has failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The operation has been canceled by the user."
+          }
+        ]
       }
     },
     "Azure.Core.azureLocation": {

--- a/specification/developersigning/DeveloperSigning/main.tsp
+++ b/specification/developersigning/DeveloperSigning/main.tsp
@@ -180,7 +180,7 @@ model ExtendedKeyUsage {
 @doc("Public root certificate from the certificate chain.")
 model BytesBody<ContentType> {
   @doc("The root certificate of the certificate chain of this profile.")
-  @body
+  @bodyRoot
   body: bytes;
 
   @doc("The content type of the x509 cert.")

--- a/specification/eventgrid/Azure.Messaging.EventGrid/main.tsp
+++ b/specification/eventgrid/Azure.Messaging.EventGrid/main.tsp
@@ -244,11 +244,11 @@ namespace Microsoft.EventGrid {
       contentType: "application/cloudevents+json; charset=utf-8";
 
       @doc("Single Cloud Event being published.")
-      @body
+      @bodyRoot
       event: CloudEvent;
     },
     {
-      @body _: PublishResult;
+      @bodyRoot _: PublishResult;
     }
   >;
 
@@ -264,11 +264,11 @@ namespace Microsoft.EventGrid {
 
       #suppress "@azure-tools/typespec-azure-core/request-body-problem" "Not using a container model for CloudEvent is intentional. Went through Stewardship Board review (#21880)."
       @doc("Array of Cloud Events being published.")
-      @body
+      @bodyRoot
       events: CloudEvent[];
     },
     {
-      @body _: PublishResult;
+      @bodyRoot _: PublishResult;
     }
   >;
 
@@ -303,7 +303,7 @@ namespace Microsoft.EventGrid {
     EventSubscription,
     {
       @doc("AcknowledgeOptions.")
-      @body
+      @bodyRoot
       acknowledgeOptions: AcknowledgeOptions;
     },
     AcknowledgeResult
@@ -318,7 +318,7 @@ namespace Microsoft.EventGrid {
     EventSubscription,
     {
       @doc("ReleaseOptions")
-      @body
+      @bodyRoot
       releaseOptions: ReleaseOptions;
 
       @added(ServiceApiVersions.v2023_10_01_preview)
@@ -338,7 +338,7 @@ namespace Microsoft.EventGrid {
     EventSubscription,
     {
       @doc("RejectOptions")
-      @body
+      @bodyRoot
       rejectOptions: RejectOptions;
     },
     RejectResult
@@ -353,7 +353,7 @@ namespace Microsoft.EventGrid {
     EventSubscription,
     {
       @doc("RenewLockOptions")
-      @body
+      @bodyRoot
       renewLockOptions: RenewLockOptions;
     },
     RenewCloudEventLocksResult

--- a/specification/loadtestservice/LoadTestService.Management/customOperation.tsp
+++ b/specification/loadtestservice/LoadTestService.Management/customOperation.tsp
@@ -36,7 +36,7 @@ interface CustomOperations {
     ...Parameters,
 
     @doc("The content of the action request")
-    @body
+    @bodyRoot
     body: Request,
   ): Response | Error;
 }

--- a/specification/loadtestservice/LoadTestService/routes.tsp
+++ b/specification/loadtestservice/LoadTestService/routes.tsp
@@ -87,7 +87,7 @@ numeric, underscore or hyphen characters.
       fileType?: FileType;
 
       @doc("The file content as application/octet-stream.")
-      @body
+      @bodyRoot
       body: bytes;
     },
     ResourceCreatedResponse<TestFileInfo>
@@ -127,7 +127,7 @@ numeric, underscore or hyphen characters.
       testId: string;
 
       @doc("App Component model.")
-      @body
+      @bodyRoot
       body: TestAppComponents;
     },
     ResourceCreatedOrOkResponse<TestAppComponents>
@@ -175,7 +175,7 @@ numeric, underscore or hyphen characters.
       testId: string;
 
       @doc("Server metric configuration model.")
-      @body
+      @bodyRoot
       body: TestServerMetricConfig;
     },
     ResourceCreatedOrOkResponse<TestServerMetricConfig>
@@ -305,7 +305,7 @@ numeric, underscore or hyphen characters.
       ...MetricDimensionsRequest;
 
       @doc("Metric dimension filter ")
-      @body
+      @bodyRoot
       body?: MetricRequestPayload;
     },
     Metrics
@@ -358,7 +358,7 @@ numeric, underscore or hyphen characters.
       testRunId: string;
 
       @doc("App Component model.")
-      @body
+      @bodyRoot
       body: TestRunAppComponents;
     },
     ResourceCreatedOrOkResponse<TestRunAppComponents>
@@ -412,7 +412,7 @@ numeric, underscore or hyphen characters.
       testRunId: string;
 
       @doc("Server metric configuration model.")
-      @body
+      @bodyRoot
       body: TestRunServerMetricConfig;
     },
     ResourceCreatedOrOkResponse<TestRunServerMetricConfig>

--- a/specification/machinelearningservices/AzureAI.Assets/routes.tsp
+++ b/specification/machinelearningservices/AzureAI.Assets/routes.tsp
@@ -29,7 +29,7 @@ interface Indexes {
       @path
       version: string;
     },
-    Index | Foundations.ErrorResponse
+    Index 
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Waiting for bug fix: https://github.com/Azure/typespec-azure-pr/issues/3739."
@@ -51,7 +51,7 @@ interface Indexes {
       @bodyRoot
       body: Index;
     },
-    ResourceCreatedOrOkResponse<Index> | Foundations.ErrorResponse
+    ResourceCreatedOrOkResponse<Index> 
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Need to use same model in both list calls."
@@ -78,7 +78,7 @@ interface Indexes {
 
       ...StandardListQueryParameters;
     },
-    PagedIndex | Foundations.ErrorResponse
+    PagedIndex 
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Need to define route."
@@ -92,7 +92,7 @@ interface Indexes {
       @path
       name: string;
     },
-    Index | Foundations.ErrorResponse
+    Index 
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Need to define route."
@@ -106,7 +106,7 @@ interface Indexes {
       @path
       name: string;
     },
-    VersionInfo | Foundations.ErrorResponse
+    VersionInfo 
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Need to define route."
@@ -117,6 +117,6 @@ interface Indexes {
     {
       ...StandardListQueryParameters;
     },
-    PagedIndex | Foundations.ErrorResponse
+    PagedIndex 
   >;
 }

--- a/specification/machinelearningservices/AzureAI.Assets/routes.tsp
+++ b/specification/machinelearningservices/AzureAI.Assets/routes.tsp
@@ -29,7 +29,7 @@ interface Indexes {
       @path
       version: string;
     },
-    Index 
+    Index
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Waiting for bug fix: https://github.com/Azure/typespec-azure-pr/issues/3739."
@@ -51,7 +51,7 @@ interface Indexes {
       @bodyRoot
       body: Index;
     },
-    ResourceCreatedOrOkResponse<Index> 
+    ResourceCreatedOrOkResponse<Index>
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Need to use same model in both list calls."
@@ -78,7 +78,7 @@ interface Indexes {
 
       ...StandardListQueryParameters;
     },
-    PagedIndex 
+    PagedIndex
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Need to define route."
@@ -92,7 +92,7 @@ interface Indexes {
       @path
       name: string;
     },
-    Index 
+    Index
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Need to define route."
@@ -106,7 +106,7 @@ interface Indexes {
       @path
       name: string;
     },
-    VersionInfo 
+    VersionInfo
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Need to define route."
@@ -117,6 +117,6 @@ interface Indexes {
     {
       ...StandardListQueryParameters;
     },
-    PagedIndex 
+    PagedIndex
   >;
 }

--- a/specification/machinelearningservices/AzureAI.Assets/routes.tsp
+++ b/specification/machinelearningservices/AzureAI.Assets/routes.tsp
@@ -48,7 +48,7 @@ interface Indexes {
       version: string;
 
       @doc("Properties of an Index Version.")
-      @body
+      @bodyRoot
       body: Index;
     },
     ResourceCreatedOrOkResponse<Index> | Foundations.ErrorResponse

--- a/specification/mobilepacketcore/MobilePacketCore.Management/common.tsp
+++ b/specification/mobilepacketcore/MobilePacketCore.Management/common.tsp
@@ -40,7 +40,7 @@ op ArmResourceCreateOrUpdate2Async<
   ...ResourceInstanceParameters<TResource, TBaseParameters>,
 
   @doc("Resource create parameters.")
-  @body
+  @bodyRoot
   resource: TResource,
 ): ArmUpdatedResponse<TResource> | ArmCreatedResponse<TResource> | ErrorResponse;
 

--- a/specification/mpcnetworkfunction/MpcNetworkFunction.Management/networkfunction.tsp
+++ b/specification/mpcnetworkfunction/MpcNetworkFunction.Management/networkfunction.tsp
@@ -90,7 +90,7 @@ op ArmResourceCreateOrUpdate2Async<
   ...ResourceInstanceParameters<TResource, TBaseParameters>,
 
   @doc("Resource create parameters.")
-  @body
+  @bodyRoot
   resource: TResource,
 ): ArmUpdatedResponse<TResource> | ArmCreatedResponse<TResource> | ErrorResponse;
 

--- a/specification/purview/Azure.Analytics.Purview.DataMap/routes.tsp
+++ b/specification/purview/Azure.Analytics.Purview.DataMap/routes.tsp
@@ -50,7 +50,7 @@ alias OkResponse<T> = {
   @statusCode
   status: 200;
 
-  @body
+  @bodyRoot
   data: T;
 };
 
@@ -253,7 +253,7 @@ Null updates are not possible.
 
       #suppress "@azure-tools/typespec-azure-core/no-unknown" "Should use unknown to model Object"
       @doc("The value of the attribute.")
-      @body
+      @bodyRoot
       body: unknown;
     },
     EntityMutationResult,
@@ -341,7 +341,7 @@ Null updates are not possible.
       guid: string;
 
       @doc("An array of classifications to be added.")
-      @body
+      @bodyRoot
       body: AtlasClassification[];
     },
     void,
@@ -361,7 +361,7 @@ Null updates are not possible.
       guid: string;
 
       @doc("An array of classifications to be updated.")
-      @body
+      @bodyRoot
       body: AtlasClassification[];
     },
     void,
@@ -536,7 +536,7 @@ be changed to other unique attributes)
       attribute?: string;
 
       @doc("An array of classification to be added.")
-      @body
+      @bodyRoot
       body: AtlasClassification[];
     },
     void,
@@ -563,7 +563,7 @@ be changed to other unique attributes)
       attribute?: string;
 
       @doc("An array of classification to be updated.")
-      @body
+      @bodyRoot
       body: AtlasClassification[];
     },
     void,
@@ -660,7 +660,7 @@ example. qualifiedName can be changed to other unique attributes)
 
       #suppress "@azure-tools/typespec-azure-core/bad-record-type" "Should use unknown to model Object"
       @doc("Business metadata payload")
-      @body
+      @bodyRoot
       body: Record<Record<unknown>>;
     },
     void,
@@ -687,7 +687,7 @@ default is false.
 
       #suppress "@azure-tools/typespec-azure-core/bad-record-type" "Should use unknown to model Object"
       @doc("BusinessMetadata payload")
-      @body
+      @bodyRoot
       body: Record<Record<unknown>>;
     },
     void,
@@ -712,7 +712,7 @@ default is false.
 
       #suppress "@azure-tools/typespec-azure-core/bad-record-type" "Should use unknown to model Object"
       @doc("Business metadata attribute payload")
-      @body
+      @bodyRoot
       body: Record<unknown>;
     },
     void,
@@ -737,7 +737,7 @@ default is false.
 
       #suppress "@azure-tools/typespec-azure-core/bad-record-type" "Should use unknown to model Object"
       @doc("Business metadata attribute payload")
-      @body
+      @bodyRoot
       body: Record<unknown>;
     },
     void,
@@ -753,7 +753,7 @@ default is false.
     {},
     {
       @header contentType: "application/octet-stream";
-      @body body: bytes;
+      @bodyRoot body: bytes;
     },
     {}
   >;
@@ -783,7 +783,7 @@ default is false.
       guid: string;
 
       @doc("set of labels to be deleted")
-      @body
+      @bodyRoot
       body?: string[];
     },
     void,
@@ -803,7 +803,7 @@ default is false.
       guid: string;
 
       @doc("set of labels to be set to the entity")
-      @body
+      @bodyRoot
       body?: string[];
     },
     void,
@@ -823,7 +823,7 @@ default is false.
       guid: string;
 
       @doc("set of labels to be added")
-      @body
+      @bodyRoot
       body?: string[];
     },
     void,
@@ -864,7 +864,7 @@ be changed to other unique attributes)
       attribute?: string;
 
       @doc("set of labels to be deleted")
-      @body
+      @bodyRoot
       body?: string[];
     },
     void,
@@ -907,7 +907,7 @@ be changed to other unique attributes)
       attribute?: string;
 
       @doc("set of labels to be set")
-      @body
+      @bodyRoot
       body?: string[];
     },
     void,
@@ -950,7 +950,7 @@ be changed to other unique attributes)
       attribute?: string;
 
       @doc("set of labels to be added")
-      @body
+      @bodyRoot
       body?: string[];
     },
     void,
@@ -1026,7 +1026,7 @@ and
   createCategories is AtlasOperation<
     {
       @doc("An array of glossary category definitions to be created.")
-      @body
+      @bodyRoot
       body: AtlasGlossaryCategory[];
     },
     OkResponse<AtlasGlossaryCategory[]>,
@@ -1108,7 +1108,7 @@ updating shortDescription and longDescription for category.
 A map containing keys as attribute names and values as corresponding attribute
 values for partial update.
 """)
-      @body
+      @bodyRoot
       body: Record<string>;
     },
     AtlasGlossaryCategory,
@@ -1256,7 +1256,7 @@ shortDescription, longDescription, abbreviation, usage and status for term.
 A map containing keys as attribute names and values as corresponding attribute
 values to be updated.
 """)
-      @body
+      @bodyRoot
       body: Record<string>;
     },
     AtlasGlossaryTerm,
@@ -1275,7 +1275,7 @@ values to be updated.
       includeTermHierarchy?: boolean;
 
       @doc("An array of glossary term definitions to be created in bulk.")
-      @body
+      @bodyRoot
       body: AtlasGlossaryTerm[];
     },
     OkResponse<AtlasGlossaryTerm[]>,
@@ -1332,7 +1332,7 @@ is an alternative to assign a term to multiple entities.
       termId: string;
 
       @doc("An array of related object IDs to which the term has to be associated.")
-      @body
+      @bodyRoot
       body: AtlasRelatedObjectId[];
     },
     void,
@@ -1352,7 +1352,7 @@ is an alternative to assign a term to multiple entities.
       termId: string;
 
       @doc("An array of related object IDs from which the term has to be dissociated.")
-      @body
+      @bodyRoot
       body: AtlasRelatedObjectId[];
     },
     void,
@@ -1550,7 +1550,7 @@ using 'ignoreTermsAndCategories=true' to reduce response body size.
 A map containing keys as attribute names and values as corresponding attribute
 values.
 """)
-      @body
+      @bodyRoot
       body: Record<string>;
     },
     AtlasGlossary,

--- a/specification/quantum/Quantum.Workspace/operations/storage.tsp
+++ b/specification/quantum/Quantum.Workspace/operations/storage.tsp
@@ -30,7 +30,7 @@ model SasUriResponse {
 
 alias BlobDetailsParam = {
   /** The details (name and container) of the blob. */
-  @body
+  @bodyRoot
   blobDetails: BlobDetails;
 };
 

--- a/specification/schemaregistry/SchemaRegistry/main.tsp
+++ b/specification/schemaregistry/SchemaRegistry/main.tsp
@@ -139,7 +139,7 @@ op getSchemaPropertiesByContent is resourceOperations.ResourceAction<
     ...SchemaContentType;
     ...SchemasContent;
   },
-  SchemaProperties
+  Http.NoContentResponse & SchemaProperties
 >;
 
 //  PUT https://{namespaceName}.servicebus.windows.net/$schemaGroups/{groupName}/schemas/{schemaName}?api-version={apiVersion}

--- a/specification/schemaregistry/SchemaRegistry/main.tsp
+++ b/specification/schemaregistry/SchemaRegistry/main.tsp
@@ -193,7 +193,7 @@ alias SchemaContentType = {
 };
 
 alias SchemasContent = {
-  @body
+  @bodyRoot
   @doc("String representation (UTF-8) of the schema.")
   schemaContent: bytes;
 };

--- a/specification/translation/Azure.AI.DocumentTranslation/main.tsp
+++ b/specification/translation/Azure.AI.DocumentTranslation/main.tsp
@@ -82,7 +82,7 @@ model DocumentTranslateResult {
   contentType: "application/octet-stream";
 
   /** Request response, response is a translated document. */
-  @body
+  @bodyRoot
   document: bytes;
 }
 

--- a/specification/translation/Azure.AI.TextTranslation/models-breaksentence.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/models-breaksentence.tsp
@@ -32,7 +32,7 @@ model BreakSentenceParameters {
 model BreakSentenceResult {
   ...CommonResultHeaders;
 
-  @body
+  @bodyRoot
   @doc("Array of the break sentence elements.")
   result: BreakSentenceItem[];
 }

--- a/specification/translation/Azure.AI.TextTranslation/models-dictionary.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/models-dictionary.tsp
@@ -40,7 +40,7 @@ model DictionaryExamplesParameters {
 model DictionaryLookupResult {
   ...CommonResultHeaders;
 
-  @body
+  @bodyRoot
   @doc("Array of the dictionary lookup elements.")
   result: DictionaryLookupItem[];
 }
@@ -49,7 +49,7 @@ model DictionaryLookupResult {
 model DictionaryExamplesResult {
   ...CommonResultHeaders;
 
-  @body
+  @bodyRoot
   @doc("Array of the dictionary examples elements.")
   result: DictionaryExampleItem[];
 }

--- a/specification/translation/Azure.AI.TextTranslation/models-translate.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/models-translate.tsp
@@ -117,7 +117,7 @@ model TranslateParameters {
 model TranslationResult {
   ...CommonResultHeaders;
 
-  @body
+  @bodyRoot
   @doc("Array of the translated text elements.")
   result: TranslatedTextItem[];
 

--- a/specification/translation/Azure.AI.TextTranslation/models-transliterate.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/models-transliterate.tsp
@@ -39,7 +39,7 @@ model TransliterateParameters {
 model TransliterateResult {
   ...CommonResultHeaders;
 
-  @body
+  @bodyRoot
   @doc("Array of transliterated texts")
   result: TransliteratedText[];
 }

--- a/specification/translation/Azure.AI.TextTranslation/routes.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/routes.tsp
@@ -24,7 +24,7 @@ op CustomOperation<
 
   #suppress "@azure-tools/typespec-azure-core/request-body-problem" "Existing spec"
   @doc("Defines the content of the request")
-  @body
+  @bodyRoot
   requestBody: TBody,
 
   @doc("Mandatory API version parameter")

--- a/specification/vmware/Microsoft.AVS/routes.tsp
+++ b/specification/vmware/Microsoft.AVS/routes.tsp
@@ -22,7 +22,7 @@ interface Locations {
     ...ResourceInstanceParameters<Location>,
 
     @doc("Optionally, check for a specific SKU")
-    @body
+    @bodyRoot
     sku?: ResourceSkuType,
   ): ArmResponse<Trial> | ErrorResponse;
 
@@ -61,7 +61,7 @@ interface PrivateClouds {
   update(
     ...ResourceInstanceParameters<PrivateCloud>,
 
-    @body
+    @bodyRoot
     @doc("The private cloud properties to be updated.")
     privateCloudUpdate: PrivateCloudUpdate,
   ): ArmResponse<PrivateCloud> | {
@@ -71,7 +71,7 @@ interface PrivateClouds {
     ...Azure.Core.Foundations.RetryAfterHeader;
     ...LocationHeader;
 
-    @body
+    @bodyRoot
     @doc("The updated private cloud.")
     placementPolicy: PrivateCloud;
   } | ErrorResponse;
@@ -130,7 +130,7 @@ interface Clusters {
   update(
     ...ResourceInstanceParameters<Cluster>,
 
-    @body
+    @bodyRoot
     @doc("The cluster properties to be updated.")
     clusterUpdate: ClusterUpdate,
   ): ArmResponse<Cluster> | {
@@ -140,7 +140,7 @@ interface Clusters {
     ...Azure.Core.Foundations.RetryAfterHeader;
     ...LocationHeader;
 
-    @body
+    @bodyRoot
     @doc("The updated cluster.")
     cluster: Cluster;
   } | ErrorResponse;
@@ -844,7 +844,7 @@ interface VirtualMachines {
   restrictMovement(
     ...ResourceInstanceParameters<VirtualMachine>,
 
-    @body
+    @bodyRoot
     @doc("The body type of the operation request.")
     restrictMovement: VirtualMachineRestrictMovement,
   ): ArmAcceptedLroResponse | ErrorResponse;
@@ -876,7 +876,7 @@ interface PlacementPolicies {
   update(
     ...ResourceInstanceParameters<PlacementPolicy>,
 
-    @body
+    @bodyRoot
     @doc("The placement policy properties to be updated.")
     placementPolicyUpdate: PlacementPolicyUpdate,
   ): ArmResponse<PlacementPolicy> | {
@@ -884,7 +884,7 @@ interface PlacementPolicies {
     ...Azure.Core.Foundations.RetryAfterHeader;
     ...LocationHeader;
 
-    @body
+    @bodyRoot
     @doc("The updatd placement policy.")
     placementPolicy: PlacementPolicy;
   } | ErrorResponse;
@@ -946,7 +946,7 @@ interface ScriptExecutions {
     ...ResourceInstanceParameters<ScriptExecution>,
 
     #suppress "@azure-tools/typespec-azure-core/request-body-problem"
-    @body
+    @bodyRoot
     @doc("Name of the desired output stream to return. If not provided, will return all. An empty array will return nothing.")
     scriptOutputStreamType?: ScriptOutputStreamType[],
   ): ArmResponse<ScriptExecution> | ErrorResponse;
@@ -984,7 +984,7 @@ interface IscsiPaths {
   delete is ArmResourceDeleteAsync<IscsiPath>;
 }
 
-// use { @body _: void } with the next version of typespec-azure
+// use { @bodyRoot _: void } with the next version of typespec-azure
 // https://github.com/Azure/typespec-azure/issues/3759
 
 // Just like ArmResourceActionSync, but with no request body.

--- a/specification/voiceservices/VoiceServices.Provisioning/main.tsp
+++ b/specification/voiceservices/VoiceServices.Provisioning/main.tsp
@@ -853,7 +853,7 @@ interface Accounts {
   deleteNumbers is Operations.ResourceAction<
     AccountResource,
     BatchNumbersDelete,
-    {}
+    NoContentResponse
   >;
 
   @tag("Number")

--- a/specification/voiceservices/VoiceServices.Provisioning/main.tsp
+++ b/specification/voiceservices/VoiceServices.Provisioning/main.tsp
@@ -951,7 +951,7 @@ op listNumbers is RpcOperation<
   {
     @statusCode statusCode: 200;
     @header contentType: "application/json";
-    @body success: PagedNumberList;
+    @bodyRoot success: PagedNumberList;
     ...CountOfRecordsHeader;
   }
 >;


### PR DESCRIPTION
Changes: 
- Converted blindly all `@body` to `@bodyRoot` as this is the exact same meaning now. Technically we could do a targeted fix and keeps good ones to `@body`
- Healthinsights was using traits in a response instead of as a trait
- Various status codes moved 204 -> 200 are now explicitly specify the 204 status code
- Communication was completely misusing `ResourceRead` with ghost properties
- Some misuse of `StatusResult`
- Some duplicated responses