### PR TITLE
Rebranding of Azure AI Studio

### DIFF
--- a/specification/search/data-plane/Azure.Search/preview/2024-11-01-preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2024-11-01-preview/searchservice.json
@@ -2851,7 +2851,7 @@
           {
             "value": "cjk_width",
             "name": "CjkWidth",
-            "description": "Normalizes CJK width differences. Folds fullwidth ASCII variants into the equivalent basic Latin, and half-width Katakana variants into the equivalent Kana. See http://lucene.apache.org/core/4_10_3/analyzers-common/org/apache/lucene/analysis/cjk/CJKWidthFilter.html"
+            "description": "Normalizes CJK width differences. Folds full-width ASCII variants into the equivalent basic Latin, and half-width Katakana variants into the equivalent Kana. See http://lucene.apache.org/core/4_10_3/analyzers-common/org/apache/lucene/analysis/cjk/CJKWidthFilter.html"
           },
           {
             "value": "classic",

--- a/specification/search/data-plane/Azure.Search/preview/2024-11-01-preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2024-11-01-preview/searchservice.json
@@ -6718,7 +6718,7 @@
           "description": "Specifies the properties of the AML vectorizer."
         }
       },
-      "description": "Specifies an Azure Machine Learning endpoint deployed via the Azure AI Studio Model Catalog for generating the vector embedding of a query string."
+      "description": "Specifies an Azure Machine Learning endpoint deployed via the Azure AI Foundry Model Catalog for generating the vector embedding of a query string."
     },
     "AMLParameters": {
       "type": "object",
@@ -6754,7 +6754,7 @@
         },
         "modelName": {
           "$ref": "#/definitions/AIStudioModelCatalogName",
-          "description": "The name of the embedding model from the Azure AI Studio Catalog that is deployed at the provided endpoint."
+          "description": "The name of the embedding model from the Azure AI Foundry Catalog that is deployed at the provided endpoint."
         }
       },
       "required": [
@@ -6802,7 +6802,7 @@
           }
         ]
       },
-      "description": "The name of the embedding model from the Azure AI Studio Catalog that will be called."
+      "description": "The name of the embedding model from the Azure AI Foundry Catalog that will be called."
     },
     "VectorSearchVectorizerKind": {
       "type": "string",
@@ -6834,7 +6834,7 @@
           {
             "value": "aml",
             "name": "AML",
-            "description": "Generate embeddings using an Azure Machine Learning endpoint deployed via the Azure AI Studio Model Catalog at query time."
+            "description": "Generate embeddings using an Azure Machine Learning endpoint deployed via the Azure AI Foundry Model Catalog at query time."
           }
         ]
       },


### PR DESCRIPTION
Replace "Azure AI Studio" references with "Azure AI Foundry", which is the new product name.