### PR TITLE
Enable stream-style-serialization in Radiology Insights

### DIFF
--- a/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/tspconfig.yaml
+++ b/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/tspconfig.yaml
@@ -39,7 +39,6 @@ options:
     partial-update: true
     emitter-output-dir: "{java-sdk-folder}/sdk/{service-directory-name}/azure-health-insights-radiologyinsights"
     flavor: azure
-    stream-style-serialization: false
     polling:
       inferRadiologyInsights:
         final-type: com.azure.health.insights.radiologyinsights.models.RadiologyInsightsInferenceResult


### PR DESCRIPTION
Removes the `stream-style-serialization: false` from Radiology Insight's `tspconfig.yaml` to enable generating code without the usage of Jackson Databind.