### PR TITLE
Removed -track2 from the SDK config name

### DIFF
--- a/dev/cognitiveservices/data-plane/Language/readme.md
+++ b/dev/cognitiveservices/data-plane/Language/readme.md
@@ -44,6 +44,6 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
 ```

--- a/documentation/ci-fix.md
+++ b/documentation/ci-fix.md
@@ -92,7 +92,6 @@ If you have an issue or with any of checks listed in the first column of the tab
 | `SDK azure-sdk-for-java`          | Weidong Xu     | [weidongxu-microsoft](https://github.com/weidongxu-microsoft) |
 | `SDK azure-sdk-for-js`            | Qiaoqiao Zhang | [qiaozha](https://github.com/qiaozha)                         |
 | `SDK azure-sdk-for-net`           | Wei Hu         | [live1206](https://github.com/live1206)                       |
-| `SDK azure-sdk-for-net-track2`    | Wei Hu         | [live1206](https://github.com/live1206)                       |
 | `SDK azure-sdk-for-python`        | Yuchao Yan     | [msyyc](https://github.com/msyyc)                             |
 
 Do the following:

--- a/documentation/samplefiles-dp/samplefiles-dp-for-multi-client/README.md
+++ b/documentation/samplefiles-dp/samplefiles-dp-for-multi-client/README.md
@@ -81,5 +81,5 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/documentation/samplefiles-dp/samplefiles-dp-for-single-client/README.md
+++ b/documentation/samplefiles-dp/samplefiles-dp-for-single-client/README.md
@@ -53,5 +53,5 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/advisor/resource-manager/readme.md
+++ b/specification/advisor/resource-manager/readme.md
@@ -121,7 +121,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/alertsmanagement/resource-manager/readme.md
+++ b/specification/alertsmanagement/resource-manager/readme.md
@@ -224,7 +224,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-libraries-for-java
   - repo: azure-sdk-for-go

--- a/specification/apicenter/data-plane/readme.md
+++ b/specification/apicenter/data-plane/readme.md
@@ -52,7 +52,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 
 ### Suppressions

--- a/specification/apimanagement/resource-manager/readme.md
+++ b/specification/apimanagement/resource-manager/readme.md
@@ -1110,7 +1110,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/app/data-plane/readme.md
+++ b/specification/app/data-plane/readme.md
@@ -47,5 +47,5 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/appcomplianceautomation/resource-manager/readme.md
+++ b/specification/appcomplianceautomation/resource-manager/readme.md
@@ -63,7 +63,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
 ```

--- a/specification/appconfiguration/resource-manager/readme.md
+++ b/specification/appconfiguration/resource-manager/readme.md
@@ -158,7 +158,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go

--- a/specification/applicationinsights/resource-manager/readme.md
+++ b/specification/applicationinsights/resource-manager/readme.md
@@ -810,7 +810,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/appplatform/resource-manager/readme.md
+++ b/specification/appplatform/resource-manager/readme.md
@@ -253,7 +253,7 @@ swagger-to-sdk:
   - repo: azure-powershell
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go

--- a/specification/attestation/data-plane/readme.md
+++ b/specification/attestation/data-plane/readme.md
@@ -74,7 +74,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 
 ## Python

--- a/specification/attestation/resource-manager/readme.md
+++ b/specification/attestation/resource-manager/readme.md
@@ -75,7 +75,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/authorization/resource-manager/readme.md
+++ b/specification/authorization/resource-manager/readme.md
@@ -639,7 +639,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/automanage/resource-manager/readme.md
+++ b/specification/automanage/resource-manager/readme.md
@@ -89,7 +89,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/automation/resource-manager/readme.md
+++ b/specification/automation/resource-manager/readme.md
@@ -684,7 +684,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/azure-kusto/resource-manager/readme.md
+++ b/specification/azure-kusto/resource-manager/readme.md
@@ -255,7 +255,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go

--- a/specification/azurefleet/resource-manager/readme.md
+++ b/specification/azurefleet/resource-manager/readme.md
@@ -87,7 +87,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/batch/resource-manager/readme.md
+++ b/specification/batch/resource-manager/readme.md
@@ -285,7 +285,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/billing/resource-manager/readme.md
+++ b/specification/billing/resource-manager/readme.md
@@ -381,7 +381,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/blueprint/resource-manager/readme.md
+++ b/specification/blueprint/resource-manager/readme.md
@@ -59,7 +59,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python

--- a/specification/botservice/resource-manager/readme.md
+++ b/specification/botservice/resource-manager/readme.md
@@ -201,7 +201,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go

--- a/specification/cdn/resource-manager/readme.md
+++ b/specification/cdn/resource-manager/readme.md
@@ -259,7 +259,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/codesigning/resource-manager/readme.md
+++ b/specification/codesigning/resource-manager/readme.md
@@ -61,7 +61,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-cli-extensions
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-typescript

--- a/specification/cognitiveservices/data-plane/AnomalyDetector/readme.md
+++ b/specification/cognitiveservices/data-plane/AnomalyDetector/readme.md
@@ -64,7 +64,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
  ```
 
 ## CSharp Settings

--- a/specification/cognitiveservices/data-plane/ContentSafety/readme.md
+++ b/specification/cognitiveservices/data-plane/ContentSafety/readme.md
@@ -84,7 +84,7 @@ This is not used by Autorest itself.
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas

--- a/specification/cognitiveservices/data-plane/FormRecognizer/readme.md
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/readme.md
@@ -144,7 +144,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 
 

--- a/specification/cognitiveservices/data-plane/Language/preview/2023-04-15-preview/readme.md
+++ b/specification/cognitiveservices/data-plane/Language/preview/2023-04-15-preview/readme.md
@@ -71,7 +71,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
 ```
 

--- a/specification/cognitiveservices/data-plane/Language/preview/2024-05-15-preview/readme.md
+++ b/specification/cognitiveservices/data-plane/Language/preview/2024-05-15-preview/readme.md
@@ -38,7 +38,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
 ```
 

--- a/specification/cognitiveservices/data-plane/Language/readme.md
+++ b/specification/cognitiveservices/data-plane/Language/readme.md
@@ -297,5 +297,5 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/cognitiveservices/data-plane/MetricsAdvisor/readme.md
+++ b/specification/cognitiveservices/data-plane/MetricsAdvisor/readme.md
@@ -30,5 +30,5 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/cognitiveservices/data-plane/TextAnalytics/readme.md
+++ b/specification/cognitiveservices/data-plane/TextAnalytics/readme.md
@@ -147,7 +147,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 
 ## CSharp Settings

--- a/specification/cognitiveservices/data-plane/TranslatorText/readme.md
+++ b/specification/cognitiveservices/data-plane/TranslatorText/readme.md
@@ -55,7 +55,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 
 ## CSharp Settings

--- a/specification/cognitiveservices/resource-manager/readme.md
+++ b/specification/cognitiveservices/resource-manager/readme.md
@@ -164,7 +164,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/communication/resource-manager/readme.md
+++ b/specification/communication/resource-manager/readme.md
@@ -140,7 +140,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -2240,7 +2240,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js

--- a/specification/confidentialledger/resource-manager/readme.md
+++ b/specification/confidentialledger/resource-manager/readme.md
@@ -118,7 +118,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/confluent/resource-manager/readme.md
+++ b/specification/confluent/resource-manager/readme.md
@@ -112,7 +112,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/consumption/resource-manager/readme.md
+++ b/specification/consumption/resource-manager/readme.md
@@ -291,7 +291,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java

--- a/specification/containerinstance/resource-manager/readme.md
+++ b/specification/containerinstance/resource-manager/readme.md
@@ -260,7 +260,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/containerregistry/data-plane/readme.md
+++ b/specification/containerregistry/data-plane/readme.md
@@ -73,7 +73,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 
 ```
 

--- a/specification/containerregistry/resource-manager/readme.md
+++ b/specification/containerregistry/resource-manager/readme.md
@@ -421,7 +421,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
@@ -1189,7 +1189,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby
     after_scripts:

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/readme.md
@@ -136,7 +136,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-node
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/cosmos-db/resource-manager/readme.md
+++ b/specification/cosmos-db/resource-manager/readme.md
@@ -1003,7 +1003,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/cost-management/resource-manager/readme.md
+++ b/specification/cost-management/resource-manager/readme.md
@@ -559,7 +559,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-node

--- a/specification/customer-insights/resource-manager/readme.md
+++ b/specification/customer-insights/resource-manager/readme.md
@@ -61,7 +61,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/dashboard/resource-manager/readme.md
+++ b/specification/dashboard/resource-manager/readme.md
@@ -103,7 +103,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-resource-manager-schemas

--- a/specification/databox/resource-manager/readme.md
+++ b/specification/databox/resource-manager/readme.md
@@ -185,7 +185,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/databoxedge/resource-manager/readme.md
+++ b/specification/databoxedge/resource-manager/readme.md
@@ -200,7 +200,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go

--- a/specification/datadog/resource-manager/readme.md
+++ b/specification/datadog/resource-manager/readme.md
@@ -99,7 +99,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/datafactory/resource-manager/readme.md
+++ b/specification/datafactory/resource-manager/readme.md
@@ -86,7 +86,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/datalake-analytics/resource-manager/readme.md
+++ b/specification/datalake-analytics/resource-manager/readme.md
@@ -82,7 +82,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/datalake-store/resource-manager/readme.md
+++ b/specification/datalake-store/resource-manager/readme.md
@@ -75,7 +75,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/datamigration/resource-manager/readme.md
+++ b/specification/datamigration/resource-manager/readme.md
@@ -514,7 +514,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/dataprotection/resource-manager/readme.md
+++ b/specification/dataprotection/resource-manager/readme.md
@@ -301,7 +301,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/datashare/resource-manager/readme.md
+++ b/specification/datashare/resource-manager/readme.md
@@ -86,7 +86,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-cli-extensions

--- a/specification/desktopvirtualization/resource-manager/readme.md
+++ b/specification/desktopvirtualization/resource-manager/readme.md
@@ -304,7 +304,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/deviceprovisioningservices/resource-manager/readme.md
+++ b/specification/deviceprovisioningservices/resource-manager/readme.md
@@ -141,7 +141,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/deviceupdate/resource-manager/readme.md
+++ b/specification/deviceupdate/resource-manager/readme.md
@@ -100,7 +100,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
     after_scripts:

--- a/specification/devspaces/resource-manager/readme.md
+++ b/specification/devspaces/resource-manager/readme.md
@@ -50,7 +50,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/devtestlabs/resource-manager/readme.md
+++ b/specification/devtestlabs/resource-manager/readme.md
@@ -69,7 +69,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java

--- a/specification/digitaltwins/data-plane/readme.md
+++ b/specification/digitaltwins/data-plane/readme.md
@@ -103,7 +103,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 
 ## Go

--- a/specification/dns/resource-manager/readme.md
+++ b/specification/dns/resource-manager/readme.md
@@ -227,7 +227,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-node

--- a/specification/dnsresolver/resource-manager/readme.md
+++ b/specification/dnsresolver/resource-manager/readme.md
@@ -68,7 +68,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-go
   - repo: azure-powershell

--- a/specification/edge/resource-manager/Microsoft.Edge/edge/readme.md
+++ b/specification/edge/resource-manager/Microsoft.Edge/edge/readme.md
@@ -55,7 +55,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 ## Az
 

--- a/specification/edge/resource-manager/Microsoft.Edge/sites/readme.md
+++ b/specification/edge/resource-manager/Microsoft.Edge/sites/readme.md
@@ -64,7 +64,7 @@ swagger-to-sdk:
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
   - repo: azure-powershell
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 ## Az
 

--- a/specification/edgeorder/resource-manager/readme.md
+++ b/specification/edgeorder/resource-manager/readme.md
@@ -82,7 +82,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-powershell

--- a/specification/elasticsan/resource-manager/readme.md
+++ b/specification/elasticsan/resource-manager/readme.md
@@ -84,7 +84,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/eventgrid/data-plane/readme.md
+++ b/specification/eventgrid/data-plane/readme.md
@@ -217,7 +217,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 
 ## C#

--- a/specification/eventgrid/resource-manager/readme.md
+++ b/specification/eventgrid/resource-manager/readme.md
@@ -333,7 +333,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/eventhub/resource-manager/readme.md
+++ b/specification/eventhub/resource-manager/readme.md
@@ -482,7 +482,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/extendedlocation/resource-manager/readme.md
+++ b/specification/extendedlocation/resource-manager/readme.md
@@ -68,7 +68,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/fluidrelay/resource-manager/readme.md
+++ b/specification/fluidrelay/resource-manager/readme.md
@@ -123,7 +123,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/frontdoor/resource-manager/readme.md
+++ b/specification/frontdoor/resource-manager/readme.md
@@ -244,7 +244,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-libraries-for-java
   - repo: azure-sdk-for-go

--- a/specification/graphservicesprod/resource-manager/readme.md
+++ b/specification/graphservicesprod/resource-manager/readme.md
@@ -60,7 +60,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js

--- a/specification/guestconfiguration/resource-manager/readme.md
+++ b/specification/guestconfiguration/resource-manager/readme.md
@@ -144,7 +144,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/readme.md
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/readme.md
@@ -143,7 +143,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-python

--- a/specification/hdinsight/resource-manager/readme.md
+++ b/specification/hdinsight/resource-manager/readme.md
@@ -269,7 +269,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-python

--- a/specification/healthcareapis/resource-manager/readme.md
+++ b/specification/healthcareapis/resource-manager/readme.md
@@ -203,7 +203,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/healthdataaiservices/data-plane/HealthDataAIServices.DeidServices/readme.md
+++ b/specification/healthdataaiservices/data-plane/HealthDataAIServices.DeidServices/readme.md
@@ -53,7 +53,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js

--- a/specification/healthdataaiservices/resource-manager/readme.md
+++ b/specification/healthdataaiservices/resource-manager/readme.md
@@ -60,7 +60,7 @@ This is not used by Autorest itself.
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/hybridcloud/resource-manager/readme.md
+++ b/specification/hybridcloud/resource-manager/readme.md
@@ -63,7 +63,7 @@ swagger-to-sdk:
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
   - repo: azure-powershell
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 ## Az
 

--- a/specification/hybridcompute/resource-manager/readme.md
+++ b/specification/hybridcompute/resource-manager/readme.md
@@ -363,7 +363,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/hybridconnectivity/resource-manager/readme.md
+++ b/specification/hybridconnectivity/resource-manager/readme.md
@@ -100,7 +100,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/hybridkubernetes/resource-manager/readme.md
+++ b/specification/hybridkubernetes/resource-manager/readme.md
@@ -160,7 +160,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-ruby
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_hybridkubernetes']
   - repo: azure-resource-manager-schemas

--- a/specification/impact/resource-manager/readme.md
+++ b/specification/impact/resource-manager/readme.md
@@ -66,7 +66,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
   - repo: azure-powershell

--- a/specification/iotcentral/resource-manager/readme.md
+++ b/specification/iotcentral/resource-manager/readme.md
@@ -93,7 +93,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/iothub/resource-manager/readme.md
+++ b/specification/iothub/resource-manager/readme.md
@@ -302,9 +302,9 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/keyvault/resource-manager/readme.md
+++ b/specification/keyvault/resource-manager/readme.md
@@ -339,7 +339,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/labservices/resource-manager/readme.md
+++ b/specification/labservices/resource-manager/readme.md
@@ -119,7 +119,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/loadtestservice/data-plane/readme.md
+++ b/specification/loadtestservice/data-plane/readme.md
@@ -103,5 +103,5 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/logic/resource-manager/readme.md
+++ b/specification/logic/resource-manager/readme.md
@@ -125,7 +125,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-trenton

--- a/specification/machinelearningservices/resource-manager/readme.md
+++ b/specification/machinelearningservices/resource-manager/readme.md
@@ -829,7 +829,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java

--- a/specification/managednetwork/resource-manager/readme.md
+++ b/specification/managednetwork/resource-manager/readme.md
@@ -50,7 +50,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/managednetworkfabric/resource-manager/readme.md
+++ b/specification/managednetworkfabric/resource-manager/readme.md
@@ -97,7 +97,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-cli-extensions
     after_scripts:

--- a/specification/managedservices/resource-manager/readme.md
+++ b/specification/managedservices/resource-manager/readme.md
@@ -103,7 +103,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java

--- a/specification/managementpartner/resource-manager/readme.md
+++ b/specification/managementpartner/resource-manager/readme.md
@@ -71,7 +71,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/maps/resource-manager/readme.md
+++ b/specification/maps/resource-manager/readme.md
@@ -141,7 +141,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/marketplace/resource-manager/readme.md
+++ b/specification/marketplace/resource-manager/readme.md
@@ -136,7 +136,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/marketplaceordering/resource-manager/readme.md
+++ b/specification/marketplaceordering/resource-manager/readme.md
@@ -86,7 +86,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/mediaservices/resource-manager/readme.md
+++ b/specification/mediaservices/resource-manager/readme.md
@@ -387,7 +387,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/migrate/resource-manager/Microsoft.Migrate/AssessmentProjects/readme.md
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/AssessmentProjects/readme.md
@@ -129,7 +129,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/migrate/resource-manager/Microsoft.Migrate/MigrateProjects/readme.md
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/MigrateProjects/readme.md
@@ -56,7 +56,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/migrate/resource-manager/Microsoft.Migrate/MordernizeProjects/readme.md
+++ b/specification/migrate/resource-manager/Microsoft.Migrate/MordernizeProjects/readme.md
@@ -47,7 +47,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/migrate/resource-manager/Microsoft.OffAzure/readme.md
+++ b/specification/migrate/resource-manager/Microsoft.OffAzure/readme.md
@@ -74,7 +74,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/migrate/resource-manager/readme.md
+++ b/specification/migrate/resource-manager/readme.md
@@ -399,7 +399,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/mixedreality/data-plane/readme.md
+++ b/specification/mixedreality/data-plane/readme.md
@@ -120,5 +120,5 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/mixedreality/resource-manager/readme.md
+++ b/specification/mixedreality/resource-manager/readme.md
@@ -161,7 +161,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go

--- a/specification/mongocluster/resource-manager/readme.md
+++ b/specification/mongocluster/resource-manager/readme.md
@@ -78,7 +78,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/monitor/resource-manager/Microsoft.Monitor/Operations/readme.md
+++ b/specification/monitor/resource-manager/Microsoft.Monitor/Operations/readme.md
@@ -56,7 +56,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/monitor/resource-manager/Microsoft.Monitor/PipelineGroups/readme.md
+++ b/specification/monitor/resource-manager/Microsoft.Monitor/PipelineGroups/readme.md
@@ -55,7 +55,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/monitor/resource-manager/readme.md
+++ b/specification/monitor/resource-manager/readme.md
@@ -1393,7 +1393,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/msi/resource-manager/readme.md
+++ b/specification/msi/resource-manager/readme.md
@@ -106,7 +106,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/mysql/resource-manager/readme.md
+++ b/specification/mysql/resource-manager/readme.md
@@ -571,7 +571,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/netapp/resource-manager/readme.md
+++ b/specification/netapp/resource-manager/readme.md
@@ -411,7 +411,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-java

--- a/specification/network/resource-manager/readme.md
+++ b/specification/network/resource-manager/readme.md
@@ -3787,7 +3787,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/notificationhubs/resource-manager/readme.md
+++ b/specification/notificationhubs/resource-manager/readme.md
@@ -120,7 +120,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/offazurespringboot/resource-manager/readme.md
+++ b/specification/offazurespringboot/resource-manager/readme.md
@@ -63,7 +63,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/operationalinsights/resource-manager/readme.md
+++ b/specification/operationalinsights/resource-manager/readme.md
@@ -325,7 +325,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/oracle/resource-manager/readme.md
+++ b/specification/oracle/resource-manager/readme.md
@@ -99,7 +99,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/peering/resource-manager/readme.md
+++ b/specification/peering/resource-manager/readme.md
@@ -133,7 +133,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node
   - repo: azure-sdk-for-ruby

--- a/specification/playwrighttesting/data-plane/readme.md
+++ b/specification/playwrighttesting/data-plane/readme.md
@@ -81,5 +81,5 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/policyinsights/resource-manager/readme.md
+++ b/specification/policyinsights/resource-manager/readme.md
@@ -331,7 +331,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js

--- a/specification/postgresql/resource-manager/readme.md
+++ b/specification/postgresql/resource-manager/readme.md
@@ -566,7 +566,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/powerbidedicated/resource-manager/readme.md
+++ b/specification/powerbidedicated/resource-manager/readme.md
@@ -60,7 +60,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-node

--- a/specification/privatedns/resource-manager/readme.md
+++ b/specification/privatedns/resource-manager/readme.md
@@ -74,7 +74,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/programmableconnectivity/data-plane/readme.md
+++ b/specification/programmableconnectivity/data-plane/readme.md
@@ -53,5 +53,5 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/providerhub/resource-manager/readme.md
+++ b/specification/providerhub/resource-manager/readme.md
@@ -100,7 +100,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-ruby
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_providerhub']
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-powershell
 ```
 

--- a/specification/purview/data-plane/readme.md
+++ b/specification/purview/data-plane/readme.md
@@ -396,5 +396,5 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/quota/resource-manager/readme.md
+++ b/specification/quota/resource-manager/readme.md
@@ -137,7 +137,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/recoveryservices/resource-manager/readme.md
+++ b/specification/recoveryservices/resource-manager/readme.md
@@ -449,7 +449,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/recoveryservicesbackup/resource-manager/readme.md
+++ b/specification/recoveryservicesbackup/resource-manager/readme.md
@@ -463,7 +463,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/recoveryservicesdatareplication/resource-manager/readme.md
+++ b/specification/recoveryservicesdatareplication/resource-manager/readme.md
@@ -55,7 +55,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-js
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 ## Az
 

--- a/specification/recoveryservicessiterecovery/resource-manager/readme.md
+++ b/specification/recoveryservicessiterecovery/resource-manager/readme.md
@@ -343,7 +343,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/redis/resource-manager/readme.md
+++ b/specification/redis/resource-manager/readme.md
@@ -193,7 +193,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/redisenterprise/resource-manager/readme.md
+++ b/specification/redisenterprise/resource-manager/readme.md
@@ -193,7 +193,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/relay/resource-manager/readme.md
+++ b/specification/relay/resource-manager/readme.md
@@ -99,7 +99,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/reservations/resource-manager/readme.md
+++ b/specification/reservations/resource-manager/readme.md
@@ -138,7 +138,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/resourcegraph/resource-manager/readme.md
+++ b/specification/resourcegraph/resource-manager/readme.md
@@ -158,7 +158,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -1628,7 +1628,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/search/data-plane/Azure.Search/readme.md
+++ b/specification/search/data-plane/Azure.Search/readme.md
@@ -1033,5 +1033,5 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```

--- a/specification/search/resource-manager/readme.md
+++ b/specification/search/resource-manager/readme.md
@@ -148,7 +148,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/security/resource-manager/readme.md
+++ b/specification/security/resource-manager/readme.md
@@ -1081,7 +1081,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/securityinsights/resource-manager/readme.md
+++ b/specification/securityinsights/resource-manager/readme.md
@@ -1132,7 +1132,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-js

--- a/specification/servicebus/resource-manager/readme.md
+++ b/specification/servicebus/resource-manager/readme.md
@@ -236,7 +236,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/servicefabric/resource-manager/readme.md
+++ b/specification/servicefabric/resource-manager/readme.md
@@ -197,7 +197,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/servicefabricmanagedclusters/resource-manager/readme.md
+++ b/specification/servicefabricmanagedclusters/resource-manager/readme.md
@@ -314,7 +314,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-resource-manager-schemas
   - repo: azure-powershell

--- a/specification/signalr/resource-manager/readme.md
+++ b/specification/signalr/resource-manager/readme.md
@@ -253,7 +253,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-node

--- a/specification/sphere/resource-manager/readme.md
+++ b/specification/sphere/resource-manager/readme.md
@@ -63,7 +63,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/sql/resource-manager/readme.md
+++ b/specification/sql/resource-manager/readme.md
@@ -3094,7 +3094,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-node

--- a/specification/sqlvirtualmachine/resource-manager/readme.md
+++ b/specification/sqlvirtualmachine/resource-manager/readme.md
@@ -114,7 +114,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-java

--- a/specification/storage/resource-manager/readme.md
+++ b/specification/storage/resource-manager/readme.md
@@ -840,7 +840,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/storageactions/resource-manager/readme.md
+++ b/specification/storageactions/resource-manager/readme.md
@@ -54,7 +54,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/storagecache/resource-manager/readme.md
+++ b/specification/storagecache/resource-manager/readme.md
@@ -169,7 +169,7 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-python
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js

--- a/specification/storagepool/resource-manager/readme.md
+++ b/specification/storagepool/resource-manager/readme.md
@@ -68,7 +68,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/storagesync/resource-manager/readme.md
+++ b/specification/storagesync/resource-manager/readme.md
@@ -148,7 +148,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/streamanalytics/resource-manager/readme.md
+++ b/specification/streamanalytics/resource-manager/readme.md
@@ -138,7 +138,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-node

--- a/specification/subscription/resource-manager/readme.md
+++ b/specification/subscription/resource-manager/readme.md
@@ -171,7 +171,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-node

--- a/specification/support/resource-manager/readme.md
+++ b/specification/support/resource-manager/readme.md
@@ -127,7 +127,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-go
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-ruby
     after_scripts:
       - bundle install && rake arm:regen_all_profiles['azure_mgmt_support']

--- a/specification/synapse/resource-manager/readme.md
+++ b/specification/synapse/resource-manager/readme.md
@@ -352,7 +352,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-python

--- a/specification/trafficmanager/resource-manager/readme.md
+++ b/specification/trafficmanager/resource-manager/readme.md
@@ -199,7 +199,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-libraries-for-java
   - repo: azure-sdk-for-go

--- a/specification/videoanalyzer/data-plane/readme.md
+++ b/specification/videoanalyzer/data-plane/readme.md
@@ -67,7 +67,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 
 ## C#

--- a/specification/voiceservices/resource-manager/readme.md
+++ b/specification/voiceservices/resource-manager/readme.md
@@ -81,7 +81,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
   - repo: azure-powershell

--- a/specification/web/resource-manager/readme.md
+++ b/specification/web/resource-manager/readme.md
@@ -2643,7 +2643,7 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/webpubsub/data-plane/readme.md
+++ b/specification/webpubsub/data-plane/readme.md
@@ -106,7 +106,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
 ```
 
 ## C#

--- a/specification/webpubsub/resource-manager/readme.md
+++ b/specification/webpubsub/resource-manager/readme.md
@@ -209,7 +209,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-node

--- a/specification/workloadmonitor/resource-manager/readme.md
+++ b/specification/workloadmonitor/resource-manager/readme.md
@@ -79,7 +79,7 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go

--- a/specification/workloads/resource-manager/Microsoft.Workloads/SAPDiscoverySites/readme.md
+++ b/specification/workloads/resource-manager/Microsoft.Workloads/SAPDiscoverySites/readme.md
@@ -67,7 +67,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
 ```

--- a/specification/workloads/resource-manager/Microsoft.Workloads/connectors/readme.md
+++ b/specification/workloads/resource-manager/Microsoft.Workloads/connectors/readme.md
@@ -57,7 +57,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
 ```

--- a/specification/workloads/resource-manager/readme.md
+++ b/specification/workloads/resource-manager/readme.md
@@ -82,7 +82,7 @@ swagger-to-sdk:
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
-  - repo: azure-sdk-for-net-track2
+  - repo: azure-sdk-for-net
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
 ```


### PR DESCRIPTION
Updated all the references of `azure-sdk-for-net-track2` in `readme.md` and `ci-fix.md`.