### PR TITLE
[workflows] Start convention to prefix templates with "_"

### DIFF
--- a/.github/workflows/_eng-tools-test.yaml
+++ b/.github/workflows/_eng-tools-test.yaml
@@ -1,4 +1,4 @@
-name: eng/tools Test
+name: Templates - eng/tools - Test
 
 on:
   workflow_call:

--- a/.github/workflows/suppressions-test.yaml
+++ b/.github/workflows/suppressions-test.yaml
@@ -13,7 +13,7 @@ on:
       - package-lock.json
       - package.json
       - tsconfig.json
-      - .github/workflows/eng-tools-test.yaml
+      - .github/workflows/_eng-tools-test.yaml
       - .github/workflows/suppressions-test.yaml
       - eng/tools/package.json
       - eng/tools/tsconfig.json

--- a/.github/workflows/suppressions-test.yaml
+++ b/.github/workflows/suppressions-test.yaml
@@ -21,6 +21,6 @@ on:
 
 jobs:
   suppressions:
-    uses: ./.github/workflows/eng-tools-test.yaml
+    uses: ./.github/workflows/_eng-tools-test.yaml
     with:
       package: suppressions

--- a/.github/workflows/typespec-validation-test.yaml
+++ b/.github/workflows/typespec-validation-test.yaml
@@ -13,7 +13,7 @@ on:
       - package-lock.json
       - package.json
       - tsconfig.json
-      - .github/workflows/eng-tools-test.yaml
+      - .github/workflows/_eng-tools-test.yaml
       - .github/workflows/typespec-validation-test.yaml
       - eng/tools/package.json
       - eng/tools/tsconfig.json

--- a/.github/workflows/typespec-validation-test.yaml
+++ b/.github/workflows/typespec-validation-test.yaml
@@ -22,6 +22,6 @@ on:
 
 jobs:
   typespec-validation:
-    uses: ./.github/workflows/eng-tools-test.yaml
+    uses: ./.github/workflows/_eng-tools-test.yaml
     with:
       package: typespec-validation


### PR DESCRIPTION
Starting convention to prefix workflow templates with `_`, which sorts first in directory listing, which seems logical for the templates.