### PR TITLE
Revert "add directive for cosmosdb"

### DIFF
--- a/specification/cosmos-db/resource-manager/readme.typescript.md
+++ b/specification/cosmos-db/resource-manager/readme.typescript.md
@@ -10,25 +10,4 @@ typescript:
   output-folder: "$(typescript-sdks-folder)/sdk/cosmosdb/arm-cosmosdb"
   override-client-name: CosmosDBManagementClient
   generate-metadata: true
-
-directive: 
-- from: swagger-document
-  where: $.paths..responses.default
-  transform: >
-    $.schema = {
-      "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
-    }
-
-- from: cosmos-db.json
-  where: $.definitions
-  transform: delete $.CloudError
-
-- from: cosmos-db.json
-  where: $.definitions
-  transform: delete $.ErrorResponse
-
-- from: dataTransferService.json
-  where: $.definitions.DataTransferJobProperties.properties.error
-  transform: >
-    $.$ref = "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
 ```


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#30903

Custom ErrorResponse will be present still, and we will stop the migration process to new v5 error response, based on the discussion with Azure SDK Breaking Change Reviewers.