### PR TITLE
Added usage models for run and runStep

### DIFF
--- a/specification/ai/OpenAI.Assistants/run_steps/models.tsp
+++ b/specification/ai/OpenAI.Assistants/run_steps/models.tsp
@@ -70,6 +70,7 @@ model RunStep {
   @doc("The Unix timestamp, in seconds, representing when this failed.")
   failedAt: utcDateTime | null;
 
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "OpenAI uses explicit nullability, distinct from optionality"
   @doc("Usage statistics related to the run step. This value will be `null` while the run step's status is `in_progress`.")
   @added(ServiceApiVersions.vFuturePlaceholder)
   usage: RunStepCompletionUsage | null;

--- a/specification/ai/OpenAI.Assistants/run_steps/models.tsp
+++ b/specification/ai/OpenAI.Assistants/run_steps/models.tsp
@@ -70,7 +70,27 @@ model RunStep {
   @doc("The Unix timestamp, in seconds, representing when this failed.")
   failedAt: utcDateTime | null;
 
+  @doc("Usage statistics related to the run step. This value will be `null` while the run step's status is `in_progress`.")
+  usage: RunStepCompletionUsage | null;
+
   ...RequiredNullableMetadata;
+}
+
+@doc("Usage statistics related to the run step.")
+@added(ServiceApiVersions.vFuturePlaceholder)
+model RunStepCompletionUsage {
+  
+  @doc("Number of completion tokens used over the course of the run step.")
+  @encodedName("application/json", "completion_tokens")
+  completionTokens: int64;
+
+  @doc("Number of prompt tokens used over the course of the run step.")
+  @encodedName("application/json", "prompt_tokens")
+  promptTokens: int64;
+
+  @doc("Total number of tokens used (prompt + completion).")
+  @encodedName("application/json", "total_tokens")
+  totalTokens: int64;
 }
 
 @doc("The possible types of run steps.")

--- a/specification/ai/OpenAI.Assistants/run_steps/models.tsp
+++ b/specification/ai/OpenAI.Assistants/run_steps/models.tsp
@@ -71,6 +71,7 @@ model RunStep {
   failedAt: utcDateTime | null;
 
   @doc("Usage statistics related to the run step. This value will be `null` while the run step's status is `in_progress`.")
+  @added(ServiceApiVersions.vFuturePlaceholder)
   usage: RunStepCompletionUsage | null;
 
   ...RequiredNullableMetadata;

--- a/specification/ai/OpenAI.Assistants/runs/models.tsp
+++ b/specification/ai/OpenAI.Assistants/runs/models.tsp
@@ -96,6 +96,7 @@ model ThreadRun {
   failedAt: utcDateTime | null;
 
   @doc("Usage statistics related to the run. This value will be `null` if the run is not in a terminal state (i.e. `in_progress`, `queued`, etc.).")
+  @added(ServiceApiVersions.vFuturePlaceholder)
   usage: RunCompletionUsage | null;
 
   ...RequiredNullableMetadata;

--- a/specification/ai/OpenAI.Assistants/runs/models.tsp
+++ b/specification/ai/OpenAI.Assistants/runs/models.tsp
@@ -95,7 +95,27 @@ model ThreadRun {
   @doc("The Unix timestamp, in seconds, representing when this failed.")
   failedAt: utcDateTime | null;
 
+  @doc("Usage statistics related to the run. This value will be `null` if the run is not in a terminal state (i.e. `in_progress`, `queued`, etc.).")
+  usage: RunCompletionUsage | null;
+
   ...RequiredNullableMetadata;
+}
+
+@doc("Usage statistics related to the run.")
+@added(ServiceApiVersions.vFuturePlaceholder)
+model RunCompletionUsage {
+  
+  @doc("Number of completion tokens used over the course of the run.")
+  @encodedName("application/json", "completion_tokens")
+  completionTokens: int64;
+
+  @doc("Number of prompt tokens used over the course of the run.")
+  @encodedName("application/json", "prompt_tokens")
+  promptTokens: int64;
+
+  @doc("Total number of tokens used (prompt + completion).")
+  @encodedName("application/json", "total_tokens")
+  totalTokens: int64;
 }
 
 @doc("The details used when creating a new run of an assistant thread.")

--- a/specification/ai/OpenAI.Assistants/runs/models.tsp
+++ b/specification/ai/OpenAI.Assistants/runs/models.tsp
@@ -95,6 +95,7 @@ model ThreadRun {
   @doc("The Unix timestamp, in seconds, representing when this failed.")
   failedAt: utcDateTime | null;
 
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "OpenAI uses explicit nullability, distinct from optionality"
   @doc("Usage statistics related to the run. This value will be `null` if the run is not in a terminal state (i.e. `in_progress`, `queued`, etc.).")
   @added(ServiceApiVersions.vFuturePlaceholder)
   usage: RunCompletionUsage | null;


### PR DESCRIPTION
While implementing streaming in Java, I noticed in the JSON that there is usage data available that we could be deserializing. Maybe this is not the right PR to address this so feel free to ignore for now :)

Reference lines in swagger:

- [Usage fieldin ThreadRun](https://github.com/openai/openai-openapi/blob/afe0b7c0922a8be09b0313532a56a7be2a950e13/openapi.yaml#L10160) and it's [definition](https://github.com/openai/openai-openapi/blob/afe0b7c0922a8be09b0313532a56a7be2a950e13/openapi.yaml#L9490-L9507)
- [Usage field in RunStep](https://github.com/openai/openai-openapi/blob/afe0b7c0922a8be09b0313532a56a7be2a950e13/openapi.yaml#L11381-L11382) and its [definition](https://github.com/openai/openai-openapi/blob/afe0b7c0922a8be09b0313532a56a7be2a950e13/openapi.yaml#L9509-L9526)