### PR TITLE
[Service Networking] Update readme.md

### DIFF
--- a/specification/servicenetworking/resource-manager/readme.md
+++ b/specification/servicenetworking/resource-manager/readme.md
@@ -93,10 +93,6 @@ swagger-to-sdk:
   - repo: azure-sdk-for-go
 ```
 
-## Python
-
-See configuration in [readme.python.md](./readme.python.md)
-
 ## Go
 
 See configuration in [readme.go.md](./readme.go.md)


### PR DESCRIPTION
Remove python generation configuration for swagger for we only generate servicenetworking SDK from typespec in the feature,