### PR TITLE
[protected-files] If no changes, write to log instead of notice

### DIFF
--- a/.github/workflows/protected-files.yaml
+++ b/.github/workflows/protected-files.yaml
@@ -29,6 +29,6 @@ jobs:
           exit 1
         }
         else {
-          Write-Output "::notice::No changes to protected files: [$($protectedFiles -join ', ')]"
+          Write-Output "No changes to protected files: [$($protectedFiles -join ', ')]"
         }
       shell: pwsh


### PR DESCRIPTION
- Notice is too noisy for non-problem logs
