### PR TITLE
hybridcompute - update readme.md for SDK commands generationadd back commands

### DIFF
--- a/specification/hybridcompute/resource-manager/readme.md
+++ b/specification/hybridcompute/resource-manager/readme.md
@@ -132,18 +132,11 @@ directive:
       verb: Set
     remove: true
   - remove-operation: Machines_CreateOrUpdate
-  - remove-operation: MachineRunCommands_Update
   - remove-operation: AgentVersion_List
   - remove-operation: AgentVersion_Get
   - remove-operation: HybridIdentityMetadata_Get
   - remove-operation: HybridIdentityMetadata_ListByMachines
-  - remove-operation: Licenses_Get
   - remove-operation: Licenses_ValidateLicense
-  - remove-operation: Licenses_ListBySubscription
-  - remove-operation: Licenses_ListByResourceGroup
-  - remove-operation: Licenses_Delete
-  - remove-operation: Licenses_Update
-  - remove-operation: Licenses_CreateOrUpdate
   - remove-operation: LicenseProfiles_Get
   - remove-operation: LicenseProfiles_Delete
   - remove-operation: LicenseProfiles_Update
@@ -152,8 +145,6 @@ directive:
   - remove-operation: NetworkConfigurations_Get
   - remove-operation: NetworkConfigurations_Update
   - remove-operation: NetworkConfigurations_CreateOrUpdate
-  - remove-operation: NetworkSecurityPerimeterConfigurations_GetByPrivateLinkScope
-  - remove-operation: NetworkSecurityPerimeterConfigurations_ListByPrivateLinkScope
   - remove-operation: NetworkSecurityPerimeterConfigurations_ReconcileForPrivateLinkScope
 ```
 


### PR DESCRIPTION
When releasing SDK for different languages, there are some API operations that we don't want to release to customers.

This PR adds updates in readme to make sure that what gets released aligns with our .NET SDK.