### PR TITLE
[workflows] Rename to "~Templates" to sort last

### DIFF
--- a/.github/workflows/_eng-tools-test.yaml
+++ b/.github/workflows/_eng-tools-test.yaml
@@ -1,4 +1,5 @@
-name: Templates - eng/tools - Test
+# Prefix with "~" to sort last in Actions list
+name: ~Templates - eng/tools - Test
 
 on:
   workflow_call:


### PR DESCRIPTION
Templates appear in Actions UI even though they are not directly runnable.  Start convention to prefix name with `~` to sort last (opposite of file name prefixed with `_` to sort first in directory listing).

![image](https://github.com/Azure/azure-rest-api-specs/assets/9459391/b2681c4b-a6cc-4072-9933-e3ac89056ecf)
