### PR TITLE
[Batch] Switch contentLength from int64 to string

### DIFF
--- a/specification/batch/Azure.Batch/common.tsp
+++ b/specification/batch/Azure.Batch/common.tsp
@@ -183,7 +183,7 @@ alias FileResponseHeaders = {
 
   @header("Content-Length")
   @doc("The length of the file.")
-  contentLength: int64;
+  contentLength: string;
 
   ...BatchEtagResponseHeaders;
 

--- a/specification/batch/Azure.Batch/examples/2024-02-01.19.0/FileListFromNode.json
+++ b/specification/batch/Azure.Batch/examples/2024-02-01.19.0/FileListFromNode.json
@@ -26,7 +26,7 @@
             "properties": {
               "creationTime": "2014-09-19T21:56:17.679195Z",
               "lastModified": "2014-09-19T21:56:17.679195Z",
-              "contentLength": 1813,
+              "contentLength": "1813",
               "contentType": "application/octet-stream"
             }
           },
@@ -37,7 +37,7 @@
             "properties": {
               "creationTime": "2014-09-19T21:56:17.5590855Z",
               "lastModified": "2014-09-19T21:56:17.5590855Z",
-              "contentLength": 0,
+              "contentLength": "0",
               "contentType": "application/octet-stream"
             }
           }

--- a/specification/batch/Azure.Batch/examples/2024-02-01.19.0/FileListFromTask.json
+++ b/specification/batch/Azure.Batch/examples/2024-02-01.19.0/FileListFromTask.json
@@ -21,7 +21,7 @@
             "properties": {
               "creationTime": "2014-09-19T21:56:17.679195Z",
               "lastModified": "2014-09-19T21:56:17.679195Z",
-              "contentLength": 1813,
+              "contentLength": "1813",
               "contentType": "application/octet-stream"
             }
           },
@@ -32,7 +32,7 @@
             "properties": {
               "creationTime": "2014-09-19T21:56:17.5590855Z",
               "lastModified": "2014-09-19T21:56:17.5590855Z",
-              "contentLength": 0,
+              "contentLength": "0",
               "contentType": "application/octet-stream"
             }
           }

--- a/specification/batch/Azure.Batch/models.tsp
+++ b/specification/batch/Azure.Batch/models.tsp
@@ -1051,7 +1051,7 @@ model FileProperties {
   lastModified: utcDateTime;
 
   @doc("The length of the file.")
-  contentLength: int64;
+  contentLength: string;
 
   @doc("The content type of the file.")
   contentType?: string;

--- a/specification/batch/data-plane/Azure.Batch/preview/2024-02-01.19.0/BatchService.json
+++ b/specification/batch/data-plane/Azure.Batch/preview/2024-02-01.19.0/BatchService.json
@@ -2491,8 +2491,7 @@
             },
             "headers": {
               "Content-Length": {
-                "type": "integer",
-                "format": "int64",
+                "type": "string",
                 "description": "The length of the file."
               },
               "ETag": {
@@ -2730,8 +2729,7 @@
             "description": "The request has succeeded.",
             "headers": {
               "Content-Length": {
-                "type": "integer",
-                "format": "int64",
+                "type": "string",
                 "description": "The length of the file."
               },
               "ETag": {
@@ -6847,8 +6845,7 @@
             },
             "headers": {
               "Content-Length": {
-                "type": "integer",
-                "format": "int64",
+                "type": "string",
                 "description": "The length of the file."
               },
               "ETag": {
@@ -7086,8 +7083,7 @@
             "description": "The request has succeeded.",
             "headers": {
               "Content-Length": {
-                "type": "integer",
-                "format": "int64",
+                "type": "string",
                 "description": "The length of the file."
               },
               "ETag": {
@@ -14266,8 +14262,7 @@
           "description": "The time at which the file was last modified."
         },
         "contentLength": {
-          "type": "integer",
-          "format": "int64",
+          "type": "string",
           "description": "The length of the file."
         },
         "contentType": {

--- a/specification/batch/data-plane/Azure.Batch/preview/2024-02-01.19.0/examples/FileListFromNode.json
+++ b/specification/batch/data-plane/Azure.Batch/preview/2024-02-01.19.0/examples/FileListFromNode.json
@@ -26,7 +26,7 @@
             "properties": {
               "creationTime": "2014-09-19T21:56:17.679195Z",
               "lastModified": "2014-09-19T21:56:17.679195Z",
-              "contentLength": 1813,
+              "contentLength": "1813",
               "contentType": "application/octet-stream"
             }
           },
@@ -37,7 +37,7 @@
             "properties": {
               "creationTime": "2014-09-19T21:56:17.5590855Z",
               "lastModified": "2014-09-19T21:56:17.5590855Z",
-              "contentLength": 0,
+              "contentLength": "0",
               "contentType": "application/octet-stream"
             }
           }

--- a/specification/batch/data-plane/Azure.Batch/preview/2024-02-01.19.0/examples/FileListFromTask.json
+++ b/specification/batch/data-plane/Azure.Batch/preview/2024-02-01.19.0/examples/FileListFromTask.json
@@ -21,7 +21,7 @@
             "properties": {
               "creationTime": "2014-09-19T21:56:17.679195Z",
               "lastModified": "2014-09-19T21:56:17.679195Z",
-              "contentLength": 1813,
+              "contentLength": "1813",
               "contentType": "application/octet-stream"
             }
           },
@@ -32,7 +32,7 @@
             "properties": {
               "creationTime": "2014-09-19T21:56:17.5590855Z",
               "lastModified": "2014-09-19T21:56:17.5590855Z",
-              "contentLength": 0,
+              "contentLength": "0",
               "contentType": "application/octet-stream"
             }
           }


### PR DESCRIPTION
This is a breaking change, but accurately reflects what the Batch service has always returned for this property.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
