### PR TITLE
Enable linter for azure-rest-api-specs

### DIFF
--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -1,0 +1,143 @@
+Azure/api-stewardship-board is an invalid team. Ensure the team exists and has write permissions.
+nickghardwick is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+minhanh-phan is not a public member of Azure.
+assafi is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+rokulka is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ChongTang is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Azure/adp is an invalid team. Ensure the team exists and has write permissions.
+taiwu is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ofirmanor is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+olalavi is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+erangon is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+orieldar is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ilaizi is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+shakednai1 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+orenhor is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+promoisha is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+alexeldeib is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ramthi is not a public member of Azure.
+'Container Apps' is not a valid label for this repository.
+jijohn14 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Juliehzl is not a public member of Azure.
+/specification/codesigning/data-plane path or file does not exist in repository.
+/specification/asazure/ path or file does not exist in repository.
+athipp is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+darshanhs90 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vrdmr is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+deathly809 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dpwatrous is not a public member of Azure.
+/specification/batchai/ path or file does not exist in repository.
+alexanderyukhanov is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+asarkar84 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+jorinmejia is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+yunhemsft is not a public member of Azure.
+jessicl-ms is not a public member of Azure.
+rrahulms is not a public member of Azure.
+t-bzhan is not a public member of Azure.
+felixwa is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+'Cognitive Services - Form Recognizer' is not a valid label for this repository.
+bojunehsu is not a public member of Azure.
+nizi1127 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+bilaakpan-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dkulkarni-ms is not a public member of Azure.
+MS-syh2qs is not a public member of Azure.
+grizzlytheodore is not a public member of Azure.
+mabhard is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+danielli90 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+smotwani is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ppatwa is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vikramd-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+yunusm is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+ZhidongPeng is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+nkuchta is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+maheshnemichand is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+najams is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+changov is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+kjeur is not a public member of Azure.
+panda-wang is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+novinc is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+djyou is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+weinong is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+seguler is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+alvinli222 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+justindavies is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+robbiezhang is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+paulgmiller is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+yizhang4321 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+circy9 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+qike-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+MehaKaushik is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+tjlvtao is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+zhangyd2015 is not a public member of Azure.
+davidzhaoyue is not a public member of Azure.
+ro-joowan is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+hitenjava is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+/specification/deploymentmanager/ path or file does not exist in repository.
+netrock is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+/specification/documentdb/ path or file does not exist in repository.
+dmakwana is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+jihochang is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Kishp01 is not a public member of Azure.
+ahamad-MS is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+damodaravadhani is not a public member of Azure.
+/specification/features/ path or file does not exist in repository.
+yugangw-msft is not a public member of Azure.
+amarzavery is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+pulkittomar is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+wawon-msft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+/specification/insights/ path or file does not exist in repository.
+gucalder is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vrmurthy01 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+randallilama is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+jlichwa is not a public member of Azure.
+pankajsn is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+tonytang-microsoft-com is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+nonstatic2014 is not a public member of Azure.
+/specification/machinelearningcompute/ path or file does not exist in repository.
+shutchings is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+jeffrey-ace is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+giakas is not a public member of Azure.
+amolr is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+smithab is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sw47 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dashimi16 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+rileymckenna is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+pilor is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+tarostok is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+/specification/postgresql/** ends with an unsupported sequence '/**' and will not match. Replace it with '/'
+/specification/provisioningservices/ path or file does not exist in repository.
+kvish is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dragonfly91 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sonathan is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+dheerendrarathor is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+avneeshrai is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+siddharthchatrolams is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+timlovellsmith is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+Azure/arm-template-deployments is an invalid team. Ensure the team exists and has write permissions.
+rajshah11 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+vivsriaus is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+pinwang81 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+bleroy is not a public member of Azure.
+tjacobhi is not a public member of Azure.
+amitchat is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+craigw is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+asinn826 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+daveirwin1 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+juhacket is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+samedder is not a public member of Azure.
+jamestao is not a public member of Azure.
+ericshape is not a public member of Azure.
+leoz-ms is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+manaas-microsoft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+atpham256 is not a public member of Azure.
+/specification/subscriptions/ path or file does not exist in repository.
+navysingla is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+yanjungao718 is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+sandshadow is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+allencal is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+hrkulkarmsft is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
+naveedaz is not a public member of Azure.
+Azure/azure-app-service-control-plane is an invalid team. Ensure the team exists and has write permissions.
+'AzureML - Compute Instance' is not a valid label for this repository.
+Azure/aml-compute-instance is an invalid team. Ensure the team exists and has write permissions.
+shahabhijeet is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.

--- a/eng/pipelines/codeowners-linter.yml
+++ b/eng/pipelines/codeowners-linter.yml
@@ -44,7 +44,7 @@ stages:
           command: custom
           custom: 'tool'
           arguments: 'install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"'
-          workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+          workingDirectory: '$(Build.SourcesDirectory)/eng/pipelines'
 
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - pwsh: |
@@ -60,7 +60,7 @@ stages:
             codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -gbl -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -bbf "$baseBranchBaselineFile"
             echo "##vso[task.setvariable variable=baseBranchBaseline]$baseBranchBaselineFile"
           displayName: 'Generate baseline file for base branch'
-          workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+          workingDirectory: '$(Build.SourcesDirectory)/eng/pipelines'
 
         - pwsh: |
             Write-Host "git checkout refs/remotes/pull/$ENV:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/merge"
@@ -73,4 +73,4 @@ stages:
           Write-Host "codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -fbl -rUri ""$(RepoLabelUri)"" -tUri ""$(TeamUserUri)"" -uUri ""$(UserOrgUri)"" -bbf ""$(baseBranchBaseline)"""
           codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -fbl -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -bbf "$(baseBranchBaseline)"
         displayName: 'Lint CODEOWNERS and filter using baseline'
-        workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+        workingDirectory: '$(Build.SourcesDirectory)/eng/pipelines'

--- a/eng/pipelines/codeowners-linter.yml
+++ b/eng/pipelines/codeowners-linter.yml
@@ -1,0 +1,76 @@
+# Lint the CODEOWNERS file for a given repository and filter out baseline errors
+# Note: Due to the nature of the verifications, which includes source paths/globs
+# for the repository, this pipeline cannot use sparse-checkout.
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+      - release/*
+  paths:
+    include:
+      - .github/CODEOWNERS
+      - .github/CODEOWNERS_baseline_errors.txt
+      - eng/common/pipelines/codeowners-linter.yml
+
+stages:
+- stage: Run
+  variables:
+    skipComponentGovernanceDetection: true
+    nugetMultiFeedWarnLevel: 'none'
+    baseBranchBaseline: ''
+
+  jobs:
+  - job: Run
+    timeoutInMinutes: 120
+    pool:
+      name: azsdk-pool-mms-ubuntu-2204-general
+      vmImage: ubuntu-22.04
+
+    variables:
+      CodeownersLinterVersion: '1.0.0-dev.20240514.2'
+      DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
+      RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
+      TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"
+      UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
+
+    steps:
+      - task: DotNetCoreCLI@2
+        displayName: 'Install CodeownersLinter'
+        inputs:
+          command: custom
+          custom: 'tool'
+          arguments: 'install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"'
+          workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+
+      - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+        - pwsh: |
+            Write-Host "git checkout $ENV:SYSTEM_PULLREQUEST_TARGETBRANCH"
+            git checkout $ENV:SYSTEM_PULLREQUEST_TARGETBRANCH
+          displayName: Checkout the base branch
+
+        - pwsh: |
+            # Generate the base branch baseline file to the Build.BinariesDirectory. This will create
+            # a baseline error file against the CODEOWNERS in the base branch
+            $baseBranchBaselineFile = "$(Build.BinariesDirectory)/CODEOWNERS_BaseBranch_Baseline_errors.txt"
+            Write-Host "codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -gbl -rUri ""$(RepoLabelUri)"" -tUri ""$(TeamUserUri)"" -uUri ""$(UserOrgUri)"" -bbf ""$baseBranchBaselineFile"""
+            codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -gbl -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -bbf "$baseBranchBaselineFile"
+            echo "##vso[task.setvariable variable=baseBranchBaseline]$baseBranchBaselineFile"
+          displayName: 'Generate baseline file for base branch'
+          workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+
+        - pwsh: |
+            Write-Host "git checkout refs/remotes/pull/$ENV:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/merge"
+            git checkout refs/remotes/pull/$ENV:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/merge
+          displayName: Checkout the PR branch
+
+      - pwsh: |
+          # In the case of a PR, the baseBranchBaseline will be set which will be used to further filter results.
+          # For scheduled runs, the baseBranchBaseline won't be set and only the existing baseline file will be used to filter
+          Write-Host "codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -fbl -rUri ""$(RepoLabelUri)"" -tUri ""$(TeamUserUri)"" -uUri ""$(UserOrgUri)"" -bbf ""$(baseBranchBaseline)"""
+          codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -fbl -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -bbf "$(baseBranchBaseline)"
+        displayName: 'Lint CODEOWNERS and filter using baseline'
+        workingDirectory: '$(Build.SourcesDirectory)/eng/common'


### PR DESCRIPTION
Unfortunately, the other repositories that have the CODEOWNERS linter is enabled get the codeowners-linter.yml file pushed out as part of the eng/common sync. azure-rest-api-specs is not a repository that we sync eng/common with, meaning that if the version of the linter changes, this will need to be updated manually. Also of note, the working directory in the yml file is eng/common, which doesn't exist in this repo and had to be changed to eng/pipelines.

The pipeline is created, I [ran a run against the refs/merge of this PR](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3871357&view=results), and it passed, as expected.