### PR TITLE
make getFileContent internal Python

### DIFF
--- a/specification/ai/Azure.AI.Projects/agents/client.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/client.tsp
@@ -220,6 +220,9 @@ namespace Azure.AI.Projects.Agents {
   @@usage(FilePurpose, Usage.input | Usage.output);
   @@usage(ListSortOrder, Usage.input | Usage.output);
 
+  // Make getFileContent internal method in Python (override with get_file_content_stream)
+  @@access(getFileContent, Access.internal, "python");
+
   // Additional, language-specific idiomatic renames
 
   @@clientName(OpenAIFile, "OpenAIFile", "csharp");

--- a/specification/ai/Azure.AI.Projects/evaluations/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/evaluations/routes.tsp
@@ -57,7 +57,7 @@ interface Evaluations {
     EvaluationSchedule,
     ListQueryParametersTrait<StandardListQueryParameters>
   >;
-  
+
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations"
   #suppress "@azure-tools/typespec-azure-core/no-response-body"
   @route("schedules/{name}/disable")


### PR DESCRIPTION
Update getFileContent method access to internal in Python because generated code works only with "stream" parameter and make an override which does that.
