### PR TITLE
fix: nested resource providers

### DIFF
--- a/profile/2019-06-01-profile.json
+++ b/profile/2019-06-01-profile.json
@@ -3,7 +3,7 @@
     "name": "2019-06-01-profile",
     "description": "Profile definition targeted for hybrid applications that could run on azure gov general availability version and azure cloud"
   },
-  "resourcemanager": {
+  "resource-manager": {
     "Microsoft.ADHybridHealthService": {
       "2014-01-01": {
         "services": [
@@ -71,2109 +71,2109 @@
         "operations": [
           "AzureGov"
         ]
+      }
+    },
+    "Microsoft.AnalysisServices": {
+      "2017-08-01-beta": {
+        "servers": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/checkNameAvailability": [
+          "AzureGov"
+        ],
+        "locations/operationresults": [
+          "AzureGov"
+        ],
+        "locations/operationstatuses": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.ApiManagement": {
+      "2018-06-01-preview": {
+        "service": [
+          "AzureGov"
+        ],
+        "validateServiceName": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "reportFeedback": [
+          "AzureGov"
+        ],
+        "checkFeedbackRequired": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Authorization": {
+      "2015-06-01": {
+        "classicAdministrators": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.AnalysisServices": {
-        "2017-08-01-beta": {
-          "servers": [
-            "AzureGov"
-          ],
-          "locations": [
-            "AzureGov"
-          ],
-          "locations/checkNameAvailability": [
-            "AzureGov"
-          ],
-          "locations/operationresults": [
-            "AzureGov"
-          ],
-          "locations/operationstatuses": [
-            "AzureGov"
-          ],
-          "operations": [
-            "AzureGov"
-          ]
-        }
+      "2018-07-01-preview": {
+        "denyAssignments": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.ApiManagement": {
-        "2018-06-01-preview": {
-          "service": [
-            "AzureGov"
-          ],
-          "validateServiceName": [
-            "AzureGov"
-          ],
-          "checkNameAvailability": [
-            "AzureGov"
-          ],
-          "reportFeedback": [
-            "AzureGov"
-          ],
-          "checkFeedbackRequired": [
-            "AzureGov"
-          ],
-          "operations": [
-            "AzureGov"
-          ]
-        }
+      "2017-05-01": {
+        "operations": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.Authorization": {
-        "2015-06-01": {
-          "classicAdministrators": [
-            "AzureGov"
-          ]
-        },
-        "2018-07-01-preview": {
-          "denyAssignments": [
-            "AzureGov"
-          ]
-        },
-        "2017-05-01": {
-          "operations": [
-            "AzureGov"
-          ]
-        },
-        "2018-05-01": {
-          "policyDefinitions": [
-            "AzureGov"
-          ],
-          "policySetDefinitions": [
-            "AzureGov"
-          ],
-          "policyAssignments": [
-            "AzureGov"
-          ]
-        },
-        "2018-09-01-preview": {
-          "checkAccess": [
-            "AzureGov"
-          ]
-        }
+      "2018-05-01": {
+        "policyDefinitions": [
+          "AzureGov"
+        ],
+        "policySetDefinitions": [
+          "AzureGov"
+        ],
+        "policyAssignments": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.Automation": {
-        "2018-06-30": {
-          "automationAccounts": [
-            "AzureGov"
-          ],
-          "automationAccounts/runbooks": [
-            "AzureGov"
-          ],
-          "automationAccounts/configurations": [
-            "AzureGov"
-          ],
-          "automationAccounts/webhooks": [
-            "AzureGov"
-          ],
-          "operations": [
-            "AzureGov"
-          ],
-          "automationAccounts/softwareUpdateConfigurations": [
-            "AzureGov"
-          ]
-        }
+      "2018-09-01-preview": {
+        "checkAccess": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Automation": {
+      "2018-06-30": {
+        "automationAccounts": [
+          "AzureGov"
+        ],
+        "automationAccounts/runbooks": [
+          "AzureGov"
+        ],
+        "automationAccounts/configurations": [
+          "AzureGov"
+        ],
+        "automationAccounts/webhooks": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "automationAccounts/softwareUpdateConfigurations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.AzureStack": {
+      "2017-06-01": {
+        "operations": [
+          "AzureGov"
+        ],
+        "registrations": [
+          "AzureGov"
+        ],
+        "registrations/products": [
+          "AzureGov"
+        ],
+        "registrations/customerSubscriptions": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.BatchAI": {
+      "2018-03-01": {
+        "clusters": [
+          "AzureGov"
+        ],
+        "jobs": [
+          "AzureGov"
+        ],
+        "fileservers": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.AzureStack": {
-        "2017-06-01": {
-          "operations": [
-            "AzureGov"
-          ],
-          "registrations": [
-            "AzureGov"
-          ],
-          "registrations/products": [
-            "AzureGov"
-          ],
-          "registrations/customerSubscriptions": [
-            "AzureGov"
-          ]
-        }
+      "2018-05-01": {
+        "workspaces": [
+          "AzureGov"
+        ],
+        "workspaces/clusters": [
+          "AzureGov"
+        ],
+        "workspaces/fileservers": [
+          "AzureGov"
+        ],
+        "workspaces/experiments": [
+          "AzureGov"
+        ],
+        "workspaces/experiments/jobs": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operationresults": [
+          "AzureGov"
+        ],
+        "locations/operationstatuses": [
+          "AzureGov"
+        ],
+        "locations/usages": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.BotService": {
+      "2018-07-12": {
+        "botServices": [
+          "AzureGov"
+        ],
+        "botServices/channels": [
+          "AzureGov"
+        ],
+        "botServices/connections": [
+          "AzureGov"
+        ],
+        "listAuthServiceProviders": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "languages": [
+          "AzureGov"
+        ],
+        "templates": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Cache": {
+      "2018-03-01": {
+        "Redis": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.CognitiveServices": {
+      "2017-04-18": {
+        "accounts": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/checkSkuAvailability": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Compute": {
+      "2018-10-01": {
+        "availabilitySets": [
+          "AzureGov"
+        ],
+        "virtualMachines": [
+          "AzureGov"
+        ],
+        "virtualMachines/extensions": [
+          "AzureGov"
+        ],
+        "virtualMachineScaleSets": [
+          "AzureGov"
+        ],
+        "virtualMachineScaleSets/extensions": [
+          "AzureGov"
+        ],
+        "virtualMachineScaleSets/virtualMachines": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operations": [
+          "AzureGov"
+        ],
+        "locations/vmSizes": [
+          "AzureGov"
+        ],
+        "locations/runCommands": [
+          "AzureGov"
+        ],
+        "locations/usages": [
+          "AzureGov"
+        ],
+        "locations/systemInfo": [
+          "AzureGov"
+        ],
+        "locations/virtualMachines": [
+          "AzureGov"
+        ],
+        "locations/publishers": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "restorePointCollections": [
+          "AzureGov"
+        ],
+        "restorePointCollections/restorePoints": [
+          "AzureGov"
+        ],
+        "locations/capsoperations": [
+          "AzureGov"
+        ],
+        "galleries": [
+          "AzureGov"
+        ],
+        "galleries/images": [
+          "AzureGov"
+        ],
+        "galleries/images/versions": [
+          "AzureGov"
+        ],
+        "images": [
+          "AzureGov"
+        ],
+        "virtualMachineScaleSets/networkInterfaces": [
+          "AzureGov"
+        ],
+        "virtualMachineScaleSets/virtualMachines/networkInterfaces": [
+          "AzureGov"
+        ],
+        "virtualMachineScaleSets/publicIPAddresses": [
+          "AzureGov"
+        ],
+        "sharedVMImages": [
+          "AzureGov"
+        ],
+        "sharedVMImages/versions": [
+          "AzureGov"
+        ],
+        "locations/artifactPublishers": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.BatchAI": {
-        "2018-03-01": {
-          "clusters": [
-            "AzureGov"
-          ],
-          "jobs": [
-            "AzureGov"
-          ],
-          "fileservers": [
-            "AzureGov"
-          ]
-        },
-        "2018-05-01": {
-          "workspaces": [
-            "AzureGov"
-          ],
-          "workspaces/clusters": [
-            "AzureGov"
-          ],
-          "workspaces/fileservers": [
-            "AzureGov"
-          ],
-          "workspaces/experiments": [
-            "AzureGov"
-          ],
-          "workspaces/experiments/jobs": [
-            "AzureGov"
-          ],
-          "operations": [
-            "AzureGov"
-          ],
-          "locations": [
-            "AzureGov"
-          ],
-          "locations/operationresults": [
-            "AzureGov"
-          ],
-          "locations/operationstatuses": [
-            "AzureGov"
-          ],
-          "locations/usages": [
-            "AzureGov"
-          ]
-        }
+      "2018-09-30": {
+        "disks": [
+          "AzureGov"
+        ],
+        "snapshots": [
+          "AzureGov"
+        ],
+        "locations/diskoperations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Consumption": {
+      "2018-10-01": {
+        "CostTags": [
+          "AzureGov"
+        ],
+        "products": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.BotService": {
-        "2018-07-12": {
-          "botServices": [
-            "AzureGov"
-          ],
-          "botServices/channels": [
-            "AzureGov"
-          ],
-          "botServices/connections": [
-            "AzureGov"
-          ],
-          "listAuthServiceProviders": [
-            "AzureGov"
-          ],
-          "checkNameAvailability": [
-            "AzureGov"
-          ],
-          "languages": [
-            "AzureGov"
-          ],
-          "templates": [
-            "AzureGov"
-          ],
-          "operations": [
-            "AzureGov"
-          ]
-        }
+      "2018-11-01-preview": {
+        "credits": [
+          "AzureGov"
+        ],
+        "events": [
+          "AzureGov"
+        ],
+        "lots": [
+          "AzureGov"
+        ],
+        "Operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.ContainerRegistry": {
+      "2017-10-01": {
+        "registries": [
+          "AzureGov"
+        ],
+        "registries/importImage": [
+          "AzureGov"
+        ],
+        "registries/replications": [
+          "AzureGov"
+        ],
+        "registries/webhooks": [
+          "AzureGov"
+        ],
+        "registries/webhooks/ping": [
+          "AzureGov"
+        ],
+        "registries/webhooks/getCallbackConfig": [
+          "AzureGov"
+        ],
+        "registries/webhooks/listEvents": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "registries/listCredentials": [
+          "AzureGov"
+        ],
+        "registries/regenerateCredential": [
+          "AzureGov"
+        ],
+        "registries/listUsages": [
+          "AzureGov"
+        ],
+        "registries/eventGridFilters": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "swagger": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.Cache": {
-        "2018-03-01": {
-          "Redis": [
-            "AzureGov"
-          ],
-          "locations": [
-            "AzureGov"
-          ],
-          "locations/operationResults": [
-            "AzureGov"
-          ],
-          "checkNameAvailability": [
-            "AzureGov"
-          ],
-          "operations": [
-            "AzureGov"
-          ]
-        }
+      "2017-03-01": {
+        "registries/GetCredentials": [
+          "AzureGov"
+        ],
+        "registries/regenerateCredentials": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.CostManagement": {
+      "2018-05-31": {
+        "Reportconfigs": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.DataBox": {
+      "2018-01-01": {
+        "jobs": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/validateAddress": [
+          "AzureGov"
+        ],
+        "locations/expresspods": [
+          "AzureGov"
+        ],
+        "locations/checkNameAvailability": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations/serviceHealth": [
+          "AzureGov"
+        ],
+        "locations/availableSkus": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.DataFactory": {
+      "2018-06-01": {
+        "factories": [
+          "AzureGov"
+        ],
+        "factories/integrationRuntimes": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/configureFactoryRepo": [
+          "AzureGov"
+        ],
+        "locations/getFeatureValue": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.DataMigration": {
+      "2018-07-15-preview": {
+        "locations": [
+          "AzureGov"
+        ],
+        "services": [
+          "AzureGov"
+        ],
+        "services/projects": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "locations/operationStatuses": [
+          "AzureGov"
+        ],
+        "locations/checkNameAvailability": [
+          "AzureGov"
+        ],
+        "slots": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.DBforMySQL": {
+      "2017-12-01-preview": {
+        "operations": [
+          "AzureGov"
+        ],
+        "servers": [
+          "AzureGov"
+        ],
+        "servers/recoverableServers": [
+          "AzureGov"
+        ],
+        "servers/virtualNetworkRules": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "locations/azureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/performanceTiers": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.DBforPostgreSQL": {
+      "2017-12-01-preview": {
+        "operations": [
+          "AzureGov"
+        ],
+        "servers": [
+          "AzureGov"
+        ],
+        "servers/recoverableServers": [
+          "AzureGov"
+        ],
+        "servers/virtualNetworkRules": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "locations/azureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/performanceTiers": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.CognitiveServices": {
-        "2017-04-18": {
-          "accounts": [
-            "AzureGov"
-          ],
-          "operations": [
-            "AzureGov"
-          ],
-          "locations": [
-            "AzureGov"
-          ],
-          "locations/checkSkuAvailability": [
-            "AzureGov"
-          ]
-        }
+      "2017-12-01": {
+        "locations/securityAlertPoliciesAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/securityAlertPoliciesOperationResults": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Devices": {
+      "2018-12-01-preview": {
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "usages": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "operationResults": [
+          "AzureGov"
+        ],
+        "IotHubs": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.DevTestLab": {
+      "2018-10-15-preview": {
+        "labs": [
+          "AzureGov"
+        ],
+        "schedules": [
+          "AzureGov"
+        ],
+        "labs/virtualMachines": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.EventHub": {
+      "2018-01-01-preview": {
+        "namespaces": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.Compute": {
-        "2018-10-01": {
-          "availabilitySets": [
-            "AzureGov"
-          ],
-          "virtualMachines": [
-            "AzureGov"
-          ],
-          "virtualMachines/extensions": [
-            "AzureGov"
-          ],
-          "virtualMachineScaleSets": [
-            "AzureGov"
-          ],
-          "virtualMachineScaleSets/extensions": [
-            "AzureGov"
-          ],
-          "virtualMachineScaleSets/virtualMachines": [
-            "AzureGov"
-          ],
-          "locations": [
-            "AzureGov"
-          ],
-          "locations/operations": [
-            "AzureGov"
-          ],
-          "locations/vmSizes": [
-            "AzureGov"
-          ],
-          "locations/runCommands": [
-            "AzureGov"
-          ],
-          "locations/usages": [
-            "AzureGov"
-          ],
-          "locations/systemInfo": [
-            "AzureGov"
-          ],
-          "locations/virtualMachines": [
-            "AzureGov"
-          ],
-          "locations/publishers": [
-            "AzureGov"
-          ],
-          "operations": [
-            "AzureGov"
-          ],
-          "restorePointCollections": [
-            "AzureGov"
-          ],
-          "restorePointCollections/restorePoints": [
-            "AzureGov"
-          ],
-          "locations/capsoperations": [
-            "AzureGov"
-          ],
-          "galleries": [
-            "AzureGov"
-          ],
-          "galleries/images": [
-            "AzureGov"
-          ],
-          "galleries/images/versions": [
-            "AzureGov"
-          ],
-          "images": [
-            "AzureGov"
-          ],
-          "virtualMachineScaleSets/networkInterfaces": [
-            "AzureGov"
-          ],
-          "virtualMachineScaleSets/virtualMachines/networkInterfaces": [
-            "AzureGov"
-          ],
-          "virtualMachineScaleSets/publicIPAddresses": [
-            "AzureGov"
-          ],
-          "sharedVMImages": [
-            "AzureGov"
-          ],
-          "sharedVMImages/versions": [
-            "AzureGov"
-          ],
-          "locations/artifactPublishers": [
-            "AzureGov"
-          ]
-        },
-        "2018-09-30": {
-          "disks": [
-            "AzureGov"
-          ],
-          "snapshots": [
-            "AzureGov"
-          ],
-          "locations/diskoperations": [
-            "AzureGov"
-          ]
-        }
+      "2015-08-01": {
+        "checkNamespaceAvailability": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.Consumption": {
-        "2018-10-01": {
-          "CostTags": [
-            "AzureGov"
-          ],
-          "products": [
-            "AzureGov"
-          ]
-        },
-        "2018-11-01-preview": {
-          "credits": [
-            "AzureGov"
-          ],
-          "events": [
-            "AzureGov"
-          ],
-          "lots": [
-            "AzureGov"
-          ],
-          "Operations": [
-            "AzureGov"
-          ]
-        }
+      "2017-04-01": {
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "sku": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Features": {
+      "2015-12-01": {
+        "features": [
+          "AzureGov"
+        ],
+        "providers": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.ImportExport": {
+      "2016-11-01": {
+        "jobs": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Insights": {
+      "2018-05-01-preview": {
+        "components": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.ContainerRegistry": {
-        "2017-10-01": {
-          "registries": [
-            "AzureGov"
-          ],
-          "registries/importImage": [
-            "AzureGov"
-          ],
-          "registries/replications": [
-            "AzureGov"
-          ],
-          "registries/webhooks": [
-            "AzureGov"
-          ],
-          "registries/webhooks/ping": [
-            "AzureGov"
-          ],
-          "registries/webhooks/getCallbackConfig": [
-            "AzureGov"
-          ],
-          "registries/webhooks/listEvents": [
-            "AzureGov"
-          ],
-          "locations/operationResults": [
-            "AzureGov"
-          ],
-          "registries/listCredentials": [
-            "AzureGov"
-          ],
-          "registries/regenerateCredential": [
-            "AzureGov"
-          ],
-          "registries/listUsages": [
-            "AzureGov"
-          ],
-          "registries/eventGridFilters": [
-            "AzureGov"
-          ],
-          "checkNameAvailability": [
-            "AzureGov"
-          ],
-          "swagger": [
-            "AzureGov"
-          ],
-          "operations": [
-            "AzureGov"
-          ],
-          "locations": [
-            "AzureGov"
-          ]
-        },
-        "2017-03-01": {
-          "registries/GetCredentials": [
-            "AzureGov"
-          ],
-          "registries/regenerateCredentials": [
-            "AzureGov"
-          ]
-        }
+      "2015-05-01": {
+        "webtests": [
+          "AzureGov"
+        ]
       },
-      "Microsoft.CostManagement": {
-        "2018-05-31": {
-          "Reportconfigs": [
-            "AzureGov"
-          ]
-        },
-        "Microsoft.DataBox": {
-          "2018-01-01": {
-            "jobs": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/validateAddress": [
-              "AzureGov"
-            ],
-            "locations/expresspods": [
-              "AzureGov"
-            ],
-            "locations/checkNameAvailability": [
-              "AzureGov"
-            ],
-            "locations/operationresults": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "locations/serviceHealth": [
-              "AzureGov"
-            ],
-            "locations/availableSkus": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.DataFactory": {
-          "2018-06-01": {
-            "factories": [
-              "AzureGov"
-            ],
-            "factories/integrationRuntimes": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/configureFactoryRepo": [
-              "AzureGov"
-            ],
-            "locations/getFeatureValue": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.DataMigration": {
-          "2018-07-15-preview": {
-            "locations": [
-              "AzureGov"
-            ],
-            "services": [
-              "AzureGov"
-            ],
-            "services/projects": [
-              "AzureGov"
-            ],
-            "locations/operationResults": [
-              "AzureGov"
-            ],
-            "locations/operationStatuses": [
-              "AzureGov"
-            ],
-            "locations/checkNameAvailability": [
-              "AzureGov"
-            ],
-            "slots": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.DBforMySQL": {
-          "2017-12-01-preview": {
-            "operations": [
-              "AzureGov"
-            ],
-            "servers": [
-              "AzureGov"
-            ],
-            "servers/recoverableServers": [
-              "AzureGov"
-            ],
-            "servers/virtualNetworkRules": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/operationResults": [
-              "AzureGov"
-            ],
-            "locations/azureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/performanceTiers": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.DBforPostgreSQL": {
-          "2017-12-01-preview": {
-            "operations": [
-              "AzureGov"
-            ],
-            "servers": [
-              "AzureGov"
-            ],
-            "servers/recoverableServers": [
-              "AzureGov"
-            ],
-            "servers/virtualNetworkRules": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/operationResults": [
-              "AzureGov"
-            ],
-            "locations/azureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/performanceTiers": [
-              "AzureGov"
-            ]
-          },
-          "2017-12-01": {
-            "locations/securityAlertPoliciesAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/securityAlertPoliciesOperationResults": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Devices": {
-          "2018-12-01-preview": {
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "usages": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "operationResults": [
-              "AzureGov"
-            ],
-            "IotHubs": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.DevTestLab": {
-          "2018-10-15-preview": {
-            "labs": [
-              "AzureGov"
-            ],
-            "schedules": [
-              "AzureGov"
-            ],
-            "labs/virtualMachines": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.EventHub": {
-          "2018-01-01-preview": {
-            "namespaces": [
-              "AzureGov"
-            ]
-          },
-          "2015-08-01": {
-            "checkNamespaceAvailability": [
-              "AzureGov"
-            ]
-          },
-          "2017-04-01": {
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "sku": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Features": {
-          "2015-12-01": {
-            "features": [
-              "AzureGov"
-            ],
-            "providers": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.ImportExport": {
-          "2016-11-01": {
-            "jobs": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/operationResults": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "microsoft.insights": {
-          "2018-05-01-preview": {
-            "components": [
-              "AzureGov"
-            ]
-          },
-          "2015-05-01": {
-            "webtests": [
-              "AzureGov"
-            ]
-          },
-          "2018-04-16": {
-            "scheduledqueryrules": [
-              "AzureGov"
-            ]
-          },
-          "2017-10-01": {
-            "components/pricingPlans": [
-              "AzureGov"
-            ],
-            "migrateToNewPricingModel": [
-              "AzureGov"
-            ],
-            "rollbackToLegacyPricingModel": [
-              "AzureGov"
-            ],
-            "listMigrationdate": [
-              "AzureGov"
-            ]
-          },
-          "2016-03-01": {
-            "logprofiles": [
-              "AzureGov"
-            ],
-            "alertrules": [
-              "AzureGov"
-            ]
-          },
-          "2018-03-01": {
-            "metricalerts": [
-              "AzureGov"
-            ]
-          },
-          "2015-04-01": {
-            "autoscalesettings": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/operationResults": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "eventCategories": [
-              "AzureGov"
-            ]
-          },
-          "2017-03-01-preview": {
-            "eventtypes": [
-              "AzureGov"
-            ]
-          },
-          "2017-05-01-preview": {
-            "diagnosticSettings": [
-              "AzureGov"
-            ],
-            "diagnosticSettingsCategories": [
-              "AzureGov"
-            ]
-          },
-          "2018-01-01": {
-            "metricDefinitions": [
-              "AzureGov"
-            ],
-            "metrics": [
-              "AzureGov"
-            ]
-          },
-          "2015-07-01": {
-            "logDefinitions": [
-              "AzureGov"
-            ]
-          },
-          "2018-09-01": {
-            "actiongroups": [
-              "AzureGov"
-            ],
-            "baseline": [
-              "AzureGov"
-            ],
-            "calculatebaseline": [
-              "AzureGov"
-            ]
-          },
-          "2017-04-01": {
-            "activityLogAlerts": [
-              "AzureGov"
-            ]
-          },
-          "2018-06-17-preview": {
-            "workbooks": [
-              "AzureGov"
-            ]
-          },
-          "2018-06-17-privatepreview": {
-            "myWorkbooks": [
-              "AzureGov"
-            ]
-          },
-          "2018-08-01-preview": {
-            "logs": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.KeyVault": {
-          "2018-02-14-preview": {
-            "vaults": [
-              "AzureGov"
-            ],
-            "vaults/secrets": [
-              "AzureGov"
-            ],
-            "vaults/accessPolicies": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "deletedVaults": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/deletedVaults": [
-              "AzureGov"
-            ],
-            "locations/deleteVirtualNetworkOrSubnets": [
-              "AzureGov"
-            ],
-            "locations/operationResults": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Logic": {
-          "2018-07-01-preview": {
-            "integrationAccounts": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.MarketplaceOrdering": {
-          "2015-06-01": {
-            "agreements": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "offertypes": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Media": {
-          "2018-07-01": {
-            "mediaservices": [
-              "AzureGov"
-            ],
-            "mediaservices/assets": [
-              "AzureGov"
-            ],
-            "mediaservices/contentKeyPolicies": [
-              "AzureGov"
-            ],
-            "mediaservices/streamingLocators": [
-              "AzureGov"
-            ],
-            "mediaservices/streamingPolicies": [
-              "AzureGov"
-            ],
-            "mediaservices/transforms": [
-              "AzureGov"
-            ],
-            "mediaservices/transforms/jobs": [
-              "AzureGov"
-            ],
-            "mediaservices/streamingEndpoints": [
-              "AzureGov"
-            ],
-            "mediaservices/liveEvents": [
-              "AzureGov"
-            ],
-            "mediaservices/liveEvents/liveOutputs": [
-              "AzureGov"
-            ],
-            "mediaservices/streamingEndpointOperations": [
-              "AzureGov"
-            ],
-            "mediaservices/liveEventOperations": [
-              "AzureGov"
-            ],
-            "mediaservices/liveOutputOperations": [
-              "AzureGov"
-            ],
-            "mediaservices/assets/assetFilters": [
-              "AzureGov"
-            ],
-            "mediaservices/accountFilters": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/checkNameAvailability": [
-              "AzureGov"
-            ]
-          },
-          "2015-10-01": {
-            "checknameavailability": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Migrate": {
-          "2018-02-02": {
-            "projects": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/checkNameAvailability": [
-              "AzureGov"
-            ],
-            "locations/assessmentOptions": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Network": {
-          "2019-02-01": {
-            "virtualNetworks": [
-              "AzureGov"
-            ],
-            "publicIPAddresses": [
-              "AzureGov"
-            ],
-            "networkInterfaces": [
-              "AzureGov"
-            ],
-            "privateEndpoints": [
-              "AzureGov"
-            ],
-            "loadBalancers": [
-              "AzureGov"
-            ],
-            "networkSecurityGroups": [
-              "AzureGov"
-            ],
-            "applicationSecurityGroups": [
-              "AzureGov"
-            ],
-            "serviceEndpointPolicies": [
-              "AzureGov"
-            ],
-            "networkIntentPolicies": [
-              "AzureGov"
-            ],
-            "routeTables": [
-              "AzureGov"
-            ],
-            "publicIPPrefixes": [
-              "AzureGov"
-            ],
-            "ddosCustomPolicies": [
-              "AzureGov"
-            ],
-            "networkWatchers": [
-              "AzureGov"
-            ],
-            "networkWatchers/connectionMonitors": [
-              "AzureGov"
-            ],
-            "networkWatchers/pingMeshes": [
-              "AzureGov"
-            ],
-            "virtualNetworkGateways": [
-              "AzureGov"
-            ],
-            "localNetworkGateways": [
-              "AzureGov"
-            ],
-            "connections": [
-              "AzureGov"
-            ],
-            "applicationGateways": [
-              "AzureGov"
-            ],
-            "applicationGatewayWebApplicationFirewallPolicies": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/operations": [
-              "AzureGov"
-            ],
-            "locations/operationResults": [
-              "AzureGov"
-            ],
-            "locations/CheckDnsNameAvailability": [
-              "AzureGov"
-            ],
-            "locations/usages": [
-              "AzureGov"
-            ],
-            "locations/virtualNetworkAvailableEndpointServices": [
-              "AzureGov"
-            ],
-            "locations/availableDelegations": [
-              "AzureGov"
-            ],
-            "locations/availablePrivateEndpointResources": [
-              "AzureGov"
-            ],
-            "locations/supportedVirtualMachineSizes": [
-              "AzureGov"
-            ],
-            "locations/checkAcceleratedNetworkingSupport": [
-              "AzureGov"
-            ],
-            "locations/validateResourceOwnership": [
-              "AzureGov"
-            ],
-            "locations/setResourceOwnership": [
-              "AzureGov"
-            ],
-            "locations/effectiveResourceOwnership": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "expressRouteCircuits": [
-              "AzureGov"
-            ],
-            "expressRouteCrossConnections": [
-              "AzureGov"
-            ],
-            "expressRouteServiceProviders": [
-              "AzureGov"
-            ],
-            "applicationGatewayAvailableWafRuleSets": [
-              "AzureGov"
-            ],
-            "applicationGatewayAvailableSslOptions": [
-              "AzureGov"
-            ],
-            "applicationGatewayAvailableServerVariables": [
-              "AzureGov"
-            ],
-            "applicationGatewayAvailableRequestHeaders": [
-              "AzureGov"
-            ],
-            "applicationGatewayAvailableResponseHeaders": [
-              "AzureGov"
-            ],
-            "routeFilters": [
-              "AzureGov"
-            ],
-            "bgpServiceCommunities": [
-              "AzureGov"
-            ],
-            "azureFirewalls": [
-              "AzureGov"
-            ],
-            "azureFirewallFqdnTags": [
-              "AzureGov"
-            ],
-            "virtualNetworkTaps": [
-              "AzureGov"
-            ],
-            "privateLinkServices": [
-              "AzureGov"
-            ],
-            "ddosProtectionPlans": [
-              "AzureGov"
-            ],
-            "networkProfiles": [
-              "AzureGov"
-            ],
-            "locations/bareMetalTenants": [
-              "AzureGov"
-            ]
-          },
-          "2018-05-01": {
-            "dnszones": [
-              "AzureGov"
-            ],
-            "dnsOperationResults": [
-              "AzureGov"
-            ],
-            "dnsOperationStatuses": [
-              "AzureGov"
-            ],
-            "getDnsResourceReference": [
-              "AzureGov"
-            ],
-            "internalNotify": [
-              "AzureGov"
-            ],
-            "dnszones/A": [
-              "AzureGov"
-            ],
-            "dnszones/AAAA": [
-              "AzureGov"
-            ],
-            "dnszones/CNAME": [
-              "AzureGov"
-            ],
-            "dnszones/PTR": [
-              "AzureGov"
-            ],
-            "dnszones/MX": [
-              "AzureGov"
-            ],
-            "dnszones/TXT": [
-              "AzureGov"
-            ],
-            "dnszones/SRV": [
-              "AzureGov"
-            ],
-            "dnszones/SOA": [
-              "AzureGov"
-            ],
-            "dnszones/NS": [
-              "AzureGov"
-            ],
-            "dnszones/CAA": [
-              "AzureGov"
-            ],
-            "dnszones/recordsets": [
-              "AzureGov"
-            ],
-            "dnszones/all": [
-              "AzureGov"
-            ]
-          },
-          "2018-08-01": {
-            "trafficmanagerprofiles": [
-              "AzureGov"
-            ],
-            "checkTrafficManagerNameAvailability": [
-              "AzureGov"
-            ],
-            "trafficManagerGeographicHierarchies": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.NotificationHubs": {
-          "2017-04-01": {
-            "namespaces": [
-              "AzureGov"
-            ],
-            "namespaces/notificationHubs": [
-              "AzureGov"
-            ],
-            "checkNamespaceAvailability": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ]
-          },
-          "2016-03-01": {
-            "operations": [
-              "AzureGov"
-            ],
-            "operationResults": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.OperationalInsights": {
-          "2015-03-20": {
-            "linkTargets": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.OperationsManagement": {
-          "2015-11-01-preview": {
-            "solutions": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.PolicyInsights": {
-          "2018-04-04": {
-            "policyEvents": [
-              "AzureGov"
-            ]
-          },
-          "2018-07-01-preview": {
-            "policyStates": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "asyncOperationResults": [
-              "AzureGov"
-            ],
-            "remediations": [
-              "AzureGov"
-            ],
-            "policyTrackedResources": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Portal": {
-          "2018-10-01-preview": {
-            "dashboards": [
-              "AzureGov"
-            ]
-          },
-          "2015-08-01-preview": {
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.PowerBI": {
-          "2016-01-29": {
-            "workspaceCollections": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/checkNameAvailability": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.PowerBIDedicated": {
-          "2017-10-01": {
-            "capacities": [
-              "AzureGov"
-            ],
-            "locations/checkNameAvailability": [
-              "AzureGov"
-            ],
-            "locations/operationresults": [
-              "AzureGov"
-            ],
-            "locations/operationstatuses": [
-              "AzureGov"
-            ]
-          },
-          "2017-01-01-preview": {
-            "locations": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.RecoveryServices": {
-          "2016-08-10": {
-            "operations": [
-              "AzureGov"
-            ]
-          },
-          "2016-06-01": {
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/backupStatus": [
-              "AzureGov"
-            ],
-            "locations/allocatedStamp": [
-              "AzureGov"
-            ],
-            "locations/allocateStamp": [
-              "AzureGov"
-            ]
-          },
-          "2018-01-10": {
-            "locations/checkNameAvailability": [
-              "AzureGov"
-            ]
-          },
-          "2017-07-01": {
-            "locations/backupValidateFeatures": [
-              "AzureGov"
-            ],
-            "locations/backupPreValidateProtection": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Relay": {
-          "2017-04-01": {
-            "namespaces": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.ResourceHealth": {
-          "2017-07-01": {
-            "availabilityStatuses": [
-              "AzureGov"
-            ]
-          },
-          "2015-01-01": {
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Resources": {
-          "2016-09-01": {
-            "tenants": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "providers": [
-              "AzureGov"
-            ],
-            "checkresourcename": [
-              "AzureGov"
-            ],
-            "resources": [
-              "AzureGov"
-            ],
-            "subscriptions": [
-              "AzureGov"
-            ],
-            "subscriptions/resources": [
-              "AzureGov"
-            ],
-            "subscriptions/providers": [
-              "AzureGov"
-            ],
-            "subscriptions/operationresults": [
-              "AzureGov"
-            ],
-            "resourceGroups": [
-              "AzureGov"
-            ],
-            "subscriptions/resourceGroups": [
-              "AzureGov"
-            ],
-            "subscriptions/resourcegroups/resources": [
-              "AzureGov"
-            ],
-            "subscriptions/locations": [
-              "AzureGov"
-            ],
-            "subscriptions/tagnames": [
-              "AzureGov"
-            ],
-            "subscriptions/tagNames/tagValues": [
-              "AzureGov"
-            ],
-            "deployments": [
-              "AzureGov"
-            ],
-            "deployments/operations": [
-              "AzureGov"
-            ],
-            "links": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Scheduler": {
-          "2016-03-01": {
-            "jobcollections": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "operationResults": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Search": {
-          "2015-08-19": {
-            "searchServices": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "resourceHealthMetadata": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          },
-          "2015-02-28": {
-            "checkServiceNameAvailability": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.ServiceBus": {
-          "2018-01-01-preview": {
-            "namespaces": [
-              "AzureGov"
-            ]
-          },
-          "2017-04-01": {
-            "namespaces/authorizationrules": [
-              "AzureGov"
-            ],
-            "namespaces/queues": [
-              "AzureGov"
-            ],
-            "namespaces/queues/authorizationrules": [
-              "AzureGov"
-            ],
-            "namespaces/topics": [
-              "AzureGov"
-            ],
-            "namespaces/topics/authorizationrules": [
-              "AzureGov"
-            ],
-            "namespaces/topics/subscriptions": [
-              "AzureGov"
-            ],
-            "namespaces/topics/subscriptions/rules": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "sku": [
-              "AzureGov"
-            ],
-            "premiumMessagingRegions": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          },
-          "2015-08-01": {
-            "checkNamespaceAvailability": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.ServiceFabric": {
-          "2018-02-01": {
-            "clusters": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/clusterVersions": [
-              "AzureGov"
-            ],
-            "locations/operations": [
-              "AzureGov"
-            ],
-            "locations/operationResults": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Solutions": {
-          "2018-09-01-preview": {
-            "applications": [
-              "AzureGov"
-            ],
-            "applicationDefinitions": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/operationstatuses": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Sql": {
-          "2017-03-01-preview": {
-            "operations": [
-              "AzureGov"
-            ],
-            "servers/databases/backupLongTermRetentionPolicies": [
-              "AzureGov"
-            ],
-            "servers/automaticTuning": [
-              "AzureGov"
-            ],
-            "servers/databases/automaticTuning": [
-              "AzureGov"
-            ],
-            "servers/securityAlertPolicies": [
-              "AzureGov"
-            ],
-            "servers/extendedAuditingSettings": [
-              "AzureGov"
-            ],
-            "locations/extendedAuditingSettingsAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/extendedAuditingSettingsOperationResults": [
-              "AzureGov"
-            ],
-            "servers/jobAgents": [
-              "AzureGov"
-            ],
-            "locations/jobAgentOperationResults": [
-              "AzureGov"
-            ],
-            "locations/jobAgentAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "servers/jobAgents/jobs": [
-              "AzureGov"
-            ],
-            "servers/jobAgents/jobs/steps": [
-              "AzureGov"
-            ],
-            "servers/jobAgents/jobs/executions": [
-              "AzureGov"
-            ],
-            "servers/dnsAliases": [
-              "AzureGov"
-            ],
-            "locations/dnsAliasAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/dnsAliasOperationResults": [
-              "AzureGov"
-            ],
-            "locations/databaseRestoreAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "servers/databases/VulnerabilityAssessment": [
-              "AzureGov"
-            ],
-            "managedInstances/administrators": [
-              "AzureGov"
-            ],
-            "managedInstances/databases": [
-              "AzureGov"
-            ],
-            "locations/managedDatabaseAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/managedDatabaseOperationResults": [
-              "AzureGov"
-            ],
-            "locations/managedDatabaseRestoreAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/managedDatabaseRestoreOperationResults": [
-              "AzureGov"
-            ],
-            "locations/managedServerSecurityAlertPoliciesAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/managedServerSecurityAlertPoliciesOperationResults": [
-              "AzureGov"
-            ],
-            "locations/securityAlertPoliciesAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/securityAlertPoliciesOperationResults": [
-              "AzureGov"
-            ],
-            "locations/administratorAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/administratorOperationResults": [
-              "AzureGov"
-            ],
-            "locations/longTermRetentionServers": [
-              "AzureGov"
-            ],
-            "locations/longTermRetentionBackups": [
-              "AzureGov"
-            ],
-            "locations/longTermRetentionPolicyOperationResults": [
-              "AzureGov"
-            ],
-            "locations/longTermRetentionPolicyAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/longTermRetentionBackupOperationResults": [
-              "AzureGov"
-            ],
-            "locations/longTermRetentionBackupAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/managedShortTermRetentionPolicyOperationResults": [
-              "AzureGov"
-            ],
-            "locations/managedShortTermRetentionPolicyAzureAsyncOperation": [
-              "AzureGov"
-            ]
-          },
-          "2014-04-01-preview": {
-            "locations": [
-              "AzureGov"
-            ],
-            "servers/serviceObjectives": [
-              "AzureGov"
-            ],
-            "servers/communicationLinks": [
-              "AzureGov"
-            ],
-            "servers/administrators": [
-              "AzureGov"
-            ],
-            "servers/administratorOperationResults": [
-              "AzureGov"
-            ],
-            "servers/restorableDroppedDatabases": [
-              "AzureGov"
-            ],
-            "servers/recoverableDatabases": [
-              "AzureGov"
-            ],
-            "servers/import": [
-              "AzureGov"
-            ],
-            "servers/importExportOperationResults": [
-              "AzureGov"
-            ],
-            "servers/operationResults": [
-              "AzureGov"
-            ],
-            "servers/databaseSecurityPolicies": [
-              "AzureGov"
-            ],
-            "servers/auditingPolicies": [
-              "AzureGov"
-            ],
-            "servers/recommendedElasticPools": [
-              "AzureGov"
-            ],
-            "servers/databases/auditingPolicies": [
-              "AzureGov"
-            ],
-            "servers/databases/connectionPolicies": [
-              "AzureGov"
-            ],
-            "servers/connectionPolicies": [
-              "AzureGov"
-            ],
-            "servers/databases/dataMaskingPolicies": [
-              "AzureGov"
-            ],
-            "servers/databases/dataMaskingPolicies/rules": [
-              "AzureGov"
-            ],
-            "servers/disasterRecoveryConfiguration": [
-              "AzureGov"
-            ],
-            "servers/databases/metricDefinitions": [
-              "AzureGov"
-            ],
-            "servers/databases/metrics": [
-              "AzureGov"
-            ],
-            "servers/aggregatedDatabaseMetrics": [
-              "AzureGov"
-            ],
-            "servers/elasticpools/metrics": [
-              "AzureGov"
-            ],
-            "servers/elasticpools/metricdefinitions": [
-              "AzureGov"
-            ],
-            "servers/databases/topQueries": [
-              "AzureGov"
-            ],
-            "servers/databases/topQueries/queryText": [
-              "AzureGov"
-            ],
-            "servers/databases/extensions": [
-              "AzureGov"
-            ]
-          },
-          "2018-06-01-preview": {
-            "locations/capabilities": [
-              "AzureGov"
-            ],
-            "locations/databaseAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/databaseOperationResults": [
-              "AzureGov"
-            ],
-            "locations/serverKeyAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/serverKeyOperationResults": [
-              "AzureGov"
-            ],
-            "servers/keys": [
-              "AzureGov"
-            ],
-            "servers/encryptionProtector": [
-              "AzureGov"
-            ],
-            "locations/encryptionProtectorOperationResults": [
-              "AzureGov"
-            ],
-            "locations/encryptionProtectorAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/serverAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/serverOperationResults": [
-              "AzureGov"
-            ],
-            "locations/usages": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "servers": [
-              "AzureGov"
-            ],
-            "servers/databases/transparentDataEncryption": [
-              "AzureGov"
-            ],
-            "servers/databases/securityAlertPolicies": [
-              "AzureGov"
-            ],
-            "servers/databases/auditingSettings": [
-              "AzureGov"
-            ],
-            "servers/auditingSettings": [
-              "AzureGov"
-            ],
-            "locations/auditingSettingsAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/auditingSettingsOperationResults": [
-              "AzureGov"
-            ],
-            "locations/firewallRulesOperationResults": [
-              "AzureGov"
-            ],
-            "locations/firewallRulesAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "servers/vulnerabilityAssessments": [
-              "AzureGov"
-            ],
-            "managedInstances/vulnerabilityAssessments": [
-              "AzureGov"
-            ],
-            "managedInstances": [
-              "AzureGov"
-            ],
-            "locations/managedInstanceAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/managedInstanceOperationResults": [
-              "AzureGov"
-            ]
-          },
-          "2017-10-01-preview": {
-            "locations/managedInstanceKeyAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/managedInstanceKeyOperationResults": [
-              "AzureGov"
-            ],
-            "locations/managedInstanceEncryptionProtectorOperationResults": [
-              "AzureGov"
-            ],
-            "locations/managedInstanceEncryptionProtectorAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "servers/tdeCertificates": [
-              "AzureGov"
-            ],
-            "locations/tdeCertAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/tdeCertOperationResults": [
-              "AzureGov"
-            ],
-            "locations/elasticPoolAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/elasticPoolOperationResults": [
-              "AzureGov"
-            ],
-            "servers/elasticpools": [
-              "AzureGov"
-            ],
-            "servers/databases/vulnerabilityAssessments": [
-              "AzureGov"
-            ],
-            "managedInstances/databases/vulnerabilityAssessments": [
-              "AzureGov"
-            ],
-            "locations/vulnerabilityAssessmentScanAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/vulnerabilityAssessmentScanOperationResults": [
-              "AzureGov"
-            ],
-            "managedInstances/recoverableDatabases": [
-              "AzureGov"
-            ],
-            "managedInstances/metrics": [
-              "AzureGov"
-            ],
-            "managedInstances/metricDefinitions": [
-              "AzureGov"
-            ],
-            "managedInstances/tdeCertificates": [
-              "AzureGov"
-            ],
-            "locations/managedInstanceTdeCertAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/managedInstanceTdeCertOperationResults": [
-              "AzureGov"
-            ],
-            "locations/shortTermRetentionPolicyOperationResults": [
-              "AzureGov"
-            ],
-            "locations/shortTermRetentionPolicyAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/instanceFailoverGroups": [
-              "AzureGov"
-            ],
-            "locations/instanceFailoverGroupAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/instanceFailoverGroupOperationResults": [
-              "AzureGov"
-            ]
-          },
-          "2015-05-01-preview": {
-            "servers/databases/geoBackupPolicies": [
-              "AzureGov"
-            ],
-            "servers/failoverGroups": [
-              "AzureGov"
-            ],
-            "locations/failoverGroupAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/failoverGroupOperationResults": [
-              "AzureGov"
-            ],
-            "locations/deleteVirtualNetworkOrSubnets": [
-              "AzureGov"
-            ],
-            "servers/virtualNetworkRules": [
-              "AzureGov"
-            ],
-            "locations/virtualNetworkRulesOperationResults": [
-              "AzureGov"
-            ],
-            "locations/virtualNetworkRulesAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "locations/deleteVirtualNetworkOrSubnetsOperationResults": [
-              "AzureGov"
-            ],
-            "locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation": [
-              "AzureGov"
-            ],
-            "servers/usages": [
-              "AzureGov"
-            ],
-            "servers/advisors": [
-              "AzureGov"
-            ],
-            "servers/elasticPools/advisors": [
-              "AzureGov"
-            ],
-            "servers/databases/advisors": [
-              "AzureGov"
-            ],
-            "servers/elasticPoolEstimates": [
-              "AzureGov"
-            ],
-            "servers/databases/auditRecords": [
-              "AzureGov"
-            ],
-            "servers/databases/VulnerabilityAssessmentScans": [
-              "AzureGov"
-            ],
-            "servers/databases/VulnerabilityAssessmentSettings": [
-              "AzureGov"
-            ],
-            "servers/databases/syncGroups": [
-              "AzureGov"
-            ],
-            "servers/databases/syncGroups/syncMembers": [
-              "AzureGov"
-            ],
-            "servers/syncAgents": [
-              "AzureGov"
-            ],
-            "virtualClusters": [
-              "AzureGov"
-            ],
-            "locations/syncGroupOperationResults": [
-              "AzureGov"
-            ],
-            "locations/syncMemberOperationResults": [
-              "AzureGov"
-            ],
-            "locations/syncAgentOperationResults": [
-              "AzureGov"
-            ],
-            "locations/syncDatabaseIds": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Storage": {
-          "2018-07-01": {
-            "storageAccounts": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "locations/asyncoperations": [
-              "AzureGov"
-            ],
-            "storageAccounts/listAccountSas": [
-              "AzureGov"
-            ],
-            "storageAccounts/listServiceSas": [
-              "AzureGov"
-            ],
-            "storageAccounts/blobServices": [
-              "AzureGov"
-            ],
-            "storageAccounts/tableServices": [
-              "AzureGov"
-            ],
-            "storageAccounts/queueServices": [
-              "AzureGov"
-            ],
-            "storageAccounts/fileServices": [
-              "AzureGov"
-            ],
-            "locations/usages": [
-              "AzureGov"
-            ],
-            "locations/deleteVirtualNetworkOrSubnets": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ]
-          },
-          "2017-10-01": {
-            "locations": [
-              "AzureGov"
-            ],
-            "usages": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.StorageSync": {
-          "2018-10-01": {
-            "storageSyncServices": [
-              "AzureGov"
-            ],
-            "storageSyncServices/syncGroups": [
-              "AzureGov"
-            ],
-            "storageSyncServices/syncGroups/cloudEndpoints": [
-              "AzureGov"
-            ],
-            "storageSyncServices/syncGroups/serverEndpoints": [
-              "AzureGov"
-            ],
-            "storageSyncServices/registeredServers": [
-              "AzureGov"
-            ],
-            "storageSyncServices/workflows": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/checkNameAvailability": [
-              "AzureGov"
-            ],
-            "locations/workflows": [
-              "AzureGov"
-            ]
-          }
-        },
-        "Microsoft.Web": {
-          "2018-02-01": {
-            "publishingUsers": [
-              "AzureGov"
-            ],
-            "ishostnameavailable": [
-              "AzureGov"
-            ],
-            "isusernameavailable": [
-              "AzureGov"
-            ],
-            "sourceControls": [
-              "AzureGov"
-            ],
-            "availableStacks": [
-              "AzureGov"
-            ],
-            "listSitesAssignedToHostName": [
-              "AzureGov"
-            ],
-            "sites/hostNameBindings": [
-              "AzureGov"
-            ],
-            "sites/slots/hostNameBindings": [
-              "AzureGov"
-            ],
-            "operations": [
-              "AzureGov"
-            ],
-            "serverFarms": [
-              "AzureGov"
-            ],
-            "runtimes": [
-              "AzureGov"
-            ],
-            "georegions": [
-              "AzureGov"
-            ],
-            "sites/premieraddons": [
-              "AzureGov"
-            ],
-            "hostingEnvironments/multiRolePools": [
-              "AzureGov"
-            ],
-            "hostingEnvironments/workerPools": [
-              "AzureGov"
-            ],
-            "deploymentLocations": [
-              "AzureGov"
-            ],
-            "ishostingenvironmentnameavailable": [
-              "AzureGov"
-            ],
-            "checkNameAvailability": [
-              "AzureGov"
-            ],
-            "billingMeters": [
-              "AzureGov"
-            ]
-          },
-          "2018-07-01-preview": {
-            "connections": [
-              "AzureGov"
-            ],
-            "customApis": [
-              "AzureGov"
-            ],
-            "locations": [
-              "AzureGov"
-            ],
-            "locations/managedApis": [
-              "AzureGov"
-            ],
-            "locations/apiOperations": [
-              "AzureGov"
-            ]
-          },
-          "2018-03-01-preview": {
-            "locations/listWsdlInterfaces": [
-              "AzureGov"
-            ],
-            "locations/extractApiDefinitionFromWsdl": [
-              "AzureGov"
-            ],
-            "locations/runtimes": [
-              "AzureGov"
-            ],
-            "connectionGateways": [
-              "AzureGov"
-            ],
-            "locations/connectionGatewayInstallations": [
-              "AzureGov"
-            ]
-          }
-        }
+      "2018-04-16": {
+        "scheduledqueryrules": [
+          "AzureGov"
+        ]
+      },
+      "2017-10-01": {
+        "components/pricingPlans": [
+          "AzureGov"
+        ],
+        "migrateToNewPricingModel": [
+          "AzureGov"
+        ],
+        "rollbackToLegacyPricingModel": [
+          "AzureGov"
+        ],
+        "listMigrationdate": [
+          "AzureGov"
+        ]
+      },
+      "2016-03-01": {
+        "logprofiles": [
+          "AzureGov"
+        ],
+        "alertrules": [
+          "AzureGov"
+        ]
+      },
+      "2018-03-01": {
+        "metricalerts": [
+          "AzureGov"
+        ]
+      },
+      "2015-04-01": {
+        "autoscalesettings": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "eventCategories": [
+          "AzureGov"
+        ]
+      },
+      "2017-03-01-preview": {
+        "eventtypes": [
+          "AzureGov"
+        ]
+      },
+      "2017-05-01-preview": {
+        "diagnosticSettings": [
+          "AzureGov"
+        ],
+        "diagnosticSettingsCategories": [
+          "AzureGov"
+        ]
+      },
+      "2018-01-01": {
+        "metricDefinitions": [
+          "AzureGov"
+        ],
+        "metrics": [
+          "AzureGov"
+        ]
+      },
+      "2015-07-01": {
+        "logDefinitions": [
+          "AzureGov"
+        ]
+      },
+      "2018-09-01": {
+        "actiongroups": [
+          "AzureGov"
+        ],
+        "baseline": [
+          "AzureGov"
+        ],
+        "calculatebaseline": [
+          "AzureGov"
+        ]
+      },
+      "2017-04-01": {
+        "activityLogAlerts": [
+          "AzureGov"
+        ]
+      },
+      "2018-06-17-preview": {
+        "workbooks": [
+          "AzureGov"
+        ]
+      },
+      "2018-06-17-privatepreview": {
+        "myWorkbooks": [
+          "AzureGov"
+        ]
+      },
+      "2018-08-01-preview": {
+        "logs": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.KeyVault": {
+      "2018-02-14-preview": {
+        "vaults": [
+          "AzureGov"
+        ],
+        "vaults/secrets": [
+          "AzureGov"
+        ],
+        "vaults/accessPolicies": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "deletedVaults": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/deletedVaults": [
+          "AzureGov"
+        ],
+        "locations/deleteVirtualNetworkOrSubnets": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Logic": {
+      "2018-07-01-preview": {
+        "integrationAccounts": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.MarketplaceOrdering": {
+      "2015-06-01": {
+        "agreements": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "offertypes": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Media": {
+      "2018-07-01": {
+        "mediaservices": [
+          "AzureGov"
+        ],
+        "mediaservices/assets": [
+          "AzureGov"
+        ],
+        "mediaservices/contentKeyPolicies": [
+          "AzureGov"
+        ],
+        "mediaservices/streamingLocators": [
+          "AzureGov"
+        ],
+        "mediaservices/streamingPolicies": [
+          "AzureGov"
+        ],
+        "mediaservices/transforms": [
+          "AzureGov"
+        ],
+        "mediaservices/transforms/jobs": [
+          "AzureGov"
+        ],
+        "mediaservices/streamingEndpoints": [
+          "AzureGov"
+        ],
+        "mediaservices/liveEvents": [
+          "AzureGov"
+        ],
+        "mediaservices/liveEvents/liveOutputs": [
+          "AzureGov"
+        ],
+        "mediaservices/streamingEndpointOperations": [
+          "AzureGov"
+        ],
+        "mediaservices/liveEventOperations": [
+          "AzureGov"
+        ],
+        "mediaservices/liveOutputOperations": [
+          "AzureGov"
+        ],
+        "mediaservices/assets/assetFilters": [
+          "AzureGov"
+        ],
+        "mediaservices/accountFilters": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/checkNameAvailability": [
+          "AzureGov"
+        ]
+      },
+      "2015-10-01": {
+        "checknameavailability": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Migrate": {
+      "2018-02-02": {
+        "projects": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/checkNameAvailability": [
+          "AzureGov"
+        ],
+        "locations/assessmentOptions": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Network": {
+      "2019-02-01": {
+        "virtualNetworks": [
+          "AzureGov"
+        ],
+        "publicIPAddresses": [
+          "AzureGov"
+        ],
+        "networkInterfaces": [
+          "AzureGov"
+        ],
+        "privateEndpoints": [
+          "AzureGov"
+        ],
+        "loadBalancers": [
+          "AzureGov"
+        ],
+        "networkSecurityGroups": [
+          "AzureGov"
+        ],
+        "applicationSecurityGroups": [
+          "AzureGov"
+        ],
+        "serviceEndpointPolicies": [
+          "AzureGov"
+        ],
+        "networkIntentPolicies": [
+          "AzureGov"
+        ],
+        "routeTables": [
+          "AzureGov"
+        ],
+        "publicIPPrefixes": [
+          "AzureGov"
+        ],
+        "ddosCustomPolicies": [
+          "AzureGov"
+        ],
+        "networkWatchers": [
+          "AzureGov"
+        ],
+        "networkWatchers/connectionMonitors": [
+          "AzureGov"
+        ],
+        "networkWatchers/pingMeshes": [
+          "AzureGov"
+        ],
+        "virtualNetworkGateways": [
+          "AzureGov"
+        ],
+        "localNetworkGateways": [
+          "AzureGov"
+        ],
+        "connections": [
+          "AzureGov"
+        ],
+        "applicationGateways": [
+          "AzureGov"
+        ],
+        "applicationGatewayWebApplicationFirewallPolicies": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operations": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "locations/CheckDnsNameAvailability": [
+          "AzureGov"
+        ],
+        "locations/usages": [
+          "AzureGov"
+        ],
+        "locations/virtualNetworkAvailableEndpointServices": [
+          "AzureGov"
+        ],
+        "locations/availableDelegations": [
+          "AzureGov"
+        ],
+        "locations/availablePrivateEndpointResources": [
+          "AzureGov"
+        ],
+        "locations/supportedVirtualMachineSizes": [
+          "AzureGov"
+        ],
+        "locations/checkAcceleratedNetworkingSupport": [
+          "AzureGov"
+        ],
+        "locations/validateResourceOwnership": [
+          "AzureGov"
+        ],
+        "locations/setResourceOwnership": [
+          "AzureGov"
+        ],
+        "locations/effectiveResourceOwnership": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "expressRouteCircuits": [
+          "AzureGov"
+        ],
+        "expressRouteCrossConnections": [
+          "AzureGov"
+        ],
+        "expressRouteServiceProviders": [
+          "AzureGov"
+        ],
+        "applicationGatewayAvailableWafRuleSets": [
+          "AzureGov"
+        ],
+        "applicationGatewayAvailableSslOptions": [
+          "AzureGov"
+        ],
+        "applicationGatewayAvailableServerVariables": [
+          "AzureGov"
+        ],
+        "applicationGatewayAvailableRequestHeaders": [
+          "AzureGov"
+        ],
+        "applicationGatewayAvailableResponseHeaders": [
+          "AzureGov"
+        ],
+        "routeFilters": [
+          "AzureGov"
+        ],
+        "bgpServiceCommunities": [
+          "AzureGov"
+        ],
+        "azureFirewalls": [
+          "AzureGov"
+        ],
+        "azureFirewallFqdnTags": [
+          "AzureGov"
+        ],
+        "virtualNetworkTaps": [
+          "AzureGov"
+        ],
+        "privateLinkServices": [
+          "AzureGov"
+        ],
+        "ddosProtectionPlans": [
+          "AzureGov"
+        ],
+        "networkProfiles": [
+          "AzureGov"
+        ],
+        "locations/bareMetalTenants": [
+          "AzureGov"
+        ]
+      },
+      "2018-05-01": {
+        "dnszones": [
+          "AzureGov"
+        ],
+        "dnsOperationResults": [
+          "AzureGov"
+        ],
+        "dnsOperationStatuses": [
+          "AzureGov"
+        ],
+        "getDnsResourceReference": [
+          "AzureGov"
+        ],
+        "internalNotify": [
+          "AzureGov"
+        ],
+        "dnszones/A": [
+          "AzureGov"
+        ],
+        "dnszones/AAAA": [
+          "AzureGov"
+        ],
+        "dnszones/CNAME": [
+          "AzureGov"
+        ],
+        "dnszones/PTR": [
+          "AzureGov"
+        ],
+        "dnszones/MX": [
+          "AzureGov"
+        ],
+        "dnszones/TXT": [
+          "AzureGov"
+        ],
+        "dnszones/SRV": [
+          "AzureGov"
+        ],
+        "dnszones/SOA": [
+          "AzureGov"
+        ],
+        "dnszones/NS": [
+          "AzureGov"
+        ],
+        "dnszones/CAA": [
+          "AzureGov"
+        ],
+        "dnszones/recordsets": [
+          "AzureGov"
+        ],
+        "dnszones/all": [
+          "AzureGov"
+        ]
+      },
+      "2018-08-01": {
+        "trafficmanagerprofiles": [
+          "AzureGov"
+        ],
+        "checkTrafficManagerNameAvailability": [
+          "AzureGov"
+        ],
+        "trafficManagerGeographicHierarchies": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.NotificationHubs": {
+      "2017-04-01": {
+        "namespaces": [
+          "AzureGov"
+        ],
+        "namespaces/notificationHubs": [
+          "AzureGov"
+        ],
+        "checkNamespaceAvailability": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ]
+      },
+      "2016-03-01": {
+        "operations": [
+          "AzureGov"
+        ],
+        "operationResults": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.OperationalInsights": {
+      "2015-03-20": {
+        "linkTargets": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.OperationsManagement": {
+      "2015-11-01-preview": {
+        "solutions": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.PolicyInsights": {
+      "2018-04-04": {
+        "policyEvents": [
+          "AzureGov"
+        ]
+      },
+      "2018-07-01-preview": {
+        "policyStates": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "asyncOperationResults": [
+          "AzureGov"
+        ],
+        "remediations": [
+          "AzureGov"
+        ],
+        "policyTrackedResources": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Portal": {
+      "2018-10-01-preview": {
+        "dashboards": [
+          "AzureGov"
+        ]
+      },
+      "2015-08-01-preview": {
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.PowerBI": {
+      "2016-01-29": {
+        "workspaceCollections": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/checkNameAvailability": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.PowerBIDedicated": {
+      "2017-10-01": {
+        "capacities": [
+          "AzureGov"
+        ],
+        "locations/checkNameAvailability": [
+          "AzureGov"
+        ],
+        "locations/operationresults": [
+          "AzureGov"
+        ],
+        "locations/operationstatuses": [
+          "AzureGov"
+        ]
+      },
+      "2017-01-01-preview": {
+        "locations": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.RecoveryServices": {
+      "2016-08-10": {
+        "operations": [
+          "AzureGov"
+        ]
+      },
+      "2016-06-01": {
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/backupStatus": [
+          "AzureGov"
+        ],
+        "locations/allocatedStamp": [
+          "AzureGov"
+        ],
+        "locations/allocateStamp": [
+          "AzureGov"
+        ]
+      },
+      "2018-01-10": {
+        "locations/checkNameAvailability": [
+          "AzureGov"
+        ]
+      },
+      "2017-07-01": {
+        "locations/backupValidateFeatures": [
+          "AzureGov"
+        ],
+        "locations/backupPreValidateProtection": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Relay": {
+      "2017-04-01": {
+        "namespaces": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.ResourceHealth": {
+      "2017-07-01": {
+        "availabilityStatuses": [
+          "AzureGov"
+        ]
+      },
+      "2015-01-01": {
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Resources": {
+      "2016-09-01": {
+        "tenants": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "providers": [
+          "AzureGov"
+        ],
+        "checkresourcename": [
+          "AzureGov"
+        ],
+        "resources": [
+          "AzureGov"
+        ],
+        "subscriptions": [
+          "AzureGov"
+        ],
+        "subscriptions/resources": [
+          "AzureGov"
+        ],
+        "subscriptions/providers": [
+          "AzureGov"
+        ],
+        "subscriptions/operationresults": [
+          "AzureGov"
+        ],
+        "resourceGroups": [
+          "AzureGov"
+        ],
+        "subscriptions/resourceGroups": [
+          "AzureGov"
+        ],
+        "subscriptions/resourcegroups/resources": [
+          "AzureGov"
+        ],
+        "subscriptions/locations": [
+          "AzureGov"
+        ],
+        "subscriptions/tagNames": [
+          "AzureGov"
+        ],
+        "subscriptions/tagNames/tagValues": [
+          "AzureGov"
+        ],
+        "deployments": [
+          "AzureGov"
+        ],
+        "deployments/operations": [
+          "AzureGov"
+        ],
+        "links": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Scheduler": {
+      "2016-03-01": {
+        "jobcollections": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "operationResults": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Search": {
+      "2015-08-19": {
+        "searchServices": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "resourceHealthMetadata": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      },
+      "2015-02-28": {
+        "checkServiceNameAvailability": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.ServiceBus": {
+      "2018-01-01-preview": {
+        "namespaces": [
+          "AzureGov"
+        ]
+      },
+      "2017-04-01": {
+        "namespaces/authorizationrules": [
+          "AzureGov"
+        ],
+        "namespaces/queues": [
+          "AzureGov"
+        ],
+        "namespaces/queues/authorizationrules": [
+          "AzureGov"
+        ],
+        "namespaces/topics": [
+          "AzureGov"
+        ],
+        "namespaces/topics/authorizationrules": [
+          "AzureGov"
+        ],
+        "namespaces/topics/subscriptions": [
+          "AzureGov"
+        ],
+        "namespaces/topics/subscriptions/rules": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "sku": [
+          "AzureGov"
+        ],
+        "premiumMessagingRegions": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      },
+      "2015-08-01": {
+        "checkNamespaceAvailability": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.ServiceFabric": {
+      "2018-02-01": {
+        "clusters": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/clusterVersions": [
+          "AzureGov"
+        ],
+        "locations/operations": [
+          "AzureGov"
+        ],
+        "locations/operationResults": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Solutions": {
+      "2018-09-01-preview": {
+        "applications": [
+          "AzureGov"
+        ],
+        "applicationDefinitions": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/operationstatuses": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Sql": {
+      "2017-03-01-preview": {
+        "operations": [
+          "AzureGov"
+        ],
+        "servers/databases/backupLongTermRetentionPolicies": [
+          "AzureGov"
+        ],
+        "servers/automaticTuning": [
+          "AzureGov"
+        ],
+        "servers/databases/automaticTuning": [
+          "AzureGov"
+        ],
+        "servers/securityAlertPolicies": [
+          "AzureGov"
+        ],
+        "servers/extendedAuditingSettings": [
+          "AzureGov"
+        ],
+        "locations/extendedAuditingSettingsAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/extendedAuditingSettingsOperationResults": [
+          "AzureGov"
+        ],
+        "servers/jobAgents": [
+          "AzureGov"
+        ],
+        "locations/jobAgentOperationResults": [
+          "AzureGov"
+        ],
+        "locations/jobAgentAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "servers/jobAgents/jobs": [
+          "AzureGov"
+        ],
+        "servers/jobAgents/jobs/steps": [
+          "AzureGov"
+        ],
+        "servers/jobAgents/jobs/executions": [
+          "AzureGov"
+        ],
+        "servers/dnsAliases": [
+          "AzureGov"
+        ],
+        "locations/dnsAliasAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/dnsAliasOperationResults": [
+          "AzureGov"
+        ],
+        "locations/databaseRestoreAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "servers/databases/VulnerabilityAssessment": [
+          "AzureGov"
+        ],
+        "managedInstances/administrators": [
+          "AzureGov"
+        ],
+        "managedInstances/databases": [
+          "AzureGov"
+        ],
+        "locations/managedDatabaseAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/managedDatabaseOperationResults": [
+          "AzureGov"
+        ],
+        "locations/managedDatabaseRestoreAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/managedDatabaseRestoreOperationResults": [
+          "AzureGov"
+        ],
+        "locations/managedServerSecurityAlertPoliciesAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/managedServerSecurityAlertPoliciesOperationResults": [
+          "AzureGov"
+        ],
+        "locations/securityAlertPoliciesAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/securityAlertPoliciesOperationResults": [
+          "AzureGov"
+        ],
+        "locations/administratorAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/administratorOperationResults": [
+          "AzureGov"
+        ],
+        "locations/longTermRetentionServers": [
+          "AzureGov"
+        ],
+        "locations/longTermRetentionBackups": [
+          "AzureGov"
+        ],
+        "locations/longTermRetentionPolicyOperationResults": [
+          "AzureGov"
+        ],
+        "locations/longTermRetentionPolicyAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/longTermRetentionBackupOperationResults": [
+          "AzureGov"
+        ],
+        "locations/longTermRetentionBackupAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/managedShortTermRetentionPolicyOperationResults": [
+          "AzureGov"
+        ],
+        "locations/managedShortTermRetentionPolicyAzureAsyncOperation": [
+          "AzureGov"
+        ]
+      },
+      "2014-04-01-preview": {
+        "locations": [
+          "AzureGov"
+        ],
+        "servers/serviceObjectives": [
+          "AzureGov"
+        ],
+        "servers/communicationLinks": [
+          "AzureGov"
+        ],
+        "servers/administrators": [
+          "AzureGov"
+        ],
+        "servers/administratorOperationResults": [
+          "AzureGov"
+        ],
+        "servers/restorableDroppedDatabases": [
+          "AzureGov"
+        ],
+        "servers/recoverableDatabases": [
+          "AzureGov"
+        ],
+        "servers/import": [
+          "AzureGov"
+        ],
+        "servers/importExportOperationResults": [
+          "AzureGov"
+        ],
+        "servers/operationResults": [
+          "AzureGov"
+        ],
+        "servers/databaseSecurityPolicies": [
+          "AzureGov"
+        ],
+        "servers/auditingPolicies": [
+          "AzureGov"
+        ],
+        "servers/recommendedElasticPools": [
+          "AzureGov"
+        ],
+        "servers/databases/auditingPolicies": [
+          "AzureGov"
+        ],
+        "servers/databases/connectionPolicies": [
+          "AzureGov"
+        ],
+        "servers/connectionPolicies": [
+          "AzureGov"
+        ],
+        "servers/databases/dataMaskingPolicies": [
+          "AzureGov"
+        ],
+        "servers/databases/dataMaskingPolicies/rules": [
+          "AzureGov"
+        ],
+        "servers/disasterRecoveryConfiguration": [
+          "AzureGov"
+        ],
+        "servers/databases/metricDefinitions": [
+          "AzureGov"
+        ],
+        "servers/databases/metrics": [
+          "AzureGov"
+        ],
+        "servers/aggregatedDatabaseMetrics": [
+          "AzureGov"
+        ],
+        "servers/elasticpools/metrics": [
+          "AzureGov"
+        ],
+        "servers/elasticpools/metricdefinitions": [
+          "AzureGov"
+        ],
+        "servers/databases/topQueries": [
+          "AzureGov"
+        ],
+        "servers/databases/topQueries/queryText": [
+          "AzureGov"
+        ],
+        "servers/databases/extensions": [
+          "AzureGov"
+        ]
+      },
+      "2018-06-01-preview": {
+        "locations/capabilities": [
+          "AzureGov"
+        ],
+        "locations/databaseAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/databaseOperationResults": [
+          "AzureGov"
+        ],
+        "locations/serverKeyAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/serverKeyOperationResults": [
+          "AzureGov"
+        ],
+        "servers/keys": [
+          "AzureGov"
+        ],
+        "servers/encryptionProtector": [
+          "AzureGov"
+        ],
+        "locations/encryptionProtectorOperationResults": [
+          "AzureGov"
+        ],
+        "locations/encryptionProtectorAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/serverAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/serverOperationResults": [
+          "AzureGov"
+        ],
+        "locations/usages": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "servers": [
+          "AzureGov"
+        ],
+        "servers/databases/transparentDataEncryption": [
+          "AzureGov"
+        ],
+        "servers/databases/securityAlertPolicies": [
+          "AzureGov"
+        ],
+        "servers/databases/auditingSettings": [
+          "AzureGov"
+        ],
+        "servers/auditingSettings": [
+          "AzureGov"
+        ],
+        "locations/auditingSettingsAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/auditingSettingsOperationResults": [
+          "AzureGov"
+        ],
+        "locations/firewallRulesOperationResults": [
+          "AzureGov"
+        ],
+        "locations/firewallRulesAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "servers/vulnerabilityAssessments": [
+          "AzureGov"
+        ],
+        "managedInstances/vulnerabilityAssessments": [
+          "AzureGov"
+        ],
+        "managedInstances": [
+          "AzureGov"
+        ],
+        "locations/managedInstanceAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/managedInstanceOperationResults": [
+          "AzureGov"
+        ]
+      },
+      "2017-10-01-preview": {
+        "locations/managedInstanceKeyAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/managedInstanceKeyOperationResults": [
+          "AzureGov"
+        ],
+        "locations/managedInstanceEncryptionProtectorOperationResults": [
+          "AzureGov"
+        ],
+        "locations/managedInstanceEncryptionProtectorAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "servers/tdeCertificates": [
+          "AzureGov"
+        ],
+        "locations/tdeCertAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/tdeCertOperationResults": [
+          "AzureGov"
+        ],
+        "locations/elasticPoolAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/elasticPoolOperationResults": [
+          "AzureGov"
+        ],
+        "servers/elasticpools": [
+          "AzureGov"
+        ],
+        "servers/databases/vulnerabilityAssessments": [
+          "AzureGov"
+        ],
+        "managedInstances/databases/vulnerabilityAssessments": [
+          "AzureGov"
+        ],
+        "locations/vulnerabilityAssessmentScanAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/vulnerabilityAssessmentScanOperationResults": [
+          "AzureGov"
+        ],
+        "managedInstances/recoverableDatabases": [
+          "AzureGov"
+        ],
+        "managedInstances/metrics": [
+          "AzureGov"
+        ],
+        "managedInstances/metricDefinitions": [
+          "AzureGov"
+        ],
+        "managedInstances/tdeCertificates": [
+          "AzureGov"
+        ],
+        "locations/managedInstanceTdeCertAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/managedInstanceTdeCertOperationResults": [
+          "AzureGov"
+        ],
+        "locations/shortTermRetentionPolicyOperationResults": [
+          "AzureGov"
+        ],
+        "locations/shortTermRetentionPolicyAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/instanceFailoverGroups": [
+          "AzureGov"
+        ],
+        "locations/instanceFailoverGroupAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/instanceFailoverGroupOperationResults": [
+          "AzureGov"
+        ]
+      },
+      "2015-05-01-preview": {
+        "servers/databases/geoBackupPolicies": [
+          "AzureGov"
+        ],
+        "servers/failoverGroups": [
+          "AzureGov"
+        ],
+        "locations/failoverGroupAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/failoverGroupOperationResults": [
+          "AzureGov"
+        ],
+        "locations/deleteVirtualNetworkOrSubnets": [
+          "AzureGov"
+        ],
+        "servers/virtualNetworkRules": [
+          "AzureGov"
+        ],
+        "locations/virtualNetworkRulesOperationResults": [
+          "AzureGov"
+        ],
+        "locations/virtualNetworkRulesAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "locations/deleteVirtualNetworkOrSubnetsOperationResults": [
+          "AzureGov"
+        ],
+        "locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation": [
+          "AzureGov"
+        ],
+        "servers/usages": [
+          "AzureGov"
+        ],
+        "servers/advisors": [
+          "AzureGov"
+        ],
+        "servers/elasticPools/advisors": [
+          "AzureGov"
+        ],
+        "servers/databases/advisors": [
+          "AzureGov"
+        ],
+        "servers/elasticPoolEstimates": [
+          "AzureGov"
+        ],
+        "servers/databases/auditRecords": [
+          "AzureGov"
+        ],
+        "servers/databases/VulnerabilityAssessmentScans": [
+          "AzureGov"
+        ],
+        "servers/databases/VulnerabilityAssessmentSettings": [
+          "AzureGov"
+        ],
+        "servers/databases/syncGroups": [
+          "AzureGov"
+        ],
+        "servers/databases/syncGroups/syncMembers": [
+          "AzureGov"
+        ],
+        "servers/syncAgents": [
+          "AzureGov"
+        ],
+        "virtualClusters": [
+          "AzureGov"
+        ],
+        "locations/syncGroupOperationResults": [
+          "AzureGov"
+        ],
+        "locations/syncMemberOperationResults": [
+          "AzureGov"
+        ],
+        "locations/syncAgentOperationResults": [
+          "AzureGov"
+        ],
+        "locations/syncDatabaseIds": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Storage": {
+      "2018-07-01": {
+        "storageAccounts": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations/asyncoperations": [
+          "AzureGov"
+        ],
+        "storageAccounts/listAccountSas": [
+          "AzureGov"
+        ],
+        "storageAccounts/listServiceSas": [
+          "AzureGov"
+        ],
+        "storageAccounts/blobServices": [
+          "AzureGov"
+        ],
+        "storageAccounts/tableServices": [
+          "AzureGov"
+        ],
+        "storageAccounts/queueServices": [
+          "AzureGov"
+        ],
+        "storageAccounts/fileServices": [
+          "AzureGov"
+        ],
+        "locations/usages": [
+          "AzureGov"
+        ],
+        "locations/deleteVirtualNetworkOrSubnets": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ]
+      },
+      "2017-10-01": {
+        "locations": [
+          "AzureGov"
+        ],
+        "usages": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.StorageSync": {
+      "2018-10-01": {
+        "storageSyncServices": [
+          "AzureGov"
+        ],
+        "storageSyncServices/syncGroups": [
+          "AzureGov"
+        ],
+        "storageSyncServices/syncGroups/cloudEndpoints": [
+          "AzureGov"
+        ],
+        "storageSyncServices/syncGroups/serverEndpoints": [
+          "AzureGov"
+        ],
+        "storageSyncServices/registeredServers": [
+          "AzureGov"
+        ],
+        "storageSyncServices/workflows": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/checkNameAvailability": [
+          "AzureGov"
+        ],
+        "locations/workflows": [
+          "AzureGov"
+        ]
+      }
+    },
+    "Microsoft.Web": {
+      "2018-02-01": {
+        "publishingUsers": [
+          "AzureGov"
+        ],
+        "ishostnameavailable": [
+          "AzureGov"
+        ],
+        "isusernameavailable": [
+          "AzureGov"
+        ],
+        "sourceControls": [
+          "AzureGov"
+        ],
+        "availableStacks": [
+          "AzureGov"
+        ],
+        "listSitesAssignedToHostName": [
+          "AzureGov"
+        ],
+        "sites/hostNameBindings": [
+          "AzureGov"
+        ],
+        "sites/slots/hostNameBindings": [
+          "AzureGov"
+        ],
+        "operations": [
+          "AzureGov"
+        ],
+        "serverFarms": [
+          "AzureGov"
+        ],
+        "runtimes": [
+          "AzureGov"
+        ],
+        "georegions": [
+          "AzureGov"
+        ],
+        "sites/premieraddons": [
+          "AzureGov"
+        ],
+        "hostingEnvironments/multiRolePools": [
+          "AzureGov"
+        ],
+        "hostingEnvironments/workerPools": [
+          "AzureGov"
+        ],
+        "deploymentLocations": [
+          "AzureGov"
+        ],
+        "ishostingenvironmentnameavailable": [
+          "AzureGov"
+        ],
+        "checkNameAvailability": [
+          "AzureGov"
+        ],
+        "billingMeters": [
+          "AzureGov"
+        ]
+      },
+      "2018-07-01-preview": {
+        "connections": [
+          "AzureGov"
+        ],
+        "customApis": [
+          "AzureGov"
+        ],
+        "locations": [
+          "AzureGov"
+        ],
+        "locations/managedApis": [
+          "AzureGov"
+        ],
+        "locations/apiOperations": [
+          "AzureGov"
+        ]
+      },
+      "2018-03-01-preview": {
+        "locations/listWsdlInterfaces": [
+          "AzureGov"
+        ],
+        "locations/extractApiDefinitionFromWsdl": [
+          "AzureGov"
+        ],
+        "locations/runtimes": [
+          "AzureGov"
+        ],
+        "connectionGateways": [
+          "AzureGov"
+        ],
+        "locations/connectionGatewayInstallations": [
+          "AzureGov"
+        ]
       }
     }
   }

--- a/profile/2019-07-01-profile.json
+++ b/profile/2019-07-01-profile.json
@@ -3,7 +3,7 @@
     "name": "2019-07-01-profile",
     "description": "Profile definition targeted for hybrid applications that could run on azure gov general availability version and azure cloud"
   },
-  "resourcemanager": {
+  "resource-manager": {
     "Microsoft.ADHybridHealthService": {
       "2014-01-01": {
         "services": [
@@ -669,7 +669,7 @@
         ]
       }
     },
-    "microsoft.insights": {
+    "Microsoft.Insights": {
       "2018-04-16": {
         "scheduledqueryrules": [
           "AzureGov",


### PR DESCRIPTION
Fixes the following in the json files under `./profile` directory to align with the structure as mentioned in the `./profile/readme.md`

- nested resource providers (RP's)
- casing of the `Microsoft.Insights` for consistency
- hyphen in the key name `resource-manager`