### PR TITLE
Revert WebApiSkill design change

### DIFF
--- a/specification/search/data-plane/Azure.Search/stable/2024-07-01/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/stable/2024-07-01/searchservice.json
@@ -8787,12 +8787,26 @@
       "allOf": [
         {
           "$ref": "#/definitions/SearchIndexerSkill"
-        },
-        {
-          "$ref": "#/definitions/WebApiParameters"
         }
       ],
       "properties": {
+        "uri": {
+          "type": "string",
+          "description": "The url for the Web API."
+        },
+        "httpHeaders": {
+          "$ref": "#/definitions/WebApiHttpHeaders",
+          "description": "The headers required to make the http request."
+        },
+        "httpMethod": {
+          "type": "string",
+          "description": "The method for the http request."
+        },
+        "timeout": {
+          "type": "string",
+          "format": "duration",
+          "description": "The desired timeout for the request. Default is 30 seconds."
+        },
         "batchSize": {
           "type": "integer",
           "format": "int32",
@@ -8804,6 +8818,17 @@
           "format": "int32",
           "x-nullable": true,
           "description": "If set, the number of parallel calls that can be made to the Web API."
+        },
+        "authResourceId": {
+          "type": "string",
+          "x-nullable": true,
+          "x-ms-format": "arm-id",
+          "description": "Applies to custom skills that connect to external code in an Azure function or some other application that provides the transformations. This value should be the application ID created for the function or app when it was registered with Azure Active Directory. When specified, the custom skill connects to the function or app using a managed ID (either system or user-assigned) of the search service and the access token of the function or app, using this value as the resource id for creating the scope of the access token."
+        },
+        "authIdentity": {
+          "$ref": "#/definitions/SearchIndexerDataIdentity",
+          "x-nullable": true,
+          "description": "The user-assigned managed identity used for outbound connections. If an authResourceId is provided and it's not specified, the system-assigned managed identity is used. On updates to the indexer, if the identity is unspecified, the value remains unchanged. If set to \"none\", the value of this property is cleared."
         }
       },
       "required": [


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

## API Info: The Basics

Most of the information about your service should be captured in the issue that serves as your [*API Spec engagement record*](https://aka.ms/azsdk/onboarding/restapischedule).

* Link to API Spec engagement record issue:

Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [x] GA release

### Change Scope

Reverting a change in design for `WebApiSkill` where it removed many properties and extended from `WebApiParameters` which defined those properties. This is being done as the change results in an internal breaking behavior for Azure SDKs generated using our Autorest code generators, and likely meaning breaks for external consumers of the Swagger file. This reverts to previous behaviors to alleviate these concerns and issues.