### PR TITLE
[TypeSpecValidationAll] Remove extra whitespace in cron string

### DIFF
--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -28,7 +28,7 @@ on:
 
   schedule:
     # Run 4x/day
-    - cron: '0 0,6,12,18 * * * '
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   typespec-validation-all:


### PR DESCRIPTION
It appears the jobs are still scheduled correctly, but it does generate an editor error.

<img width="220" alt="image" src="https://github.com/user-attachments/assets/1c49566b-26cd-403f-bbb7-bdd4175bdec1">
