### PR TITLE
Microsoft.web: functionAppConfig property only applies to Flex Consumption

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-04-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-04-01/CommonDefinitions.json
@@ -2955,7 +2955,7 @@
             },
             "functionAppConfig": {
               "$ref": "#/definitions/FunctionAppConfig",
-              "description": "Configuration specific of the Azure Function app."
+              "description": "Configuration specific of the Azure Function app. Only applicable to Flex Consumption"
             },
             "daprConfig": {
               "$ref": "#/definitions/DaprConfig",


### PR DESCRIPTION
The aim of the PR is adding a reference that functionAppConfig property on Microsoft.web only applies to Flex Consumption.

If you try to use it on another Function app sku/tier you get this error:

![image](https://github.com/user-attachments/assets/7231933c-16b4-40ef-a48a-ba8218d4d859)

This is important because adding this detail to the Azure REST API reference will reflect on the Public documentation here https://learn.microsoft.com/en-us/azure/templates/microsoft.web/2024-04-01/sites?pivots=deployment-language-bicep
