### PR TITLE
[Microsoft.IntegrationSpaces] Making TrackingDataStores and its properties in Integration Application optional.

### DIFF
--- a/specification/azureintegrationspaces/resource-manager/Microsoft.IntegrationSpaces/preview/2023-11-14-preview/openapi.json
+++ b/specification/azureintegrationspaces/resource-manager/Microsoft.IntegrationSpaces/preview/2023-11-14-preview/openapi.json
@@ -2247,10 +2247,7 @@
             "$ref": "#/definitions/TrackingDataStore"
           }
         }
-      },
-      "required": [
-        "trackingDataStores"
-      ]
+      }
     },
     "ApplicationResource": {
       "type": "object",
@@ -3018,13 +3015,7 @@
           "type": "string",
           "description": "The data store ingestion URI."
         }
-      },
-      "required": [
-        "databaseName",
-        "dataStoreResourceId",
-        "dataStoreUri",
-        "dataStoreIngestionUri"
-      ]
+      }
     },
     "TrackingEventDefinition": {
       "type": "object",

--- a/specification/azureintegrationspaces/suppressions.yaml
+++ b/specification/azureintegrationspaces/suppressions.yaml
@@ -1,0 +1,3 @@
+- tool: TypeSpecRequirement
+  path: resource-manager/Microsoft.IntegrationSpaces/preview/2023-11-14-preview/**/*.json
+  reason: There's a good chance we might deprovision this RP. If not, for this Preview version, TypeSpec will be added later on.


### PR DESCRIPTION
[Microsoft.IntegrationSpaces] Making TrackingDataStores and its properties in Integration Application optional.

This is to publish changes already checked in the RPSaasMaster in the private repo - https://github.com/Azure/azure-rest-api-specs-pr/pull/18210

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
