### PR TITLE
Make message classes internal

### DIFF
--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -34,10 +34,22 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
 @@access(AI.Model.ChatCompletionsToolChoicePreset, Access.public);
 @@access(AI.Model.ChatRequestMessage, Access.public);
-@@access(AI.Model.ChatRequestAssistantMessage, Access.public, "csharp,java,javascript");
-@@access(AI.Model.ChatRequestSystemMessage, Access.public, "csharp,java,javascript");
-@@access(AI.Model.ChatRequestToolMessage, Access.public, "csharp,java,javascript");
-@@access(AI.Model.ChatRequestUserMessage, Access.public, "csharp,java,javascript");
+@@access(AI.Model.ChatRequestAssistantMessage,
+  Access.public,
+  "csharp,java,javascript"
+);
+@@access(AI.Model.ChatRequestSystemMessage,
+  Access.public,
+  "csharp,java,javascript"
+);
+@@access(AI.Model.ChatRequestToolMessage,
+  Access.public,
+  "csharp,java,javascript"
+);
+@@access(AI.Model.ChatRequestUserMessage,
+  Access.public,
+  "csharp,java,javascript"
+);
 @@access(AI.Model.ChatResponseMessage, Access.public);
 @@access(AI.Model.ChatRole, Access.public);
 @@access(AI.Model.CompletionsFinishReason, Access.public);
@@ -65,6 +77,11 @@ namespace Customizations; // The actual name here doesn't matter and is here for
   Access.public,
   "python"
 );
+
+@@access(AI.Model.ChatRequestAssistantMessage, Access.internal, "python");
+@@access(AI.Model.ChatRequestSystemMessage, Access.internal, "python");
+@@access(AI.Model.ChatRequestToolMessage, Access.internal, "python");
+@@access(AI.Model.ChatRequestUserMessage, Access.internal, "python");
 
 @@clientName(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
   "JsonSchemaFormat",

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -22,64 +22,61 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.getImageEmbeddings, Access.internal);
 @@access(AI.Model.getModelInfo, Access.internal, "python");
 
-// SDK emitters now generate all Models as public, even if the operation using them is internal. So
-// we no longer need to explicity make all Models public.
-//
-// // Since we made all operator methods internal, we need to explicity
-// // say we still want the models they use to be public, since they will be used by hand-written operator methods.
-// @@access(AI.Model.ChatChoice, Access.public);
-// @@access(AI.Model.ChatCompletions, Access.public);
-// @@access(AI.Model.ChatCompletionsToolCall, Access.public);
-// @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
-// @@access(AI.Model.ChatCompletionsNamedToolChoice, Access.public);
-// @@access(AI.Model.ChatCompletionsNamedToolChoiceFunction, Access.public);
-// @@access(AI.Model.ChatCompletionsToolCall, Access.public);
-// @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
-// @@access(AI.Model.ChatCompletionsToolChoicePreset, Access.public);
-// @@access(AI.Model.ChatRequestMessage, Access.public);
-// @@access(AI.Model.ChatRequestAssistantMessage,
-//   Access.public,
-//   "csharp,java,javascript"
-// );
-// @@access(AI.Model.ChatRequestSystemMessage,
-//   Access.public,
-//   "csharp,java,javascript"
-// );
-// @@access(AI.Model.ChatRequestToolMessage,
-//   Access.public,
-//   "csharp,java,javascript"
-// );
-// @@access(AI.Model.ChatRequestUserMessage,
-//   Access.public,
-//   "csharp,java,javascript"
-// );
-// @@access(AI.Model.ChatResponseMessage, Access.public);
-// @@access(AI.Model.ChatRole, Access.public);
-// @@access(AI.Model.CompletionsFinishReason, Access.public);
-// @@access(AI.Model.CompletionsUsage, Access.public);
-// @@access(AI.Model.EmbeddingEncodingFormat, Access.public, "python");
-// @@access(AI.Model.ImageEmbeddingInput, Access.public, "python");
-// @@access(AI.Model.EmbeddingInputType, Access.public, "python");
-// @@access(AI.Model.EmbeddingItem, Access.public, "python");
-// @@access(AI.Model.EmbeddingsResult, Access.public, "python");
-// @@access(AI.Model.EmbeddingsUsage, Access.public, "python");
-// @@access(AI.Model.FunctionCall, Access.public);
-// @@access(AI.Model.FunctionDefinition, Access.public);
-// @@access(AI.Model.ModelInfo, Access.public);
-// @@access(AI.Model.ModelType, Access.public);
-// @@access(AI.Model.ChatMessageContentItem, Access.public);
-// @@access(AI.Model.ChatMessageTextContentItem, Access.public);
-// @@access(AI.Model.ChatMessageImageContentItem, Access.public);
-// @@access(AI.Model.ChatMessageImageUrl, Access.public);
-// @@access(AI.Model.ChatMessageImageDetailLevel, Access.public);
-// @@access(AI.Model.StreamingChatCompletionsUpdate, Access.public, "python");
-// @@access(AI.Model.StreamingChatChoiceUpdate, Access.public, "python");
-// @@access(AI.Model.StreamingChatResponseMessageUpdate, Access.public, "python");
-// @@access(AI.Model.StreamingChatResponseToolCallUpdate, Access.public, "python");
-// @@access(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
-//   Access.public,
-//   "python"
-// );
+// Since we made all operator methods internal, we need to explicity
+// say we still want the models they use to be public, since they will be used by hand-written operator methods.
+@@access(AI.Model.ChatChoice, Access.public);
+@@access(AI.Model.ChatCompletions, Access.public);
+@@access(AI.Model.ChatCompletionsToolCall, Access.public);
+@@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
+@@access(AI.Model.ChatCompletionsNamedToolChoice, Access.public);
+@@access(AI.Model.ChatCompletionsNamedToolChoiceFunction, Access.public);
+@@access(AI.Model.ChatCompletionsToolCall, Access.public);
+@@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
+@@access(AI.Model.ChatCompletionsToolChoicePreset, Access.public);
+@@access(AI.Model.ChatRequestMessage, Access.public, "csharp,java,javascript");
+@@access(AI.Model.ChatRequestAssistantMessage,
+  Access.public,
+  "csharp,java,javascript"
+);
+@@access(AI.Model.ChatRequestSystemMessage,
+  Access.public,
+  "csharp,java,javascript"
+);
+@@access(AI.Model.ChatRequestToolMessage,
+  Access.public,
+  "csharp,java,javascript"
+);
+@@access(AI.Model.ChatRequestUserMessage,
+  Access.public,
+  "csharp,java,javascript"
+);
+@@access(AI.Model.ChatResponseMessage, Access.public);
+@@access(AI.Model.ChatRole, Access.public);
+@@access(AI.Model.CompletionsFinishReason, Access.public);
+@@access(AI.Model.CompletionsUsage, Access.public);
+@@access(AI.Model.EmbeddingEncodingFormat, Access.public, "python");
+@@access(AI.Model.ImageEmbeddingInput, Access.public, "python");
+@@access(AI.Model.EmbeddingInputType, Access.public, "python");
+@@access(AI.Model.EmbeddingItem, Access.public, "python");
+@@access(AI.Model.EmbeddingsResult, Access.public, "python");
+@@access(AI.Model.EmbeddingsUsage, Access.public, "python");
+@@access(AI.Model.FunctionCall, Access.public);
+@@access(AI.Model.FunctionDefinition, Access.public);
+@@access(AI.Model.ModelInfo, Access.public);
+@@access(AI.Model.ModelType, Access.public);
+@@access(AI.Model.ChatMessageContentItem, Access.public);
+@@access(AI.Model.ChatMessageTextContentItem, Access.public);
+@@access(AI.Model.ChatMessageImageContentItem, Access.public);
+@@access(AI.Model.ChatMessageImageUrl, Access.public);
+@@access(AI.Model.ChatMessageImageDetailLevel, Access.public);
+@@access(AI.Model.StreamingChatCompletionsUpdate, Access.public, "python");
+@@access(AI.Model.StreamingChatChoiceUpdate, Access.public, "python");
+@@access(AI.Model.StreamingChatResponseMessageUpdate, Access.public, "python");
+@@access(AI.Model.StreamingChatResponseToolCallUpdate, Access.public, "python");
+@@access(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
+  Access.public,
+  "python"
+);
 
 // In Python we hand-write the 4 input message classes, so we make them internal here.
 // The base class ChatRequestMessage has to have the same access as the derived classes,

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -33,11 +33,11 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.ChatCompletionsToolCall, Access.public);
 @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
 @@access(AI.Model.ChatCompletionsToolChoicePreset, Access.public);
-@@access(AI.Model.ChatRequestAssistantMessage, Access.public);
 @@access(AI.Model.ChatRequestMessage, Access.public);
-@@access(AI.Model.ChatRequestSystemMessage, Access.public);
-@@access(AI.Model.ChatRequestToolMessage, Access.public);
-@@access(AI.Model.ChatRequestUserMessage, Access.public);
+@@access(AI.Model.ChatRequestAssistantMessage, Access.public, "csharp,java,javascript");
+@@access(AI.Model.ChatRequestSystemMessage, Access.public, "csharp,java,javascript");
+@@access(AI.Model.ChatRequestToolMessage, Access.public, "csharp,java,javascript");
+@@access(AI.Model.ChatRequestUserMessage, Access.public, "csharp,java,javascript");
 @@access(AI.Model.ChatResponseMessage, Access.public);
 @@access(AI.Model.ChatRole, Access.public);
 @@access(AI.Model.CompletionsFinishReason, Access.public);
@@ -72,13 +72,6 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 );
 
 // We use shorter names in the Python client library
-@@clientName(AI.Model.ChatRequestSystemMessage, "SystemMessage", "python");
-@@clientName(AI.Model.ChatRequestUserMessage, "UserMessage", "python");
-@@clientName(AI.Model.ChatRequestAssistantMessage,
-  "AssistantMessage",
-  "python"
-);
-@@clientName(AI.Model.ChatRequestToolMessage, "ToolMessage", "python");
 @@clientName(AI.Model.ChatMessageContentItem, "ContentItem", "python");
 @@clientName(AI.Model.ChatMessageTextContentItem, "TextContentItem", "python");
 @@clientName(AI.Model.ChatMessageImageContentItem,

--- a/specification/ai/ModelClient/client.tsp
+++ b/specification/ai/ModelClient/client.tsp
@@ -22,62 +22,69 @@ namespace Customizations; // The actual name here doesn't matter and is here for
 @@access(AI.Model.getImageEmbeddings, Access.internal);
 @@access(AI.Model.getModelInfo, Access.internal, "python");
 
-// Since we made all operator methods internal, we need to explicity
-// say we still want the models they use to be public, since they will be used by hand-written operator methods.
-@@access(AI.Model.ChatChoice, Access.public);
-@@access(AI.Model.ChatCompletions, Access.public);
-@@access(AI.Model.ChatCompletionsToolCall, Access.public);
-@@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
-@@access(AI.Model.ChatCompletionsNamedToolChoice, Access.public);
-@@access(AI.Model.ChatCompletionsNamedToolChoiceFunction, Access.public);
-@@access(AI.Model.ChatCompletionsToolCall, Access.public);
-@@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
-@@access(AI.Model.ChatCompletionsToolChoicePreset, Access.public);
-@@access(AI.Model.ChatRequestMessage, Access.public);
-@@access(AI.Model.ChatRequestAssistantMessage,
-  Access.public,
-  "csharp,java,javascript"
-);
-@@access(AI.Model.ChatRequestSystemMessage,
-  Access.public,
-  "csharp,java,javascript"
-);
-@@access(AI.Model.ChatRequestToolMessage,
-  Access.public,
-  "csharp,java,javascript"
-);
-@@access(AI.Model.ChatRequestUserMessage,
-  Access.public,
-  "csharp,java,javascript"
-);
-@@access(AI.Model.ChatResponseMessage, Access.public);
-@@access(AI.Model.ChatRole, Access.public);
-@@access(AI.Model.CompletionsFinishReason, Access.public);
-@@access(AI.Model.CompletionsUsage, Access.public);
-@@access(AI.Model.EmbeddingEncodingFormat, Access.public, "python");
-@@access(AI.Model.ImageEmbeddingInput, Access.public, "python");
-@@access(AI.Model.EmbeddingInputType, Access.public, "python");
-@@access(AI.Model.EmbeddingItem, Access.public, "python");
-@@access(AI.Model.EmbeddingsResult, Access.public, "python");
-@@access(AI.Model.EmbeddingsUsage, Access.public, "python");
-@@access(AI.Model.FunctionCall, Access.public);
-@@access(AI.Model.FunctionDefinition, Access.public);
-@@access(AI.Model.ModelInfo, Access.public);
-@@access(AI.Model.ModelType, Access.public);
-@@access(AI.Model.ChatMessageContentItem, Access.public);
-@@access(AI.Model.ChatMessageTextContentItem, Access.public);
-@@access(AI.Model.ChatMessageImageContentItem, Access.public);
-@@access(AI.Model.ChatMessageImageUrl, Access.public);
-@@access(AI.Model.ChatMessageImageDetailLevel, Access.public);
-@@access(AI.Model.StreamingChatCompletionsUpdate, Access.public, "python");
-@@access(AI.Model.StreamingChatChoiceUpdate, Access.public, "python");
-@@access(AI.Model.StreamingChatResponseMessageUpdate, Access.public, "python");
-@@access(AI.Model.StreamingChatResponseToolCallUpdate, Access.public, "python");
-@@access(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
-  Access.public,
-  "python"
-);
+// SDK emitters now generate all Models as public, even if the operation using them is internal. So
+// we no longer need to explicity make all Models public.
+//
+// // Since we made all operator methods internal, we need to explicity
+// // say we still want the models they use to be public, since they will be used by hand-written operator methods.
+// @@access(AI.Model.ChatChoice, Access.public);
+// @@access(AI.Model.ChatCompletions, Access.public);
+// @@access(AI.Model.ChatCompletionsToolCall, Access.public);
+// @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
+// @@access(AI.Model.ChatCompletionsNamedToolChoice, Access.public);
+// @@access(AI.Model.ChatCompletionsNamedToolChoiceFunction, Access.public);
+// @@access(AI.Model.ChatCompletionsToolCall, Access.public);
+// @@access(AI.Model.ChatCompletionsToolDefinition, Access.public);
+// @@access(AI.Model.ChatCompletionsToolChoicePreset, Access.public);
+// @@access(AI.Model.ChatRequestMessage, Access.public);
+// @@access(AI.Model.ChatRequestAssistantMessage,
+//   Access.public,
+//   "csharp,java,javascript"
+// );
+// @@access(AI.Model.ChatRequestSystemMessage,
+//   Access.public,
+//   "csharp,java,javascript"
+// );
+// @@access(AI.Model.ChatRequestToolMessage,
+//   Access.public,
+//   "csharp,java,javascript"
+// );
+// @@access(AI.Model.ChatRequestUserMessage,
+//   Access.public,
+//   "csharp,java,javascript"
+// );
+// @@access(AI.Model.ChatResponseMessage, Access.public);
+// @@access(AI.Model.ChatRole, Access.public);
+// @@access(AI.Model.CompletionsFinishReason, Access.public);
+// @@access(AI.Model.CompletionsUsage, Access.public);
+// @@access(AI.Model.EmbeddingEncodingFormat, Access.public, "python");
+// @@access(AI.Model.ImageEmbeddingInput, Access.public, "python");
+// @@access(AI.Model.EmbeddingInputType, Access.public, "python");
+// @@access(AI.Model.EmbeddingItem, Access.public, "python");
+// @@access(AI.Model.EmbeddingsResult, Access.public, "python");
+// @@access(AI.Model.EmbeddingsUsage, Access.public, "python");
+// @@access(AI.Model.FunctionCall, Access.public);
+// @@access(AI.Model.FunctionDefinition, Access.public);
+// @@access(AI.Model.ModelInfo, Access.public);
+// @@access(AI.Model.ModelType, Access.public);
+// @@access(AI.Model.ChatMessageContentItem, Access.public);
+// @@access(AI.Model.ChatMessageTextContentItem, Access.public);
+// @@access(AI.Model.ChatMessageImageContentItem, Access.public);
+// @@access(AI.Model.ChatMessageImageUrl, Access.public);
+// @@access(AI.Model.ChatMessageImageDetailLevel, Access.public);
+// @@access(AI.Model.StreamingChatCompletionsUpdate, Access.public, "python");
+// @@access(AI.Model.StreamingChatChoiceUpdate, Access.public, "python");
+// @@access(AI.Model.StreamingChatResponseMessageUpdate, Access.public, "python");
+// @@access(AI.Model.StreamingChatResponseToolCallUpdate, Access.public, "python");
+// @@access(AI.Model.ChatCompletionsResponseFormatJsonSchemaDefinition,
+//   Access.public,
+//   "python"
+// );
 
+// In Python we hand-write the 4 input message classes, so we make them internal here.
+// The base class ChatRequestMessage has to have the same access as the derived classes,
+// so we make it internal as well. However the Python code will make it public again without changes.
+@@access(AI.Model.ChatRequestMessage, Access.internal, "python");
 @@access(AI.Model.ChatRequestAssistantMessage, Access.internal, "python");
 @@access(AI.Model.ChatRequestSystemMessage, Access.internal, "python");
 @@access(AI.Model.ChatRequestToolMessage, Access.internal, "python");


### PR DESCRIPTION
Make these Models internal for Python only:
```
  AI.Model.ChatRequestMessage
  AI.Model.ChatRequestAssistantMessage
  AI.Model.ChatRequestSystemMessage
  AI.Model.ChatRequestToolMessage
  AI.Model.ChatRequestUserMessage
```
So I can hand-write alternative ones, having a positional input argument for the content, so I can write `UserMessage("my message")` as a short alternative to `UserMessage(content="my message")`. Both options will be supported by the Python SDK.
Note that the base Model `ChatRequestMessage` had to also be made internal, due to TypeSpec/Emitter limitation, even though I don't need to re-write in in Python. The Python code makes it public again as is.