### PR TITLE
[Az.DataProtection] New ADLS backup parameter

### DIFF
--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-01-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-01-01/dataprotection.json
@@ -5163,7 +5163,7 @@
       "type": "object",
       "allOf": [
         {
-          "$ref": "#/definitions/BackupDatasourceParameters"
+          "$ref": "#/definitions/BlobBackupDatasourceParameters"
         }
       ],
       "properties": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-01-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-01-01/dataprotection.json
@@ -5154,6 +5154,29 @@
       },
       "x-ms-discriminator-value": "BlobBackupDatasourceParameters"
     },
+    "AdlsBlobBackupDatasourceParameters": {
+      "description": "Parameters to be used during configuration of backup of azure data lake storage account blobs",
+      "required": [
+        "containersList",
+        "objectType"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupDatasourceParameters"
+        }
+      ],
+      "properties": {
+        "containersList": {
+          "description": "List of containers to be backed up during configuration of backup of azure data lake storage account blobs",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-discriminator-value": "AdlsBlobBackupDatasourceParameters"
+    },
     "AzureRetentionRule": {
       "allOf": [
         {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-01-01/examples/BackupInstanceOperations/GetBackupInstance_ADLSBlobBackupDatasourceParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-01-01/examples/BackupInstanceOperations/GetBackupInstance_ADLSBlobBackupDatasourceParameters.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "subscriptionId": "54707983-993e-43de-8d94-074451394eda",
+    "resourceGroupName": "adlsrg",
+    "vaultName": "adlsvault",
+    "api-version": "2025-01-01",
+    "backupInstanceName": "adlsbackupinstance"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupInstances/adlsbackupinstance",
+        "name": "adlsbackupinstance",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "adlsbackupinstance",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adls5blbcentraluseuap2",
+            "resourceType": "Microsoft.Storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adls5blbcentraluseuap2",
+            "resourceType": "Microsoft.Storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupPolicies/adlspolicy",
+            "policyParameters": {
+              "backupDatasourceParametersList": [
+                {
+                  "containersList": [
+                    "container1",
+                    "container2"
+                  ],
+                  "objectType": "AdlsBlobBackupDatasourceParameters"
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "ProtectionConfigured"
+          },
+          "currentProtectionState": "ProtectionConfigured",
+          "provisioningState": "Succeeded",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-01-01/examples/BackupInstanceOperations/PutBackupInstance_ADLSBackupDatasourceParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-01-01/examples/BackupInstanceOperations/PutBackupInstance_ADLSBackupDatasourceParameters.json
@@ -1,0 +1,151 @@
+{
+  "parameters": {
+    "subscriptionId": "54707983-993e-43de-8d94-074451394eda",
+    "resourceGroupName": "adlsrg",
+    "vaultName": "adlsvault",
+    "api-version": "2025-01-01",
+    "backupInstanceName": "adlsstorageaccount-adlsstorageaccount-19a76f8a-c176-4f7d-819e-95157e2b0071",
+    "parameters": {
+      "tags": {
+        "key1": "val1"
+      },
+      "properties": {
+        "friendlyName": "adlsstorageaccount\\adlsbackupinstance",
+        "dataSourceInfo": {
+          "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+          "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+          "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+          "resourceName": "adlsstorageaccount",
+          "resourceType": "microsoft.storage/storageAccounts",
+          "resourceLocation": "centraluseuap",
+          "objectType": "Datasource"
+        },
+        "dataSourceSetInfo": {
+          "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+          "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+          "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+          "resourceName": "adlsstorageaccount",
+          "resourceType": "microsoft.storage/storageAccounts",
+          "resourceLocation": "centraluseuap",
+          "objectType": "DatasourceSet"
+        },
+        "policyInfo": {
+          "policyId": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupPolicies/adlspolicy",
+          "policyParameters": {
+            "backupDatasourceParametersList": [
+              {
+                "objectType": "AdlsBlobBackupDatasourceParameters",
+                "containersList": [
+                  "container1"
+                ]
+              }
+            ]
+          }
+        },
+        "objectType": "BackupInstance"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/54707983-993e-43de-8d94-074451394eda/resourcegroups/adlsrg/providers/Microsoft.Resources/deployments/ConfigureProtection-2097/operationStatuses/08584622124860116406?api-version=2022-12-01&t=638749912006014742&c=MIIHhzCCBm-gAwIBAgITfAaTiaklTwdb3CiPmAAABpOJqTANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUw",
+        "Retry-After": "60"
+      },
+      "body": {
+        "id": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupInstances/19a76f8a-c176-4f7d-819e-95157e2b0077",
+        "name": "19a76f8a-c176-4f7d-819e-95157e2b0077",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "adlsstorageaccount\\adlsbackupinstance",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adlsstorageaccount",
+            "resourceType": "microsoft.storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adlsstorageaccount",
+            "resourceType": "microsoft.storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupPolicies/adlspolicy",
+            "policyParameters": {
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "AdlsBlobBackupDatasourceParameters",
+                  "containersList": []
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioning",
+          "objectType": "BackupInstance"
+        }
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupInstances/19a76f8a-c176-4f7d-819e-95157e2b0077",
+        "name": "19a76f8a-c176-4f7d-819e-95157e2b0077",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "adlsstorageaccount\\adlsbackupinstance",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adlsstorageaccount",
+            "resourceType": "microsoft.storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adlsstorageaccount",
+            "resourceType": "microsoft.storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupPolicies/adlspolicy",
+            "policyParameters": {
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "AdlsBlobBackupDatasourceParameters",
+                  "containersList": [
+                      "container1"
+                  ]
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioned",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Adding AdlsBlobBackupDatasourceParameters property for ADLS Blob Backup Parameters
@ianngeorges - This is a parameter addition to the current stable "[2025-01-01](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-01-01)" The added new "AdlsBlobBackupDatasourceParameters" property is similar to the existing BlobBackupDatasourceParameters, and will support the new ADLS blob backup workload.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
