### PR TITLE
Update comment.yml: delete all remaining workflow-bot rules (moved to pipeline-bot)

### DIFF
--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -1,5 +1,0 @@
----
-- rule:
-    type: label
-    label: new-rp-namespace
-    onLabeledComments: "Hi, @${PRAuthor}, our workflow has detected that there is no management SDK ever released for your RP, to further process SDK onboard for your RP, you should have the SDK client library name of your RP reviewed and approved. </br> <b>Action Required</b>: <li> Follow this guidance [Naming for new initial management or client libraries (new SDKs) - Overview (azure.com)](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/821/Naming-for-new-initial-management-or-client-libraries-(new-SDKs)) to create an issue for management client library name arch board review. </li> <li>Paste the issue link that you created in step 1 in this PR</li> </br> <b> Impact</b>: SDK release owner will take the approved management client library name to release SDK. No client library name approval will leads to SDK release delayed."

--- a/.github/comment.yml
+++ b/.github/comment.yml
@@ -1,24 +1,5 @@
 ---
 - rule:
     type: label
-    repoAllowList:
-      - Azure/azure-rest-api-specs-pr
-    variables:
-      to: Azure/azure-rest-api-specs/main
-    label: Approved-OkToMerge
-    onLabeledComments: >-
-      Hi @${PRAuthor}! Your PR is approved. Congratulations. :partying_face::rocket: </br>
-      If this PR is targeting `main` branch, then it cannot be merged, as `azure-rest-api-specs-pr` repo `main` branch 
-      is mirrored from `azure-rest-api-specs` `main` branch.<br/>
-      If you want to publish the PR to the public repo (`Azure/azure-rest-api-specs`) `main` branch,
-      see [aka.ms/azsdk/move-pr](https://aka.ms/azsdk/move-pr).
-
-- rule:
-    type: label
-    label: ArcReview
-    onLabeledComments: "Hi @${PRAuthor} and @arcboard, one or more change(s) have been detected in your Arc enabled VM's or Arc enabled Server's RPs. Please review the changes and ensure that no gaps have been introduced with respect to the ARM API modeling consistency across Azure Arc and Azure Compute. For further details, see guidelines at [Consistency in ARM Modeling](https://msazure.visualstudio.com/One/_wiki/wikis/One.wiki/377428/Consistency-in-ARM-Modeling?anchor=general-design-guidance). To approve the change(s), set the label to ArcSignedOff. If you have any questions, please mail to arcboard@microsoft.com."
-
-- rule:
-    type: label
     label: new-rp-namespace
     onLabeledComments: "Hi, @${PRAuthor}, our workflow has detected that there is no management SDK ever released for your RP, to further process SDK onboard for your RP, you should have the SDK client library name of your RP reviewed and approved. </br> <b>Action Required</b>: <li> Follow this guidance [Naming for new initial management or client libraries (new SDKs) - Overview (azure.com)](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/821/Naming-for-new-initial-management-or-client-libraries-(new-SDKs)) to create an issue for management client library name arch board review. </li> <li>Paste the issue link that you created in step 1 in this PR</li> </br> <b> Impact</b>: SDK release owner will take the approved management client library name to release SDK. No client library name approval will leads to SDK release delayed."


### PR DESCRIPTION
Contributes to:
- https://github.com/Azure/azure-sdk-tools/issues/8279

Moved to pipeline-bot in:

- [Pull Request 552463](https://devdiv.visualstudio.com/DevDiv/_git/openapi-alps/pullrequest/552463): In preparation for `workflow-bot` deletion: migrate rules `Approved-OkToMerge`, `ArcReview` and `new-rp-namespace`

