### PR TITLE
Revert "Move face to sdk/vision"

### DIFF
--- a/specification/ai/Face/tspconfig.yaml
+++ b/specification/ai/Face/tspconfig.yaml
@@ -1,6 +1,6 @@
 parameters:
   "service-dir":
-    default: "sdk/vision"
+    default: "sdk/face"
   "dependencies":
     "additionalDirectories": []
     default: ""


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#29107
Detail discussion in https://github.com/Azure/azure-sdk-for-js/issues/29670