### PR TITLE
update python config

### DIFF
--- a/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
@@ -1,0 +1,6 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+@@clientName(Microsoft.HealthDataAIServices, "HealthDataAIServicesMgmt", "python");

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
@@ -3,4 +3,7 @@ import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
 
-@@clientName(Microsoft.HealthDataAIServices, "HealthDataAIServicesMgmt", "python");
+@@clientName(Microsoft.HealthDataAIServices,
+  "HealthDataAIServicesMgmt",
+  "python"
+);


### PR DESCRIPTION
To release Python SDK of https://github.com/Azure/sdk-release-request/issues/5388, we need to configure client.tsp to specify the client name for greenfield SDKs.