### PR TITLE
[recoveryservicessiterecovery] update python config

### DIFF
--- a/specification/recoveryservicessiterecovery/resource-manager/readme.python.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.python.md
@@ -32,15 +32,15 @@ directive:
 - from: swagger-document
   where: $.parameters.FabricName
   transform: >
-    $["x-ms-parameter-location"] = "client";
+    $["x-ms-parameter-location"] = "method";
 
 - from: swagger-document
   where: $.parameters.ProtectionContainerName
   transform: >
-    $["x-ms-parameter-location"] = "client";
+    $["x-ms-parameter-location"] = "method";
 
 - from: swagger-document
   where: $.parameters.ReplicationProtectionClusterName
   transform: >
-    $["x-ms-parameter-location"] = "client";
+    $["x-ms-parameter-location"] = "method";
 ```

--- a/specification/recoveryservicessiterecovery/resource-manager/readme.python.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.python.md
@@ -23,8 +23,24 @@ directive:
   where: $.parameters.ResourceGroupName
   transform: >
     $["x-ms-parameter-location"] = "client"; 
+
 - from: swagger-document
   where: $.parameters.ResourceName
+  transform: >
+    $["x-ms-parameter-location"] = "client";
+
+- from: swagger-document
+  where: $.parameters.FabricName
+  transform: >
+    $["x-ms-parameter-location"] = "client";
+
+- from: swagger-document
+  where: $.parameters.ProtectionContainerName
+  transform: >
+    $["x-ms-parameter-location"] = "client";
+
+- from: swagger-document
+  where: $.parameters.ReplicationProtectionClusterName
   transform: >
     $["x-ms-parameter-location"] = "client";
 ```

--- a/specification/recoveryservicessiterecovery/resource-manager/readme.python.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.python.md
@@ -16,3 +16,15 @@ clear-output-folder: true
 no-namespace-folders: true
 output-folder: $(python-sdks-folder)/recoveryservices/azure-mgmt-recoveryservicessiterecovery/azure/mgmt/recoveryservicessiterecovery
 ```
+
+``` yaml $(python)
+directive: 
+- from: swagger-document
+  where: $.parameters.ResourceGroupName
+  transform: >
+    $["x-ms-parameter-location"] = "client"; 
+- from: swagger-document
+  where: $.parameters.ResourceName
+  transform: >
+    $["x-ms-parameter-location"] = "client";
+```


### PR DESCRIPTION
Service team added unexpected `x-ms-parameter-location: client` in https://github.com/Azure/azure-rest-api-specs/blob/d85634405ec3b905f1b0bfc350e47cb704aedb61/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2024-04-01/service.json#L28032 which adds additional client signature in generated SDK. I have asked service team to remove it them in https://github.com/Azure/azure-rest-api-specs/pull/30307/commits/fd9c9ba499462f099ef0fd4a316c668d0bb27bc9 in https://github.com/Azure/azure-rest-api-specs/pull/30307.
However, Python SDK already GAed with these additional client signatures so we have to add python configuration to avoid breakings.