### PR TITLE
Remove RequestMerge comment handler

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -2531,11 +2531,6 @@ configuration:
           label: no-recent-activity
       description: 
     - if:
-      - payloadType: Issue_Comment
-      - and:
-        - isPullRequest
-      then:
-    - if:
       - payloadType: Pull_Request
       then:
       - if:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -2535,13 +2535,6 @@ configuration:
       - and:
         - isPullRequest
       then:
-      - if:
-        - commentContains:
-            pattern: "^/pr RequestMerge$"
-            isRegex: true
-        then:
-        - addLabel:
-            label: MergeRequested
     - if:
       - payloadType: Pull_Request
       then:


### PR DESCRIPTION
Removes the RequestMerge comment handler from the gitops bot. 

Contributes to https://github.com/Azure/azure-sdk-tools/issues/7648
