### PR TITLE
Add some missing properties identified in NSP common-types

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1898,6 +1898,7 @@ networkacls
 networkinterfaces
 networkruleset
 networkrulesets
+networksecurityperimeter
 networksettings
 networkstatus
 networktraversal

--- a/specification/common-types/resource-management/v5/networksecurityperimeter.json
+++ b/specification/common-types/resource-management/v5/networksecurityperimeter.json
@@ -293,6 +293,19 @@
           "x-ms-identifiers": [
             "name"
           ]
+        },
+        "diagnosticSettingsVersion": {
+          "description": "Current diagnostic settings version",
+          "type": "integer",
+          "format": "int32"
+        },
+        "enabledLogCategories": {
+          "description": "List of log categories that are enabled",
+          "type": "array",
+          "items": {
+            "description": "Log category",
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
Updating common-types to add 'diagnosticSettingsVersion' and 'enabledLogCategories' which were missed in the original definition. This is caught while checking the first PR that is trying to use the new common types, and have been cross-checked against some existing NSP definitions like storage.