### PR TITLE
Fix create vector store file API according to new service definition

### DIFF
--- a/specification/ai/Azure.AI.Projects/agents/vector_stores/files/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/vector_stores/files/routes.tsp
@@ -56,8 +56,8 @@ op createVectorStoreFile is Azure.Core.Foundations.Operation<
 
     /** The data sources to be used. This option is mutually exclusive with fileId. */
     @doc("Azure asset ID.")
-    @encodedName("application/json", "data_sources")
-    dataSources?: VectorStoreDataSource[];
+    @encodedName("application/json", "data_source")
+    dataSource?: VectorStoreDataSource;
 
     /** The chunking strategy used to chunk the file(s). If not set, will use the auto strategy. */
     @encodedName("application/json", "chunking_strategy")

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
@@ -3270,14 +3270,10 @@
                   "description": "Identifier of the file.",
                   "x-ms-client-name": "fileId"
                 },
-                "data_sources": {
-                  "type": "array",
+                "data_source": {
+                  "$ref": "#/definitions/Agents.VectorStoreDataSource",
                   "description": "Azure asset ID.",
-                  "items": {
-                    "$ref": "#/definitions/Agents.VectorStoreDataSource"
-                  },
-                  "x-ms-client-name": "dataSources",
-                  "x-ms-identifiers": []
+                  "x-ms-client-name": "dataSource"
                 },
                 "chunking_strategy": {
                   "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyRequest",


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
