### PR TITLE
Add @typespec/streams as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@typespec/http": "0.62.0",
         "@typespec/openapi": "0.62.0",
         "@typespec/openapi3": "0.62.0",
+        "@typespec/prettier-plugin-typespec": "0.62.0",
         "@typespec/rest": "0.62.0",
         "@typespec/streams": "0.62.0",
         "@typespec/versioning": "0.62.0",
@@ -691,6 +692,32 @@
         "@typespec/http": "~0.61.0",
         "@typespec/openapi": "~0.61.0",
         "@typespec/versioning": "~0.61.0"
+      }
+    },
+    "node_modules/@autorest/openapi-to-typespec/node_modules/@typespec/prettier-plugin-typespec": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@typespec/prettier-plugin-typespec/-/prettier-plugin-typespec-0.61.0.tgz",
+      "integrity": "sha512-GtOK8KbQxBLgbicEdFIt22alQuP3n+9HYioF0HGzTKwG/EIWMopLOEpT6kr33Q8s3z1h6Vp2Au9qVR8FtAL3xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier": "~3.3.3"
+      }
+    },
+    "node_modules/@autorest/openapi-to-typespec/node_modules/@typespec/prettier-plugin-typespec/node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@autorest/openapi-to-typespec/node_modules/@typespec/rest": {
@@ -3672,9 +3699,9 @@
       }
     },
     "node_modules/@typespec/prettier-plugin-typespec": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@typespec/prettier-plugin-typespec/-/prettier-plugin-typespec-0.61.0.tgz",
-      "integrity": "sha512-GtOK8KbQxBLgbicEdFIt22alQuP3n+9HYioF0HGzTKwG/EIWMopLOEpT6kr33Q8s3z1h6Vp2Au9qVR8FtAL3xQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@typespec/prettier-plugin-typespec/-/prettier-plugin-typespec-0.62.0.tgz",
+      "integrity": "sha512-VJRtX4RcUYE0qiQpKL8K7Mgfozy/icieaoap44XR+2OmWegZmuR1Qjq5iWtjLBS7MFwSXHel+BT/LBlqu1v+dA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@typespec/openapi": "0.62.0",
         "@typespec/openapi3": "0.62.0",
         "@typespec/rest": "0.62.0",
+        "@typespec/streams": "0.62.0",
         "@typespec/versioning": "0.62.0",
         "azure-rest-api-specs-eng-tools": "file:eng/tools",
         "oav": "^3.5.1",
@@ -704,6 +705,21 @@
       "peerDependencies": {
         "@typespec/compiler": "~0.61.0",
         "@typespec/http": "~0.61.0"
+      }
+    },
+    "node_modules/@autorest/openapi-to-typespec/node_modules/@typespec/streams": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.61.0.tgz",
+      "integrity": "sha512-MEFwYmYVibuTwVwJ6UKa9kgM3AP5bn/MWIhB/dTgYicXEgbUk+o9RHqg7JsySFyL0PO9XoqQBFiJhWM758f+pQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "~0.61.0"
       }
     },
     "node_modules/@autorest/openapi-to-typespec/node_modules/@typespec/versioning": {
@@ -3677,6 +3693,19 @@
       "peerDependencies": {
         "@typespec/compiler": "~0.62.0",
         "@typespec/http": "~0.62.0"
+      }
+    },
+    "node_modules/@typespec/streams": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.62.0.tgz",
+      "integrity": "sha512-JmIJOOlR6NlYLhTVxw0vo3rQPfezzheXluCO00qO89TsdJFUyEz/Y2y5p9/JQbS0zLqtPpvNgPIksNH1Q6psSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "~0.62.0"
       }
     },
     "node_modules/@typespec/versioning": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@typespec/openapi": "0.62.0",
     "@typespec/openapi3": "0.62.0",
     "@typespec/rest": "0.62.0",
+    "@typespec/streams": "0.62.0",
     "@typespec/versioning": "0.62.0",
     "azure-rest-api-specs-eng-tools": "file:eng/tools",
     "oav": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@typespec/http": "0.62.0",
     "@typespec/openapi": "0.62.0",
     "@typespec/openapi3": "0.62.0",
+    "@typespec/prettier-plugin-typespec": "0.62.0",
     "@typespec/rest": "0.62.0",
     "@typespec/streams": "0.62.0",
     "@typespec/versioning": "0.62.0",


### PR DESCRIPTION
- Intention is to pin all TSP packages, not just leaf nodes
- Ensures branch "tsp-next" resolves the correct packages
