### PR TITLE
Remove stream-style-serialization: false from Document Translation

### DIFF
--- a/specification/translation/Azure.AI.DocumentTranslation/tspconfig.yaml
+++ b/specification/translation/Azure.AI.DocumentTranslation/tspconfig.yaml
@@ -37,7 +37,6 @@ options:
     partial-update: true
     generate-tests: false
     flavor: azure
-    stream-style-serialization: false
     generate-sample-project: false
   "@azure-tools/typespec-ts":
     package-dir: "ai-translation-document-rest"


### PR DESCRIPTION
Remove the `tsp.config.yaml` setting `stream-style-serialization: false` from the Java settings to have Document Translation use `azure-json` instead of Jackson for serialization.