### PR TITLE
[Security Insights Enrichment API] Add missing `x-ms-pageable` & update `operationId`

### DIFF
--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/preview/2024-04-01-preview/Enrichment.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/preview/2024-04-01-preview/Enrichment.json
@@ -45,7 +45,7 @@
           "Enrichment"
         ],
         "description": "Get geodata for a single IP address",
-        "operationId": "IPGeodata_Get",
+        "operationId": "IPGeodata_List",
         "parameters": [
           {
             "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
@@ -90,7 +90,7 @@
           "Enrichment"
         ],
         "description": "Get whois information for a single domain name",
-        "operationId": "DomainWhois_Get",
+        "operationId": "DomainWhois_List",
         "parameters": [
           {
             "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/preview/2024-04-01-preview/Enrichment.json
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/preview/2024-04-01-preview/Enrichment.json
@@ -73,6 +73,9 @@
               "$ref": "../../../common/2.0/types.json#/definitions/CloudError"
             }
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
         }
       }
     },
@@ -115,6 +118,9 @@
               "$ref": "../../../common/2.0/types.json#/definitions/CloudError"
             }
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
         }
       }
     }


### PR DESCRIPTION
- Adds missing `x-ms-pageable` property in Enrichment API. 
- Updates operation id to follow convetions of `*_List`

> Enrichment API does not actually return any list of data, but due to convention, the linter throws an error as it believes that the return is a list, and therefore a `x-ms-pageable` should exist.