### PR TITLE
[ADLS Docs] Update Delete Path Documentation to callout versioning

### DIFF
--- a/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
@@ -2175,7 +2175,7 @@
       "delete": {
         "operationId": "Path_Delete",
         "summary": "Delete File | Delete Directory",
-        "description": "Delete the file or directory. This operation supports conditional HTTP requests.  For more information, see [Specifying Conditional Headers for Blob Service Operations](https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations).",
+        "description": "Delete the file or directory. This operation supports conditional HTTP requests.  For more information, see [Specifying Conditional Headers for Blob Service Operations](https://docs.microsoft.com/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations).  Note: The 'Path - Delete' API does not support deletion of blob versions. For more information on deleting blobs with versions, see [Delete Blob](https://learn.microsoft.com/rest/api/storageservices/delete-blob?tabs=microsoft-entra-id).",
         "tags": [
           "File and Directory Operations"
         ],


### PR DESCRIPTION
This PR aims to make it more clear to customers that the Delete Path APIs are not compatible with blobs with versions, and should instead be using the Delete Blobs API. This PR links to the documentation which shows customers the correct API and that `versionid` is an exposed parameter to this API while it is not on Delete Path.