### PR TITLE
[Text Translation] Override names only in specified languages

### DIFF
--- a/specification/translation/Azure.AI.TextTranslation/client.tsp
+++ b/specification/translation/Azure.AI.TextTranslation/client.tsp
@@ -8,68 +8,194 @@ import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
 
-@@clientName(TextTranslation.BreakSentenceItem.sentLen, "SentencesLengths");
-
-@@clientName(TextTranslation.BackTranslation.numExamples, "ExamplesCount");
-
-@@clientName(TextTranslation.DictionaryLookupParameters.from, "SourceLanguage");
-
-@@clientName(TextTranslation.DictionaryLookupParameters.to, "TargetLanguage");
-
-@@clientName(TextTranslation.DictionaryExamplesParameters.from,
-  "SourceLanguage"
+@@clientName(TextTranslation.BreakSentenceItem.sentLen,
+  "SentencesLengths",
+  "dotnet"
+);
+@@clientName(TextTranslation.BreakSentenceItem.sentLen,
+  "SentencesLengths",
+  "java"
 );
 
-@@clientName(TextTranslation.DictionaryExamplesParameters.to, "TargetLanguage");
+@@clientName(TextTranslation.BackTranslation.numExamples,
+  "ExamplesCount",
+  "dotnet"
+);
+@@clientName(TextTranslation.BackTranslation.numExamples,
+  "ExamplesCount",
+  "java"
+);
 
-@@clientName(TextTranslation.TranslationLanguage.dir, "Directionality");
+@@clientName(TextTranslation.DictionaryLookupParameters.from,
+  "SourceLanguage",
+  "dotnet"
+);
+@@clientName(TextTranslation.DictionaryLookupParameters.from,
+  "SourceLanguage",
+  "java"
+);
 
-@@clientName(TextTranslation.SourceDictionaryLanguage.dir, "Directionality");
+@@clientName(TextTranslation.DictionaryLookupParameters.to,
+  "TargetLanguage",
+  "dotnet"
+);
+@@clientName(TextTranslation.DictionaryLookupParameters.to,
+  "TargetLanguage",
+  "java"
+);
 
-@@clientName(TextTranslation.TargetDictionaryLanguage.dir, "Directionality");
+@@clientName(TextTranslation.DictionaryExamplesParameters.from,
+  "SourceLanguage",
+  "dotnet"
+);
+@@clientName(TextTranslation.DictionaryExamplesParameters.from,
+  "SourceLanguage",
+  "java"
+);
 
-@@clientName(TextTranslation.LanguageScript.dir, "Directionality");
+@@clientName(TextTranslation.DictionaryExamplesParameters.to,
+  "TargetLanguage",
+  "dotnet"
+);
+@@clientName(TextTranslation.DictionaryExamplesParameters.to,
+  "TargetLanguage",
+  "java"
+);
 
-@@clientName(TextTranslation.TranslationText.sentLen, "SentenceBoundaries");
+@@clientName(TextTranslation.TranslationLanguage.dir,
+  "Directionality",
+  "dotnet"
+);
+@@clientName(TextTranslation.TranslationLanguage.dir, "Directionality", "java");
 
-@@clientName(TextTranslation.TranslationText.to, "TargetLanguage");
+@@clientName(TextTranslation.SourceDictionaryLanguage.dir,
+  "Directionality",
+  "dotnet"
+);
+@@clientName(TextTranslation.SourceDictionaryLanguage.dir,
+  "Directionality",
+  "java"
+);
+
+@@clientName(TextTranslation.TargetDictionaryLanguage.dir,
+  "Directionality",
+  "dotnet"
+);
+@@clientName(TextTranslation.TargetDictionaryLanguage.dir,
+  "Directionality",
+  "java"
+);
+
+@@clientName(TextTranslation.LanguageScript.dir, "Directionality", "dotnet");
+@@clientName(TextTranslation.LanguageScript.dir, "Directionality", "java");
+
+@@clientName(TextTranslation.TranslationText.sentLen,
+  "SentenceBoundaries",
+  "dotnet"
+);
+@@clientName(TextTranslation.TranslationText.sentLen,
+  "SentenceBoundaries",
+  "java"
+);
+
+@@clientName(TextTranslation.TranslationText.to, "TargetLanguage", "dotnet");
+@@clientName(TextTranslation.TranslationText.to, "TargetLanguage", "java");
 
 @@clientName(TextTranslation.SentenceBoundaries.srcSentLen,
-  "SourceSentencesLengths"
+  "SourceSentencesLengths",
+  "dotnet"
+);
+@@clientName(TextTranslation.SentenceBoundaries.srcSentLen,
+  "SourceSentencesLengths",
+  "java"
 );
 
 @@clientName(TextTranslation.SentenceBoundaries.transSentLen,
-  "TranslatedSentencesLengths"
+  "TranslatedSentencesLengths",
+  "dotnet"
+);
+@@clientName(TextTranslation.SentenceBoundaries.transSentLen,
+  "TranslatedSentencesLengths",
+  "java"
 );
 
-@@clientName(TextTranslation.DetectedLanguage.score, "Confidence");
+@@clientName(TextTranslation.DetectedLanguage.score, "Confidence", "dotnet");
+@@clientName(TextTranslation.DetectedLanguage.score, "Confidence", "java");
 
-@@clientName(TextTranslation.TranslateParameters.from, "SourceLanguage");
+@@clientName(TextTranslation.TranslateParameters.from,
+  "SourceLanguage",
+  "dotnet"
+);
+@@clientName(TextTranslation.TranslateParameters.from,
+  "SourceLanguage",
+  "java"
+);
 
-@@clientName(TextTranslation.TranslateParameters.to, "TargetLanguages");
+@@clientName(TextTranslation.TranslateParameters.to,
+  "TargetLanguages",
+  "dotnet"
+);
+@@clientName(TextTranslation.TranslateParameters.to, "TargetLanguages", "java");
 
 @@clientName(TextTranslation.TranslateParameters.fromScript,
-  "SourceLanguageScript"
+  "SourceLanguageScript",
+  "dotnet"
+);
+@@clientName(TextTranslation.TranslateParameters.fromScript,
+  "SourceLanguageScript",
+  "java"
 );
 
 @@clientName(TextTranslation.TranslateParameters.toScript,
-  "TargetLanguageScript"
+  "TargetLanguageScript",
+  "dotnet"
+);
+@@clientName(TextTranslation.TranslateParameters.toScript,
+  "TargetLanguageScript",
+  "java"
 );
 
 @@clientName(TextTranslation.TranslateParameters.suggestedFrom,
-  "SuggestedSourceLanguage"
+  "SuggestedSourceLanguage",
+  "dotnet"
+);
+@@clientName(TextTranslation.TranslateParameters.suggestedFrom,
+  "SuggestedSourceLanguage",
+  "java"
 );
 
-@@clientName(TextTranslation.TranslatedTextAlignment.proj, "Projections");
+@@clientName(TextTranslation.TranslatedTextAlignment.proj,
+  "Projections",
+  "dotnet"
+);
+@@clientName(TextTranslation.TranslatedTextAlignment.proj,
+  "Projections",
+  "java"
+);
 
 @@clientName(TextTranslation.TransliterateParameters.fromScript,
-  "SourceLanguageScript"
+  "SourceLanguageScript",
+  "dotnet"
+);
+@@clientName(TextTranslation.TransliterateParameters.fromScript,
+  "SourceLanguageScript",
+  "java"
 );
 
 @@clientName(TextTranslation.TransliterateParameters.toScript,
-  "TargetLanguageScript"
+  "TargetLanguageScript",
+  "dotnet"
+);
+@@clientName(TextTranslation.TransliterateParameters.toScript,
+  "TargetLanguageScript",
+  "java"
 );
 
 @@clientName(TextTranslation.TransliterableScript.toScripts,
-  "TargetLanguageScripts"
+  "TargetLanguageScripts",
+  "dotnet"
+);
+@@clientName(TextTranslation.TransliterableScript.toScripts,
+  "TargetLanguageScripts",
+  "java"
 );


### PR DESCRIPTION
Override names only in specified languages to keep the names of languages like Python.
