### PR TITLE
Remove adp from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,8 +16,6 @@
 # PRLabel: %Cognitive Services
 /dev/cognitiveservices/data-plane/Language/ @assafi @rokulka @ChongTang @annatisch @heaths @deyaaeldeen @kristapratico @mssfang @joseharriaga @minhanh-phan @Azure/api-stewardship-board
 
-/specification/adp/ @Azure/adp
-
 # PRLabel: %FarmBeats
 /specification/agrifood/data-plane @Azure/api-stewardship-board
 


### PR DESCRIPTION
adp spec was removed in https://github.com/Azure/azure-rest-api-specs/pull/30648 so removing the entry from codeowners.

