### PR TITLE
Repurposed azure-sdk-for-net

### DIFF
--- a/specificationRepositoryConfiguration.json
+++ b/specificationRepositoryConfiguration.json
@@ -18,10 +18,6 @@
     },
     "azure-sdk-for-net": {
       "integrationRepository": "azure-sdk/azure-sdk-for-net",
-      "mainRepository": "Azure/azure-sdk-for-net"
-    },
-    "azure-sdk-for-net-track2": {
-      "integrationRepository": "azure-sdk/azure-sdk-for-net",
       "mainRepository": "Azure/azure-sdk-for-net",
       "configFilePath": "eng/swagger_to_sdk_config.json"
     },
@@ -53,10 +49,6 @@
         },
         "azure-sdk-for-net": {
           "integrationRepository": "azure-sdk/azure-sdk-for-net-pr",
-          "mainRepository": "Azure/azure-sdk-for-net-pr"
-        },
-        "azure-sdk-for-net-track2": {
-          "integrationRepository": "azure-sdk/azure-sdk-for-net-pr",
           "mainRepository": "Azure/azure-sdk-for-net-pr",
           "configFilePath": "eng/swagger_to_sdk_config.json"
         },
@@ -74,7 +66,7 @@
   "typespecEmitterToSdkRepositoryMapping": {
     "@azure-tools/typespec-python": "azure-sdk-for-python",
     "@azure-tools/typespec-java": "azure-sdk-for-java",
-    "@azure-tools/typespec-csharp": "azure-sdk-for-net-track2",
+    "@azure-tools/typespec-csharp": "azure-sdk-for-net",
     "@azure-tools/typespec-ts": "azure-sdk-for-js",
     "@azure-tools/typespec-go": "azure-sdk-for-go"
   }


### PR DESCRIPTION
Use `azure-sdk-for-net` for the .NET track2 SDK and remove the `azure-sdk-for-net-track2` references.