### PR TITLE
[Storage] Add `crate-version` and rename package and crate to `azure_storage_blobs`

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
+++ b/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
@@ -36,8 +36,9 @@ options:
     namespace: com.azure.storage.blob
     flavor: azure
   "@azure-tools/typespec-rust":
-    package-dir: "storage_blob"
-    crate-name: "storage_blob"
+    package-dir: "azure_storage_blobs"
+    crate-name: "azure_storage_blobs"
+    crate-version: "0.1.0"
     flavor: azure
 linter:
   extends:


### PR DESCRIPTION
As title states, this PR adds `crate-version` and renames the package and crate to `azure_storage_blobs`.