### PR TITLE
[TypeSpecValidation] Pass target path to "tsp compile"

### DIFF
--- a/eng/tools/typespec-validation/src/rules/compile.ts
+++ b/eng/tools/typespec-validation/src/rules/compile.ts
@@ -14,8 +14,7 @@ export class CompileRule implements Rule {
 
     if (await host.checkFileExists(path.join(folder, "main.tsp"))) {
       let [err, stdout, stderr] = await host.runCmd(
-        `npm exec --no -- tsp compile . --warn-as-error`,
-        folder,
+        `npm exec --no -- tsp compile --warn-as-error ${folder}`,
       );
       if (
         stdout.toLowerCase().includes("no emitter was configured") ||
@@ -31,10 +30,11 @@ export class CompileRule implements Rule {
       stdOutput += stdout;
       errorOutput += stderr;
     }
-    if (await host.checkFileExists(path.join(folder, "client.tsp"))) {
+
+    const clientTsp = path.join(folder, "client.tsp");
+    if (await host.checkFileExists(clientTsp)) {
       let [err, stdout, stderr] = await host.runCmd(
-        `npm exec --no -- tsp compile client.tsp --no-emit --warn-as-error`,
-        folder,
+        `npm exec --no -- tsp compile --no-emit --warn-as-error ${clientTsp}`,
       );
       if (err) {
         success = false;

--- a/eng/tools/typespec-validation/src/tsv-host.ts
+++ b/eng/tools/typespec-validation/src/tsv-host.ts
@@ -5,7 +5,7 @@ export interface TsvHost {
   isDirectory(path: string): Promise<boolean>;
   gitOperation(folder: string): IGitOperation;
   readTspConfig(folder: string): Promise<string>;
-  runCmd(cmd: string, cwd: string): Promise<[Error | null, string, string]>;
+  runCmd(cmd: string, cwd?: string): Promise<[Error | null, string, string]>;
   normalizePath(folder: string): string;
   gitDiffTopSpecFolder(host: TsvHost, folder: string): Promise<RuleResult>;
   globby(patterns: string[]): Promise<string[]>;

--- a/eng/tools/typespec-validation/src/utils.ts
+++ b/eng/tools/typespec-validation/src/utils.ts
@@ -3,7 +3,7 @@ import { exec } from "child_process";
 import defaultPath, { PlatformPath } from "path";
 import { TsvHost } from "./tsv-host.js";
 
-export async function runCmd(cmd: string, cwd: string) {
+export async function runCmd(cmd: string, cwd?: string) {
   console.log(`run command:${cmd}`);
   const { err, stdout, stderr } = (await new Promise((res) =>
     exec(

--- a/eng/tools/typespec-validation/test/compile.test.ts
+++ b/eng/tools/typespec-validation/test/compile.test.ts
@@ -14,7 +14,7 @@ describe("compile", function () {
   it("should fail if no emitter was configured", async function () {
     let host = new TsvTestHost();
     host.runCmd = async (cmd: string, _cwd: string): Promise<[Error | null, string, string]> => {
-      if (cmd.includes("tsp compile .")) {
+      if (cmd.includes("tsp compile")) {
         return [null, "no emitter was configured", ""];
       } else {
         return [null, "", ""];
@@ -29,7 +29,7 @@ describe("compile", function () {
   it("should fail if no output was generated", async function () {
     let host = new TsvTestHost();
     host.runCmd = async (cmd: string, _cwd: string): Promise<[Error | null, string, string]> => {
-      if (cmd.includes("tsp compile .")) {
+      if (cmd.includes("tsp compile")) {
         return [null, "no output was generated", ""];
       } else {
         return [null, "", ""];


### PR DESCRIPTION
- Earlier bugs required running "tsp compile" from target dir
- Should effectively be a no-op for the tool and its users
