### PR TITLE
remove unknown for ACS call automation calllocator for  beta5

### DIFF
--- a/specification/communication/data-plane/CallAutomation/preview/2024-11-15-preview/communicationservicescallautomation.json
+++ b/specification/communication/data-plane/CallAutomation/preview/2024-11-15-preview/communicationservicescallautomation.json
@@ -2149,7 +2149,6 @@
     "CallLocatorKind": {
       "description": "The call locator kind.",
       "enum": [
-        "unknown",
         "groupCallLocator",
         "serverCallLocator",
         "roomCallLocator"


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
This pr is to remove a enum value, unknown, for CallLocator for ACS call automation beta5 version. This value is exposed by mistake. This value is for error message and will never be accepted by service and the service will not emit this value to customer.