### PR TITLE
[Microsoft.App] Removed daprAIConnectionString from ManagedEnvironment, replaced with daprAIInstrumentationKey

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/preview/2024-08-02-preview/ManagedEnvironments.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2024-08-02-preview/ManagedEnvironments.json
@@ -1616,11 +1616,6 @@
               "description": "Azure Monitor instrumentation key used by Dapr to export Service to Service communication telemetry",
               "x-ms-secret": true
             },
-            "daprAIConnectionString": {
-              "type": "string",
-              "description": "Application Insights connection string used by Dapr to export Service to Service communication telemetry",
-              "x-ms-secret": true
-            },
             "vnetConfiguration": {
               "description": "Vnet configuration for the environment",
               "$ref": "#/definitions/VnetConfiguration"


### PR DESCRIPTION
# Choose a PR Template

The `daprAIConnectionString` property has been removed from ManagedEnvironment and replaced with `daprAIInstrumentationKey`.

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
