### PR TITLE
hybridcompute - add back license profiles operations and esu PATCH

### DIFF
--- a/specification/hybridcompute/resource-manager/Microsoft.HybridCompute/preview/2024-05-20-preview/privateLinkScopes.json
+++ b/specification/hybridcompute/resource-manager/Microsoft.HybridCompute/preview/2024-05-20-preview/privateLinkScopes.json
@@ -951,6 +951,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "OK"
+          },
           "202": {
             "description": "Accepted.",
             "headers": {

--- a/specification/hybridcompute/resource-manager/readme.md
+++ b/specification/hybridcompute/resource-manager/readme.md
@@ -132,21 +132,18 @@ directive:
       verb: Set
     remove: true
 
-  # we don't want user to interact with them / we don't support some operations
+  # internal operations
   - remove-operation: AgentVersion_List
   - remove-operation: AgentVersion_Get
+  # we don't use them, pending to remove in the future
   - remove-operation: HybridIdentityMetadata_Get
   - remove-operation: HybridIdentityMetadata_ListByMachines
-  - remove-operation: Licenses_ValidateLicense
-  - remove-operation: LicenseProfiles_Get
-  - remove-operation: LicenseProfiles_Delete
-  - remove-operation: LicenseProfiles_Update
-  - remove-operation: LicenseProfiles_List
-  - remove-operation: LicenseProfiles_CreateOrUpdate
+  # we want to retire them and use setting operations instead
   - remove-operation: NetworkConfigurations_Get
   - remove-operation: NetworkConfigurations_Update
   - remove-operation: NetworkConfigurations_CreateOrUpdate
-  - remove-operation: MachineRunCommands_Update #PATCH
+  # we don't want enable PATCH for run command
+  - remove-operation: MachineRunCommands_Update
 
 ```
 


### PR DESCRIPTION
When releasing SDK for different languages, there are some API operations that we don't want to release to customers.

This PR adds updates in readme to make sure that what gets released aligns with our .NET SDK.