### PR TITLE
Don't check custom-words.txt

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -28,7 +28,8 @@
         "**/package-lock.json",
         "cSpell.json",
         "eng/**",
-        "node_modules/**"
+        "node_modules/**",
+        "custom-words.txt"
     ],
     "ignoreRegExpList": [
         "v\\d",

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1,3 +1,4 @@
+test
 a128cbcpad
 a192cbcpad
 a256cbcpad

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1,4 +1,3 @@
-test
 a128cbcpad
 a192cbcpad
 a256cbcpad


### PR DESCRIPTION
Spell check currently checks `custom-words.txt` if it changes... edits to `custom-words.txt` results in spelling error detections (cspell seems to have a sequencing issue). Regardless this can be mitigated by excluding checks of `custom-words.txt`. 