### PR TITLE
{AKS}: remove `default` from networkPlugin

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-09-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2024-09-02-preview/managedClusters.json
@@ -8741,7 +8741,6 @@
         "kubenet",
         "none"
       ],
-      "default": "kubenet",
       "x-ms-enum": {
         "name": "NetworkPlugin",
         "modelAsString": true,


### PR DESCRIPTION
NetworkPlugin will be defaulted based on k8s version rather than API version going forward. The default value in k8s < 1.30 will remain kubenet while in 1.30+ it will be CNI Overlay.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
