### PR TITLE
doc, java, update typespec config

### DIFF
--- a/documentation/onboard-dpg-in-sdkautomation/java/README.md
+++ b/documentation/onboard-dpg-in-sdkautomation/java/README.md
@@ -3,7 +3,6 @@
 See [Use SDK Automation from REST API specifications](https://github.com/Azure/azure-sdk-for-java/wiki/TypeSpec-Java-Quickstart#use-sdk-automation-from-rest-api-specifications) in TypeSpec Java QuickStart.
 
 `flavor` is always `azure` for Azure SDK.
-`examples-directory` is same as that in e.g. typespec-autorest emitter.
 
 ## Example for Java data-plane SDK
 
@@ -16,7 +15,6 @@ See [Use SDK Automation from REST API specifications](https://github.com/Azure/a
     package-dir: "azure-ai-openai"
     flavor: azure
     namespace: "com.azure.ai.openai"
-    examples-directory: "{project-root}/examples"
 ```
 
 ## Example for Java management-plane SDK
@@ -33,7 +31,6 @@ See [Use SDK Automation from REST API specifications](https://github.com/Azure/a
     flavor: "azure"
     namespace: "com.azure.resourcemanager.standbypool"
     service-name: "Standby Pool"
-    examples-directory: "{project-root}/examples"
 ```
 
 # Add AutoRest Configuration for Java SDK 


### PR DESCRIPTION
1. recommended would now be `examples-dir`
2. `{project-root}/examples` is already the default value in typespec, in normal case service does not need to set it explicitly

I've searched the documentation folder, this is all what I found.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
