### PR TITLE
[web] Update readme.python.md

### DIFF
--- a/specification/web/resource-manager/readme.python.md
+++ b/specification/web/resource-manager/readme.python.md
@@ -32,6 +32,7 @@ batch:
 ```yaml $(multiapiscript)
 output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/
 perform-load: false
+clear-output-folder: false
 ```
 
 ### Tag: package-2024-04 and python

--- a/specification/web/resource-manager/readme.python.md
+++ b/specification/web/resource-manager/readme.python.md
@@ -32,7 +32,6 @@ batch:
 ```yaml $(multiapiscript)
 output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/
 perform-load: false
-clear-output-folder: false
 ```
 
 ### Tag: package-2024-04 and python

--- a/specification/web/resource-manager/readme.python.md
+++ b/specification/web/resource-manager/readme.python.md
@@ -22,23 +22,10 @@ default-api-version: "2024-04-01"
 clear-output-folder: true
 batch:
   - tag: package-2024-04
-  - tag: package-2023-12
   - tag: package-2023-01
   - tag: package-2022-09
-  - tag: package-2021-03-only
-  - tag: package-2021-01-15-only
-  - tag: package-2021-01-only
-  - tag: package-2020-12-only
-  - tag: package-2020-09-only
-  - tag: package-2020-06-only
-  - tag: package-2019-08-only
-  - tag: package-2018-11-only
   - tag: package-2018-02-only
-  - tag: package-2016-09-only
-  - tag: package-2016-08-only
   - tag: package-2016-03-only
-  - tag: package-2015-08-only
-  - tag: package-2015-04-only
   - multiapiscript: true
 ```
 
@@ -56,16 +43,6 @@ Please also specify `--python-sdks-folder=<path to the root directory of your az
 ``` yaml $(tag) == 'package-2024-04' && $(python)
 namespace: azure.mgmt.web.v2024_04_01
 output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2024_04_01
-```
-
-### Tag: package-2023-12 and python
-
-These settings apply only when `--tag=package-2023-12 --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-``` yaml $(tag) == 'package-2023-12' && $(python)
-namespace: azure.mgmt.web.v2023_12_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2023_12_01
 ```
 
 ### Tag: package-2023-01 and python
@@ -88,86 +65,6 @@ namespace: azure.mgmt.web.v2022_09_01
 output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2022_09_01
 ```
 
-### Tag: package-2021-03-only and python
-
-These settings apply only when `--tag=package-2021-03-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2021-03-only' && $(python)
-namespace: azure.mgmt.web.v2021_03_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2021_03_01
-```
-
-### Tag: package-2021-01-15-only and python
-
-These settings apply only when `--tag=package-2021-01-15-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2021-01-15-only' && $(python)
-namespace: azure.mgmt.web.v2021_01_15
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2021_01_15
-```
-
-### Tag: package-2021-01-only and python
-
-These settings apply only when `--tag=package-2021-01-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2021-01-only' && $(python)
-namespace: azure.mgmt.web.v2021_01_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2021_01_01
-```
-
-### Tag: package-2020-12-only and python
-
-These settings apply only when `--tag=package-2020-12-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2020-12-only' && $(python)
-namespace: azure.mgmt.web.v2020_12_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2020_12_01
-```
-
-### Tag: package-2020-09-only and python
-
-These settings apply only when `--tag=package-2020-09-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2020-09-only' && $(python)
-namespace: azure.mgmt.web.v2020_09_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2020_09_01
-```
-
-### Tag: package-2020-06-only and python
-
-These settings apply only when `--tag=package-2020-06-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2020-06-only' && $(python)
-namespace: azure.mgmt.web.v2020_06_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2020_06_01
-```
-
-### Tag: package-2019-08-only and python
-
-These settings apply only when `--tag=package-2019-08-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2019-08-only' && $(python)
-namespace: azure.mgmt.web.v2019_08_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2019_08_01
-```
-
-### Tag: package-2018-11-only and python
-
-These settings apply only when `--tag=package-2018-11-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2018-11-only' && $(python)
-namespace: azure.mgmt.web.v2018_11_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2018_11_01
-```
-
 ### Tag: package-2018-02-only and python
 
 These settings apply only when `--tag=package-2018-02-only --python` is specified on the command line.
@@ -176,26 +73,6 @@ Please also specify `--python-sdks-folder=<path to the root directory of your az
 ```yaml $(tag) == 'package-2018-02-only' && $(python)
 namespace: azure.mgmt.web.v2018_02_01
 output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2018_02_01
-```
-
-### Tag: package-2016-09-only and python
-
-These settings apply only when `--tag=package-2016-09-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2016-09-only' && $(python)
-namespace: azure.mgmt.web.v2016_09_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2016_09_01
-```
-
-### Tag: package-2016-08-only and python
-
-These settings apply only when `--tag=package-2016-08-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2016-08-only' && $(python)
-namespace: azure.mgmt.web.v2016_08_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2016_08_01
 ```
 
 ### Tag: package-2016-03-only and python
@@ -208,22 +85,3 @@ namespace: azure.mgmt.web.v2016_03_01
 output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2016_03_01
 ```
 
-### Tag: package-2015-08-only and python
-
-These settings apply only when `--tag=package-2019-04-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2015-08-only' && $(python)
-namespace: azure.mgmt.web.v2015_08_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2015_08_01
-```
-
-### Tag: package-2015-04-only and python
-
-These settings apply only when `--tag=package-2019-04-only --python` is specified on the command line.
-Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
-
-```yaml $(tag) == 'package-2015-04-only' && $(python)
-namespace: azure.mgmt.web.v2015_04_01
-output-folder: $(python-sdks-folder)/appservice/azure-mgmt-web/azure/mgmt/web/v2015_04_01
-```


### PR DESCRIPTION
for https://github.com/Azure/sdk-release-request/issues/5711.
We just need to keep several api-versions needed by CLI: “2018-02-01 / 2016-03-01/2023-01-01/2022-09-01” which is confirmed in e-mail `Re: Trim Python SDK azure-mgmt-web used by azure CLI`

