### PR TITLE
Adding source-sink for Mongo vCore

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-09-01-preview/dataTransferService.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2024-09-01-preview/dataTransferService.json
@@ -345,6 +345,7 @@
           "enum": [
             "CosmosDBCassandra",
             "CosmosDBMongo",
+            "CosmosDBMongoVCore",
             "CosmosDBSql",
             "AzureBlobStorage"
           ],
@@ -417,6 +418,34 @@
         "collectionName"
       ],
       "x-ms-discriminator-value": "CosmosDBMongo"
+    },
+    "CosmosMongoVCoreDataTransferDataSourceSink": {
+      "type": "object",
+      "description": "A CosmosDB Mongo vCore API data source/sink",
+      "properties": {
+        "databaseName": {
+          "type": "string"
+        },
+        "collectionName": {
+          "type": "string"
+        },
+        "hostName": {
+          "type": "string"
+        },
+        "connectionStringKeyVaultUri": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DataTransferDataSourceSink"
+        }
+      ],
+      "required": [
+        "databaseName",
+        "collectionName"
+      ],
+      "x-ms-discriminator-value": "CosmosDBMongoVCore"
     },
     "CosmosSqlDataTransferDataSourceSink": {
       "type": "object",


### PR DESCRIPTION
In this PR, we are adding support for Mongo vCore source/sink in the existing container copy APIs.
