### PR TITLE
Use RunStepFileSearchToolCallResults instead of a string in search tool deserialization step during streaming.

### DIFF
--- a/specification/ai/Azure.AI.Projects/agents/run_steps/models.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/run_steps/models.tsp
@@ -265,7 +265,7 @@ model RunStepDeltaFileSearchToolCall extends RunStepDeltaToolCall {
 
   /** Reserved for future use. */
   @encodedName("application/json", "file_search")
-  fileSearch?: Record<string>;
+  fileSearch?: RunStepFileSearchToolCallResults;
 }
 
 /** Represents a Code Interpreter tool call within a streaming run step's tool call details. */

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
@@ -6536,11 +6536,8 @@
       "description": "Represents a file search tool call within a streaming run step's tool call details.",
       "properties": {
         "file_search": {
-          "type": "object",
+          "$ref": "#/definitions/Agents.RunStepFileSearchToolCallResults",
           "description": "Reserved for future use.",
-          "additionalProperties": {
-            "type": "string"
-          },
           "x-ms-client-name": "fileSearch"
         }
       },


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
