### PR TITLE
APC endpoint type fix/generation path

### DIFF
--- a/specification/programmableconnectivity/Azure.ProgrammableConnectivity/main.tsp
+++ b/specification/programmableconnectivity/Azure.ProgrammableConnectivity/main.tsp
@@ -26,7 +26,7 @@ using Azure.Core;
   "Azure Programmable Connectivity Endpoint.",
   {
     @doc("An Azure Programmable Connectivity Endpoint providing access to Network APIs, for example https://{region}.apcgatewayapi.azure.com")
-    endpoint: string,
+    endpoint: url,
   }
 )
 @versioned(APCVersions)

--- a/specification/programmableconnectivity/Azure.ProgrammableConnectivity/tspconfig.yaml
+++ b/specification/programmableconnectivity/Azure.ProgrammableConnectivity/tspconfig.yaml
@@ -1,6 +1,12 @@
 parameters:
+  "python-sdk-folder":
+    default: "{project-root}/azure-sdk-for-python/"
+  "csharp-sdk-folder":
+    default: "{project-root}/azure-sdk-for-net/"
   "service-dir":
-    default: "sdk/programmableconnectivity"
+    default: "sdk/communication"
+  "service-directory-name":
+    default: "communication"
   "dependencies":
     "additionalDirectories": []
     default: ""
@@ -14,14 +20,18 @@ options:
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
   "@azure-tools/typespec-csharp":
     package-dir: "Azure.Communication.ProgrammableConnectivity"
+    emitter-output-dir: "{csharp-sdk-folder}/sdk/{service-directory-name}/{namespace}/src"
     clear-output-folder: true
     model-namespace: false
     namespace: "{package-dir}"
     flavor: azure
   "@azure-tools/typespec-python":
-    package-mode: "dataplane"
-    package-dir: "azure-programmableconnectivity"
+    package-pprint-name: '"Programmable Connectivity"'
+    emitter-output-dir: "{python-sdk-folder}/sdk/{service-directory-name}/{package-name}"
+    package-dir: "azure-communication-programmableconnectivity"
     package-name: "{package-dir}"
+    package-version: 1.0.0b1
+    package-mode: "dataplane"
     flavor: azure
 linter:
   extends:


### PR DESCRIPTION
Draft. Needed to fix APC Python generation code with `tsp-client` version `0.7.0`.

Also fixes the generation path of APC SDK code into `communication/` directory.