### PR TITLE
[TypeSpecValidationAll] Add workflow_dispatch, validate typespec-next on trigger

### DIFF
--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ toJson(github.event_name == 'schedule' && '["", typespec-next]' || '[""]') }}
+        ref: ${{ fromJSON(github.event_name == 'schedule' && '["", typespec-next]' || '[""]') }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ fromJSON(github.event_name == 'pull_request' && '["default", "typespec-next"]' || '["default"]') }}
+        ref: ${{ fromJSON(github.event_name != 'schedule' && '["default", "typespec-next"]' || '["default"]') }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ fromJSON(github.event_name != 'schedule' && '["default", "typespec-next"]' || '["default"]') }}
+        ref: ${{ fromJSON(github.event_name == 'schedule' && '["default", "typespec-next"]' || '["default"]') }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ fromJSON(github.event_name == 'schedule' && '["default", typespec-next]' || '["default"]') }}
+        ref: ${{ fromJSON(github.event_name != 'schedule' && '["default", typespec-next]' || '["default"]') }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ fromJSON(!(github.event_name == 'schedule') && '["default", typespec-next]' || '["default"]') }}
+        ref: ${{ fromJSON(github.event_name == 'pull_request' && '["default", typespec-next]' || '["default"]') }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ fromJSON(github.event_name == 'pull_request' && '["default", typespec-next]' || '["default"]') }}
+        ref: ${{ fromJSON(github.event_name == 'pull_request' && '["default", "typespec-next"]' || '["default"]') }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -30,6 +30,8 @@ on:
     # Run 4x/day
     - cron: '0 0,6,12,18 * * *'
 
+  workflow_dispatch:
+
 jobs:
   typespec-validation-all:
     name: TypeSpec Validation All
@@ -41,6 +43,8 @@ jobs:
         shard: [0, 1, 2]
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
+        # When triggered by schedule, validate both the default branch and typespec-next
+        ref: ${{ (github.event_name == 'schedule') && '["", typespec-next]' || '[""]' }}
 
     runs-on: ${{ matrix.os }}
 
@@ -51,7 +55,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          ref: ${{ matrix.ref }}
 
       - name: Setup Node 20 and run `npm ci`
         uses: ./.github/actions/setup-node-npm-ci

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,6 +44,8 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
+        # Use the placeholder string "default" instead of passing "" directly, since the latter gets ignored by
+        # the GitHub Jobs UI.
         ref: ${{ fromJSON(github.event_name == 'schedule' && '["default", "typespec-next"]' || '["default"]') }}
 
     runs-on: ${{ matrix.os }}
@@ -55,6 +57,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          # Convert placeholder string 'default' to '', which tells the action to checkout the default ref.
           ref: ${{ matrix.ref != 'default' && matrix.ref || '' }}
 
       - name: Setup Node 20 and run `npm ci`

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ fromJSON(github.event_name != 'schedule' && '["default", typespec-next]' || '["default"]') }}
+        ref: ${{ fromJSON(!(github.event_name == 'schedule') && '["default", typespec-next]' || '["default"]') }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ github.event_name == 'schedule' && '["", typespec-next]' || '[""]' }}
+        ref: ${{ toJson(github.event_name == 'schedule' && '["", typespec-next]' || '[""]') }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ (github.event_name == 'schedule') && '["", typespec-next]' || '[""]' }}
+        ref: ${{ github.event_name == 'schedule' && '["", typespec-next]' || '[""]' }}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -44,7 +44,7 @@ jobs:
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
         # When triggered by schedule, validate both the default branch and typespec-next
-        ref: ${{ fromJSON(github.event_name == 'schedule' && '["", typespec-next]' || '[""]') }}
+        ref: ${{ fromJSON(github.event_name == 'schedule' && '["default", typespec-next]' || '["default"]') }}
 
     runs-on: ${{ matrix.os }}
 
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.ref }}
+          ref: ${{ matrix.ref != 'default' && matrix.ref || '' }}
 
       - name: Setup Node 20 and run `npm ci`
         uses: ./.github/actions/setup-node-npm-ci


### PR DESCRIPTION
Validation run: https://github.com/Azure/azure-rest-api-specs/actions/runs/11582175101.  Confirmed `typespec-next` uses composite action from the checked-out ref.