### PR TITLE
Azure.AI.Projects TypeSpec updates to support making two REST API calls to get AppInsights connection string

### DIFF
--- a/specification/ai/Azure.AI.Projects/connections/client.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/client.tsp
@@ -2,10 +2,11 @@ import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
 
-@@access(Azure.AI.Projects.Connections.get, Access.internal);
-@@access(Azure.AI.Projects.Connections.list, Access.internal);
-@@access(Azure.AI.Projects.Connections.listSecrets, Access.internal);
-@@access(Azure.AI.Projects.ConnectionsListSecretsResponse, Access.internal);
+@@access(Azure.AI.Projects.Connections.getWorkspace, Access.internal);
+@@access(Azure.AI.Projects.Connections.listConnections, Access.internal);
+@@access(Azure.AI.Projects.Connections.getConnection, Access.internal);
+@@access(Azure.AI.Projects.Connections.getConnectionWithSecrets, Access.internal);
+@@access(Azure.AI.Projects.GetConnectionResponse, Access.internal);
 @@access(Azure.AI.Projects.ConnectionProperties, Access.internal);
 @@access(Azure.AI.Projects.ConnectionPropertiesApiKeyAuth, Access.internal);
 @@access(Azure.AI.Projects.ConnectionPropertiesAADAuth, Access.internal);

--- a/specification/ai/Azure.AI.Projects/connections/client.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/client.tsp
@@ -5,7 +5,9 @@ using Azure.ClientGenerator.Core;
 @@access(Azure.AI.Projects.Connections.getWorkspace, Access.internal);
 @@access(Azure.AI.Projects.Connections.listConnections, Access.internal);
 @@access(Azure.AI.Projects.Connections.getConnection, Access.internal);
-@@access(Azure.AI.Projects.Connections.getConnectionWithSecrets, Access.internal);
+@@access(Azure.AI.Projects.Connections.getConnectionWithSecrets,
+  Access.internal
+);
 @@access(Azure.AI.Projects.GetConnectionResponse, Access.internal);
 @@access(Azure.AI.Projects.ConnectionProperties, Access.internal);
 @@access(Azure.AI.Projects.ConnectionPropertiesApiKeyAuth, Access.internal);

--- a/specification/ai/Azure.AI.Projects/connections/model.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/model.tsp
@@ -16,7 +16,7 @@ namespace Azure.AI.Projects;
 
 @doc("Response from the Workspace - Get operation")
 model GetWorkspaceResponse {
-  @doc("A unique identifier for the resouce")
+  @doc("A unique identifier for the resource")
   id: string;
 
   @doc("The name of the resource")

--- a/specification/ai/Azure.AI.Projects/connections/model.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/model.tsp
@@ -28,7 +28,6 @@ model GetWorkspaceResponse {
 
 @doc("workspace properties")
 model WorkspaceProperties {
-
   @doc("Authentication type of the connection target")
   applicationInsights: string;
 }

--- a/specification/ai/Azure.AI.Projects/connections/model.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/model.tsp
@@ -14,8 +14,27 @@ using Azure.Core.Traits;
 
 namespace Azure.AI.Projects;
 
+@doc("Response from the Workspace - Get operation")
+model GetWorkspaceResponse {
+  @doc("A unique identifier for the resouce")
+  id: string;
+
+  @doc("The name of the resource")
+  name: string;
+
+  @doc("The properties of the resource")
+  properties: WorkspaceProperties;
+}
+
+@doc("workspace properties")
+model WorkspaceProperties {
+
+  @doc("Authentication type of the connection target")
+  applicationInsights: string;
+}
+
 @doc("Response from the listSecrets operation")
-model ConnectionsListSecretsResponse {
+model GetConnectionResponse {
   @doc("A unique identifier for the connection")
   id: string;
 
@@ -27,9 +46,9 @@ model ConnectionsListSecretsResponse {
 }
 
 @doc("Response from the list operation")
-model ConnectionsListResponse {
+model ListConnectionsResponse {
   @doc("A list of connection list secrets")
-  value: ConnectionsListSecretsResponse[];
+  value: GetConnectionResponse[];
 }
 
 #suppress "@azure-tools/typespec-azure-core/no-string-discriminator"

--- a/specification/ai/Azure.AI.Projects/connections/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/routes.tsp
@@ -19,11 +19,7 @@ namespace Azure.AI.Projects.Connections;
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations"
 @doc("Gets the properties of the specified machine learning workspace.")
 @get
-op getWorkspace is Azure.Core.Foundations.Operation<
-  {
-  },
-  GetWorkspaceResponse
->;
+op getWorkspace is Azure.Core.Foundations.Operation<{}, GetWorkspaceResponse>;
 
 /*
  See https://learn.microsoft.com/rest/api/azureml/workspace-connections/list?view=rest-azureml-2024-07-01-preview

--- a/specification/ai/Azure.AI.Projects/connections/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/routes.tsp
@@ -14,6 +14,18 @@ using Azure.Core.Foundations;
 namespace Azure.AI.Projects.Connections;
 
 /*
+ See https://learn.microsoft.com/en-us/rest/api/azureml/workspaces/get?view=rest-azureml-2024-07-01-preview
+*/
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations"
+@doc("Gets the properties of the specified machine learning workspace.")
+@get
+op getWorkspace is Azure.Core.Foundations.Operation<
+  {
+  },
+  GetWorkspaceResponse
+>;
+
+/*
  See https://learn.microsoft.com/rest/api/azureml/workspace-connections/list?view=rest-azureml-2024-07-01-preview
 */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations"
@@ -21,7 +33,7 @@ namespace Azure.AI.Projects.Connections;
 @doc("List the details of all the connections (not including their credentials)")
 @route("connections")
 @get
-op list is Azure.Core.Foundations.Operation<
+op listConnections is Azure.Core.Foundations.Operation<
   {
     @query
     @doc("Category of the workspace connection.")
@@ -35,7 +47,7 @@ op list is Azure.Core.Foundations.Operation<
     @doc("Target of the workspace connection.")
     target?: string;
   },
-  ConnectionsListResponse
+  ListConnectionsResponse
 >;
 
 /*
@@ -45,12 +57,12 @@ op list is Azure.Core.Foundations.Operation<
 @doc("Get the details of a single connection, without credentials.")
 @route("connections/{connectionName}")
 @get
-op get is Azure.Core.Foundations.Operation<
+op getConnection is Azure.Core.Foundations.Operation<
   {
     @doc("Connection Name")
     connectionName: string;
   },
-  ConnectionsListSecretsResponse
+  GetConnectionResponse
 >;
 
 /*
@@ -60,7 +72,7 @@ op get is Azure.Core.Foundations.Operation<
 @doc("Get the details of a single connection, including credentials (if available).")
 @route("connections/{connectionName}/listsecrets")
 @post
-op listSecrets is Azure.Core.Foundations.Operation<
+op getConnectionWithSecrets is Azure.Core.Foundations.Operation<
   {
     @doc("Connection Name")
     connectionName: string;
@@ -68,5 +80,5 @@ op listSecrets is Azure.Core.Foundations.Operation<
     @doc("The body is ignored. TODO: Can we remove this?")
     ignored: string;
   },
-  ConnectionsListSecretsResponse
+  GetConnectionResponse
 >;

--- a/specification/ai/Azure.AI.Projects/diagnostics/client.tsp
+++ b/specification/ai/Azure.AI.Projects/diagnostics/client.tsp
@@ -1,0 +1,7 @@
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+@@access(Azure.AI.Projects.Diagnostics.getAppInsights, Access.internal);
+@@access(Azure.AI.Projects.GetAppInsightsResponse, Access.internal);
+@@access(Azure.AI.Projects.AppInsightsProperties, Access.internal);

--- a/specification/ai/Azure.AI.Projects/diagnostics/model.tsp
+++ b/specification/ai/Azure.AI.Projects/diagnostics/model.tsp
@@ -14,7 +14,6 @@ using Azure.Core.Traits;
 
 namespace Azure.AI.Projects;
 
-
 @doc("Response from getting properties of the Application Insights resource")
 model GetAppInsightsResponse {
   @doc("A unique identifier for the resouce")

--- a/specification/ai/Azure.AI.Projects/diagnostics/model.tsp
+++ b/specification/ai/Azure.AI.Projects/diagnostics/model.tsp
@@ -16,7 +16,7 @@ namespace Azure.AI.Projects;
 
 @doc("Response from getting properties of the Application Insights resource")
 model GetAppInsightsResponse {
-  @doc("A unique identifier for the resouce")
+  @doc("A unique identifier for the resource")
   id: string;
 
   @doc("The name of the resource")

--- a/specification/ai/Azure.AI.Projects/diagnostics/model.tsp
+++ b/specification/ai/Azure.AI.Projects/diagnostics/model.tsp
@@ -1,0 +1,34 @@
+import "@typespec/rest";
+import "@azure-tools/typespec-autorest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@typespec/openapi";
+import "@typespec/versioning";
+
+using TypeSpec.OpenAPI;
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.Core.Traits;
+
+namespace Azure.AI.Projects;
+
+
+@doc("Response from getting properties of the Application Insights resource")
+model GetAppInsightsResponse {
+  @doc("A unique identifier for the resouce")
+  id: string;
+
+  @doc("The name of the resource")
+  name: string;
+
+  @doc("The properties of the resource")
+  properties: AppInsightsProperties;
+}
+
+@doc("The properties of the Application Insights resource")
+model AppInsightsProperties {
+  @doc("Authentication type of the connection target")
+  ConnectionString: string;
+}

--- a/specification/ai/Azure.AI.Projects/diagnostics/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/diagnostics/routes.tsp
@@ -18,9 +18,12 @@ namespace Azure.AI.Projects.Diagnostics;
 */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations"
 @doc("Gets the properties of the specified Application Insights resource")
+@route("components/{resourceName}")
 @get
 op getAppInsights is Azure.Core.Foundations.Operation<
   {
+    @doc("The AppInsights Azure resource Name")
+    resourceName: string;
   },
   GetAppInsightsResponse
 >;

--- a/specification/ai/Azure.AI.Projects/diagnostics/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/diagnostics/routes.tsp
@@ -1,0 +1,26 @@
+import "@typespec/rest";
+import "@azure-tools/typespec-autorest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "./model.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.Core.Traits;
+using Azure.Core.Foundations;
+
+namespace Azure.AI.Projects.Diagnostics;
+
+/*
+ See https://learn.microsoft.com/en-us/rest/api/azureml/workspaces/get?view=rest-azureml-2024-07-01-preview
+*/
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations"
+@doc("Gets the properties of the specified Application Insights resource")
+@get
+op getAppInsights is Azure.Core.Foundations.Operation<
+  {
+  },
+  GetAppInsightsResponse
+>;

--- a/specification/ai/Azure.AI.Projects/diagnostics/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/diagnostics/routes.tsp
@@ -22,7 +22,7 @@ namespace Azure.AI.Projects.Diagnostics;
 @get
 op getAppInsights is Azure.Core.Foundations.Operation<
   {
-    @doc("The AppInsights Azure resource Url. It should have the format: `/subscriptions/{subscription_id}/resourceGroups/{resouce_group_name}/providers/microsoft.insights/components/{resouce-name}`")
+    @doc("The AppInsights Azure resource Url. It should have the format: '/subscriptions/{subscription_id}/resourceGroups/{resource_group_name}/providers/microsoft.insights/components/{resourcename}'")
     appInsightsResourceUrl: string;
   },
   GetAppInsightsResponse

--- a/specification/ai/Azure.AI.Projects/diagnostics/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/diagnostics/routes.tsp
@@ -18,12 +18,12 @@ namespace Azure.AI.Projects.Diagnostics;
 */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations"
 @doc("Gets the properties of the specified Application Insights resource")
-@route("components/{resourceName}")
+@route("/{appInsightsResourceUrl}")
 @get
 op getAppInsights is Azure.Core.Foundations.Operation<
   {
-    @doc("The AppInsights Azure resource Name")
-    resourceName: string;
+    @doc("The AppInsights Azure resource Url. It should have the format: `/subscriptions/{subscription_id}/resourceGroups/{resouce_group_name}/providers/microsoft.insights/components/{resouce-name}`")
+    appInsightsResourceUrl: string;
   },
   GetAppInsightsResponse
 >;

--- a/specification/ai/Azure.AI.Projects/main.tsp
+++ b/specification/ai/Azure.AI.Projects/main.tsp
@@ -14,6 +14,7 @@ import "./agents/vector_stores/files/routes.tsp";
 import "./agents/vector_stores/file_batches/routes.tsp";
 import "./connections/routes.tsp";
 import "./evaluations/routes.tsp";
+import "./diagnostics/routes.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.Rest;

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
@@ -82,7 +82,7 @@
           {
             "name": "appInsightsResourceUrl",
             "in": "path",
-            "description": "The AppInsights Azure resource Url. It should have the format: `/subscriptions/{subscription_id}/resourceGroups/{resouce_group_name}/providers/microsoft.insights/components/{resouce-name}`",
+            "description": "The AppInsights Azure resource Url. It should have the format: '/subscriptions/{subscription_id}/resourceGroups/{resource_group_name}/providers/microsoft.insights/components/{resourcename}'",
             "required": true,
             "type": "string"
           }
@@ -8721,7 +8721,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "A unique identifier for the resouce"
+          "description": "A unique identifier for the resource"
         },
         "name": {
           "type": "string",
@@ -8767,7 +8767,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "A unique identifier for the resouce"
+          "description": "A unique identifier for the resource"
         },
         "name": {
           "type": "string",

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
@@ -71,6 +71,37 @@
   },
   "tags": [],
   "paths": {
+    "/": {
+      "get": {
+        "operationId": "Connections_GetWorkspace",
+        "description": "Gets the properties of the specified machine learning workspace.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/GetWorkspaceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
     "/assistants": {
       "get": {
         "operationId": "Agents_ListAgents",
@@ -346,9 +377,47 @@
         }
       }
     },
+    "/components/{resourceName}": {
+      "get": {
+        "operationId": "Diagnostics_GetAppInsights",
+        "description": "Gets the properties of the specified Application Insights resource",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The AppInsights Azure resource Name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/GetAppInsightsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
     "/connections": {
       "get": {
-        "operationId": "Connections_List",
+        "operationId": "Connections_ListConnections",
         "description": "List the details of all the connections (not including their credentials)",
         "parameters": [
           {
@@ -412,7 +481,7 @@
           "200": {
             "description": "The request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/ConnectionsListResponse"
+              "$ref": "#/definitions/ListConnectionsResponse"
             }
           },
           "default": {
@@ -432,7 +501,7 @@
     },
     "/connections/{connectionName}": {
       "get": {
-        "operationId": "Connections_Get",
+        "operationId": "Connections_GetConnection",
         "description": "Get the details of a single connection, without credentials.",
         "parameters": [
           {
@@ -450,7 +519,7 @@
           "200": {
             "description": "The request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/ConnectionsListSecretsResponse"
+              "$ref": "#/definitions/GetConnectionResponse"
             }
           },
           "default": {
@@ -470,7 +539,7 @@
     },
     "/connections/{connectionName}/listsecrets": {
       "post": {
-        "operationId": "Connections_ListSecrets",
+        "operationId": "Connections_GetConnectionWithSecrets",
         "description": "Get the details of a single connection, including credentials (if available).",
         "parameters": [
           {
@@ -505,7 +574,7 @@
           "200": {
             "description": "The request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/ConnectionsListSecretsResponse"
+              "$ref": "#/definitions/GetConnectionResponse"
             }
           },
           "default": {
@@ -8065,6 +8134,19 @@
         }
       }
     },
+    "AppInsightsProperties": {
+      "type": "object",
+      "description": "The properties of the Application Insights resource",
+      "properties": {
+        "ConnectionString": {
+          "type": "string",
+          "description": "Authentication type of the connection target"
+        }
+      },
+      "required": [
+        "ConnectionString"
+      ]
+    },
     "ApplicationInsightsConfiguration": {
       "type": "object",
       "description": "Data Source for Application Insights.",
@@ -8320,45 +8402,6 @@
           }
         ]
       }
-    },
-    "ConnectionsListResponse": {
-      "type": "object",
-      "description": "Response from the list operation",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "A list of connection list secrets",
-          "items": {
-            "$ref": "#/definitions/ConnectionsListSecretsResponse"
-          }
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "ConnectionsListSecretsResponse": {
-      "type": "object",
-      "description": "Response from the listSecrets operation",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "A unique identifier for the connection"
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the resource"
-        },
-        "properties": {
-          "$ref": "#/definitions/ConnectionProperties",
-          "description": "The properties of the resource"
-        }
-      },
-      "required": [
-        "id",
-        "name",
-        "properties"
-      ]
     },
     "CreatedEvaluationResponse": {
       "type": "object",
@@ -8672,6 +8715,75 @@
         ]
       }
     },
+    "GetAppInsightsResponse": {
+      "type": "object",
+      "description": "Response from getting properties of the Application Insights resource",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique identifier for the resouce"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "properties": {
+          "$ref": "#/definitions/AppInsightsProperties",
+          "description": "The properties of the resource"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "properties"
+      ]
+    },
+    "GetConnectionResponse": {
+      "type": "object",
+      "description": "Response from the listSecrets operation",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique identifier for the connection"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "properties": {
+          "$ref": "#/definitions/ConnectionProperties",
+          "description": "The properties of the resource"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "properties"
+      ]
+    },
+    "GetWorkspaceResponse": {
+      "type": "object",
+      "description": "Response from the Workspace - Get operation",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique identifier for the resouce"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "properties": {
+          "$ref": "#/definitions/WorkspaceProperties",
+          "description": "The properties of the resource"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "properties"
+      ]
+    },
     "InputData": {
       "type": "object",
       "description": "Abstract data class for input data configuration.",
@@ -8684,6 +8796,22 @@
       "discriminator": "type",
       "required": [
         "type"
+      ]
+    },
+    "ListConnectionsResponse": {
+      "type": "object",
+      "description": "Response from the list operation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "A list of connection list secrets",
+          "items": {
+            "$ref": "#/definitions/GetConnectionResponse"
+          }
+        }
+      },
+      "required": [
+        "value"
       ]
     },
     "PagedEvaluation": {
@@ -8901,6 +9029,19 @@
           }
         ]
       }
+    },
+    "WorkspaceProperties": {
+      "type": "object",
+      "description": "workspace properties",
+      "properties": {
+        "applicationInsights": {
+          "type": "string",
+          "description": "Authentication type of the connection target"
+        }
+      },
+      "required": [
+        "applicationInsights"
+      ]
     }
   },
   "parameters": {

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
@@ -71,6 +71,44 @@
   },
   "tags": [],
   "paths": {
+    "/{appInsightsResourceUrl}": {
+      "get": {
+        "operationId": "Diagnostics_GetAppInsights",
+        "description": "Gets the properties of the specified Application Insights resource",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "appInsightsResourceUrl",
+            "in": "path",
+            "description": "The AppInsights Azure resource Url. It should have the format: `/subscriptions/{subscription_id}/resourceGroups/{resouce_group_name}/providers/microsoft.insights/components/{resouce-name}`",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/GetAppInsightsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "operationId": "Connections_GetWorkspace",
@@ -360,44 +398,6 @@
             "description": "Status information about the requested deletion operation.",
             "schema": {
               "$ref": "#/definitions/Agents.AgentDeletionStatus"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
-            },
-            "headers": {
-              "x-ms-error-code": {
-                "type": "string",
-                "description": "String error code indicating what went wrong."
-              }
-            }
-          }
-        }
-      }
-    },
-    "/components/{resourceName}": {
-      "get": {
-        "operationId": "Diagnostics_GetAppInsights",
-        "description": "Gets the properties of the specified Application Insights resource",
-        "parameters": [
-          {
-            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          },
-          {
-            "name": "resourceName",
-            "in": "path",
-            "description": "The AppInsights Azure resource Name",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/GetAppInsightsResponse"
             }
           },
           "default": {


### PR DESCRIPTION
* Add one more "route" under the /connection folder, to make the "Workspace - Get" REST API call, which returns properties of the Azure AI Project. This includes the AppInsight resource URL.
* Rename some of the existing operations under the /connection folder so they make more sense
* Add new folder "diagnostics", with one REST API call to get the properties of the AppInsights resource, which includes the AppInsights connection string.