### PR TITLE
Remove extra space

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -13,7 +13,7 @@
         "subchannel",
         "umls"
     ],
-    "allowCompoundWords ": true,
+    "allowCompoundWords": true,
     "dictionaryDefinitions": [
         {
             "name": "custom-words",


### PR DESCRIPTION
There is an error in cSpell.json... there's an extra space at the end of "allowCompoundWords" which is causing that setting to not take effect. This PR fixes the issue. 

Expected error on `deviceregistry` (cSpell.json not fixed) ([link](https://github.com/Azure/azure-rest-api-specs/actions/runs/12782627552/job/35632420392?pr=32149#step:3:43)):

![image](https://github.com/user-attachments/assets/7019a470-26f5-44d6-88a6-ee8c6cfc04b9)


No error on `deviceregistry` (cspell.json fixed) ([link](https://github.com/Azure/azure-rest-api-specs/actions/runs/12782677093/job/35632547831?pr=32149#step:3:30)):

![image](https://github.com/user-attachments/assets/b1cd5800-b4cd-4fd2-a85d-8712115de7c1)

(also `tsp` and `config` are noted as compound words and not counted as a spelling error)