### PR TITLE
Microsoft.Monitor add missing etag attribute to /accounts

### DIFF
--- a/specification/monitor/Microsoft.Monitor.Management/tspconfig.yaml
+++ b/specification/monitor/Microsoft.Monitor.Management/tspconfig.yaml
@@ -14,3 +14,4 @@ options:
     examples-directory: "examples"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/azuremonitor.json"
     new-line: lf
+    omit-unreachable-types: true

--- a/specification/monitor/Microsoft.Monitor.Management/typespec/azureMonitorWorkspace.tsp
+++ b/specification/monitor/Microsoft.Monitor.Management/typespec/azureMonitorWorkspace.tsp
@@ -22,6 +22,11 @@ model AzureMonitorWorkspace
   @path
   @segment("accounts")
   name: string;
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "ETag is not included in TrackedResource."
+  @doc("Resource entity tag (ETag)")
+  @visibility("read")
+  etag?: string;
 }
 
 @doc("Properties that need to be specified to create a new workspace.")
@@ -32,6 +37,10 @@ model AzureMonitorWorkspaceProperties {
 
   @doc("Information about metrics for the Azure Monitor workspace")
   metrics?: Metrics;
+
+  @doc("The provisioning state of the Azure Monitor workspace. Set to Succeeded if everything is healthy.")
+  @visibility("read")
+  provisioningState?: ProvisioningState;
 
   @doc("The Data Collection Rule and Endpoint used for ingestion by default.")
   @visibility("read")
@@ -44,10 +53,6 @@ model AzureMonitorWorkspaceProperties {
   @doc("Gets or sets allow or disallow public network access to workspace")
   @visibility("read")
   publicNetworkAccess?: PublicNetworkAccess;
-
-  @doc("The provisioning state of the Azure Monitor workspace. Set to Succeeded if everything is healthy.")
-  @visibility("read")
-  provisioningState?: ProvisioningState;
 }
 
 @doc("Information about metrics for the workspace")

--- a/specification/monitor/resource-manager/Microsoft.Monitor/preview/2023-10-01-preview/azuremonitor.json
+++ b/specification/monitor/resource-manager/Microsoft.Monitor/preview/2023-10-01-preview/azuremonitor.json
@@ -749,6 +749,11 @@
           "$ref": "#/definitions/AzureMonitorWorkspaceProperties",
           "description": "The resource-specific properties for this resource.",
           "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource entity tag (ETag)",
+          "readOnly": true
         }
       },
       "allOf": [
@@ -843,6 +848,11 @@
           "$ref": "#/definitions/Metrics",
           "description": "Information about metrics for the Azure Monitor workspace"
         },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The provisioning state of the Azure Monitor workspace. Set to Succeeded if everything is healthy.",
+          "readOnly": true
+        },
         "defaultIngestionSettings": {
           "$ref": "#/definitions/IngestionSettings",
           "description": "The Data Collection Rule and Endpoint used for ingestion by default.",
@@ -859,11 +869,6 @@
         "publicNetworkAccess": {
           "$ref": "#/definitions/PublicNetworkAccess",
           "description": "Gets or sets allow or disallow public network access to workspace",
-          "readOnly": true
-        },
-        "provisioningState": {
-          "$ref": "#/definitions/ProvisioningState",
-          "description": "The provisioning state of the Azure Monitor workspace. Set to Succeeded if everything is healthy.",
           "readOnly": true
         }
       }
@@ -1724,78 +1729,6 @@
         }
       }
     },
-    "StreamEncodingType": {
-      "type": "string",
-      "description": "Encoding types for streams.",
-      "enum": [
-        "nop",
-        "utf-8",
-        "utf-16le",
-        "utf-16be",
-        "ascii",
-        "big5"
-      ],
-      "x-ms-enum": {
-        "name": "StreamEncodingType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "nop",
-            "value": "nop",
-            "description": "No encoding validation. Treats the file as a stream of raw bytes."
-          },
-          {
-            "name": "utf_8",
-            "value": "utf-8",
-            "description": "UTF-8 encoding."
-          },
-          {
-            "name": "utf_16le",
-            "value": "utf-16le",
-            "description": "UTF-16 encoding with little-endian byte order."
-          },
-          {
-            "name": "utf_16be",
-            "value": "utf-16be",
-            "description": "UTF-16 encoding with little-endian byte order."
-          },
-          {
-            "name": "ascii",
-            "value": "ascii",
-            "description": "ASCII encoding."
-          },
-          {
-            "name": "big5",
-            "value": "big5",
-            "description": "The Big5 Chinese character encoding."
-          }
-        ]
-      }
-    },
-    "SyslogProtocol": {
-      "type": "string",
-      "description": "The syslog protocol to parse messages.",
-      "enum": [
-        "rfc3164",
-        "rfc5424"
-      ],
-      "x-ms-enum": {
-        "name": "SyslogProtocol",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "rfc3164",
-            "value": "rfc3164",
-            "description": "rfc3164 protocol."
-          },
-          {
-            "name": "rfc5424",
-            "value": "rfc5424",
-            "description": "rfc5424 protocol."
-          }
-        ]
-      }
-    },
     "SyslogReceiver": {
       "type": "object",
       "description": "Base receiver using TCP as transport protocol.",
@@ -1847,20 +1780,6 @@
       },
       "required": [
         "url"
-      ]
-    },
-    "TcpReceiver": {
-      "type": "object",
-      "description": "Base receiver using TCP as transport protocol.",
-      "properties": {
-        "endpoint": {
-          "type": "string",
-          "description": "TCP endpoint definition. Example: 0.0.0.0:<port>.",
-          "pattern": "^[a-zA-Z0-9-\\.]+:[0-9]+$"
-        }
-      },
-      "required": [
-        "endpoint"
       ]
     },
     "UdpReceiver": {


### PR DESCRIPTION
Microsoft.Monitor add missing etag attribute to /accounts to keep backwards compatibility with non typespec version.

Similar updates are completed for private branch RPSaaSMaster.

Work item:
https://msazure.visualstudio.com/One/_workitems/edit/28464928

Work item:

https://msazure.visualstudio.com/One/_workitems/edit/28464928

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
