### PR TITLE
fix docs creating bad docstrings in healthinsights

### DIFF
--- a/specification/ai/HealthInsights/HealthInsights.Common/model.common.fhir.elements.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.Common/model.common.fhir.elements.tsp
@@ -55,7 +55,7 @@ alias value_x = {
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Keep is much as close to FHIR Spec"
 @doc("""
   Base for all elements
-  Based on [FHIR Element](https://www.hl7.org/fhir/datatypes.html#Element)
+  Based on [FHIR Element](https://www.hl7.org/fhir/R4/element.html)
   """)
 model Extension extends Element {
   @doc("Source of the definition for the extension code - a logical name or a URL.")

--- a/specification/ai/HealthInsights/HealthInsights.TrialMatcher/model.trialmatcher.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.TrialMatcher/model.trialmatcher.tsp
@@ -20,7 +20,7 @@ model TrialMatcherModelConfiguration {
   ...ModelConfiguration;
 
   @doc("""
-    The clinical trials that the patient(s) should be matched to. <br />The trial
+    The clinical trials that the patient(s) should be matched to. The trial
     selection can be given as a list of custom clinical trials and/or a list of
     filters to known clinical trial registries. In case both are given, the
     resulting trial set is a union of the two sets.

--- a/specification/ai/data-plane/HealthInsights/stable/2024-04-01/openapi.json
+++ b/specification/ai/data-plane/HealthInsights/stable/2024-04-01/openapi.json
@@ -982,7 +982,7 @@
     },
     "Fhir.R4.Extension": {
       "type": "object",
-      "description": "Base for all elements\nBased on [FHIR Element](https://www.hl7.org/fhir/datatypes.html#Element)",
+      "description": "Base for all elements\nBased on [FHIR Element](https://www.hl7.org/fhir/R4/element.html)",
       "properties": {
         "url": {
           "$ref": "#/definitions/Fhir.R4.fhirUri",


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
