### PR TITLE
workflow-bot: update comment.yml: add support for `NotReadyForARMReview` and simplify the file

### DIFF
--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -24,6 +24,12 @@
     onLabeledComments: "Hi, @${PRAuthor}, our workflow has detected that there is no management SDK ever released for your RP, to further process SDK onboard for your RP, you should have the SDK client library name of your RP reviewed and approved. </br> <b>Action Required</b>: <li> Follow this guidance [Naming for new initial management or client libraries (new SDKs) - Overview (azure.com)](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/821/Naming-for-new-initial-management-or-client-libraries-(new-SDKs)) to create an issue for management client library name arch board review. </li> <li>Paste the issue link that you created in step 1 in this PR</li> </br> <b> Impact</b>: SDK release owner will take the approved management client library name to release SDK. No client library name approval will leads to SDK release delayed."
 
 - rule:
+    type: label
+    label: ARMChangesRequested
+    onLabeledRemoveLabels:
+        - WaitForARMFeedback
+
+- rule:
     type: unlabeled
     label: ARMChangesRequested
     onUnlabeledAddLabels:

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -15,16 +15,6 @@
 
 - rule:
     type: label
-    label: CI-NewRPNamespaceWithoutRPaaS
-    onLabeledComments: "Hi @${PRAuthor} This PR was flagged for introducing a new RP namespace that is not being onboarded with [RPaaS](https://armwiki.azurewebsites.net/rpaas/overview.html). Label: `CI-NewRPNamespaceWithoutRPaaS`. Merging this PR to the main branch will be blocked as RPaaS is required for new RPs. To resolve this and allow the PR to be merged into the main branch, please [use RPaaS to onboard the new RP](https://armwiki.azurewebsites.net/rpaas/gettingstarted.html). Otherwise, please see [aka.ms/RPaaSException](https://aka.ms/RPaaSException) to discuss an exception."
-
-- rule:
-    type: label
-    label: CI-RpaaSRPNotInPrivateRepo
-    onLabeledComments: "Hi @${PRAuthor} This PR was flagged for attempting to introduce a new RP namespace to the main branch without first merging the new RP to the RPSaaSMaster branch. Label: `CI-RpaaSRPNotInPrivateRepo`. Please add the new RP in a merge to RPSaaSMaster before continuing the merge to main."
-
-- rule:
-    type: label
     label: ArcReview
     onLabeledComments: "Hi @${PRAuthor} and @arcboard, one or more change(s) have been detected in your Arc enabled VM's or Arc enabled Server's RPs. Please review the changes and ensure that no gaps have been introduced with respect to the ARM API modeling consistency across Azure Arc and Azure Compute. For further details, see guidelines at [Consistency in ARM Modeling](https://msazure.visualstudio.com/One/_wiki/wikis/One.wiki/377428/Consistency-in-ARM-Modeling?anchor=general-design-guidance). To approve the change(s), set the label to ArcSignedOff. If you have any questions, please mail to arcboard@microsoft.com."
 
@@ -32,25 +22,6 @@
     type: label
     label: new-rp-namespace
     onLabeledComments: "Hi, @${PRAuthor}, our workflow has detected that there is no management SDK ever released for your RP, to further process SDK onboard for your RP, you should have the SDK client library name of your RP reviewed and approved. </br> <b>Action Required</b>: <li> Follow this guidance [Naming for new initial management or client libraries (new SDKs) - Overview (azure.com)](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/821/Naming-for-new-initial-management-or-client-libraries-(new-SDKs)) to create an issue for management client library name arch board review. </li> <li>Paste the issue link that you created in step 1 in this PR</li> </br> <b> Impact</b>: SDK release owner will take the approved management client library name to release SDK. No client library name approval will leads to SDK release delayed."
-
-- rule:
-    type: label
-    label: NotReadyForARMReview
-    onLabeledComments: >-
-      This PR has `NotReadyForARMReview` label. This happens if your PR has `BreakingChangeReviewRequired` label without approval, OR `VersioningReviewLabel` without approval, OR `CI-NewRPNamespaceWithoutRPaaS` label without approval, OR `CI-RpaaSRPNotInPrivateRepo` label. Consult the `Next Steps to Merge` comment to fix the issue and once fixed/approved, add to your PR a comment with contents `/azp run`. Automation will re-evaluate your PR and if everything looks good, it will add `WaitForARMFeedback` label which will put your PR on the ARM review queue. <br/>
-      Learn more about the queue at [aka.ms/azsdk/pr-arm-review](https://aka.ms/azsdk/pr-arm-review).
-    onLabeledRemoveLabels:
-        - WaitForARMFeedback
-
-- rule:
-    type: label
-    label: ARMChangesRequested
-    onLabeledComments: >-
-      This PR has `ARMChangesRequested` label. Please address or respond to feedback from the ARM API reviewer. <br/>
-      When you are ready to continue the ARM API review, please remove the `ARMChangesRequested` label. <br/>
-      Learn more at [aka.ms/azsdk/pr-arm-review](https://aka.ms/azsdk/pr-arm-review).
-    onLabeledRemoveLabels:
-        - WaitForARMFeedback
 
 - rule:
     type: unlabeled

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -34,32 +34,13 @@
     onLabeledComments: "Hi, @${PRAuthor}, our workflow has detected that there is no management SDK ever released for your RP, to further process SDK onboard for your RP, you should have the SDK client library name of your RP reviewed and approved. </br> <b>Action Required</b>: <li> Follow this guidance [Naming for new initial management or client libraries (new SDKs) - Overview (azure.com)](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/821/Naming-for-new-initial-management-or-client-libraries-(new-SDKs)) to create an issue for management client library name arch board review. </li> <li>Paste the issue link that you created in step 1 in this PR</li> </br> <b> Impact</b>: SDK release owner will take the approved management client library name to release SDK. No client library name approval will leads to SDK release delayed."
 
 - rule:
-    type: checkbox
-    keywords:
-      - "Update existing version to fix swagger quality issues in S360"
-    onCheckedLabels:
-      - FixS360
-
-- rule:
     type: label
-    label: ARMReview
-    booleanFilterExpression: "!(ARMSignedOff||ARMChangesRequested||Approved-OkToMerge)"
-    onLabeledAddLabels:
-        - WaitForARMFeedback
-
-- rule:
-    type: label
-    label: WaitForARMFeedback
-    onLabeledRemoveLabels:
-        - ARMChangesRequested
-        - ARMSignedOff
-        
-- rule:
-    type: label
-    label: ARMSignedOff
+    label: NotReadyForARMReview
+    onLabeledComments: >-
+      This PR has `NotReadyForARMReview` label. This happens if your PR has `BreakingChangeReviewRequired` label without approval, OR `VersioningReviewLabel` without approval, OR `CI-NewRPNamespaceWithoutRPaaS` label without approval, OR `CI-RpaaSRPNotInPrivateRepo` label. Consult the `Next Steps to Merge` comment to fix the issue and once fixed/approved, add to your PR a comment with contents `/azp run`. Automation will re-evaluate your PR and if everything looks good, it will add `WaitForARMFeedback` label which will put your PR on the ARM review queue. <br/>
+      Learn more about the queue at [aka.ms/azsdk/pr-arm-review](https://aka.ms/azsdk/pr-arm-review).
     onLabeledRemoveLabels:
         - WaitForARMFeedback
-        - ARMChangesRequested
 
 - rule:
     type: label
@@ -72,36 +53,7 @@
         - WaitForARMFeedback
 
 - rule:
-    type: label
-    label: Approved-BreakingChange
-    booleanFilterExpression: "!(ARMSignedOff||WaitForARMFeedback||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
-    onLabeledAddLabels:
-        - WaitForARMFeedback
-
-- rule:
-    type: label
-    label: BreakingChange-Approved-*
-    booleanFilterExpression: "!(ARMSignedOff||WaitForARMFeedback||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
-    onLabeledAddLabels:
-        - WaitForARMFeedback
-
-- rule:
-    type: label
-    label: Versioning-Approved-*
-    booleanFilterExpression: "!(ARMSignedOff||WaitForARMFeedback||ARMChangesRequested||Approved-OkToMerge||WaitForARMRevisit)&&ARMReview"
-    onLabeledAddLabels:
-        - WaitForARMFeedback
-
-- rule:
     type: unlabeled
     label: ARMChangesRequested
-    booleanFilterExpression: "!(CI-NewRPNamespaceWithoutRPaaS||CI-RpaaSRPNotInPrivateRepo)"
     onUnlabeledAddLabels:
         - WaitForARMFeedback
-
-- rule:
-    type: unlabeled
-    label: ARMChangesRequested
-    booleanFilterExpression: "CI-NewRPNamespaceWithoutRPaaS||CI-RpaaSRPNotInPrivateRepo"
-    onUnlabeledAddLabels:
-        - ARMChangesRequested


### PR DESCRIPTION
Contributes to implementation of:
- https://github.com/Azure/azure-sdk-tools/issues/6624

Companion change:
- [Pull Request 547143](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps/pullrequest/547143): Add "NotReadyForArmReview" label handling; fix "RPaasException" label handling; rework requiredLabelsRules

I removed most rules from the `comment.yml` because I converted them to "required label rules" in `openapi-alps` in the companion PR.