### PR TITLE
[dependabot.yml] Allow all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-name: "@azure-tools/*"
-      - dependency-name: "@typespec/*"
-    groups:
-      typespec:
-        patterns:
-          - "*"


### PR DESCRIPTION
- Previous "allow" and "groups" may have been unintentionally disallowing some updates
- Can ignore specific dependencies if defaults are too noisy
