### PR TITLE
Remove custom types from EventGrid Namespaces Java client

### DIFF
--- a/specification/eventgrid/Azure.Messaging.EventGrid/tspconfig.yaml
+++ b/specification/eventgrid/Azure.Messaging.EventGrid/tspconfig.yaml
@@ -39,8 +39,6 @@ options:
     generate-tests: false
     enable-sync-stack: true
     customization-class: customization/src/main/java/EventGridCustomization.java
-    custom-types: "CloudEvent,PublishResult"
-    custom-types-subpackage: "implementation.models"
     dev-options:
       loglevel: info
     flavor: azure


### PR DESCRIPTION
These types aren't actually used so instead of leaving unused files on disk we delete them. Part of that is to remove these from the config options.