### PR TITLE
Fix invalid versioning in client.tsp

### DIFF
--- a/specification/cognitiveservices/ContentSafety/client.tsp
+++ b/specification/cognitiveservices/ContentSafety/client.tsp
@@ -4,7 +4,7 @@ import "./main.tsp";
 using Azure.ClientGenerator.Core;
 
 @TypeSpec.Versioning.useDependency(Azure.Core.Versions.v1_0_Preview_2)
-@TypeSpec.Versioning.useDependency(ContentSafety.Versions.v2023_10_01)
+@TypeSpec.Versioning.useDependency(ContentSafety.Versions.v2024_02_15_Preview)
 namespace Customizations;
 
 @client({

--- a/specification/loadtestservice/LoadTestService/client.tsp
+++ b/specification/loadtestservice/LoadTestService/client.tsp
@@ -5,8 +5,6 @@ using TypeSpec.Versioning;
 using Azure.ClientGenerator.Core;
 using Microsoft.LoadTestService;
 
-@useDependency(APIVersions.v2022_11_01)
-@useDependency(APIVersions.v2023_04_01_preview)
 @useDependency(APIVersions.v2024_05_01_preview)
 namespace Customizations;
 


### PR DESCRIPTION
Those specs where specifying an older api verison but referencing operations added in new ones causing failure in new validation