### PR TITLE
[dependabot] Ignore @azure-tools/typespec-liftr-base

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
   # Updated manually to align with repo microsoft/typespec
   - dependency-name: "typescript"
   - dependency-name: "prettier"
+  # Updated manually by the Liftr team
+  - dependency-name: "@azure-tools/typespec-liftr-base"
   # minimatch@9 is the last version to support Node 18
   - dependency-name: "minimatch"
     versions: [ ">= 10.0.0"]


### PR DESCRIPTION
- Updated manually by the Liftr team
