### PR TITLE
change required property as optional for servicenetworking

### DIFF
--- a/specification/servicenetworking/ServiceNetworking.Management/main.tsp
+++ b/specification/servicenetworking/ServiceNetworking.Management/main.tsp
@@ -109,7 +109,7 @@ model SecurityPolicy is TrackedResource<SecurityPolicyProperties> {
 model SecurityPolicyProperties {
   /** Type of the Traffic Controller Security Policy */
   @visibility("read")
-  policyType: PolicyType;
+  policyType?: PolicyType;
 
   /** Web Application Firewall Policy of the Traffic Controller Security Policy */
   wafPolicy?: WafPolicy;

--- a/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/preview/2024-05-01-preview/TrafficController.json
+++ b/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/preview/2024-05-01-preview/TrafficController.json
@@ -1707,10 +1707,7 @@
           "description": "Provisioning State of Traffic Controller SecurityPolicy Resource",
           "readOnly": true
         }
-      },
-      "required": [
-        "policyType"
-      ]
+      }
     },
     "SecurityPolicyUpdate": {
       "type": "object",


### PR DESCRIPTION
fix as policyType is used in request and response but it's not alloewed in the following doc
https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/Semantic-and-Model-Violations-Reference.md#readonly_property_not_allowed_in_request
 