### PR TITLE
Remove out of date codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -111,7 +111,7 @@
 /specification/deviceregistry/ @marcodalessandro @rohankhandelwal @riteshrao
 
 # PRLabel: %Device Update
-/specification/deviceupdate/data-plane/ @mikekistler @Azure/api-stewardship-board
+/specification/deviceupdate/data-plane/ @Azure/api-stewardship-board
 
 /specification/documentdb/ @dmakwana
 
@@ -142,7 +142,7 @@
 /specification/keyvault/ @heaths @randallilama @jlichwa
 
 # PRLabel: %Load Test Service
-/specification/loadtestservice/data-plane/ @mikekistler @Azure/api-stewardship-board
+/specification/loadtestservice/data-plane/ @Azure/api-stewardship-board
 
 # PRLabel: %Logic App
 /specification/logic/ @pankajsn @tonytang-microsoft-com
@@ -182,7 +182,7 @@
 /specification/powerbidedicated/ @tarostok
 
 # PRLabel: %Purview
-/specification/purview/data-plane @mikekistler @Azure/api-stewardship-board
+/specification/purview/data-plane @Azure/api-stewardship-board
 
 # PRLabel: %PostgreSQL
 /specification/postgresql/** @Azure/azure-sdk-write-postgresql


### PR DESCRIPTION
Former owner failing the linter - see https://dev.azure.com/azure-sdk/public/_build/results?buildId=4196244&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=8c98ab76-57b2-59d0-3d3a-18dce788f3ba