### PR TITLE
Removes azure-resource-manager-schemas from SDK automation. It can be…

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -1,0 +1,27 @@
+name: SpellCheck
+
+on: pull_request
+
+jobs:
+  spellcheck:
+    name: SpellCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Run spelling check
+        run: |
+          ./eng/common/scripts/check-spelling-in-changed-files.ps1 `
+              -CSpellConfigPath 'cSpell.json' `
+              -SourceCommittish HEAD `
+              -TargetCommittish HEAD^ `
+              -ExitWithError
+          if ($LASTEXITCODE) {
+            Write-Host "Spelling errors found in changed files. See https://aka.ms/ci-fix#spell-check"
+            exit $LASTEXITCODE
+          }
+        shell: pwsh


### PR DESCRIPTION
… re-added without reverting this commit. (#30893) (#31918)

This change produces an extra warning but no obvious new errors.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
