### PR TITLE
Introduce Key attestation feature

### DIFF
--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/examples/GetKeyAttestation-example.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/examples/GetKeyAttestation-example.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "vaultBaseUrl": "https://myvault.vault.azure.net/",
+    "key-name": "KeyAttestationTest",
+    "key-version": "78deebed173b48e48f55abf87ed4cf71",
+    "api-version": "7.6-preview.2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "key": {
+          "kid": "https://myvault.vault.azure.net/keys/KeyAttestationTest/78deebed173b48e48f55abf87ed4cf71",
+          "kty": "RSA",
+          "key_ops": [
+            "encrypt",
+            "decrypt",
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey"
+          ],
+          "n": "2HJAE5fU3Cw2Rt9hEuq-F6XjINKGa-zskfISVqopqUy60GOs2eyhxbWbJBeUXNor_gf-tXtNeuqeBgitLeVa640UDvnEjYTKWjCniTxZRaU7ewY8BfTSk-7KxoDdLsPSpX_MX4rwlAx-_1UGk5t4sQgTbm9T6Fm2oqFd37dsz5-Gj27UP2GTAShfJPFD7MqU_zIgOI0pfqsbNL5xTQVM29K6rX4jSPtylZV3uWJtkoQIQnrIHhk1d0SC0KwlBV3V7R_LVYjiXLyIXsFzSNYgQ68ZjAwt8iL7I8Osa-ehQLM13DVvLASaf7Jnu3sC3CWl3Gyirgded6cfMmswJzY87w",
+          "e": "AQAB"
+        },
+        "attributes": {
+          "enabled": true,
+          "created": 1493942451,
+          "updated": 1493942451,
+          "recoveryLevel": "Recoverable+Purgeable",
+          "attestation": {
+            "certificates": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1nQ0FRRXdEUVlKS29aSWh2Y05BUUVMQlFBd2daRXhDekF",
+            "privateKeyAttestation": "AAAAAAAAAAMAAASoAAADlAAAA5QAAQAAPBVew",
+            "publicKeyAttestation": "AAAAAAAAAAMAAASoAAADlAAAA5QAAQAAAAgAAAAAABwAAAAjAAADgAAAAAAAAAABAxwLQ"
+          }
+        },
+        "tags": {
+          "purpose": "unit test",
+          "test name ": "CreateGetDeleteKeyTest"
+        }
+      }
+    }
+  }
+}

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
@@ -335,7 +335,6 @@
           {
             "name": "key-version",
             "in": "path",
-            "required": false,
             "type": "string",
             "description": "Adding the version parameter retrieves attestation blob for specific version of a key. This URI fragment is optional. If not specified, the latest version of the key attestation blob is returned."
           },

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
@@ -1541,7 +1541,7 @@
         "certificates": {
           "type": "string",
           "format": "base64url",
-          "description": "A base64url encoded string containing certificates in PEM format, used for attestation validation."
+          "description": "A base64url-encoded string containing certificates in PEM format, used for attestation validation."
         },
         "privateKeyAttestation": {
           "type": "string",

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
@@ -1537,6 +1537,7 @@
       "description": "The attributes of a key managed by the key vault service."
     },
     "KeyAttestation": {
+      "type": "object",
       "properties": {
         "certificates": {
           "type": "string",
@@ -1551,7 +1552,7 @@
         "publicKeyAttestation": {
           "type": "string",
           "format": "base64url",
-          "description": "The public key attestation blob corresponding to a public key in case of assymetric key."
+          "description": "The public key attestation blob corresponding to a public key in case of asymmetric key."
         }
       }
     },

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
@@ -335,7 +335,7 @@
           {
             "name": "key-version",
             "in": "path",
-            "required": true,
+            "required": false,
             "type": "string",
             "description": "Adding the version parameter retrieves attestation blob for specific version of a key. This URI fragment is optional. If not specified, the latest version of the key attestation blob is returned."
           },
@@ -1542,17 +1542,17 @@
         "certificates": {
           "type": "string",
           "format": "base64url",
-          "description": "The certificates used for validating attestation."
+          "description": "A base64url encoded string containing certificates in PEM format, used for attestation validation."
         },
         "privateKeyAttestation": {
           "type": "string",
           "format": "base64url",
-          "description": "The attestation blob corresponding to a private key."
+          "description": "The attestation blob bytes encoded as base64url string corresponding to a private key."
         },
         "publicKeyAttestation": {
           "type": "string",
           "format": "base64url",
-          "description": "The attestation blob corresponding to a public key in case of asymmetric key."
+          "description": "The attestation blob bytes encoded as base64url string corresponding to a public key in case of asymmetric key."
         }
       }
     },

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
@@ -1552,7 +1552,7 @@
         "publicKeyAttestation": {
           "type": "string",
           "format": "base64url",
-          "description": "The public key attestation blob corresponding to a public key in case of asymmetric key."
+          "description": "The attestation blob corresponding to a public key in case of asymmetric key."
         }
       }
     },

--- a/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
+++ b/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.6-preview.2/keys.json
@@ -316,6 +316,54 @@
         }
       }
     },
+    "/keys/{key-name}/{key-version}/attestation": {
+      "get": {
+        "tags": [
+          "Keys"
+        ],
+        "operationId": "GetKeyAttestation",
+        "summary": "Gets the public part of a stored key along with its attestation blob.",
+        "description": "The get key attestation operation returns the key along with its attestation blob. This operation requires the keys/get permission.",
+        "parameters": [
+          {
+            "name": "key-name",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the key to retrieve attestation for."
+          },
+          {
+            "name": "key-version",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Adding the version parameter retrieves attestation blob for specific version of a key. This URI fragment is optional. If not specified, the latest version of the key attestation blob is returned."
+          },
+          {
+            "$ref": "common.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A key bundle containing the key, its attributes and attestation blob.",
+            "schema": {
+              "$ref": "#/definitions/KeyBundle"
+            }
+          },
+          "default": {
+            "description": "Key Vault error response describing why the operation failed.",
+            "schema": {
+              "$ref": "common.json#/definitions/KeyVaultError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get key attestation": {
+            "$ref": "./examples/GetKeyAttestation-example.json"
+          }
+        }
+      }
+    },
     "/keys/{key-name}/versions": {
       "get": {
         "tags": [
@@ -1480,9 +1528,32 @@
           "type": "string",
           "description": "The underlying HSM Platform.",
           "readOnly": true
+        },
+        "attestation": {
+          "$ref": "#/definitions/KeyAttestation",
+          "description": "The key or key version attestation information."
         }
       },
       "description": "The attributes of a key managed by the key vault service."
+    },
+    "KeyAttestation": {
+      "properties": {
+        "certificates": {
+          "type": "string",
+          "format": "base64url",
+          "description": "The certificates used for validating attestation."
+        },
+        "privateKeyAttestation": {
+          "type": "string",
+          "format": "base64url",
+          "description": "The attestation blob corresponding to a private key."
+        },
+        "publicKeyAttestation": {
+          "type": "string",
+          "format": "base64url",
+          "description": "The public key attestation blob corresponding to a public key in case of assymetric key."
+        }
+      }
     },
     "KeyBundle": {
       "properties": {


### PR DESCRIPTION
This change introduces a new feature called Key attestation. This feature allows customers to extract certificates and attestation blob(s) to validate that a given key has been created within the Hardware security module. In case of a symmetric key, only private key portion attestation blob is returned whereas in case of an asymmetric key, the public and private key portion attestation blobs are returned. This feature does not return the private key, only the attestation of private key portion. 
