### PR TITLE
Add "None" as a supported value for authentication type of a connection

### DIFF
--- a/specification/ai/Azure.AI.Projects/connections/model.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/model.tsp
@@ -75,6 +75,9 @@ enum AuthenticationType {
 
   @doc("Shared Access Signature (SAS) authentication")
   SAS: "SAS",
+
+  @doc("No authentication")
+  None: "None",
 }
 
 @doc("Connection properties for connections with API key authentication")
@@ -102,6 +105,13 @@ model InternalConnectionPropertiesSASAuth extends InternalConnectionProperties {
 
   @doc("Credentials will only be present for authType=ApiKey")
   credentials: CredentialsSASAuth;
+}
+
+#suppress "@azure-tools/typespec-azure-core/casing-style"
+@doc("Connection properties for connections with no authentication")
+model InternalConnectionPropertiesNoAuth extends InternalConnectionProperties {
+  @doc("Authentication type of the connection target")
+  authType: AuthenticationType.None;
 }
 
 @doc("The credentials needed for API key authentication")

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
@@ -8813,7 +8813,8 @@
       "enum": [
         "ApiKey",
         "AAD",
-        "SAS"
+        "SAS",
+        "None"
       ],
       "x-ms-enum": {
         "name": "AuthenticationType",
@@ -8833,6 +8834,11 @@
             "name": "SAS",
             "value": "SAS",
             "description": "Shared Access Signature (SAS) authentication"
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No authentication"
           }
         ]
       }
@@ -9387,6 +9393,16 @@
         }
       ],
       "x-ms-discriminator-value": "ApiKey"
+    },
+    "InternalConnectionPropertiesNoAuth": {
+      "type": "object",
+      "description": "Connection properties for connections with no authentication",
+      "allOf": [
+        {
+          "$ref": "#/definitions/InternalConnectionProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "None"
     },
     "InternalConnectionPropertiesSASAuth": {
       "type": "object",


### PR DESCRIPTION
Add "None" as possible authentication type for connections. We see this today with external blob storage connections. The AzureML Workspace Connection REST API "list" is not able to extract auth type and credentials. This REST API returns `"authType": "None"` and that crashes the emitted C# SDK when it tries to deserialize the connection properties class. Thank you @ShivangiReja for reporting this [here](https://github.com/Azure/azure-sdk-for-net/issues/47874).