### PR TITLE
[eng/tools] Use TypeScript project references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ eng/tools/**/dist
 !eng/tools/**/cmd/*.js
 !eng/tools/**/eslint.config.js
 
+# TypeScript cache
+*.tsbuildinfo
+
 # No package-lock.json files should be commited except the top-level.
 **/package-lock.json
 !/package-lock.json

--- a/eng/tools/package.json
+++ b/eng/tools/package.json
@@ -7,5 +7,9 @@
     "@azure-tools/typespec-requirement": "file:typespec-requirement",
     "@azure-tools/typespec-validation": "file:typespec-validation"
   },
+  "scripts": {
+    "build": "tsc -b",
+    "postinstall": "npm run build"
+  },
   "private": true
 }

--- a/eng/tools/package.json
+++ b/eng/tools/package.json
@@ -8,7 +8,7 @@
     "@azure-tools/typespec-validation": "file:typespec-validation"
   },
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc --build",
     "postinstall": "npm run build"
   },
   "private": true

--- a/eng/tools/specs-model/package.json
+++ b/eng/tools/specs-model/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "postinstall": "npm run build",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose",
     "lint": "eslint . -c eslint.config.js --report-unused-disable-directives --max-warnings 0",

--- a/eng/tools/specs-model/package.json
+++ b/eng/tools/specs-model/package.json
@@ -7,7 +7,7 @@
     "get-specs-model": "cmd/get-specs-model.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose",
     "lint": "eslint . -c eslint.config.js --report-unused-disable-directives --max-warnings 0",

--- a/eng/tools/suppressions/package.json
+++ b/eng/tools/suppressions/package.json
@@ -7,7 +7,7 @@
     "get-suppressions": "cmd/get-suppressions.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose"
   },

--- a/eng/tools/suppressions/package.json
+++ b/eng/tools/suppressions/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "postinstall": "npm run build",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose"
   },

--- a/eng/tools/tsconfig.json
+++ b/eng/tools/tsconfig.json
@@ -7,6 +7,7 @@
     // override "importHelpers:true" in root tsconfig.json
     "importHelpers": false,
 
+    // required to use project references
     "composite": true,
   },
   "references": [

--- a/eng/tools/tsconfig.json
+++ b/eng/tools/tsconfig.json
@@ -5,6 +5,15 @@
     "module": "Node16",
 
     // override "importHelpers:true" in root tsconfig.json
-    "importHelpers": false
-  }
+    "importHelpers": false,
+
+    "composite": true,
+  },
+  "references": [
+    { "path": "./specs-model" },
+    { "path": "./suppressions" },
+    { "path": "./tsp-client-tests" },
+    { "path": "./typespec-requirement" },
+    { "path": "./typespec-validation" }
+  ]
 }

--- a/eng/tools/tsp-client-tests/package.json
+++ b/eng/tools/tsp-client-tests/package.json
@@ -10,7 +10,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "postinstall": "npm run build",
     "test": "vitest",
     "test:ci": "vitest run --reporter=verbose"
   },

--- a/eng/tools/tsp-client-tests/package.json
+++ b/eng/tools/tsp-client-tests/package.json
@@ -9,7 +9,7 @@
     "vitest": "^2.0.4"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "vitest",
     "test:ci": "vitest run --reporter=verbose"
   },

--- a/eng/tools/typespec-requirement/package.json
+++ b/eng/tools/typespec-requirement/package.json
@@ -10,7 +10,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "postinstall": "npm run build",
     "test": "vitest",
     "test:ci": "vitest run --reporter=verbose"
   },

--- a/eng/tools/typespec-requirement/package.json
+++ b/eng/tools/typespec-requirement/package.json
@@ -9,7 +9,7 @@
     "vitest": "^2.0.4"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "vitest",
     "test:ci": "vitest run --reporter=verbose"
   },

--- a/eng/tools/typespec-validation/package.json
+++ b/eng/tools/typespec-validation/package.json
@@ -20,7 +20,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "postinstall": "cd ../suppressions && npm run build && cd ../typespec-validation && npm run build",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose"
   },

--- a/eng/tools/typespec-validation/package.json
+++ b/eng/tools/typespec-validation/package.json
@@ -19,7 +19,7 @@
     "vitest": "^2.0.4"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose"
   },

--- a/eng/tools/typespec-validation/tsconfig.json
+++ b/eng/tools/typespec-validation/tsconfig.json
@@ -2,5 +2,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-  }
+  },
+  "references": [
+    { "path": "../suppressions" }
+  ]
 }


### PR DESCRIPTION
- Replaces "postinstall" step in each package, with one in tools folder
- Allows one call to `tsc` to compile all projects in the correct dependency order
- No change to usage or dev of tools
