### PR TITLE
[healthinsights] Fix the createJob definition in Radiology Insights

### DIFF
--- a/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/route.radiologyinsights.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/route.radiologyinsights.tsp
@@ -18,9 +18,48 @@ interface RadiologyInsights {
   @get
   getJob is HealthInsightsOperations.ResourceRead<RadiologyInsightsJob>;
 
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Does not fit standard operation"
   @summary("Create Radiology Insights job")
   @tag("RadiologyInsights")
   @doc("Creates a Radiology Insights job with the given request body.")
   @pollingOperation(RadiologyInsights.getJob)
-  createJob is HealthInsightsOperations.LongRunningResourceCreateOrReplace<RadiologyInsightsJob>;
+  @route("radiology-insights/jobs/{id}")
+  @put
+  createJob is Foundations.Operation<
+    {
+      @doc("The unique ID of the job.")
+      @maxLength(36)
+      @minLength(3)
+      @pattern("^[a-zA-Z0-9][a-zA-Z0-9-_]+[a-zA-Z0-9]$")
+      @path
+      id: string;
+
+      ...Azure.Core.ExpandQueryParameter;
+
+      @doc("The Radiology Insights request.")
+      @body
+      resource: RadiologyInsightsJob;
+    },
+    (RadiologyInsightsInferenceResult & {
+      @doc("An opaque, globally-unique, server-generated string identifier for the request.")
+      @header("x-ms-request-id")
+      requestId: RequestIdResponseHeader;
+
+      @doc("The location for monitoring the operation state.")
+      @header("Operation-Location")
+      operationLocation: url;
+    }) | (RadiologyInsightsInferenceResult & {
+      @statusCode _: 201;
+
+      @doc("An opaque, globally-unique, server-generated string identifier for the request.")
+      @header("x-ms-request-id")
+      requestId: RequestIdResponseHeader;
+
+      @doc("The location for monitoring the operation state.")
+      @header("Operation-Location")
+      operationLocation: url;
+    }),
+    ServiceTraits,
+    HealthInsightsErrorResponse
+  >;
 }

--- a/specification/ai/data-plane/HealthInsights/stable/2024-04-01/openapi.json
+++ b/specification/ai/data-plane/HealthInsights/stable/2024-04-01/openapi.json
@@ -164,7 +164,7 @@
           {
             "name": "resource",
             "in": "body",
-            "description": "The resource instance.",
+            "description": "The Radiology Insights request.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/RadiologyInsightsJob"
@@ -175,7 +175,7 @@
           "200": {
             "description": "The request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/RadiologyInsightsJob"
+              "$ref": "#/definitions/RadiologyInsightsInferenceResult"
             },
             "headers": {
               "Operation-Location": {
@@ -193,7 +193,7 @@
           "201": {
             "description": "The request has succeeded and a new resource has been created as a result.",
             "schema": {
-              "$ref": "#/definitions/RadiologyInsightsJob"
+              "$ref": "#/definitions/RadiologyInsightsInferenceResult"
             },
             "headers": {
               "Operation-Location": {


### PR DESCRIPTION
This PR is updating the createJob definition to better represent the final response for the operation, the changes should have no impact on the REST API. 