### PR TITLE
[python] Update readme.md

### DIFF
--- a/specification/hybridconnectivity/resource-manager/readme.md
+++ b/specification/hybridconnectivity/resource-manager/readme.md
@@ -101,7 +101,6 @@ This is not used by Autorest itself.
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
   - repo: azure-sdk-for-net
-  - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js


### PR DESCRIPTION
Python is going to generate SDK from typespec after https://github.com/Azure/azure-rest-api-specs/pull/31699 merged so we don't need keep configuration for swagger.