### PR TITLE
AOAI Fix Custom Blocklist Properties to Optional

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/azure_content_filtering.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/azure_content_filtering.tsp
@@ -191,5 +191,5 @@ model ContentFilterDetailedResults {
   ...FilteredResultBase;
 
   @doc("The collection of detailed blocklist result information.")
-  details: ContentFilterBlocklistIdResult[];
+  details?: ContentFilterBlocklistIdResult[];
 }

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-04-01-preview/inference.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-04-01-preview/inference.json
@@ -3005,8 +3005,7 @@
           }
         ],
         "required": [
-          "filtered",
-          "details"
+          "filtered"
         ]
       },
       "promptFilterResult": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-04-01-preview/inference.yaml
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-04-01-preview/inference.yaml
@@ -1973,7 +1973,6 @@ components:
                         type: array
         required:
             - filtered
-            - details
     promptFilterResult:
       type: object
       description: Content filtering results for a single prompt in the request.

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-05-01-preview/inference.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-05-01-preview/inference.json
@@ -3465,8 +3465,7 @@
           }
         ],
         "required": [
-          "filtered",
-          "details"
+          "filtered"
         ]
       },
       "promptFilterResult": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-05-01-preview/inference.yaml
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-05-01-preview/inference.yaml
@@ -2238,7 +2238,6 @@ components:
                         type: array
         required:
             - filtered
-            - details
     promptFilterResult:
       type: object
       description: Content filtering results for a single prompt in the request.

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-07-01-preview/inference.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-07-01-preview/inference.json
@@ -3465,8 +3465,7 @@
           }
         ],
         "required": [
-          "filtered",
-          "details"
+          "filtered"
         ]
       },
       "promptFilterResult": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-07-01-preview/inference.yaml
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-07-01-preview/inference.yaml
@@ -2238,7 +2238,6 @@ components:
                         type: array
         required:
             - filtered
-            - details
     promptFilterResult:
       type: object
       description: Content filtering results for a single prompt in the request.

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-08-01-preview/inference.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-08-01-preview/inference.json
@@ -3251,8 +3251,7 @@
           }
         ],
         "required": [
-          "filtered",
-          "details"
+          "filtered"
         ]
       },
       "promptFilterResult": {


### PR DESCRIPTION
The service returns `custom_blocklist` when the deployment has a custom blocklist applied. `custom_blocklist` is of type `contentFilterDetailedResults`, and the `details` is marked as required in the spec. 

However, when `filtered` is false for custom blocklists, the service does not return any details since there is nothing that is filtered. The spec should match the service behavior and mark property `details` as optional