### PR TITLE
Update StorageBlobTierChangedEventData - add fields accessTier and previousTier

### DIFF
--- a/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/Storage.json
+++ b/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/Storage.json
@@ -325,6 +325,14 @@
           "description": "The type of blob.",
           "type": "string"
         },
+        "accessTier": {
+          "description": "The current tier of the blob.",
+          "type": "string"
+        },
+        "previousTier": {
+          "description": "The previous tier of the blob.",
+          "type": "string"
+        },
         "url": {
           "description": "The path to the blob.",
           "type": "string"


### PR DESCRIPTION
Update StorageBlobTierChangedEventData with new fields - accessTier and previousTier. These fields will be populated in the event when the tier change api is called on a blob.

The changes are tested in the backend and can be deployed in production after the schema changes are reviewed and merged.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
