### PR TITLE
Add script for update swagger from TypeSpec

### DIFF
--- a/eng/scripts/TypeSpec-Generate-Swagger.ps1
+++ b/eng/scripts/TypeSpec-Generate-Swagger.ps1
@@ -1,0 +1,22 @@
+[CmdletBinding()]
+param (
+  [switch]$CheckAll = $false,
+  [string]$BaseCommitish = "HEAD^",
+  [string]$TargetCommitish = "HEAD"
+)
+
+$typespecFolders = &"$PSScriptRoot/Get-TypeSpec-Folders.ps1" -BaseCommitish:$BaseCommitish -TargetCommitish:$TargetCommitish -CheckAll:$CheckAll
+if ($typespecFolders) {
+    $typespecFolders = $typespecFolders.Split('',[System.StringSplitOptions]::RemoveEmptyEntries)
+    foreach ($typespecFolder in $typespecFolders) {
+        Push-Location $typespecFolder
+        tsp compile .
+        Pop-Location
+    }
+  } else {
+    if ($CheckAll) {
+      LogError "TypeSpec Generate Swagger - All did not generate any swaggers"
+      LogJobFailure
+      exit 1
+    }
+  }

--- a/eng/scripts/TypeSpec-Generate-Swagger.ps1
+++ b/eng/scripts/TypeSpec-Generate-Swagger.ps1
@@ -10,7 +10,7 @@ if ($typespecFolders) {
     $typespecFolders = $typespecFolders.Split('',[System.StringSplitOptions]::RemoveEmptyEntries)
     foreach ($typespecFolder in $typespecFolders) {
         Push-Location $typespecFolder
-        tsp compile .
+        npx tsp compile .
         Pop-Location
     }
   } else {


### PR DESCRIPTION
For this script itself, it is regenerating all the swagger which is generated from TypeSpec. It is a part of this [pipeline](https://github.com/Azure/typespec-azure/pull/1099), whose purpose is for a WIP TypeSpec version, we could know its impact for swagger generation.