### PR TITLE
Added information to the Weather services query uri parameter

### DIFF
--- a/specification/maps/data-plane/Weather/stable/1.1/weather.json
+++ b/specification/maps/data-plane/Weather/stable/1.1/weather.json
@@ -243,7 +243,7 @@
       "name": "query",
       "in": "query",
       "x-ms-client-name": "coordinates",
-      "description": "The applicable query specified as a comma separated string composed by latitude followed by longitude e.g. \"47.641268,-122.125679\".",
+      "description": "The applicable query specified as a comma separated string composed by latitude followed by longitude e.g. \"47.641268,-122.125679\".\n\nWeather information is generally available for locations on land, bodies of water surrounded by land, and areas of the ocean that are within approximately 50 nautical miles of a coastline.",
       "required": true,
       "x-ms-parameter-location": "method",
       "type": "array",


### PR DESCRIPTION
DOC UPDATE: Added information to the query uri parameter: 'Weather information is generally available for locations on land, bodies of water surrounded by land, and areas of the ocean that are within approximately 50 nautical miles of a coastline.'