### PR TITLE
Sync missing specifications from V5 to V6 in common-types

### DIFF
--- a/specification/common-types/resource-management/v6/customermanagedkeys.json
+++ b/specification/common-types/resource-management/v6/customermanagedkeys.json
@@ -1,0 +1,68 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "5.0",
+    "title": "Common types"
+  },
+  "paths": {},
+  "definitions": {
+    "encryption": {
+      "type": "object",
+      "description": "All encryption configuration for a resource.",
+      "properties": {
+        "infrastructureEncryption": {
+          "type": "string",
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
+          "x-ms-enum": {
+            "name": "InfrastructureEncryption",
+            "modelAsString": true
+          },
+          "description": "(Optional) Discouraged to include in resource definition. Only needed where it is possible to disable platform (AKA infrastructure) encryption. Azure SQL TDE is an example of this. Values are enabled and disabled."
+        },
+        "customerManagedKeyEncryption": {
+          "type": "object",
+          "description": "All Customer-managed key encryption properties for the resource.",
+          "properties": {
+            "keyEncryptionKeyIdentity": {
+              "type": "object",
+              "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
+              "properties": {
+                "identityType": {
+                  "type": "string",
+                  "enum": [
+                    "systemAssignedIdentity",
+                    "userAssignedIdentity",
+                    "delegatedResourceIdentity"
+                  ],
+                  "description": "The type of identity to use. Values can be systemAssignedIdentity, userAssignedIdentity, or delegatedResourceIdentity."
+                },
+                "userAssignedIdentityResourceId": {
+                  "type": "string",
+                  "format": "arm-id",
+                  "description": "User assigned identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity."
+                },
+                "federatedClientId": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "application client identity to use for accessing key encryption key Url in a different tenant. Ex: f83c6b1b-4d34-47e4-bb34-9d83df58b540"
+                },
+                "delegatedIdentityClientId": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "delegated identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity and userAssignedIdentity - internal use only."
+                }
+              }
+            },
+            "keyEncryptionKeyUrl": {
+              "type": "string",
+              "description": "key encryption key Url, versioned or unversioned. Ex: https://contosovault.vault.azure.net/keys/contosokek/562a4bb76b524a1493a6afe8e536ee78 or https://contosovault.vault.azure.net/keys/contosokek."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/common-types/resource-management/v6/managedidentitywithdelegation.json
+++ b/specification/common-types/resource-management/v6/managedidentitywithdelegation.json
@@ -1,0 +1,54 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "5.0",
+    "title": "Common types"
+  },
+  "paths": {},
+  "definitions": {
+    "ManagedServiceIdentityWithDelegation": {
+      "description": "Managed service identity (system assigned and/or user assigned identities and/or delegated identities) - internal use only.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "managedidentity.json#/definitions/ManagedServiceIdentity"
+        }
+      ],
+      "properties": {
+        "delegatedResources": {
+          "$ref": "#/definitions/DelegatedResources"
+        }
+      }
+    },
+    "DelegatedResources": {
+      "description": "The set of delegated resources. The delegated resources dictionary keys will be source resource internal ids - internal use only.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/DelegatedResource"
+      }
+    },
+    "DelegatedResource": {
+      "type": "object",
+      "description": "Delegated resource properties - internal use only.",
+      "properties": {
+        "resourceId": {
+          "description": "The ARM resource id of the delegated resource - internal use only.",
+          "type": "string"
+        },
+        "tenantId": {
+          "description": "The tenant id of the delegated resource - internal use only.",
+          "format": "uuid",
+          "type": "string"
+        },
+        "referralResource": {
+          "description": "The delegation id of the referral delegation (optional) - internal use only.",
+          "type": "string"
+        },
+        "location": {
+          "description": "The source resource location - internal use only.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/specification/common-types/resource-management/v6/mobo.json
+++ b/specification/common-types/resource-management/v6/mobo.json
@@ -1,0 +1,38 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "5.0",
+    "title": "Common types"
+  },
+  "paths": {},
+  "definitions": {
+    "ManagedOnBehalfOfConfiguration": {
+      "type": "object",
+      "description": "Managed-On-Behalf-Of configuration properties. This configuration exists for the resources where a resource provider manages those resources on behalf of the resource owner.",
+      "properties": {
+        "moboBrokerResources": {
+          "type": "array",
+          "description": "Managed-On-Behalf-Of broker resources",
+          "items": {
+            "$ref": "#/definitions/MoboBrokerResource"
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      },
+      "readOnly": true
+    },
+    "MoboBrokerResource": {
+      "type": "object",
+      "description": "Managed-On-Behalf-Of broker resource. This resource is created by the Resource Provider to manage some resources on behalf of the user.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource identifier of a Managed-On-Behalf-Of broker resource"
+        }
+      }
+    }
+  }
+}

--- a/specification/common-types/resource-management/v6/networksecurityperimeter.json
+++ b/specification/common-types/resource-management/v6/networksecurityperimeter.json
@@ -1,0 +1,433 @@
+{
+  "swagger": "2.0",
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "info": {
+    "version": "0000-00-00",
+    "title": "Network security perimeter common type definitions",
+    "description": "Common types for network security perimeters based on a shared API specification. These common, versioned type definitions are intended for resource providers (RPs, except Network RP) to use, and reuse, for defining their own API versions that share a set of type definitions that is consistent across providers.",
+    "contact": {}
+  },
+  "paths": {},
+  "definitions": {
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "Allow, disallow, or let network security perimeter configuration control public network access to the protected resource. Value is optional but if passed in, it must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.",
+      "enum": [
+        "Enabled",
+        "Disabled",
+        "SecuredByPerimeter"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Enabled",
+            "description": "Allows public network access to the resource"
+          },
+          {
+            "value": "Disabled",
+            "description": "Disallows public network access to the resource"
+          },
+          {
+            "value": "SecuredByPerimeter",
+            "description": "The network security perimeter configuration rules allow or disallow public network access to the resource. Requires an associated network security perimeter."
+          }
+        ]
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationListResult": {
+      "description": "Result of a list NSP (network security perimeter) configurations request.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Array of network security perimeter results.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+          }
+        },
+        "nextLink": {
+          "description": "The link used to get the next page of results.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfiguration": {
+      "description": "Network security perimeter (NSP) configuration resource",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "./types.json#/definitions/ProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProvisioningState": {
+      "description": "Provisioning state of a network security perimeter configuration that is being created or updated.",
+      "enum": [
+        "Succeeded",
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Accepted",
+        "Failed",
+        "Canceled"
+      ],
+      "type": "string",
+      "readOnly": true,
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterConfigurationProvisioningState",
+        "modelAsString": true
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProperties": {
+      "description": "Network security configuration properties.",
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProvisioningState"
+        },
+        "provisioningIssues": {
+          "description": "List of provisioning issues, if any",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/ProvisioningIssue"
+          },
+          "x-ms-identifiers": []
+        },
+        "networkSecurityPerimeter": {
+          "$ref": "#/definitions/NetworkSecurityPerimeter"
+        },
+        "resourceAssociation": {
+          "$ref": "#/definitions/ResourceAssociation"
+        },
+        "profile": {
+          "$ref": "#/definitions/NetworkSecurityProfile"
+        }
+      }
+    },
+    "ProvisioningIssue": {
+      "description": "Describes a provisioning issue for a network security perimeter configuration",
+      "type": "object",
+      "readOnly": true,
+      "properties": {
+        "name": {
+          "description": "Name of the issue",
+          "type": "string",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/ProvisioningIssueProperties"
+        }
+      }
+    },
+    "ProvisioningIssueProperties": {
+      "description": "Details of a provisioning issue for a network security perimeter (NSP) configuration. Resource providers should generate separate provisioning issue elements for each separate issue detected, and include a meaningful and distinctive description, as well as any appropriate suggestedResourceIds and suggestedAccessRules",
+      "type": "object",
+      "readOnly": true,
+      "properties": {
+        "issueType": {
+          "description": "Type of issue",
+          "type": "string",
+          "readOnly": true,
+          "enum": [
+            "Unknown",
+            "ConfigurationPropagationFailure",
+            "MissingPerimeterConfiguration",
+            "MissingIdentityConfiguration"
+          ],
+          "x-ms-enum": {
+            "name": "IssueType",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "Unknown",
+                "description": "Unknown issue type"
+              },
+              {
+                "value": "ConfigurationPropagationFailure",
+                "description": "An error occurred while applying the network security perimeter (NSP) configuration."
+              },
+              {
+                "value": "MissingPerimeterConfiguration",
+                "description": "A network connectivity issue is happening on the resource which could be addressed either by adding new resources to the network security perimeter (NSP) or by modifying access rules."
+              },
+              {
+                "value": "MissingIdentityConfiguration",
+                "description": "An managed identity hasn't been associated with the resource. The resource will still be able to validate inbound traffic from the network security perimeter (NSP) or matching inbound access rules, but it won't be able to perform outbound access as a member of the NSP."
+              }
+            ]
+          }
+        },
+        "severity": {
+          "description": "Severity of the issue.",
+          "enum": [
+            "Warning",
+            "Error"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "Severity",
+            "modelAsString": true
+          }
+        },
+        "description": {
+          "description": "Description of the issue",
+          "type": "string",
+          "readOnly": true
+        },
+        "suggestedResourceIds": {
+          "description": "Fully qualified resource IDs of suggested resources that can be associated to the network security perimeter (NSP) to remediate the issue.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "description": "Fully qualified resource ID of the suggested resource",
+            "type": "string",
+            "format": "arm-id",
+            "readOnly": true
+          }
+        },
+        "suggestedAccessRules": {
+          "description": "Access rules that can be added to the network security profile (NSP) to remediate the issue.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/AccessRule"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "NetworkSecurityPerimeter": {
+      "description": "Information about a network security perimeter (NSP)",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Fully qualified Azure resource ID of the NSP resource",
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "resourceType": "Microsoft.Network/networkSecurityPerimeters"
+              }
+            ]
+          }
+        },
+        "perimeterGuid": {
+          "description": "Universal unique ID (UUID) of the network security perimeter",
+          "type": "string",
+          "format": "uuid"
+        },
+        "location": {
+          "description": "Location of the network security perimeter",
+          "type": "string",
+          "x-ms-mutability": [
+            "create",
+            "read"
+          ]
+        }
+      }
+    },
+    "ResourceAssociationAccessMode": {
+      "description": "Access mode of the resource association",
+      "enum": [
+        "Enforced",
+        "Learning",
+        "Audit"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "ResourceAssociationAccessMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Enforced",
+            "description": "Enforced access mode - traffic to the resource that failed access checks is blocked"
+          },
+          {
+            "value": "Learning",
+            "description": "Learning access mode - traffic to the resource is enabled for analysis but not blocked"
+          },
+          {
+            "value": "Audit",
+            "description": "Audit access mode - traffic to the resource that fails access checks is logged but not blocked"
+          }
+        ]
+      }
+    },
+    "ResourceAssociation": {
+      "description": "Information about resource association",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the resource association",
+          "type": "string"
+        },
+        "accessMode": {
+          "$ref": "#/definitions/ResourceAssociationAccessMode"
+        }
+      }
+    },
+    "NetworkSecurityProfile": {
+      "description": "Network security perimeter configuration profile",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the profile",
+          "type": "string"
+        },
+        "accessRulesVersion": {
+          "description": "Current access rules version",
+          "type": "integer",
+          "format": "int32"
+        },
+        "accessRules": {
+          "description": "List of Access Rules",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AccessRule"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "diagnosticSettingsVersion": {
+          "description": "Current diagnostic settings version",
+          "type": "integer",
+          "format": "int32"
+        },
+        "enabledLogCategories": {
+          "description": "List of log categories that are enabled",
+          "type": "array",
+          "items": {
+            "description": "Log category",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AccessRule": {
+      "description": "Access rule in a network security perimeter configuration profile",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the access rule",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/AccessRuleProperties"
+        }
+      }
+    },
+    "AccessRuleDirection": {
+      "description": "Direction of Access Rule",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "AccessRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Inbound",
+            "description": "Applies to inbound network traffic to the secured resources."
+          },
+          {
+            "value": "Outbound",
+            "description": "Applies to outbound network traffic from the secured resources"
+          }
+        ]
+      }
+    },
+    "AccessRuleProperties": {
+      "description": "Properties of Access Rule",
+      "type": "object",
+      "properties": {
+        "direction": {
+          "$ref": "#/definitions/AccessRuleDirection"
+        },
+        "addressPrefixes": {
+          "description": "Address prefixes in the CIDR format for inbound rules",
+          "type": "array",
+          "items": {
+            "description": "An IP address prefix (CIDR) for inbound rules",
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "description": "Subscriptions for inbound rules",
+          "type": "array",
+          "items": {
+            "description": "Subscription identifiers",
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "The fully qualified Azure resource ID of the subscription e.g. ('/subscriptions/00000000-0000-0000-0000-000000000000') ",
+                "type": "string",
+                "format": "arm-id"
+              }
+            }
+          }
+        },
+        "networkSecurityPerimeters": {
+          "description": "Network security perimeters for inbound rules",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeter"
+          }
+        },
+        "fullyQualifiedDomainNames": {
+          "description": "Fully qualified domain names (FQDN) for outbound rules",
+          "type": "array",
+          "items": {
+            "description": "A fully qualified domain name (FQDN)",
+            "type": "string"
+          }
+        },
+        "emailAddresses": {
+          "description": "Email addresses for outbound rules",
+          "type": "array",
+          "items": {
+            "description": "An email address",
+            "type": "string"
+          }
+        },
+        "phoneNumbers": {
+          "description": "Phone numbers for outbound rules",
+          "type": "array",
+          "items": {
+            "description": "A phone number",
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "NetworkSecurityPerimeterConfigurationNameParameter": {
+      "name": "networkSecurityPerimeterConfigurationName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "x-ms-parameter-location": "method",
+      "description": "The name for a network security perimeter configuration"
+    }
+  }
+}


### PR DESCRIPTION
In the [common-types V6 directory](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/common-types/resource-management/v6), there are some specifications missing that are present in the [V5 directory](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/common-types/resource-management/v5). To ensure that all available specifications are consistently included in the respective version folders, I am creating this pull request to copy the files from V5 to V6.

The files being copied are:
- customermanagedkeys
- managedidentitywithdelegation
- mobo
- networksecurityperimeter