### PR TITLE
Update readme.md to remove -track2 for python

### DIFF
--- a/specification/computeschedule/resource-manager/readme.md
+++ b/specification/computeschedule/resource-manager/readme.md
@@ -50,7 +50,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-python-track2
+  - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js


### PR DESCRIPTION
Remove -track2 word in readme.md for python there is no need to keep it now.