### PR TITLE
[typespec-next] Add conditionals for branch

### DIFF
--- a/.github/workflows/_reusable-eng-tools-test.yaml
+++ b/.github/workflows/_reusable-eng-tools-test.yaml
@@ -45,12 +45,19 @@ jobs:
             eng
             ${{ inputs.sparse-checkout-paths }}
 
+      # TODO: Merge latest from main/RPSaaSMaster after checkout
+
       - name: Use Node ${{ matrix.node-version }}.x
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}.x
 
-      - run: npm install --no-package-lock
+      - if: github.ref_name == 'typespec-next' || github.base_ref == 'typespec-next'
+        run: npm install --no-package-lock
+        shell: pwsh
+
+      - if: github.ref_name != 'typespec-next' && github.base_ref != 'typespec-next'
+        run: npm ci
         shell: pwsh
 
       - run: npm ls -a

--- a/eng/pipelines/templates/steps/merge-parent-if-typespec-next.yml
+++ b/eng/pipelines/templates/steps/merge-parent-if-typespec-next.yml
@@ -1,0 +1,24 @@
+steps:
+  - script: git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" merge -Xours origin/main
+    displayName: git merge origin/main
+    condition: |
+      and(
+        succeeded(),
+        eq(variables['Build.Repository.Name'], 'azure-rest-api-specs'),
+        or(
+          eq(variables['Build.SourceBranchName'], 'typespec-next'),
+          eq(variables['System.PullRequest.targetBranchName'], 'typespec-next')
+        )
+      )
+
+  - script: git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" merge -Xours origin/RPSaaSMaster
+    displayName: git merge origin/RPSaaSMaster
+    condition: |
+      and(
+        succeeded(),
+        eq(variables['Build.Repository.Name'], 'azure-rest-api-specs-pr'),
+        or(
+          eq(variables['Build.SourceBranchName'], 'typespec-next'),
+          eq(variables['System.PullRequest.targetBranchName'], 'typespec-next')
+        )
+      )

--- a/eng/pipelines/templates/steps/npm-install.yml
+++ b/eng/pipelines/templates/steps/npm-install.yml
@@ -13,6 +13,25 @@ steps:
 
   - script: npm install --no-package-lock
     displayName: npm install --no-package-lock
+    condition: |
+      and(
+        succeeded(),
+        or(
+          eq(variables['Build.SourceBranchName'], 'typespec-next'),
+          eq(variables['System.PullRequest.targetBranchName'], 'typespec-next')
+        )
+      )
+
+  - script: npm ci
+    displayName: npm ci
+    condition: |
+      and(
+        succeeded(),
+        and(
+          ne(variables['Build.SourceBranchName'], 'typespec-next'),
+          ne(variables['System.PullRequest.targetBranchName'], 'typespec-next')
+        )
+      )
 
   - script: npm ls -a
     displayName: npm ls -a

--- a/eng/pipelines/typespec-validation-all.yml
+++ b/eng/pipelines/typespec-validation-all.yml
@@ -53,8 +53,7 @@ jobs:
     vmImage: $(OSVmImage)
 
   steps:
-  - script: git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" merge -Xours origin/main
-    displayName: git merge origin/main
+  - template: /eng/pipelines/templates/steps/merge-parent-if-typespec-next.yml
 
   - template: /eng/pipelines/templates/steps/npm-install.yml
 

--- a/eng/pipelines/typespec-validation.yml
+++ b/eng/pipelines/typespec-validation.yml
@@ -8,8 +8,7 @@ jobs:
     vmImage: ubuntu-22.04
 
   steps:
-  - script: git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" merge -Xours origin/main
-    displayName: git merge origin/main
+  - template: /eng/pipelines/templates/steps/merge-parent-if-typespec-next.yml
 
   - template: /eng/pipelines/templates/steps/npm-install.yml
 
@@ -17,3 +16,24 @@ jobs:
       $(Build.SourcesDirectory)/eng/scripts/TypeSpec-Validation.ps1 -GitClean -BaseCommitish HEAD~2 -Verbose
     displayName: Validate Impacted Specs
     ignoreLASTEXITCODE: true
+    condition: |
+      and(
+        succeeded(),
+        or(
+          eq(variables['Build.SourceBranchName'], 'typespec-next'),
+          eq(variables['System.PullRequest.targetBranchName'], 'typespec-next')
+        )
+      )
+
+  - pwsh: |
+      $(Build.SourcesDirectory)/eng/scripts/TypeSpec-Validation.ps1 -GitClean -Verbose
+    displayName: Validate Impacted Specs
+    ignoreLASTEXITCODE: true
+    condition: |
+      and(
+        succeeded(),
+        and(
+          ne(variables['Build.SourceBranchName'], 'typespec-next'),
+          ne(variables['System.PullRequest.targetBranchName'], 'typespec-next')
+        )
+      )


### PR DESCRIPTION
If this works, going forward we should only need to update the `package.json` in `typespec-next`, rather than also needing to update the workflows.  Example of update we currently need: https://github.com/Azure/azure-rest-api-specs/commit/775d38d05fb2173159c604c2eaac1981c7d91fbf