### PR TITLE
Update control_plane_template.md: ARM merge queue now only includes PRs that have `resource-manager` label

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/control_plane_template.md
@@ -87,6 +87,6 @@ If one or multiple validation error/warning suppression(s) is detected in your P
 - If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
 
 [ARM review queue]: https://aka.ms/azsdk/pr-arm-review#about-the-arm-review-queue
-[public repo merge queue]: https://github.com/Azure/azure-rest-api-specs/pulls?q=is%3Aopen+is%3Apr+label%3AMergeRequested+draft%3Afalse+sort%3Acreated-asc
-[private repo merge queue]: https://github.com/Azure/azure-rest-api-specs-pr/pulls?q=is%3Aopen+is%3Apr+label%3AMergeRequested+-label%3AApproved-OkToMerge+draft%3Afalse+sort%3Acreated-asc
+[public repo merge queue]: https://github.com/Azure/azure-rest-api-specs/pulls?q=is%3Aopen+is%3Apr+label%3AMergeRequested+label%3Aresource-manager+draft%3Afalse+sort%3Acreated-asc
+[private repo merge queue]: https://github.com/Azure/azure-rest-api-specs-pr/pulls?q=is%3Aopen+is%3Apr+label%3AMergeRequested+label%3Aresource-manager+-label%3AApproved-OkToMerge+draft%3Afalse+sort%3Acreated-asc
 [Breaking Changes review process]: https://aka.ms/brch


### PR DESCRIPTION
Update control_plane_template.md: ARM merge queue now only includes PRs that have `resource-manager` label

Sometimes people get confused and add `MergeRequested` label for `data-plane` PRs, resulting in extra work for ARM reviewers.

With this change we will save time of ARM reviewers. As a result probably some data-plane PR authors will get confused why their PR is not getting looked at and no ARM engineer will look at them. For now such PR authors are supposed to read the provided guidance which clarifies the next steps. If this will be a major problem we will address it eventually.