### PR TITLE
Remove unused autorest using

### DIFF
--- a/specification/loadtestservice/LoadTestService.Management/models.tsp
+++ b/specification/loadtestservice/LoadTestService.Management/models.tsp
@@ -10,7 +10,6 @@ using TypeSpec.Versioning;
 using Azure.Core;
 using Azure.ResourceManager;
 using OpenAPI;
-using Autorest;
 using Azure.ResourceManager.Private;
 
 namespace Microsoft.LoadTestService;


### PR DESCRIPTION
The using was unused and as arm library doesn't import autorest library anymore this is failing in typespec-next.