### PR TITLE
Fix deprecated linter reference in verifiedid

### DIFF
--- a/specification/verifiedid/Microsoft.VerifiedId/tspconfig.yaml
+++ b/specification/verifiedid/Microsoft.VerifiedId/tspconfig.yaml
@@ -1,6 +1,6 @@
 linter:
   extends:
-    - "@azure-tools/typespec-azure-resource-manager/all"
+    - "@azure-tools/typespec-azure-rulesets/resource-manager"
 emit:
   - "@azure-tools/typespec-autorest"
 options:


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
