### PR TITLE
Rename EmbeddingInput to ImageEmbeddingInput

### DIFF
--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -40,7 +40,7 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.CompletionsFinishReason, Access.public);
 @@access(AI.Model.CompletionsUsage, Access.public);
 @@access(AI.Model.EmbeddingEncodingFormat, Access.public, "python");
-@@access(AI.Model.EmbeddingInput, Access.public, "python");
+@@access(AI.Model.ImageEmbeddingInput, Access.public, "python");
 @@access(AI.Model.EmbeddingInputType, Access.public, "python");
 @@access(AI.Model.EmbeddingItem, Access.public, "python");
 @@access(AI.Model.EmbeddingsResult, Access.public, "python");

--- a/specification/ai/ModelClient/models/image_embeddings.tsp
+++ b/specification/ai/ModelClient/models/image_embeddings.tsp
@@ -44,7 +44,7 @@ alias ImageEmbeddingsOptions = {
 @doc("Represents an image with optional text.")
 model ImageEmbeddingInput {
   @doc("""
-    The input image, in PNG format.
+    The input image encoded in base64 string as a data URL. Example: `data:image/{format};base64,{data}`.
     """)
   image: string;
 

--- a/specification/ai/ModelClient/models/image_embeddings.tsp
+++ b/specification/ai/ModelClient/models/image_embeddings.tsp
@@ -11,7 +11,7 @@ alias ImageEmbeddingsOptions = {
     Input image to embed. To embed multiple inputs in a single request, pass an array.
     The input must not exceed the max input tokens for the model.
     """)
-  input: EmbeddingInput[];
+  input: ImageEmbeddingInput[];
 
   @doc("""
     Optional. The number of dimensions the resulting output embeddings should have.
@@ -42,7 +42,7 @@ alias ImageEmbeddingsOptions = {
 };
 
 @doc("Represents an image with optional text.")
-model EmbeddingInput {
+model ImageEmbeddingInput {
   @doc("""
     The input image, in PNG format.
     """)

--- a/specification/ai/ModelClient/tspconfig.yaml
+++ b/specification/ai/ModelClient/tspconfig.yaml
@@ -16,7 +16,6 @@ options:
   "@azure-tools/typespec-autorest":
     azure-resource-provider-folder: "data-plane"
     emitter-output-dir: "{project-root}/.."
-    examples-directory: "{project-root}/examples"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
   "@azure-tools/typespec-python":
     package-mode: dataplane

--- a/specification/ai/data-plane/AI.Model/preview/2024-05-01-preview/openapi.json
+++ b/specification/ai/data-plane/AI.Model/preview/2024-05-01-preview/openapi.json
@@ -1309,7 +1309,7 @@
       "properties": {
         "image": {
           "type": "string",
-          "description": "The input image, in PNG format."
+          "description": "The input image encoded in base64 string as a data URL. Example: `data:image/{format};base64,{data}`."
         },
         "text": {
           "type": "string",

--- a/specification/ai/data-plane/AI.Model/preview/2024-05-01-preview/openapi.json
+++ b/specification/ai/data-plane/AI.Model/preview/2024-05-01-preview/openapi.json
@@ -381,7 +381,7 @@
                   "type": "array",
                   "description": "Input image to embed. To embed multiple inputs in a single request, pass an array.\nThe input must not exceed the max input tokens for the model.",
                   "items": {
-                    "$ref": "#/definitions/EmbeddingInput"
+                    "$ref": "#/definitions/ImageEmbeddingInput"
                   },
                   "x-ms-identifiers": []
                 },
@@ -1135,23 +1135,6 @@
         ]
       }
     },
-    "EmbeddingInput": {
-      "type": "object",
-      "description": "Represents an image with optional text.",
-      "properties": {
-        "image": {
-          "type": "string",
-          "description": "The input image, in PNG format."
-        },
-        "text": {
-          "type": "string",
-          "description": "Optional. The text input to feed into the model (like DINO, CLIP).\nReturns a 422 error if the model doesn't support the value or parameter."
-        }
-      },
-      "required": [
-        "image"
-      ]
-    },
     "EmbeddingInputType": {
       "type": "string",
       "description": "Represents the input types used for embedding search.",
@@ -1320,6 +1303,23 @@
         "name"
       ]
     },
+    "ImageEmbeddingInput": {
+      "type": "object",
+      "description": "Represents an image with optional text.",
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "The input image, in PNG format."
+        },
+        "text": {
+          "type": "string",
+          "description": "Optional. The text input to feed into the model (like DINO, CLIP).\nReturns a 422 error if the model doesn't support the value or parameter."
+        }
+      },
+      "required": [
+        "image"
+      ]
+    },
     "ModelInfo": {
       "type": "object",
       "description": "Represents some basic information about the AI model.",
@@ -1352,7 +1352,7 @@
         "text_generation",
         "image_embeddings",
         "audio_generation",
-        "chat"
+        "chat_completion"
       ],
       "x-ms-enum": {
         "name": "ModelType",
@@ -1361,32 +1361,32 @@
           {
             "name": "embeddings",
             "value": "embeddings",
-            "description": "Embeddings."
+            "description": "A model capable of generating embeddings from a text"
           },
           {
             "name": "image_generation",
             "value": "image_generation",
-            "description": "Image generation"
+            "description": "A model capable of generating images from an image and text description"
           },
           {
             "name": "text_generation",
             "value": "text_generation",
-            "description": "Text generation"
+            "description": "A text generation model"
           },
           {
             "name": "image_embeddings",
             "value": "image_embeddings",
-            "description": "Image embeddings"
+            "description": "A model capable of generating embeddings from an image"
           },
           {
             "name": "audio_generation",
             "value": "audio_generation",
-            "description": "Audio generation"
+            "description": "A text-to-audio generative model"
           },
           {
-            "name": "chat",
-            "value": "chat",
-            "description": "Chat completions"
+            "name": "chat_completion",
+            "value": "chat_completion",
+            "description": "A model capable of taking chat-formatted messages and generate responses"
           }
         ]
       }


### PR DESCRIPTION
* Rename EmbeddingInput to ImageEmbeddingInput, since this is only used by the ImageEmbeddingsClient, and I get confused by other "Embeddings" classes that are used by both EmbeddingsClient and ImageEmbeddingsClient.
* Update the description of the "Image" field in ImageEmbeddingInput, per latest REST API spec
* Remove the line `examples-directory: "{project-root}/examples"` from tspconfig.yaml, since new TSP compile tool says it's deprecated and needs to be removed. The default is to generate examples in the `{project-root}/examples` folder

Validated by running:
```
npx tsp format **\*.tsp
npx tsv .
```

The last command updates the Swagger file. Looks like it has not been updated in a while, so I see other changes there, not only the ones mentioned above.

