### PR TITLE
change delete to disableSchedule and remove samplingRate

### DIFF
--- a/specification/ai/Azure.AI.Projects/evaluations/model.tsp
+++ b/specification/ai/Azure.AI.Projects/evaluations/model.tsp
@@ -194,12 +194,6 @@ model RecurrenceSchedule {
   monthDays?: int32[];
 }
 
-@doc("SamplingStrategy Definition")
-model SamplingStrategy {
-  @doc("Sampling rate")
-  rate: float32;
-}
-
 @doc("Evaluation Schedule Definition")
 // NoteNote: I modeled ScheduledEvaluation as a type of Evaluation. But can also be modeled as a separate Schedule entity. We can discuss
 @resource("schedules")
@@ -239,9 +233,6 @@ model EvaluationSchedule {
 
   @doc("Trigger for the evaluation.")
   trigger: Trigger;
-
-  @doc("Sampling strategy for the evaluation.")
-  samplingStrategy: SamplingStrategy;
 }
 
 // Define the response model with status code 201

--- a/specification/ai/Azure.AI.Projects/evaluations/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/evaluations/routes.tsp
@@ -57,6 +57,19 @@ interface Evaluations {
     EvaluationSchedule,
     ListQueryParametersTrait<StandardListQueryParameters>
   >;
+  
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations"
+  #suppress "@azure-tools/typespec-azure-core/no-response-body"
+  @route("schedules/{name}/disable")
+  @patch
+  @doc("Disable the evaluation schedule.")
+  disableSchedule(
+    @query
+    @doc("The API version to use for this operation.")
+    apiVersion: string,
 
-  deleteSchedule is EvaluationsOperations.ResourceDelete<EvaluationSchedule>;
+    @path
+    @doc("Name of the evaluation schedule.")
+    name: string,
+  ): NoContentResponse | ErrorResponse;
 }

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
@@ -958,37 +958,31 @@
             }
           }
         }
-      },
-      "delete": {
-        "operationId": "Evaluations_DeleteSchedule",
-        "description": "Resource delete operation template.",
+      }
+    },
+    "/evaluations/schedules/{name}/disable": {
+      "patch": {
+        "operationId": "Evaluations_DisableSchedule",
+        "description": "Disable the evaluation schedule.",
         "parameters": [
           {
-            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+            "name": "apiVersion",
+            "in": "query",
+            "description": "The API version to use for this operation.",
+            "required": true,
+            "type": "string"
           },
           {
             "name": "name",
             "in": "path",
-            "description": "Name of the schedule, which also serves as the unique identifier for the evaluation",
+            "description": "Name of the evaluation schedule.",
             "required": true,
-            "type": "string",
-            "maxLength": 254,
-            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_]*$"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+            "type": "string"
           }
         ],
         "responses": {
           "204": {
-            "description": "There is no content to send for this request, but the headers may be useful. ",
-            "headers": {
-              "x-ms-client-request-id": {
-                "type": "string",
-                "format": "uuid",
-                "description": "An opaque, globally-unique, client-generated string identifier for the request."
-              }
-            }
+            "description": "There is no content to send for this request, but the headers may be useful."
           },
           "default": {
             "description": "An unexpected error response.",
@@ -8522,18 +8516,13 @@
         "trigger": {
           "$ref": "#/definitions/Trigger",
           "description": "Trigger for the evaluation."
-        },
-        "samplingStrategy": {
-          "$ref": "#/definitions/SamplingStrategy",
-          "description": "Sampling strategy for the evaluation."
         }
       },
       "required": [
         "name",
         "data",
         "evaluators",
-        "trigger",
-        "samplingStrategy"
+        "trigger"
       ]
     },
     "EvaluationUpdate": {
@@ -8926,20 +8915,6 @@
         }
       ],
       "x-ms-discriminator-value": "Recurrence"
-    },
-    "SamplingStrategy": {
-      "type": "object",
-      "description": "SamplingStrategy Definition",
-      "properties": {
-        "rate": {
-          "type": "number",
-          "format": "float",
-          "description": "Sampling rate"
-        }
-      },
-      "required": [
-        "rate"
-      ]
     },
     "SystemData": {
       "type": "object",


### PR DESCRIPTION
This pull request updates from 'deleteSchedule` to the `disableSchedule`. These allow for the disabling of evaluations based on the name of the schedule. 
SamplingRate is removed from app insights.