### PR TITLE
Fix environment patch

### DIFF
--- a/specification/devcenter/DevCenter/Environments/models.tsp
+++ b/specification/devcenter/DevCenter/Environments/models.tsp
@@ -223,7 +223,9 @@ alias EnvironmentUpdateProperties = {
   parameters?: Record<unknown>;
 };
 
-alias EnvironmentPatchProperties = {
+@doc("Properties of an environment. These properties can be updated via PATCH after the resource has been created.")
+@added(APIVersions.v2024_02_01)
+model EnvironmentPatchProperties {
   @doc("""
     The time the expiration date will be triggered (UTC), after which the
     environment and associated resources will be deleted.

--- a/specification/devcenter/DevCenter/Environments/models.tsp
+++ b/specification/devcenter/DevCenter/Environments/models.tsp
@@ -232,7 +232,7 @@ model EnvironmentPatchProperties {
     """)
   @added(APIVersions.v2024_02_01)
   expirationDate?: utcDateTime;
-};
+}
 
 @doc("Outputs from environment deployment.")
 @added(APIVersions.v2024_02_01)

--- a/specification/devcenter/DevCenter/Environments/routes.tsp
+++ b/specification/devcenter/DevCenter/Environments/routes.tsp
@@ -88,7 +88,7 @@ interface Environments {
 
       @doc("Represents an environment.")
       @body
-      body: Environment;
+      body: EnvironmentPatchProperties;
     },
     Environment
   >;

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-05-01-preview/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-05-01-preview/devcenter.json
@@ -2759,7 +2759,14 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/EnvironmentUpdate"
+              "type": "object",
+              "properties": {
+                "expirationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
+                }
+              }
             }
           }
         ],
@@ -5298,22 +5305,6 @@
             "description": "The environment type is not enabled for use in the project."
           }
         ]
-      }
-    },
-    "EnvironmentUpdate": {
-      "type": "object",
-      "description": "Properties of an environment.",
-      "properties": {
-        "expirationDate": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-        },
-        "parameters": {
-          "type": "object",
-          "description": "Parameters object for the environment.",
-          "additionalProperties": {}
-        }
       }
     },
     "HardwareProfile": {

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-05-01-preview/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-05-01-preview/devcenter.json
@@ -2759,14 +2759,7 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "expirationDate": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-                }
-              }
+              "$ref": "#/definitions/EnvironmentPatchProperties"
             }
           }
         ],
@@ -5033,6 +5026,17 @@
           "additionalProperties": {
             "$ref": "#/definitions/EnvironmentOutput"
           }
+        }
+      }
+    },
+    "EnvironmentPatchProperties": {
+      "type": "object",
+      "description": "Properties of an environment. These properties can be updated via PATCH after the resource has been created.",
+      "properties": {
+        "expirationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
         }
       }
     },

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-08-01-preview/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-08-01-preview/devcenter.json
@@ -2810,7 +2810,14 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/EnvironmentUpdate"
+              "type": "object",
+              "properties": {
+                "expirationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
+                }
+              }
             }
           }
         ],
@@ -5349,22 +5356,6 @@
             "description": "The environment type is not enabled for use in the project."
           }
         ]
-      }
-    },
-    "EnvironmentUpdate": {
-      "type": "object",
-      "description": "Properties of an environment.",
-      "properties": {
-        "expirationDate": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-        },
-        "parameters": {
-          "type": "object",
-          "description": "Parameters object for the environment.",
-          "additionalProperties": {}
-        }
       }
     },
     "HardwareProfile": {

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-08-01-preview/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-08-01-preview/devcenter.json
@@ -2810,14 +2810,7 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "expirationDate": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-                }
-              }
+              "$ref": "#/definitions/EnvironmentPatchProperties"
             }
           }
         ],
@@ -5084,6 +5077,17 @@
           "additionalProperties": {
             "$ref": "#/definitions/EnvironmentOutput"
           }
+        }
+      }
+    },
+    "EnvironmentPatchProperties": {
+      "type": "object",
+      "description": "Properties of an environment. These properties can be updated via PATCH after the resource has been created.",
+      "properties": {
+        "expirationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
         }
       }
     },

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-09-01-preview/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-09-01-preview/devcenter.json
@@ -3029,14 +3029,7 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "expirationDate": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-                }
-              }
+              "$ref": "#/definitions/EnvironmentPatchProperties"
             }
           }
         ],
@@ -5355,6 +5348,17 @@
           "additionalProperties": {
             "$ref": "#/definitions/EnvironmentOutput"
           }
+        }
+      }
+    },
+    "EnvironmentPatchProperties": {
+      "type": "object",
+      "description": "Properties of an environment. These properties can be updated via PATCH after the resource has been created.",
+      "properties": {
+        "expirationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
         }
       }
     },

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-09-01-preview/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-09-01-preview/devcenter.json
@@ -3029,7 +3029,14 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/EnvironmentUpdate"
+              "type": "object",
+              "properties": {
+                "expirationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
+                }
+              }
             }
           }
         ],
@@ -5620,22 +5627,6 @@
             "description": "The environment type is not enabled for use in the project."
           }
         ]
-      }
-    },
-    "EnvironmentUpdate": {
-      "type": "object",
-      "description": "Properties of an environment.",
-      "properties": {
-        "expirationDate": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-        },
-        "parameters": {
-          "type": "object",
-          "description": "Parameters object for the environment.",
-          "additionalProperties": {}
-        }
       }
     },
     "HardwareProfile": {

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-10-01-preview/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-10-01-preview/devcenter.json
@@ -3103,14 +3103,7 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "expirationDate": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-                }
-              }
+              "$ref": "#/definitions/EnvironmentPatchProperties"
             }
           }
         ],
@@ -5463,6 +5456,17 @@
           "additionalProperties": {
             "$ref": "#/definitions/EnvironmentOutput"
           }
+        }
+      }
+    },
+    "EnvironmentPatchProperties": {
+      "type": "object",
+      "description": "Properties of an environment. These properties can be updated via PATCH after the resource has been created.",
+      "properties": {
+        "expirationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
         }
       }
     },

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-10-01-preview/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/preview/2024-10-01-preview/devcenter.json
@@ -3103,7 +3103,14 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/EnvironmentUpdate"
+              "type": "object",
+              "properties": {
+                "expirationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
+                }
+              }
             }
           }
         ],
@@ -5728,22 +5735,6 @@
             "description": "The environment type is not enabled for use in the project."
           }
         ]
-      }
-    },
-    "EnvironmentUpdate": {
-      "type": "object",
-      "description": "Properties of an environment.",
-      "properties": {
-        "expirationDate": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-        },
-        "parameters": {
-          "type": "object",
-          "description": "Parameters object for the environment.",
-          "additionalProperties": {}
-        }
       }
     },
     "HardwareProfile": {

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/stable/2024-02-01/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/stable/2024-02-01/devcenter.json
@@ -2142,7 +2142,14 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/EnvironmentUpdate"
+              "type": "object",
+              "properties": {
+                "expirationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
+                }
+              }
             }
           }
         ],
@@ -4079,22 +4086,6 @@
             "description": "The environment type is not enabled for use in the project."
           }
         ]
-      }
-    },
-    "EnvironmentUpdate": {
-      "type": "object",
-      "description": "Properties of an environment.",
-      "properties": {
-        "expirationDate": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-        },
-        "parameters": {
-          "type": "object",
-          "description": "Parameters object for the environment.",
-          "additionalProperties": {}
-        }
       }
     },
     "HardwareProfile": {

--- a/specification/devcenter/data-plane/Microsoft.DevCenter/stable/2024-02-01/devcenter.json
+++ b/specification/devcenter/data-plane/Microsoft.DevCenter/stable/2024-02-01/devcenter.json
@@ -2142,14 +2142,7 @@
             "description": "Represents an environment.",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "expirationDate": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
-                }
-              }
+              "$ref": "#/definitions/EnvironmentPatchProperties"
             }
           }
         ],
@@ -3934,6 +3927,17 @@
           "additionalProperties": {
             "$ref": "#/definitions/EnvironmentOutput"
           }
+        }
+      }
+    },
+    "EnvironmentPatchProperties": {
+      "type": "object",
+      "description": "Properties of an environment. These properties can be updated via PATCH after the resource has been created.",
+      "properties": {
+        "expirationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time the expiration date will be triggered (UTC), after which the\nenvironment and associated resources will be deleted."
         }
       }
     },


### PR DESCRIPTION
Environment has two properties that can be updated after resource creation: `expirationDate` and `parameters`. However, `parameters` can only be updated during CreateOrReplace and not Patch, as its update results in a LRO.

During the transition from Swagger to TypeSpec, we mistakenly indicated that both properties could be updated during the patch operation. This pull request aims to correct that.

No SDK for 2024-02-01 - when the patch operation got added - has been released, so we don't foresee any incompatibility issues. Our backend has never accepted `parameters` in the patch operation, so this change will be a fix to the [documentation ](https://learn.microsoft.com/en-us/rest/api/devcenter/developer/environments/patch-environment?view=rest-devcenter-developer-2024-02-01&tabs=HTTP#request-body)

