### PR TITLE
Errorresponse correction

### DIFF
--- a/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/namespaces.json
+++ b/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/namespaces.json
@@ -382,7 +382,7 @@
           "default": {
             "description": "EventHub error response describing why the operation failed.",
             "schema": {
-              "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../common/v2/definitions.json#/definitions/ErrorResponse"
             }
           }
         },

--- a/specification/eventhub/resource-manager/readme.md
+++ b/specification/eventhub/resource-manager/readme.md
@@ -314,23 +314,8 @@ directive:
     from: namespaces-preview.json
     reason: Not a mandatory check
   - suppress: LroErrorContent
-    from: Clusters-preview.json
+    from: namespaces.json
     reason: Not a mandatory check
-  - suppress: MissingTypeObject
-    from: Clusters-preview.json
-    reason: Not a mandatory check
-  - suppress: SystemDataDefinitionsCommonTypes
-    from: Clusters-preview.json
-    reason: Not a mandatory check  
-  - suppress: ResourceNameRestriction
-    from: Clusters-preview.json
-    reason: Not a mandatory check 
-  - suppress: GetCollectionOnlyHasValueAndNextLink
-    from: Clusters-preview.json
-    reason: Not a mandatory check  
-  - suppress: XmsPageableForListCalls
-    from: Clusters-preview.json
-    reason: Not a mandatory check  
 
   - suppress: LroLocationHeader
     from: Clusters-preview.json

--- a/specification/eventhub/resource-manager/readme.md
+++ b/specification/eventhub/resource-manager/readme.md
@@ -313,6 +313,24 @@ directive:
   - suppress: LroPostReturn
     from: namespaces-preview.json
     reason: Not a mandatory check
+  - suppress: LroErrorContent
+    from: Clusters-preview.json
+    reason: Not a mandatory check
+  - suppress: MissingTypeObject
+    from: Clusters-preview.json
+    reason: Not a mandatory check
+  - suppress: SystemDataDefinitionsCommonTypes
+    from: Clusters-preview.json
+    reason: Not a mandatory check  
+  - suppress: ResourceNameRestriction
+    from: Clusters-preview.json
+    reason: Not a mandatory check 
+  - suppress: GetCollectionOnlyHasValueAndNextLink
+    from: Clusters-preview.json
+    reason: Not a mandatory check  
+  - suppress: XmsPageableForListCalls
+    from: Clusters-preview.json
+    reason: Not a mandatory check  
 
   - suppress: LroLocationHeader
     from: Clusters-preview.json

--- a/specification/eventhub/resource-manager/readme.md
+++ b/specification/eventhub/resource-manager/readme.md
@@ -315,7 +315,7 @@ directive:
     reason: Not a mandatory check
   - suppress: LroErrorContent
     from: namespaces.json
-    reason: Not a mandatory check
+    reason: Suppress it for now to avoid breaking change because it is referenced by many files. 
 
   - suppress: LroLocationHeader
     from: Clusters-preview.json


### PR DESCRIPTION
# Choose a PR Template
ErrorResponse model from `common-type` which is different with others referenced from `Microsoft.EventHub/common/` is giving duplicate model issue when preparing JS sdk for eventhub 2024-05-01-preview. So correcting the ErrorResponse.
Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
