### PR TITLE
[mongocluster] Update tspconfig.yaml for SDK generation

### DIFF
--- a/specification/mongocluster/DocumentDB.MongoCluster.Management/tspconfig.yaml
+++ b/specification/mongocluster/DocumentDB.MongoCluster.Management/tspconfig.yaml
@@ -16,6 +16,7 @@ options:
     generate-test: true
     generate-sample: true
     examples-dir: "{project-root}/examples"
+    api-version: "2024-06-01-preview"
   "@azure-tools/typespec-java":
     package-dir: "azure-resourcemanager-mongocluster"
     flavor: "azure"

--- a/specification/mongocluster/DocumentDB.MongoCluster.Management/tspconfig.yaml
+++ b/specification/mongocluster/DocumentDB.MongoCluster.Management/tspconfig.yaml
@@ -22,6 +22,7 @@ options:
     flavor: "azure"
     namespace: "com.azure.resourcemanager.mongocluster"
     service-name: "Mongo Cluster"
+    api-version: "2024-06-01-preview"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/mongocluster"
     package-dir: "armmongocluster"


### PR DESCRIPTION
Since latest api-version for mongocluster is `2024-07-01` while service hope we could release `2024-06-01-preview` at first,  we have to add api-version in tspconfig.yaml so that SDK could be generated with the targeted API version.

for https://github.com/Azure/sdk-release-request/issues/5489