### PR TITLE
[Storage] [ADLS Docs] Fix capitalization for etag response header in Path

### DIFF
--- a/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
@@ -131,7 +131,7 @@
         "lastModified": {
           "type": "string"
         },
-        "eTag": {
+        "etag": {
           "type": "string"
         },
         "contentLength": {


### PR DESCRIPTION
As title states, this pull-request contains the updates to the public REST docs regarding the `etag` response header being capitalized incorrectly. It should now accurately reflect the capitalization found on the actual responses.