### PR TITLE
remove unknown CallLoator type

### DIFF
--- a/specification/communication/data-plane/CallAutomation/stable/2024-09-15/communicationservicescallautomation.json
+++ b/specification/communication/data-plane/CallAutomation/stable/2024-09-15/communicationservicescallautomation.json
@@ -1655,7 +1655,6 @@
     "CallLocatorKind": {
       "description": "The call locator kind.",
       "enum": [
-        "unknown",
         "groupCallLocator",
         "serverCallLocator",
         "roomCallLocator"


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.


This pr is to remove a enum value, unknown, for CallLocator for ACS call automation. This value is **exposed by mistake**. This value is for error message and will never be accepted by service and the service will not emit this value to customer. 