### PR TITLE
fix: Remove default value for MQ servicename

### DIFF
--- a/specification/iotoperations/IoTOperations.Management/models/broker/listeners.tsp
+++ b/specification/iotoperations/IoTOperations.Management/models/broker/listeners.tsp
@@ -33,7 +33,7 @@ model BrokerListenerResource is ProxyResource<BrokerListenerProperties> {
 @doc("Defines a Broker listener. A listener is a collection of ports on which the broker accepts connections from clients.")
 model BrokerListenerProperties {
   @doc("Kubernetes Service name of this listener.")
-  serviceName?: string = "aio-mq-dmqtt-frontend";
+  serviceName?: string;
 
   @doc("Ports on which this listener accepts client connections.")
   @OpenAPI.extension("x-ms-identifiers", ["port"])

--- a/specification/iotoperations/resource-manager/Microsoft.IoTOperations/preview/2024-08-15-preview/iotoperations.json
+++ b/specification/iotoperations/resource-manager/Microsoft.IoTOperations/preview/2024-08-15-preview/iotoperations.json
@@ -3100,8 +3100,7 @@
       "properties": {
         "serviceName": {
           "type": "string",
-          "description": "Kubernetes Service name of this listener.",
-          "default": "aio-mq-dmqtt-frontend"
+          "description": "Kubernetes Service name of this listener."
         },
         "ports": {
           "type": "array",


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
