### PR TITLE
remove `-track2` for python sdk generation

### DIFF
--- a/documentation/ci-fix.md
+++ b/documentation/ci-fix.md
@@ -94,7 +94,6 @@ If you have an issue or with any of checks listed in the first column of the tab
 | `SDK azure-sdk-for-net`           | Wei Hu         |
 | `SDK azure-sdk-for-net-track2`    | Wei Hu         |
 | `SDK azure-sdk-for-python`        | Yuchao Yan     |
-| `SDK azure-sdk-for-python-track2` | Yuchao Yan     |
 
 Do the following:
 

--- a/specification/computeschedule/resource-manager/readme.md
+++ b/specification/computeschedule/resource-manager/readme.md
@@ -50,7 +50,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-python-track2
+  - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/healthdataaiservices/data-plane/HealthDataAIServices.DeidServices/readme.md
+++ b/specification/healthdataaiservices/data-plane/HealthDataAIServices.DeidServices/readme.md
@@ -54,7 +54,7 @@ This is not used by Autorest itself.
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-net-track2
-  - repo: azure-sdk-for-python-track2
+  - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-cli-extensions


### PR DESCRIPTION
There is no need to keep -track2 since all the Python SDK is already track2 SDK now.
Thanks [hint](https://github.com/Azure/azure-rest-api-specs/pull/29926#issuecomment-2245595741) from @weshaggard 