### PR TITLE
Update specificationRepositoryConfiguration.json to remove track2 for python

### DIFF
--- a/specificationRepositoryConfiguration.json
+++ b/specificationRepositoryConfiguration.json
@@ -29,10 +29,6 @@
       "integrationRepository": "azure-sdk/azure-sdk-for-python",
       "mainRepository": "Azure/azure-sdk-for-python"
     },
-    "azure-sdk-for-python-track2": {
-      "integrationRepository": "azure-sdk/azure-sdk-for-python",
-      "mainRepository": "Azure/azure-sdk-for-python"
-    },
     "azure-resource-manager-schemas": {
       "integrationRepository": "azure-sdk/azure-resource-manager-schemas",
       "mainRepository": "Azure/azure-resource-manager-schemas"
@@ -69,10 +65,6 @@
           "configFilePath": "eng/swagger_to_sdk_config.json"
         },
         "azure-sdk-for-python": {
-          "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",
-          "mainRepository": "Azure/azure-sdk-for-python-pr"
-        },
-        "azure-sdk-for-python-track2": {
           "integrationRepository": "azure-sdk/azure-sdk-for-python-pr",
           "mainRepository": "Azure/azure-sdk-for-python-pr"
         },


### PR DESCRIPTION
There is no need to keep `-track2` since all the Python SDK is already track2 SDK now.
