### PR TITLE
Updating EnableVMAgentPlatformUpdates

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-08-01/computeRPCommon.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-08-01/computeRPCommon.json
@@ -1282,8 +1282,9 @@
           "description": "Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Windows virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Windows Virtual Machine."
         }
       },
       "description": "Specifies Windows operating system settings on the virtual machine."
@@ -1335,8 +1336,9 @@
           "description": "[Preview Feature] Specifies settings related to VM Guest Patching on Linux."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Linux virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Linux Virtual Machine."
         }
       },
       "description": "Specifies the Linux operating system settings on the virtual machine. For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/linux/endorsed-distros)."

--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-11-01/computeRPCommon.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-11-01/computeRPCommon.json
@@ -1284,8 +1284,9 @@
           "description": "Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Windows virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Windows Virtual Machine."
         }
       },
       "description": "Specifies Windows operating system settings on the virtual machine."
@@ -1337,8 +1338,9 @@
           "description": "[Preview Feature] Specifies settings related to VM Guest Patching on Linux."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Linux virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Linux Virtual Machine."
         }
       },
       "description": "Specifies the Linux operating system settings on the virtual machine. <br><br>For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/linux/endorsed-distros)."

--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01/computeRPCommon.json
@@ -1285,8 +1285,9 @@
           "description": "Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Windows virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Windows Virtual Machine."
         }
       },
       "description": "Specifies Windows operating system settings on the virtual machine."
@@ -1338,8 +1339,9 @@
           "description": "[Preview Feature] Specifies settings related to VM Guest Patching on Linux."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Linux virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Linux Virtual Machine."
         }
       },
       "description": "Specifies the Linux operating system settings on the virtual machine. For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/linux/endorsed-distros)."

--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-07-01/computeRPCommon.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-07-01/computeRPCommon.json
@@ -1285,8 +1285,9 @@
           "description": "Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Windows virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Windows Virtual Machine."
         }
       },
       "description": "Specifies Windows operating system settings on the virtual machine."
@@ -1338,8 +1339,9 @@
           "description": "[Preview Feature] Specifies settings related to VM Guest Patching on Linux."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Linux virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Linux Virtual Machine."
         }
       },
       "description": "Specifies the Linux operating system settings on the virtual machine. For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/linux/endorsed-distros)."

--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-09-01/computeRPCommon.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-09-01/computeRPCommon.json
@@ -1331,8 +1331,9 @@
           "description": "Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Windows virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Windows Virtual Machine."
         }
       },
       "description": "Specifies Windows operating system settings on the virtual machine."
@@ -1384,8 +1385,9 @@
           "description": "[Preview Feature] Specifies settings related to VM Guest Patching on Linux."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Linux virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Linux Virtual Machine."
         }
       },
       "description": "Specifies the Linux operating system settings on the virtual machine. For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/linux/endorsed-distros)."

--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json
@@ -1395,8 +1395,9 @@
           "description": "Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Windows virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Windows Virtual Machine."
         }
       },
       "description": "Specifies Windows operating system settings on the virtual machine."
@@ -1448,8 +1449,9 @@
           "description": "[Preview Feature] Specifies settings related to VM Guest Patching on Linux."
         },
         "enableVMAgentPlatformUpdates": {
+          "readOnly": true,
           "type": "boolean",
-          "description": "Indicates whether VMAgent Platform Updates is enabled for the Linux virtual machine. Default value is false."
+          "description": "Indicates whether VMAgent Platform Updates are enabled for the Linux Virtual Machine."
         }
       },
       "description": "Specifies the Linux operating system settings on the virtual machine. For a list of supported Linux distributions, see [Linux on Azure-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/linux/endorsed-distros)."


### PR DESCRIPTION
We've now gained confidence in the VMAgentVersioning feature, and are now making EnableVMAgentPlatformUpdates read only. We're still displaying this property to the customer in case there's any desire to disable it. 
