### PR TITLE
Update StorageBlobTierChangedEventData - add fields accessTier and previousTier

### DIFF
--- a/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/Microsoft.Storage/Storage.tsp
+++ b/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/Microsoft.Storage/Storage.tsp
@@ -200,6 +200,12 @@ namespace Microsoft.EventGrid.SystemEvents {
     /** The type of blob. */
     blobType?: string;
 
+    /** The current tier of the blob. */
+    accessTier?: string;
+
+    /** The previous tier of the blob. */
+    previousTier?: string;
+
     /** The path to the blob. */
     url?: string;
 

--- a/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/Microsoft.Storage/Storage.tsp
+++ b/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/Microsoft.Storage/Storage.tsp
@@ -180,6 +180,23 @@ namespace Microsoft.EventGrid.SystemEvents {
     errorList?: string;
   }
 
+  /** The access tier of the blob. */
+  union AccessTier {
+    /** The blob is in access tier Hot */
+    "Hot",
+
+    /** The blob is in access tier Cool */
+    "Cool",
+
+    /** The blob is in access tier Cold */
+    "Cold",
+
+    /** The blob is in access tier Archive */
+    "Archive",
+
+    string,
+  }
+
   /** Schema of the Data property of an EventGridEvent for a Microsoft.Storage.BlobTierChanged event. */
   model StorageBlobTierChangedEventData {
     /** The name of the API/operation that triggered this event. */
@@ -201,10 +218,10 @@ namespace Microsoft.EventGrid.SystemEvents {
     blobType?: string;
 
     /** The current tier of the blob. */
-    accessTier?: string;
+    accessTier: AccessTier;
 
     /** The previous tier of the blob. */
-    previousTier?: string;
+    previousTier: AccessTier;
 
     /** The path to the blob. */
     url?: string;

--- a/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/examples/2024-01-01/blob_tier_changed.json
+++ b/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/examples/2024-01-01/blob_tier_changed.json
@@ -11,6 +11,8 @@
     "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "contentLength": 17555,
     "blobType": "BlockBlob",
+    "accessTier": "Hot",
+    "previousTier": "Cool",
     "url": "https://jolovstorage.blob.core.windows.net/gaocontainer/Template1.xlsx",
     "sequencer": "0000000000000000000000000000B00D0000000005b7c63a",
     "storageDiagnostics": {

--- a/specification/eventgrid/data-plane/Microsoft.EventGrid/stable/2024-01-01/SystemEvents.json
+++ b/specification/eventgrid/data-plane/Microsoft.EventGrid/stable/2024-01-01/SystemEvents.json
@@ -8488,8 +8488,6 @@
         }
       },
       "required": [
-        "accessTier",
-        "previousTier",
         "storageDiagnostics"
       ]
     },

--- a/specification/eventgrid/data-plane/Microsoft.EventGrid/stable/2024-01-01/SystemEvents.json
+++ b/specification/eventgrid/data-plane/Microsoft.EventGrid/stable/2024-01-01/SystemEvents.json
@@ -22,6 +22,42 @@
   "tags": [],
   "paths": {},
   "definitions": {
+    "AccessTier": {
+      "type": "string",
+      "description": "The access tier of the blob.",
+      "enum": [
+        "Hot",
+        "Cool",
+        "Cold",
+        "Archive"
+      ],
+      "x-ms-enum": {
+        "name": "AccessTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Hot",
+            "value": "Hot",
+            "description": "The blob is in access tier Hot"
+          },
+          {
+            "name": "Cool",
+            "value": "Cool",
+            "description": "The blob is in access tier Cool"
+          },
+          {
+            "name": "Cold",
+            "value": "Cold",
+            "description": "The blob is in access tier Cold"
+          },
+          {
+            "name": "Archive",
+            "value": "Archive",
+            "description": "The blob is in access tier Archive"
+          }
+        ]
+      }
+    },
     "AcsChatEventBaseProperties": {
       "type": "object",
       "description": "Schema of common properties of all chat events",
@@ -8426,11 +8462,11 @@
           "description": "The type of blob."
         },
         "accessTier": {
-          "type": "string",
+          "$ref": "#/definitions/AccessTier",
           "description": "The current tier of the blob."
         },
         "previousTier": {
-          "type": "string",
+          "$ref": "#/definitions/AccessTier",
           "description": "The previous tier of the blob."
         },
         "url": {
@@ -8452,6 +8488,8 @@
         }
       },
       "required": [
+        "accessTier",
+        "previousTier",
         "storageDiagnostics"
       ]
     },

--- a/specification/eventgrid/data-plane/Microsoft.EventGrid/stable/2024-01-01/SystemEvents.json
+++ b/specification/eventgrid/data-plane/Microsoft.EventGrid/stable/2024-01-01/SystemEvents.json
@@ -8425,6 +8425,14 @@
           "type": "string",
           "description": "The type of blob."
         },
+        "accessTier": {
+          "type": "string",
+          "description": "The current tier of the blob."
+        },
+        "previousTier": {
+          "type": "string",
+          "description": "The previous tier of the blob."
+        },
         "url": {
           "type": "string",
           "description": "The path to the blob."

--- a/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/Storage.json
+++ b/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/Storage.json
@@ -325,6 +325,14 @@
           "description": "The type of blob.",
           "type": "string"
         },
+        "accessTier": {
+          "description": "The current tier of the blob.",
+          "type": "string"
+        },
+        "previousTier": {
+          "description": "The previous tier of the blob.",
+          "type": "string"
+        },
         "url": {
           "description": "The path to the blob.",
           "type": "string"

--- a/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/Storage.json
+++ b/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/Storage.json
@@ -327,11 +327,31 @@
         },
         "accessTier": {
           "description": "The current tier of the blob.",
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "Hot",
+            "Cool",
+            "Cold",
+            "Archive"
+          ],
+          "x-ms-enum": {
+            "name": "AccessTier",
+            "modelAsString": true
+          }
         },
         "previousTier": {
           "description": "The previous tier of the blob.",
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "Hot",
+            "Cool",
+            "Cold",
+            "Archive"
+          ],
+          "x-ms-enum": {
+            "name": "PreviousTier",
+            "modelAsString": true
+          }
         },
         "url": {
           "description": "The path to the blob.",

--- a/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/examples/cloud-events-schema/blob_tier_changed.json
+++ b/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/examples/cloud-events-schema/blob_tier_changed.json
@@ -11,6 +11,8 @@
     "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "contentLength": 17555,
     "blobType": "BlockBlob",
+    "accessTier": "Hot",
+    "previousTier": "Cool",
     "url": "https://jolovstorage.blob.core.windows.net/gaocontainer/Template1.xlsx",
     "sequencer": "0000000000000000000000000000B00D0000000005b7c63a",
     "storageDiagnostics": {

--- a/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/examples/event-grid-schema/blob_tier_changed.json
+++ b/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/examples/event-grid-schema/blob_tier_changed.json
@@ -10,6 +10,8 @@
     "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "contentLength": 17555,
     "blobType": "BlockBlob",
+    "accessTier": "Hot",
+    "previousTier": "Cool",
     "url": "https://jolovstorage.blob.core.windows.net/gaocontainer/Template1.xlsx",
     "sequencer": "0000000000000000000000000000B00D0000000005b7c63a",
     "storageDiagnostics": {


### PR DESCRIPTION
Update StorageBlobTierChangedEventData - add fields accessTier and previousTier.

We are adding new fields to the event 'StorageBlobTierChangedEvent' - these fields contain information about the previous tier and the current tier of the blob after the SetBlobTier operation.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
