### PR TITLE
[Event Grid] Update tspconfig.yaml for python SDK (DO NOT MERGE)

### DIFF
--- a/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/tspconfig.yaml
+++ b/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/tspconfig.yaml
@@ -21,7 +21,6 @@ options:
     package-version: 4.12.0b1
     package-dir: "azure-eventgrid"
     package-name: "{package-dir}"
-    emitter-output-dir: "{project-root}/{service-dir}/{package-name}"
     flavor: azure
   # Uncomment this line and add "@azure-tools/typespec-csharp" to your package.json to generate C# code
   "@azure-tools/typespec-csharp":


### PR DESCRIPTION
`emitter-output-dir` is not needed for Python SDK generation