### PR TITLE
Updates TypeSpec-generated OpenAPI3 models to make details optional

### DIFF
--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-04-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-04-01-preview/generated.json
@@ -3119,8 +3119,7 @@
         }
       },
       "required": [
-        "filtered",
-        "details"
+        "filtered"
       ]
     },
     "ContentFilterDetectionResult": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-05-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-05-01-preview/generated.json
@@ -3274,8 +3274,7 @@
         }
       },
       "required": [
-        "filtered",
-        "details"
+        "filtered"
       ]
     },
     "ContentFilterDetectionResult": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-07-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-07-01-preview/generated.json
@@ -3951,8 +3951,7 @@
         }
       },
       "required": [
-        "filtered",
-        "details"
+        "filtered"
       ]
     },
     "ContentFilterDetectionResult": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-06-01/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-06-01/generated.json
@@ -3274,8 +3274,7 @@
         }
       },
       "required": [
-        "filtered",
-        "details"
+        "filtered"
       ]
     },
     "ContentFilterDetectionResult": {


### PR DESCRIPTION
#30632 made the `details` field in content filtering optional. However the TypeSpec validation was failing due to a few generated files being missing from that PR.

This updates the generated.json files for Azure Open AI.
