### PR TITLE
[VideoTranslation]Rename operation ID for translation/iteration creation API due to we don't support replace in the API.

### DIFF
--- a/specification/cognitiveservices/Speech.VideoTranslation/examples/2024-05-20-preview/IterationOperations_CreateIteration.json
+++ b/specification/cognitiveservices/Speech.VideoTranslation/examples/2024-05-20-preview/IterationOperations_CreateIteration.json
@@ -1,6 +1,6 @@
 {
   "title": "Create Iteration",
-  "operationId": "IterationOperations_CreateOrReplaceIteration",
+  "operationId": "IterationOperations_CreateIteration",
   "parameters": {
     "Endpoint": "https://eastus.api.cognitive.microsoft.com/",
     "api-version": "2024-05-20-preview",

--- a/specification/cognitiveservices/Speech.VideoTranslation/examples/2024-05-20-preview/TranslationOperations_CreateTranslation.json
+++ b/specification/cognitiveservices/Speech.VideoTranslation/examples/2024-05-20-preview/TranslationOperations_CreateTranslation.json
@@ -1,6 +1,6 @@
 {
   "title": "Create Translation",
-  "operationId": "TranslationOperations_CreateOrReplaceTranslation",
+  "operationId": "TranslationOperations_CreateTranslation",
   "parameters": {
     "Endpoint": "https://eastus.api.cognitive.microsoft.com/",
     "api-version": "2024-05-20-preview",

--- a/specification/cognitiveservices/Speech.VideoTranslation/main.tsp
+++ b/specification/cognitiveservices/Speech.VideoTranslation/main.tsp
@@ -275,8 +275,7 @@ model Operation {
 
 interface TranslationOperations {
   // LongRunningResourceCreateOrReplace will generate PUT, to align with CNV other creation operation.
-  // Because auto generated operation ID contains OrReplace(TranslationOperations_CreateOrReplaceTranslation), which will cause the operation title of the API doc's to be "Translation Operations - Create Or Replace Translation"
-  // Because we don't support replace, specify the operation ID explicitly to avoid the misunderstanding API description.
+  #suppress "@azure-tools/typespec-azure-core/no-operation-id" "Because auto generated operation ID contains OrReplace(TranslationOperations_CreateOrReplaceTranslation), which will cause the operation title of the API doc's to be [Translation Operations - Create Or Replace Translation], because we don't support replace, specify the operation ID explicitly to avoid the misunderstanding API description."
   @doc("Creates a translation.")
   @TypeSpec.OpenAPI.operationId("TranslationOperations_CreateTranslation")
   @pollingOperation(OperationOperations.getOperation)
@@ -300,11 +299,10 @@ interface TranslationOperations {
 
 interface IterationOperations {
   // LongRunningResourceCreateOrReplace will generate PUT, to align with CNV other creation operation.
-  // Because auto generated operation ID contains OrReplace(IterationOperations_CreateOrReplaceIteration), which will cause the operation title of the API doc's to be "Iteration Operations - Create Or Replace Iteration"
-  // Because we don't support replace, specify the operation ID explicitly to avoid the misunderstanding API description.
+  #suppress "@azure-tools/typespec-azure-core/no-operation-id" "Because auto generated operation ID contains OrReplace(IterationOperations_CreateOrReplaceIteration), which will cause the operation title of the API doc's to be [Iteration Operations - Create Or Replace Iteration], because we don't support replace, specify the operation ID explicitly to avoid the misunderstanding API description."
+  @TypeSpec.OpenAPI.operationId("IterationOperations_CreateIteration")
   @doc("Creates an iteration.")
   @pollingOperation(OperationOperations.getOperation)
-  @TypeSpec.OpenAPI.operationId("IterationOperations_CreateIteration")
   createOrReplaceIteration is ops.LongRunningResourceCreateOrReplace<
     Iteration,
     RequestHeadersTrait<OperationIdHeader>

--- a/specification/cognitiveservices/Speech.VideoTranslation/main.tsp
+++ b/specification/cognitiveservices/Speech.VideoTranslation/main.tsp
@@ -276,8 +276,9 @@ model Operation {
 interface TranslationOperations {
   // LongRunningResourceCreateOrReplace will generate PUT, to align with CNV other creation operation.
   #suppress "@azure-tools/typespec-azure-core/no-operation-id" "Because auto generated operation ID contains OrReplace(TranslationOperations_CreateOrReplaceTranslation), which will cause the operation title of the API doc's to be [Translation Operations - Create Or Replace Translation], because we don't support replace, specify the operation ID explicitly to avoid the misunderstanding API description."
-  @doc("Creates a translation.")
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "The same as @azure-tools/typespec-azure-core/no-operation-id, no-operation-id is warning by tsp compile while no-openapi is validation by PR TypeSpec Validation pipeline."
   @TypeSpec.OpenAPI.operationId("TranslationOperations_CreateTranslation")
+  @doc("Creates a translation.")
   @pollingOperation(OperationOperations.getOperation)
   createOrReplaceTranslation is ops.LongRunningResourceCreateOrReplace<
     Translation,
@@ -300,6 +301,7 @@ interface TranslationOperations {
 interface IterationOperations {
   // LongRunningResourceCreateOrReplace will generate PUT, to align with CNV other creation operation.
   #suppress "@azure-tools/typespec-azure-core/no-operation-id" "Because auto generated operation ID contains OrReplace(IterationOperations_CreateOrReplaceIteration), which will cause the operation title of the API doc's to be [Iteration Operations - Create Or Replace Iteration], because we don't support replace, specify the operation ID explicitly to avoid the misunderstanding API description."
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "The same as @azure-tools/typespec-azure-core/no-operation-id, no-operation-id is warning by tsp compile while no-openapi is validation by PR TypeSpec Validation pipeline."
   @TypeSpec.OpenAPI.operationId("IterationOperations_CreateIteration")
   @doc("Creates an iteration.")
   @pollingOperation(OperationOperations.getOperation)

--- a/specification/cognitiveservices/Speech.VideoTranslation/main.tsp
+++ b/specification/cognitiveservices/Speech.VideoTranslation/main.tsp
@@ -170,7 +170,7 @@ model IterationResult {
 
 @doc("Iteration input.")
 model IterationInput {
-  @doc("Webvtt file for content editing.")
+  @doc("Webvtt file for content editing, this parameter is required from the second iteration creation request of the translation.")
   webvttFile?: WebvttFile;
 
   @doc("Number of speakers in the video.")
@@ -275,7 +275,10 @@ model Operation {
 
 interface TranslationOperations {
   // LongRunningResourceCreateOrReplace will generate PUT, to align with CNV other creation operation.
+  // Because auto generated operation ID contains OrReplace(TranslationOperations_CreateOrReplaceTranslation), which will cause the operation title of the API doc's to be "Translation Operations - Create Or Replace Translation"
+  // Because we don't support replace, specify the operation ID explicitly to avoid the misunderstanding API description.
   @doc("Creates a translation.")
+  @TypeSpec.OpenAPI.operationId("TranslationOperations_CreateTranslation")
   @pollingOperation(OperationOperations.getOperation)
   createOrReplaceTranslation is ops.LongRunningResourceCreateOrReplace<
     Translation,
@@ -297,8 +300,11 @@ interface TranslationOperations {
 
 interface IterationOperations {
   // LongRunningResourceCreateOrReplace will generate PUT, to align with CNV other creation operation.
+  // Because auto generated operation ID contains OrReplace(IterationOperations_CreateOrReplaceIteration), which will cause the operation title of the API doc's to be "Iteration Operations - Create Or Replace Iteration"
+  // Because we don't support replace, specify the operation ID explicitly to avoid the misunderstanding API description.
   @doc("Creates an iteration.")
   @pollingOperation(OperationOperations.getOperation)
+  @TypeSpec.OpenAPI.operationId("IterationOperations_CreateIteration")
   createOrReplaceIteration is ops.LongRunningResourceCreateOrReplace<
     Iteration,
     RequestHeadersTrait<OperationIdHeader>

--- a/specification/cognitiveservices/data-plane/Speech/VideoTranslation/preview/2024-05-20-preview/VideoTranslation.json
+++ b/specification/cognitiveservices/data-plane/Speech/VideoTranslation/preview/2024-05-20-preview/VideoTranslation.json
@@ -221,7 +221,7 @@
         }
       },
       "put": {
-        "operationId": "TranslationOperations_CreateOrReplaceTranslation",
+        "operationId": "TranslationOperations_CreateTranslation",
         "tags": [
           "VideoTranslation"
         ],
@@ -295,7 +295,7 @@
         },
         "x-ms-examples": {
           "Create Translation": {
-            "$ref": "./examples/TranslationOperations_CreateOrReplaceTranslation.json"
+            "$ref": "./examples/TranslationOperations_CreateTranslation.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -468,7 +468,7 @@
         }
       },
       "put": {
-        "operationId": "IterationOperations_CreateOrReplaceIteration",
+        "operationId": "IterationOperations_CreateIteration",
         "tags": [
           "VideoTranslation"
         ],
@@ -552,7 +552,7 @@
         },
         "x-ms-examples": {
           "Create Iteration": {
-            "$ref": "./examples/IterationOperations_CreateOrReplaceIteration.json"
+            "$ref": "./examples/IterationOperations_CreateIteration.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -680,7 +680,7 @@
       "properties": {
         "webvttFile": {
           "$ref": "#/definitions/WebvttFile",
-          "description": "Webvtt file for content editing."
+          "description": "Webvtt file for content editing, this parameter is required from the second iteration creation request of the translation."
         },
         "speakerCount": {
           "type": "integer",

--- a/specification/cognitiveservices/data-plane/Speech/VideoTranslation/preview/2024-05-20-preview/examples/IterationOperations_CreateIteration.json
+++ b/specification/cognitiveservices/data-plane/Speech/VideoTranslation/preview/2024-05-20-preview/examples/IterationOperations_CreateIteration.json
@@ -1,6 +1,6 @@
 {
   "title": "Create Iteration",
-  "operationId": "IterationOperations_CreateOrReplaceIteration",
+  "operationId": "IterationOperations_CreateIteration",
   "parameters": {
     "Endpoint": "https://eastus.api.cognitive.microsoft.com/",
     "api-version": "2024-05-20-preview",

--- a/specification/cognitiveservices/data-plane/Speech/VideoTranslation/preview/2024-05-20-preview/examples/TranslationOperations_CreateTranslation.json
+++ b/specification/cognitiveservices/data-plane/Speech/VideoTranslation/preview/2024-05-20-preview/examples/TranslationOperations_CreateTranslation.json
@@ -1,6 +1,6 @@
 {
   "title": "Create Translation",
-  "operationId": "TranslationOperations_CreateOrReplaceTranslation",
+  "operationId": "TranslationOperations_CreateTranslation",
   "parameters": {
     "Endpoint": "https://eastus.api.cognitive.microsoft.com/",
     "api-version": "2024-05-20-preview",


### PR DESCRIPTION
Rename operation ID for translation/iteration creation API due to we don't support replace in the API.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
