### PR TITLE
Integrate Armstrong Validation into the spec PR check.

### DIFF
--- a/eng/pipelines/armstrong-validation.yml
+++ b/eng/pipelines/armstrong-validation.yml
@@ -8,6 +8,6 @@ jobs:
 
   steps:
   - pwsh: |
-      $(Build.SourcesDirectory)/eng/scripts/TypeSpec-Requirement.ps1 -Verbose
+      $(Build.SourcesDirectory)/eng/scripts/Armstrong-Validation.ps1 -Verbose
     displayName: Armstrong Validation
     ignoreLASTEXITCODE: true

--- a/eng/pipelines/armstrong-validation.yml
+++ b/eng/pipelines/armstrong-validation.yml
@@ -1,0 +1,13 @@
+trigger: none
+
+jobs:
+- job:
+  pool:
+    name: azsdk-pool-mms-ubuntu-2204-general
+    vmImage: ubuntu-22.04
+
+  steps:
+  - pwsh: |
+      $(Build.SourcesDirectory)/eng/scripts/TypeSpec-Requirement.ps1 -Verbose
+    displayName: Armstrong Validation
+    ignoreLASTEXITCODE: true

--- a/eng/scripts/Armstrong-Validation.ps1
+++ b/eng/scripts/Armstrong-Validation.ps1
@@ -1,0 +1,197 @@
+[CmdletBinding()]
+param (
+  [Parameter(Position = 0)]
+  [string] $BaseCommitish = "HEAD^",
+  [Parameter(Position = 1)]
+  [string] $TargetCommitish = "HEAD"
+)
+Set-StrictMode -Version 3
+
+. $PSScriptRoot/ChangedFiles-Functions.ps1
+. $PSScriptRoot/Logging-Functions.ps1
+
+$script:psYamlInstalled = $false
+function Ensure-PowerShell-Yaml-Installed {
+  if ($script:psYamlInstalled) {
+    # If already checked once in this script, don't log anything further
+    return;
+  }
+
+  $script:psYamlInstalled = [bool] (Get-Module -ListAvailable -Name powershell-yaml | Where-Object { $_.Version -eq "0.4.7" })
+
+  if ($script:psYamlInstalled) {
+    LogInfo "Module powershell-yaml@0.4.7 already installed"
+  }
+  else {
+    LogInfo "Installing module powershell-yaml@0.4.7"
+    Install-Module -Name powershell-yaml -RequiredVersion 0.4.7 -Force -Scope CurrentUser
+    $script:psYamlInstalled = $true
+  }
+}
+
+function Find-Suppressions-Yaml {
+  param (
+    [string]$fileInSpecFolder
+  )
+
+  $currentDirectory = Get-Item (Split-Path -Path $fileInSpecFolder)
+
+  while ($currentDirectory) {
+    $suppressionsFile = Join-Path -Path $currentDirectory.FullName -ChildPath "suppressions.yaml"
+
+    if (Test-Path $suppressionsFile) {
+      return $suppressionsFile
+    } else {
+      $currentDirectory = $currentDirectory.Parent
+    }
+  }
+
+  return $null
+}
+
+function Get-Suppression {
+  param (
+    [string]$fileInSpecFolder
+  )
+
+  $suppressionsFile = Find-Suppressions-Yaml $fileInSpecFolder
+  if ($suppressionsFile) {
+    Ensure-PowerShell-Yaml-Installed
+
+    $suppressions = Get-Content -Path $suppressionsFile -Raw | ConvertFrom-Yaml
+    foreach ($suppression in $suppressions) {
+      $tool = $suppression["tool"]
+      $path = $suppression["path"]
+
+      if ($tool -eq "ArmstrongValidation") {
+        # Paths in suppressions.yml are relative to the file itself
+        $fullPath = Join-Path -Path (Split-Path -Path $suppressionsFile) -ChildPath $path
+
+        # If path is not specified, suppression applies to all files
+        if (!$path -or ($fileInSpecFolder -like $fullPath)) {
+          return $suppression
+        }
+      }
+    }
+  }
+
+  return $null
+}
+
+function Get-ChangedTerraformFiles($changedFiles = (Get-ChangedFiles)) {
+  $changedFiles = Get-ChangedFilesUnderSpecification $changedFiles
+
+  $changedSwaggerFiles = $changedFiles.Where({ 
+    $_.EndsWith("main.tf")
+  })
+    
+  return $changedSwaggerFiles
+}
+
+$script:armstrongInstalled = $false
+function Ensure-Armstrong-Installed {
+  if ($script:armstrongInstalled) {
+    # If already checked once in this script, don't log anything further
+    return;
+  }
+
+  $script:armstrongInstalled = $true
+
+  if ($PSVersionTable.OS -like "*Windows*") {
+    LogInfo "Skipping Armstrong install on Windows"
+    return;
+  }
+
+  # Armstrong will be installed under $HOME/go/bin
+  $armstrongPath = Join-Path -Path $HOME -ChildPath "go/bin"
+  $env:PATH += ":$armstrongPath"
+
+  # install golang
+  if (!(Get-Command "go" -ErrorAction SilentlyContinue)) {
+    LogInfo "Installing Go..."
+    sudo apt-get update
+    sudo apt-get install -y golang-go
+  } else {
+      LogInfo "Go is already installed."
+  }
+
+
+  # install armstrong
+  if (!(Get-Command "armstrong" -ErrorAction SilentlyContinue)) {
+    LogInfo "Installing Armstrong..."
+    go install github.com/azure/armstrong@latest
+  } else {
+      LogInfo "Armstrong is already installed."
+  }
+
+}
+
+function Validate-Terraform-Error($repoPath, $filePath) {
+  $fileDirectory = (Split-Path -Parent $filePath)
+  # delete existing old error reports
+  Remove-Item -Path "${fileDirectory}/armstrong_credscan_*" -Recurse -Force *> $null
+
+  # run armstrong credscan
+  $specPath = Join-Path -Path $repoPath -ChildPath "specification"
+  LogInfo "armstrong credscan -working-dir $fileDirectory -swagger-repo $specPath"
+  armstrong credscan -working-dir $fileDirectory -swagger-repo $specPath
+
+  $result = @()
+  # error reports are stored in a directory named armstrong_credscan_<timestamp>
+  Get-ChildItem -Path $fileDirectory -Directory -Filter "armstrong_credscan_*" | ForEach-Object {
+    $errorJsonPath = Join-Path -Path $_.FullName -ChildPath "errors.json"
+    if (Test-Path -Path $errorJsonPath) {
+      $content = Get-Content -Path $errorJsonPath
+      $result += $content
+    }
+  }
+
+  return $result -join "`n"
+}
+
+$repoPath = Resolve-Path "$PSScriptRoot/../.."
+
+$terraformErrors = @()
+
+$filesToCheck = (Get-ChangedTerraformFiles (Get-ChangedFiles $BaseCommitish $TargetCommitish))
+
+if (!$filesToCheck) {
+  LogInfo "No Terraform files found to check"
+}
+else {
+  foreach ($file in $filesToCheck) {
+    LogInfo "Checking $file"
+
+    $fullPath = (Join-Path $repoPath $file)
+
+    $suppression = Get-Suppression $fullPath
+    if ($suppression) {
+      $reason = $suppression["reason"] ?? "<no reason specified>"
+
+      LogInfo "  Suppressed: $reason"
+      # Skip further checks, to avoid potential errors on files already suppressed
+      continue
+    }
+
+    try {
+      Ensure-Armstrong-Installed
+      LogInfo "  Validating errors from Terraform file: $fullPath"
+      $terraformErrors += (Validate-Terraform-Error $repoPath $fullPath)
+    }
+    catch {
+      $terraformErrors += "  failed to validate errors from Terraform file: $file`n    $_"
+    }
+  }
+}
+
+if ($terraformErrors.Count -gt -1)
+{
+  $errorString = "Armstrong Validation failed for some files. To fix, address the following errors: `n"
+  $errorString += $terraformErrors -join "`n"
+  LogError $errorString
+
+  LogJobFailure
+  exit 1
+}
+
+exit 0

--- a/eng/scripts/Armstrong-Validation.ps1
+++ b/eng/scripts/Armstrong-Validation.ps1
@@ -184,7 +184,7 @@ else {
   }
 }
 
-if ($terraformErrors.Count -gt -1)
+if ($terraformErrors.Count -gt 0)
 {
   $errorString = "Armstrong Validation failed for some files. To fix, address the following errors: `n"
   $errorString += $terraformErrors -join "`n"

--- a/eng/scripts/Armstrong-Validation.ps1
+++ b/eng/scripts/Armstrong-Validation.ps1
@@ -41,7 +41,8 @@ function Find-Suppressions-Yaml {
 
     if (Test-Path $suppressionsFile) {
       return $suppressionsFile
-    } else {
+    }
+    else {
       $currentDirectory = $currentDirectory.Parent
     }
   }
@@ -82,8 +83,8 @@ function Get-ChangedTerraformFiles($changedFiles = (Get-ChangedFiles)) {
   $changedFiles = Get-ChangedFilesUnderSpecification $changedFiles
 
   $changedSwaggerFiles = $changedFiles.Where({ 
-    $_.EndsWith("main.tf")
-  })
+      $_.EndsWith("main.tf")
+    })
     
   return $changedSwaggerFiles
 }
@@ -111,8 +112,9 @@ function Ensure-Armstrong-Installed {
     LogInfo "Installing Go..."
     sudo apt-get update
     sudo apt-get install -y golang-go
-  } else {
-      LogInfo "Go is already installed."
+  }
+  else {
+    LogInfo "Go is already installed."
   }
 
 
@@ -120,8 +122,9 @@ function Ensure-Armstrong-Installed {
   if (!(Get-Command "armstrong" -ErrorAction SilentlyContinue)) {
     LogInfo "Installing Armstrong..."
     go install github.com/azure/armstrong@latest
-  } else {
-      LogInfo "Armstrong is already installed."
+  }
+  else {
+    LogInfo "Armstrong is already installed."
   }
 
 }
@@ -141,12 +144,13 @@ function Validate-Terraform-Error($repoPath, $filePath) {
   Get-ChildItem -Path $fileDirectory -Directory -Filter "armstrong_credscan_*" | ForEach-Object {
     $errorJsonPath = Join-Path -Path $_.FullName -ChildPath "errors.json"
     if (Test-Path -Path $errorJsonPath) {
-      $content = Get-Content -Path $errorJsonPath
-      $result += $content
+      Get-Content -Path $errorJsonPath -Raw | ConvertFrom-Json | ForEach-Object {
+        $result += "$_"
+      }
     }
   }
 
-  return $result -join "`n"
+  return $result
 }
 
 $repoPath = Resolve-Path "$PSScriptRoot/../.."
@@ -184,8 +188,7 @@ else {
   }
 }
 
-if ($terraformErrors.Count -gt 0)
-{
+if ($terraformErrors.Count -gt 0) {
   $errorString = "Armstrong Validation failed for some files. To fix, address the following errors: `n"
   $errorString += $terraformErrors -join "`n"
   LogError $errorString


### PR DESCRIPTION
# Description

This task is used to check the added/updated [Armstrong](https://github.com/ms-zhenhua/armstrong) configuration files submitted by users. Since setting plain text for `x-ms-secret` values may cause security risks, this task will help find out such issues and remind the users to hide such secret information. 
1. The code logic is the same as [Pull Request 544843](https://dev.azure.com/devdiv/DevDiv/_git/openapi-alps/pullrequest/544843)
2. I added a new suppression tool `ArmstrongValidation` for this validation.