### PR TITLE
[Contoso.Management] Fix typos in readme.md

### DIFF
--- a/specification/contosowidgetmanager/resource-manager/readme.md
+++ b/specification/contosowidgetmanager/resource-manager/readme.md
@@ -30,7 +30,7 @@ tag: package-2021-10-01-preview
 
 These settings apply only when `--tag=package-2021-10-01-preview` is specified on the command line.
 
-```yaml $(tag) == 'package-2023-07-01-preview'
+```yaml $(tag) == 'package-2021-10-01-preview'
 input-file:
   - Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
 ```

--- a/specification/contosowidgetmanager/resource-manager/readme.md
+++ b/specification/contosowidgetmanager/resource-manager/readme.md
@@ -23,7 +23,7 @@ These are the global settings for the containerstorage.
 
 ```yaml
 openapi-type: arm
-tag: 2021-10-01-preview
+tag: package-2021-10-01-preview
 ```
 
 ### Tag: package-2021-10-01-preview


### PR DESCRIPTION
- Was preventing checks like LintDiff from running correctly

LintDiff failure in this PR is expected, since the previous version cannot be validated.