### PR TITLE
[CODEOWNERS] - add ADR required reviewers for deviceregistry directory to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,6 +107,9 @@
 
 /specification/deploymentmanager/ @netrock
 
+# PRLabel: %Device Registry
+/specification/deviceregistry/ @marcodalessandro @rohankhandelwal @riteshrao
+
 # PRLabel: %Device Update
 /specification/deviceupdate/data-plane/ @mikekistler @Azure/api-stewardship-board
 


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
