### PR TITLE
[HdiOnAks] Adding PublicIpTag property to ClusterPoolNetworkProfile

### DIFF
--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/preview/2024-05-01-preview/hdinsight.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/preview/2024-05-01-preview/hdinsight.json
@@ -1677,7 +1677,7 @@
       }
     },
     "IpTag": {
-      "type":"object",
+      "type": "object",
       "properties": {
         "ipTagType": {
           "type": "string",

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/preview/2024-05-01-preview/hdinsight.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/preview/2024-05-01-preview/hdinsight.json
@@ -1585,8 +1585,30 @@
       "properties": {
         "clusterPoolVersion": {
           "$ref": "#/definitions/ClusterPoolVersionPattern"
+        },
+        "publicIpTag": {
+          "description": "Gets or sets the IP tag for the public IPs created along with the HDInsightOnAks ClusterPools and Clusters. ",
+          "$ref": "#/definitions/IpTag"
         }
       }
+    },
+    "IpTag": {
+      "type": "object",
+      "required": [
+        "ipTagType",
+        "tag"
+      ],
+      "properties": {
+        "ipTagType": {
+          "type": "string",
+          "description": "Gets or sets the ipTag type: Example FirstPartyUsage."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Gets or sets value of the IpTag associated with the public IP. Example HDInsight, SQL, Storage etc"
+        }
+      },
+      "description": "Contains the IpTag associated with the public IP address"
     },
     "ClusterPoolComputeProfile": {
       "type": "object",
@@ -1669,26 +1691,8 @@
           },
           "title": "The IP ranges authorized to access the AKS API server.",
           "description": "IP ranges are specified in CIDR format, e.g. 137.117.106.88/29. This feature is not compatible with private AKS clusters. So you cannot set enablePrivateApiServer to true and apiServerAuthorizedIpRanges at the same time. Currently, this property is not supported and please don't use it."
-        },
-        "publicIpTag": {
-          "description": "Gets or sets the IP tag for the public IPs created along with the HDInsightOnAks ClusterPools and Clusters. ",
-          "$ref": "#/definitions/IpTag"
         }
       }
-    },
-    "IpTag": {
-      "type": "object",
-      "properties": {
-        "ipTagType": {
-          "type": "string",
-          "description": "Gets or sets the ipTag type: Example FirstPartyUsage."
-        },
-        "tag": {
-          "type": "string",
-          "description": "Gets or sets value of the IpTag associated with the public IP. Example HDInsight, SQL, Storage etc"
-        }
-      },
-      "description": "Contains the IpTag associated with the public IP address"
     },
     "ClusterPoolLogAnalyticsProfile": {
       "type": "object",

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/preview/2024-05-01-preview/hdinsight.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/preview/2024-05-01-preview/hdinsight.json
@@ -1677,6 +1677,7 @@
       }
     },
     "IpTag": {
+      "type":"object",
       "properties": {
         "ipTagType": {
           "type": "string",

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/preview/2024-05-01-preview/hdinsight.json
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/preview/2024-05-01-preview/hdinsight.json
@@ -1669,8 +1669,25 @@
           },
           "title": "The IP ranges authorized to access the AKS API server.",
           "description": "IP ranges are specified in CIDR format, e.g. 137.117.106.88/29. This feature is not compatible with private AKS clusters. So you cannot set enablePrivateApiServer to true and apiServerAuthorizedIpRanges at the same time. Currently, this property is not supported and please don't use it."
+        },
+        "publicIpTag": {
+          "description": "Gets or sets the IP tag for the public IPs created along with the HDInsightOnAks ClusterPools and Clusters. ",
+          "$ref": "#/definitions/IpTag"
         }
       }
+    },
+    "IpTag": {
+      "properties": {
+        "ipTagType": {
+          "type": "string",
+          "description": "Gets or sets the ipTag type: Example FirstPartyUsage."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Gets or sets value of the IpTag associated with the public IP. Example HDInsight, SQL, Storage etc"
+        }
+      },
+      "description": "Contains the IpTag associated with the public IP address"
     },
     "ClusterPoolLogAnalyticsProfile": {
       "type": "object",


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.


Only adding a PublicIpTag property to ClusterPool creation request body. Please note that:
1. This property is optional and readonly (not allowed for patching)
1. The definition of this property - IpTag is commonly defined and copied from other [existing Azure services' API Spec](https://github.com/search?q=repo%3AAzure%2Fazure-rest-api-specs-pr%20IpTag&type=code)
1. Only ClusterPool creation specifies this property, meaning that the Cluster creation will inherit this value and create IPs with the same tag
