### PR TITLE
Update CODEOWNERS for Key Vault (CP, DP)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -137,7 +137,10 @@
 /specification/iothub/ @rkmanda
 
 # PRLabel: %KeyVault
-/specification/keyvault/ @heaths @randallilama @jlichwa
+/specification/keyvault/ @vickm @chen-karen @cheathamb36 @lgonsoulin
+
+# PRLabel: %KeyVault
+/specification/keyvault/data-plane/ @vickm @chen-karen @cheathamb36 @lgonsoulin @heaths
 
 # PRLabel: %Load Test Service
 /specification/loadtestservice/data-plane/ @Azure/api-stewardship-board


### PR DESCRIPTION
Need to update the codeowners from Key Vault anyway, and I - as the service buddy from the REST API board - only review data-plane APIs anyway. Lots of ARM reviews keep notifying me.