### PR TITLE
Added BlobAccessTierNotSupportedForAccountType to BlobErrorCode

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-01-05/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-01-05/blob.json
@@ -10608,7 +10608,8 @@
         "AuthorizationProtocolMismatch",
         "AuthorizationPermissionMismatch",
         "AuthorizationServiceMismatch",
-        "AuthorizationResourceTypeMismatch"
+        "AuthorizationResourceTypeMismatch",
+        "BlobAccessTierNotSupportedForAccountType"
       ],
       "x-ms-enum": {
         "name": "StorageErrorCode",


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
