### PR TITLE
Make all response format models internal

### DIFF
--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -16,8 +16,9 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@usage(AI.Model.StreamingChatResponseMessageUpdate, Usage.output);
 @@usage(AI.Model.StreamingChatResponseToolCallUpdate, Usage.output);
 
-// Since we made all operator methods internal, we need to expliclty
-// say we still want the models they use to be public.
+// Since we made all operator methods internal, we need to explicity
+// say we still want the models they use to be generated.
+// Note that for some programming languages, we will make some of these classes internal (see below)
 @@access(AI.Model.ChatChoice, Access.public);
 @@access(AI.Model.ChatCompletions, Access.public);
 @@access(AI.Model.ChatCompletionsToolCall, Access.public);
@@ -25,8 +26,9 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.ChatCompletionsNamedToolChoice, Access.public);
 @@access(AI.Model.ChatCompletionsNamedToolChoiceFunction, Access.public);
 @@access(AI.Model.ChatCompletionsResponseFormat, Access.public);
-@@access(AI.Model.ChatCompletionsResponseFormatJsonObject, Access.public);
 @@access(AI.Model.ChatCompletionsResponseFormatText, Access.public);
+@@access(AI.Model.ChatCompletionsResponseFormatJsonObject, Access.public);
+@@access(AI.Model.ChatCompletionsResponseFormatJsonSchema, Access.public);
 @@access(AI.Model.ChatCompletionsToolCall, Access.public);
 @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
 @@access(AI.Model.ChatCompletionsToolChoicePreset, Access.public);
@@ -65,10 +67,42 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.getImageEmbeddings, Access.internal);
 @@access(AI.Model.getModelInfo, Access.internal, "python");
 
-// Hide the JSON schema class in favor of a factory method on the ChatCompletionsResponseFormat class
+// Hide the Response Format related classes favor of a factory method on the ChatCompletionsResponseFormat class
+@@access(AI.Model.ChatCompletionsResponseFormat, Access.internal, "python");
+@@access(AI.Model.ChatCompletionsResponseFormatText, Access.internal, "python");
+@@access(AI.Model.ChatCompletionsResponseFormatJsonObject,
+  Access.internal,
+  "python"
+);
 @@access(AI.Model.ChatCompletionsResponseFormatJsonSchema,
   Access.internal,
-  "csharp"
+  "csharp,python"
+);
+@@access(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
+  Access.internal,
+  "python"
+);
+
+// Add "Internal" suffix to the internal Response Format classes, as we hand-code a new public class named ChatCompletionsResponseFormat.
+@@clientName(AI.Model.ChatCompletionsResponseFormat,
+  "ChatCompletionsResponseFormatInternal",
+  "python"
+);
+@@clientName(AI.Model.ChatCompletionsResponseFormatText,
+  "ChatCompletionsResponseFormatTextInternal",
+  "python"
+);
+@@clientName(AI.Model.ChatCompletionsResponseFormatJsonObject,
+  "ChatCompletionsResponseFormatJsonObjectInternal",
+  "python"
+);
+@@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchema,
+  "ChatCompletionsResponseFormatJsonSchemaInternal",
+  "python"
+);
+@@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
+  "ChatCompletionsResponseFormatJsonSchemaDefinitionInternal",
+  "python"
 );
 
 // We use shorter names in the Python client library

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -30,7 +30,6 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
 @@access(AI.Model.ChatCompletionsNamedToolChoice, Access.public);
 @@access(AI.Model.ChatCompletionsNamedToolChoiceFunction, Access.public);
-@@access(AI.Model.ChatCompletionsResponseFormat, Access.public);
 @@access(AI.Model.ChatCompletionsToolCall, Access.public);
 @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
 @@access(AI.Model.ChatCompletionsToolChoicePreset, Access.public);

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -16,6 +16,14 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@usage(AI.Model.StreamingChatResponseMessageUpdate, Usage.output);
 @@usage(AI.Model.StreamingChatResponseToolCallUpdate, Usage.output);
 
+@@usage(AI.Model.ChatCompletionsResponseFormat, Usage.input);
+@@usage(AI.Model.ChatCompletionsResponseFormatText, Usage.input);
+@@usage(AI.Model.ChatCompletionsResponseFormatJsonObject, Usage.input);
+@@usage(AI.Model.ChatCompletionsResponseFormatJsonSchema, Usage.input);
+@@usage(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
+  Usage.input
+);
+
 // The operators need to be hidden, since we hand-write the public versions of those
 @@access(AI.Model.getChatCompletions, Access.internal);
 @@access(AI.Model.getEmbeddings, Access.internal);
@@ -64,23 +72,23 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 
 @@clientName(AI.Model.ChatCompletionsResponseFormat,
   "ChatCompletionsResponseFormatInternal",
-  "python"
+  "python,csharp"
 );
 @@clientName(AI.Model.ChatCompletionsResponseFormatText,
   "ChatCompletionsResponseFormatTextInternal",
-  "python"
+  "python,csharp"
 );
 @@clientName(AI.Model.ChatCompletionsResponseFormatJsonObject,
   "ChatCompletionsResponseFormatJsonObjectInternal",
-  "python"
+  "python,csharp"
 );
 @@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchema,
   "ChatCompletionsResponseFormatJsonSchemaInternal",
-  "python"
+  "python,csharp"
 );
 @@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
   "ChatCompletionsResponseFormatJsonSchemaDefinitionInternal",
-  "python"
+  "python,csharp"
 );
 
 // We use shorter names in the Python client library

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -64,24 +64,6 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.getImageEmbeddings, Access.internal);
 @@access(AI.Model.getModelInfo, Access.internal, "python");
 
-// Hide Response Format related derived classes in favor of a factory method on ChatCompletionsResponseFormat.
-@@access(AI.Model.ChatCompletionsResponseFormatText,
-  Access.internal,
-  "csharp,python"
-);
-@@access(AI.Model.ChatCompletionsResponseFormatJsonObject,
-  Access.internal,
-  "csharp,python"
-);
-@@access(AI.Model.ChatCompletionsResponseFormatJsonSchema,
-  Access.internal,
-  "csharp,python"
-);
-@@access(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
-  Access.internal,
-  "csharp,python"
-);
-
 // We use shorter names in the Python client library
 @@clientName(AI.Model.ChatRequestSystemMessage, "SystemMessage", "python");
 @@clientName(AI.Model.ChatRequestUserMessage, "UserMessage", "python");

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -67,8 +67,7 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.getImageEmbeddings, Access.internal);
 @@access(AI.Model.getModelInfo, Access.internal, "python");
 
-// Hide the Response Format related classes favor of a factory method on the ChatCompletionsResponseFormat class
-@@access(AI.Model.ChatCompletionsResponseFormat, Access.internal, "python");
+// Hide Response Format related derived classes in favor of a factory method on ChatCompletionsResponseFormat.
 @@access(AI.Model.ChatCompletionsResponseFormatText, Access.internal, "python");
 @@access(AI.Model.ChatCompletionsResponseFormatJsonObject,
   Access.internal,
@@ -80,28 +79,6 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 );
 @@access(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
   Access.internal,
-  "python"
-);
-
-// Add "Internal" suffix to the internal Response Format classes, as we hand-code a new public class named ChatCompletionsResponseFormat.
-@@clientName(AI.Model.ChatCompletionsResponseFormat,
-  "ChatCompletionsResponseFormatInternal",
-  "python"
-);
-@@clientName(AI.Model.ChatCompletionsResponseFormatText,
-  "ChatCompletionsResponseFormatTextInternal",
-  "python"
-);
-@@clientName(AI.Model.ChatCompletionsResponseFormatJsonObject,
-  "ChatCompletionsResponseFormatJsonObjectInternal",
-  "python"
-);
-@@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchema,
-  "ChatCompletionsResponseFormatJsonSchemaInternal",
-  "python"
-);
-@@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
-  "ChatCompletionsResponseFormatJsonSchemaDefinitionInternal",
   "python"
 );
 

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -17,7 +17,7 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@usage(AI.Model.StreamingChatResponseToolCallUpdate, Usage.output);
 
 // Since we made all operator methods internal, we need to explicity
-// say we still want the models they use to be generated.
+// say we still want the models they use to be public, since they will be used by hand-written operator methods.
 // Note that for some programming languages, we will make some of these classes internal (see below)
 @@access(AI.Model.ChatChoice, Access.public);
 @@access(AI.Model.ChatCompletions, Access.public);

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -16,9 +16,14 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@usage(AI.Model.StreamingChatResponseMessageUpdate, Usage.output);
 @@usage(AI.Model.StreamingChatResponseToolCallUpdate, Usage.output);
 
+// The operators need to be hidden, since we hand-write the public versions of those
+@@access(AI.Model.getChatCompletions, Access.internal);
+@@access(AI.Model.getEmbeddings, Access.internal);
+@@access(AI.Model.getImageEmbeddings, Access.internal);
+@@access(AI.Model.getModelInfo, Access.internal, "python");
+
 // Since we made all operator methods internal, we need to explicity
 // say we still want the models they use to be public, since they will be used by hand-written operator methods.
-// Note that for some programming languages, we will make some of these classes internal (see below)
 @@access(AI.Model.ChatChoice, Access.public);
 @@access(AI.Model.ChatCompletions, Access.public);
 @@access(AI.Model.ChatCompletionsToolCall, Access.public);
@@ -57,12 +62,6 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.StreamingChatChoiceUpdate, Access.public, "python");
 @@access(AI.Model.StreamingChatResponseMessageUpdate, Access.public, "python");
 @@access(AI.Model.StreamingChatResponseToolCallUpdate, Access.public, "python");
-
-// The operators need to be hidden, since we hand-write the public versions of those
-@@access(AI.Model.getChatCompletions, Access.internal);
-@@access(AI.Model.getEmbeddings, Access.internal);
-@@access(AI.Model.getImageEmbeddings, Access.internal);
-@@access(AI.Model.getModelInfo, Access.internal, "python");
 
 // We use shorter names in the Python client library
 @@clientName(AI.Model.ChatRequestSystemMessage, "SystemMessage", "python");

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -26,9 +26,6 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.ChatCompletionsNamedToolChoice, Access.public);
 @@access(AI.Model.ChatCompletionsNamedToolChoiceFunction, Access.public);
 @@access(AI.Model.ChatCompletionsResponseFormat, Access.public);
-@@access(AI.Model.ChatCompletionsResponseFormatText, Access.public);
-@@access(AI.Model.ChatCompletionsResponseFormatJsonObject, Access.public);
-@@access(AI.Model.ChatCompletionsResponseFormatJsonSchema, Access.public);
 @@access(AI.Model.ChatCompletionsToolCall, Access.public);
 @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
 @@access(AI.Model.ChatCompletionsToolChoicePreset, Access.public);
@@ -68,10 +65,13 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.getModelInfo, Access.internal, "python");
 
 // Hide Response Format related derived classes in favor of a factory method on ChatCompletionsResponseFormat.
-@@access(AI.Model.ChatCompletionsResponseFormatText, Access.internal, "python");
+@@access(AI.Model.ChatCompletionsResponseFormatText,
+  Access.internal,
+  "csharp,python"
+);
 @@access(AI.Model.ChatCompletionsResponseFormatJsonObject,
   Access.internal,
-  "python"
+  "csharp,python"
 );
 @@access(AI.Model.ChatCompletionsResponseFormatJsonSchema,
   Access.internal,
@@ -79,7 +79,7 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 );
 @@access(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
   Access.internal,
-  "python"
+  "csharp,python"
 );
 
 // We use shorter names in the Python client library

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -62,6 +62,27 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.StreamingChatResponseMessageUpdate, Access.public, "python");
 @@access(AI.Model.StreamingChatResponseToolCallUpdate, Access.public, "python");
 
+@@clientName(AI.Model.ChatCompletionsResponseFormat,
+  "ChatCompletionsResponseFormatInternal",
+  "python"
+);
+@@clientName(AI.Model.ChatCompletionsResponseFormatText,
+  "ChatCompletionsResponseFormatTextInternal",
+  "python"
+);
+@@clientName(AI.Model.ChatCompletionsResponseFormatJsonObject,
+  "ChatCompletionsResponseFormatJsonObjectInternal",
+  "python"
+);
+@@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchema,
+  "ChatCompletionsResponseFormatJsonSchemaInternal",
+  "python"
+);
+@@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
+  "ChatCompletionsResponseFormatJsonSchemaDefinitionInternal",
+  "python"
+);
+
 // We use shorter names in the Python client library
 @@clientName(AI.Model.ChatRequestSystemMessage, "SystemMessage", "python");
 @@clientName(AI.Model.ChatRequestUserMessage, "UserMessage", "python");

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -16,14 +16,6 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@usage(AI.Model.StreamingChatResponseMessageUpdate, Usage.output);
 @@usage(AI.Model.StreamingChatResponseToolCallUpdate, Usage.output);
 
-@@usage(AI.Model.ChatCompletionsResponseFormat, Usage.input);
-@@usage(AI.Model.ChatCompletionsResponseFormatText, Usage.input);
-@@usage(AI.Model.ChatCompletionsResponseFormatJsonObject, Usage.input);
-@@usage(AI.Model.ChatCompletionsResponseFormatJsonSchema, Usage.input);
-@@usage(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
-  Usage.input
-);
-
 // The operators need to be hidden, since we hand-write the public versions of those
 @@access(AI.Model.getChatCompletions, Access.internal);
 @@access(AI.Model.getEmbeddings, Access.internal);
@@ -69,26 +61,14 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.StreamingChatChoiceUpdate, Access.public, "python");
 @@access(AI.Model.StreamingChatResponseMessageUpdate, Access.public, "python");
 @@access(AI.Model.StreamingChatResponseToolCallUpdate, Access.public, "python");
+@@access(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
+  Access.public,
+  "python"
+);
 
-@@clientName(AI.Model.ChatCompletionsResponseFormat,
-  "ChatCompletionsResponseFormatInternal",
-  "python,csharp"
-);
-@@clientName(AI.Model.ChatCompletionsResponseFormatText,
-  "ChatCompletionsResponseFormatTextInternal",
-  "python,csharp"
-);
-@@clientName(AI.Model.ChatCompletionsResponseFormatJsonObject,
-  "ChatCompletionsResponseFormatJsonObjectInternal",
-  "python,csharp"
-);
-@@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchema,
-  "ChatCompletionsResponseFormatJsonSchemaInternal",
-  "python,csharp"
-);
 @@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
-  "ChatCompletionsResponseFormatJsonSchemaDefinitionInternal",
-  "python,csharp"
+  "JsonSchemaFormat",
+  "python"
 );
 
 // We use shorter names in the Python client library

--- a/specification/ai/ModelClient/models/chat_completions.tsp
+++ b/specification/ai/ModelClient/models/chat_completions.tsp
@@ -266,25 +266,33 @@ model ChatCompletionsResponseFormatJsonObject
 }
 
 @doc("""
-  The definition of a JSON schema, used to define the output format of a chat completion message. The AI model
+  Defines the response format for chat completions as JSON with a given schema. The AI model
   will need to adhere to this schema when generating completions.
   """)
 model ChatCompletionsResponseFormatJsonSchemaDefinition {
-  /** A name that labels this JSON schema. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64. */
+  @doc("""
+    A name that labels this JSON schema. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
+    """)
   name: string;
 
-  /** The definition of the JSON schema. See https://json-schema.org/overview/what-is-jsonschema.
-  Note that AI models usually only support a subset of the keywords defined by JSON schema. Consult your AI model documentation
-  to determine what is supported. */
+  @doc("""
+    The definition of the JSON schema. See https://json-schema.org/overview/what-is-jsonschema.
+    Note that AI models usually only support a subset of the keywords defined by JSON schema. Consult your AI model documentation
+    to determine what is supported.
+    """)
   schema: Record<unknown>;
 
-  /** A description of the response format, used by the AI model to determine how to generate responses in this format. */
+  @doc("""
+    A description of the response format, used by the AI model to determine how to generate responses in this format.
+    """)
   description?: string;
 
-  /** If set to true, the service will error out if the provided JSON schema contains keywords
-  not supported by the AI model. An example of such keyword may be `maxLength` for JSON type `string`.
-  If false, and the provided JSON schema contains keywords not supported
-  by the AI model, the AI model will not error out. Instead it will ignore the unsupported keywords.*/
+  @doc("""
+    If set to true, the service will error out if the provided JSON schema contains keywords
+    not supported by the AI model. An example of such keyword may be `maxLength` for JSON type `string`.
+    If false, and the provided JSON schema contains keywords not supported
+    by the AI model, the AI model will not error out. Instead it will ignore the unsupported keywords.
+    """)
   strict?: boolean = false;
 }
 

--- a/specification/ai/ModelClient/models/chat_completions.tsp
+++ b/specification/ai/ModelClient/models/chat_completions.tsp
@@ -266,23 +266,25 @@ model ChatCompletionsResponseFormatJsonObject
 }
 
 @doc("""
-  The definition of the required JSON schema in the response, and associated metadata.
+  The definition of a JSON schema, used to define the output format of a chat completion message. The AI model
+  will need to adhere to this schema when generating completions.
   """)
 model ChatCompletionsResponseFormatJsonSchemaDefinition {
-  /** The name of the response format. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64. */
+  /** A name that labels this JSON schema. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64. */
   name: string;
 
-  /** The definition of the JSON schema */
+  /** The definition of the JSON schema. See https://json-schema.org/overview/what-is-jsonschema.
+  Note that AI models usually only support a subset of the keywords defined by JSON schema. Consult your AI model documentation
+  to determine what is supported. */
   schema: Record<unknown>;
 
   /** A description of the response format, used by the AI model to determine how to generate responses in this format. */
   description?: string;
 
-  @doc("""
-    Whether to enable strict schema adherence when generating the output.
-    If set to true, the model will always follow the exact schema defined in the `schema` field. Only a subset of
-    JSON Schema is supported when `strict` is `true`.
-    """)
+  /** If set to true, the service will error out if the provided JSON schema contains keywords
+  not supported by the AI model. An example of such keyword may be `maxLength` for JSON type `string`.
+  If false, and the provided JSON schema contains keywords not supported
+  by the AI model, the AI model will not error out. Instead it will ignore the unsupported keywords.*/
   strict?: boolean = false;
 }
 

--- a/specification/ai/data-plane/AI.Model/preview/2024-05-01-preview/openapi.json
+++ b/specification/ai/data-plane/AI.Model/preview/2024-05-01-preview/openapi.json
@@ -688,15 +688,15 @@
     },
     "ChatCompletionsResponseFormatJsonSchemaDefinition": {
       "type": "object",
-      "description": "The definition of the required JSON schema in the response, and associated metadata.",
+      "description": "The definition of a JSON schema, used to define the output format of a chat completion message. The AI model\nwill need to adhere to this schema when generating completions.",
       "properties": {
         "name": {
           "type": "string",
-          "description": "The name of the response format. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64."
+          "description": "A name that labels this JSON schema. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64."
         },
         "schema": {
           "type": "object",
-          "description": "The definition of the JSON schema",
+          "description": "The definition of the JSON schema. See https://json-schema.org/overview/what-is-jsonschema.\n  Note that AI models usually only support a subset of the keywords defined by JSON schema. Consult your AI model documentation\n  to determine what is supported.",
           "additionalProperties": {}
         },
         "description": {
@@ -705,7 +705,7 @@
         },
         "strict": {
           "type": "boolean",
-          "description": "Whether to enable strict schema adherence when generating the output.\nIf set to true, the model will always follow the exact schema defined in the `schema` field. Only a subset of\nJSON Schema is supported when `strict` is `true`.",
+          "description": "If set to true, the service will error out if the provided JSON schema contains keywords\n  not supported by the AI model. An example of such keyword may be `maxLength` for JSON type `string`.\n  If false, and the provided JSON schema contains keywords not supported\n  by the AI model, the AI model will not error out. Instead it will ignore the unsupported keywords.",
           "default": false
         }
       },

--- a/specification/ai/data-plane/AI.Model/preview/2024-05-01-preview/openapi.json
+++ b/specification/ai/data-plane/AI.Model/preview/2024-05-01-preview/openapi.json
@@ -688,7 +688,7 @@
     },
     "ChatCompletionsResponseFormatJsonSchemaDefinition": {
       "type": "object",
-      "description": "The definition of a JSON schema, used to define the output format of a chat completion message. The AI model\nwill need to adhere to this schema when generating completions.",
+      "description": "Defines the response format for chat completions as JSON with a given schema. The AI model\nwill need to adhere to this schema when generating completions.",
       "properties": {
         "name": {
           "type": "string",
@@ -696,7 +696,7 @@
         },
         "schema": {
           "type": "object",
-          "description": "The definition of the JSON schema. See https://json-schema.org/overview/what-is-jsonschema.\n  Note that AI models usually only support a subset of the keywords defined by JSON schema. Consult your AI model documentation\n  to determine what is supported.",
+          "description": "The definition of the JSON schema. See https://json-schema.org/overview/what-is-jsonschema.\nNote that AI models usually only support a subset of the keywords defined by JSON schema. Consult your AI model documentation\nto determine what is supported.",
           "additionalProperties": {}
         },
         "description": {
@@ -705,7 +705,7 @@
         },
         "strict": {
           "type": "boolean",
-          "description": "If set to true, the service will error out if the provided JSON schema contains keywords\n  not supported by the AI model. An example of such keyword may be `maxLength` for JSON type `string`.\n  If false, and the provided JSON schema contains keywords not supported\n  by the AI model, the AI model will not error out. Instead it will ignore the unsupported keywords.",
+          "description": "If set to true, the service will error out if the provided JSON schema contains keywords\nnot supported by the AI model. An example of such keyword may be `maxLength` for JSON type `string`.\nIf false, and the provided JSON schema contains keywords not supported\nby the AI model, the AI model will not error out. Instead it will ignore the unsupported keywords.",
           "default": false
         }
       },


### PR DESCRIPTION
Except for model `ChatCompletionsResponseFormatJsonSchemaDefinition`, which for the Python client library is kept public but renamed to `JsonSchemaFormat`.
