### PR TITLE
Add support for URL citation, and use "agentId" instead of "assistantId" in client SDKs (wire protocol still uses "assistant_id")

### DIFF
--- a/specification/ai/Azure.AI.Projects/agents/messages/models.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/messages/models.tsp
@@ -151,7 +151,7 @@ model MessageTextDetails {
   annotations: MessageTextAnnotation[];
 }
 
-// Annotations, used by text content: "file_citation" | "file_path"
+// Annotations, used by text content: "file_citation" | "file_path" | "url_citation"
 
 @discriminator("type")
 @doc("An abstract representation of an annotation to text thread message content.")
@@ -169,7 +169,7 @@ model MessageTextAnnotation {
 @doc("A citation within the message that points to a specific URL associated with the message. Generated when the agent uses tools such as 'bing_grounding' to search the Internet.")
 model MessageTextUrlCitationAnnotation extends MessageTextAnnotation {
   @doc("The object type, which is always 'url_citation'.")
-  type: "file_citation";
+  type: "url_citation";
 
   @encodedName("application/json", "url_citation")
   @doc("The details of the URL citation.")
@@ -387,7 +387,7 @@ model MessageDeltaTextAnnotation {
 @doc("A citation within the message that points to a specific URL associated with the message. Generated when the agent uses tools such as 'bing_grounding' to search the Internet.")
 model MessageDeltaTextUrlCitationAnnotation extends MessageDeltaTextAnnotation {
   @doc("The object type, which is always 'url_citation'.")
-  type: "file_citation";
+  type: "url_citation";
 
   @encodedName("application/json", "url_citation")
   @doc("The details of the URL citation.")

--- a/specification/ai/Azure.AI.Projects/agents/messages/models.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/messages/models.tsp
@@ -76,7 +76,7 @@ model ThreadMessage {
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "OpenAI uses explicit nullability, distinct from optionality"
   @encodedName("application/json", "assistant_id")
   @doc("If applicable, the ID of the agent that authored this message.")
-  assistantId: string | null;
+  agentId: string | null;
 
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "OpenAI uses explicit nullability, distinct from optionality"
   @encodedName("application/json", "run_id")

--- a/specification/ai/Azure.AI.Projects/agents/messages/models.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/messages/models.tsp
@@ -164,6 +164,35 @@ model MessageTextAnnotation {
   text: string;
 }
 
+// URL citation annotation + details
+
+@doc("A citation within the message that points to a specific URL associated with the message. Generated when the agent uses tools such as 'bing_grounding' to search the Internet.")
+model MessageTextUrlCitationAnnotation extends MessageTextAnnotation {
+  @doc("The object type, which is always 'url_citation'.")
+  type: "file_citation";
+
+  @encodedName("application/json", "url_citation")
+  @doc("The details of the URL citation.")
+  urlCitation: MessageTextUrlCitationDetails;
+
+  @encodedName("application/json", "start_index")
+  @doc("The first text index associated with this text annotation.")
+  startIndex?: int32;
+
+  @encodedName("application/json", "end_index")
+  @doc("The last text index associated with this text annotation.")
+  endIndex?: int32;
+}
+
+@doc("A representation of a URL citation, as used in text thread message content.")
+model MessageTextUrlCitationDetails {
+  @doc("The URL associated with this citation.")
+  url: string;
+
+  @doc("The title of the URL.")
+  title?: string;
+}
+
 // File citation annotation + details
 
 @doc("A citation within the message that points to a specific quote from a specific File associated with the agent or the message. Generated when the agent uses the 'file_search' tool to search files.")
@@ -355,6 +384,33 @@ model MessageDeltaTextAnnotation {
   type: string;
 }
 
+@doc("A citation within the message that points to a specific URL associated with the message. Generated when the agent uses tools such as 'bing_grounding' to search the Internet.")
+model MessageDeltaTextUrlCitationAnnotation extends MessageDeltaTextAnnotation {
+  @doc("The object type, which is always 'url_citation'.")
+  type: "file_citation";
+
+  @encodedName("application/json", "url_citation")
+  @doc("The details of the URL citation.")
+  urlCitation: MessageDeltaTextUrlCitationDetails;
+
+  @encodedName("application/json", "start_index")
+  @doc("The first text index associated with this text annotation.")
+  startIndex?: int32;
+
+  @encodedName("application/json", "end_index")
+  @doc("The last text index associated with this text annotation.")
+  endIndex?: int32;
+}
+
+@doc("A representation of a URL citation, as used in text thread message content.")
+model MessageDeltaTextUrlCitationDetails {
+  @doc("The URL associated with this citation.")
+  url: string;
+
+  @doc("The title of the URL.")
+  title?: string;
+}
+
 /** Represents a streamed file citation applied to a streaming text content part. */
 model MessageDeltaTextFileCitationAnnotation
   extends MessageDeltaTextAnnotation {
@@ -413,13 +469,4 @@ model MessageDeltaTextFilePathAnnotationObject {
   /** The file ID for the annotation. */
   @encodedName("application/json", "file_id")
   fileId?: string;
-}
-
-/** A representation of the URL used for the text citation. */
-model MessageDeltaTextUrlCitationDetails {
-  /** The URL where the citation is from. */
-  url?: string;
-
-  /** The title of the URL. */
-  title?: string;
 }

--- a/specification/ai/Azure.AI.Projects/agents/models.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/models.tsp
@@ -139,7 +139,7 @@ model CreateAgentOptions {
 model UpdateAgentOptions {
   @path
   @doc("The ID of the agent to modify.")
-  assistantId: string;
+  agentId: string;
 
   @doc("The ID of the model to use.")
   `model`?: string;

--- a/specification/ai/Azure.AI.Projects/agents/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/routes.tsp
@@ -51,7 +51,7 @@ op listAgents is Azure.Core.Foundations.Operation<
 /**
  * Retrieves an existing agent.
  *
- * @param assistantId The ID of the agent to retrieve.
+ * @param agentId The ID of the agent to retrieve.
  * @returns The requested agent instance.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
@@ -59,12 +59,12 @@ op listAgents is Azure.Core.Foundations.Operation<
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "mirrored API name parity"
 @get
-@route("/assistants/{assistantId}")
+@route("/assistants/{agentId}")
 op getAgent is Azure.Core.Foundations.Operation<
   {
     @doc("Identifier of the agent.")
     @path
-    assistantId: string;
+    agentId: string;
   },
   Agent
 >;
@@ -79,7 +79,7 @@ op getAgent is Azure.Core.Foundations.Operation<
 #suppress "@azure-tools/typespec-azure-core/no-operation-id" "non-standard operations"
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @post
-@route("/assistants/{assistantId}")
+@route("/assistants/{agentId}")
 op updateAgent is Azure.Core.Foundations.Operation<
   {
     /**
@@ -93,19 +93,19 @@ op updateAgent is Azure.Core.Foundations.Operation<
 /**
  * Deletes an agent.
  *
- * @param assistantId The ID of the agent to delete.
+ * @param agentId The ID of the agent to delete.
  * @returns Status information about the requested deletion operation.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
 #suppress "@azure-tools/typespec-azure-core/no-operation-id" "non-standard operations"
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "not yet versioned"
 @delete
-@route("/assistants/{assistantId}")
+@route("/assistants/{agentId}")
 op deleteAgent is Azure.Core.Foundations.Operation<
   {
     @doc("Identifier of the agent.")
     @path
-    assistantId: string;
+    agentId: string;
   },
   AgentDeletionStatus
 >;

--- a/specification/ai/Azure.AI.Projects/agents/run_steps/models.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/run_steps/models.tsp
@@ -19,7 +19,7 @@ model RunStep {
 
   @encodedName("application/json", "assistant_id")
   @doc("The ID of the agent associated with the run step.")
-  assistantId: string;
+  agentId: string;
 
   @encodedName("application/json", "thread_id")
   @doc("The ID of the thread that was run.")

--- a/specification/ai/Azure.AI.Projects/agents/runs/models.tsp
+++ b/specification/ai/Azure.AI.Projects/agents/runs/models.tsp
@@ -23,7 +23,7 @@ model ThreadRun {
 
   @encodedName("application/json", "assistant_id")
   @doc("The ID of the agent associated with the thread this run was performed against.")
-  assistantId: string;
+  agentId: string;
 
   @doc("The status of the agent thread run.")
   status: RunStatus;
@@ -187,7 +187,7 @@ model RunCompletionUsage {
 model CreateRunOptions {
   @doc("The ID of the agent that should run the thread.")
   @encodedName("application/json", "assistant_id")
-  assistantId: string;
+  agentId: string;
 
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "OpenAI uses explicit nullability, distinct from optionality"
   @doc("The overridden model name that the agent should use to run the thread.")
@@ -351,7 +351,7 @@ model SubmitToolOutputsDetails {
 model CreateAndRunThreadOptions {
   @encodedName("application/json", "assistant_id")
   @doc("The ID of the agent for which the thread should be created.")
-  assistantId: string;
+  agentId: string;
 
   @doc("The details used to create the new thread. If no thread is provided, an empty one will be created.")
   thread?: AgentThreadCreationOptions;

--- a/specification/ai/Azure.AI.Projects/connections/model.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/model.tsp
@@ -147,7 +147,7 @@ enum ConnectionType {
   AzureAISearch: "CognitiveSearch",
 
   @doc("Generic connection that uses API Key authentication")
-  APIKey: "API Key",
+  APIKey: "ApiKey",
 }
 
 /*

--- a/specification/ai/Azure.AI.Projects/connections/model.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/model.tsp
@@ -145,6 +145,9 @@ enum ConnectionType {
 
   @doc("Azure AI Search")
   AzureAISearch: "CognitiveSearch",
+
+  @doc("Generic connection that uses API Key authentication")
+  APIKey: "API Key",
 }
 
 /*

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
@@ -301,7 +301,7 @@
         }
       }
     },
-    "/assistants/{assistantId}": {
+    "/assistants/{agentId}": {
       "get": {
         "operationId": "Agents_GetAgent",
         "description": "Retrieves an existing agent.",
@@ -310,7 +310,7 @@
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
           },
           {
-            "name": "assistantId",
+            "name": "agentId",
             "in": "path",
             "description": "Identifier of the agent.",
             "required": true,
@@ -346,7 +346,7 @@
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
           },
           {
-            "$ref": "#/parameters/Agents.UpdateAgentOptions.assistantId"
+            "$ref": "#/parameters/Agents.UpdateAgentOptions.agentId"
           },
           {
             "name": "body",
@@ -386,7 +386,7 @@
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
           },
           {
-            "name": "assistantId",
+            "name": "agentId",
             "in": "path",
             "description": "Identifier of the agent.",
             "required": true,
@@ -434,7 +434,8 @@
               "Serverless",
               "AzureBlob",
               "AIServices",
-              "CognitiveSearch"
+              "CognitiveSearch",
+              "API Key"
             ],
             "x-ms-enum": {
               "name": "ConnectionType",
@@ -464,6 +465,11 @@
                   "name": "AzureAISearch",
                   "value": "CognitiveSearch",
                   "description": "Azure AI Search"
+                },
+                {
+                  "name": "APIKey",
+                  "value": "API Key",
+                  "description": "Generic connection that uses API Key authentication"
                 }
               ]
             }
@@ -4187,7 +4193,7 @@
         "assistant_id": {
           "type": "string",
           "description": "The ID of the agent for which the thread should be created.",
-          "x-ms-client-name": "assistantId"
+          "x-ms-client-name": "agentId"
         },
         "thread": {
           "$ref": "#/definitions/Agents.AgentThreadCreationOptions",
@@ -4353,7 +4359,7 @@
         "assistant_id": {
           "type": "string",
           "description": "The ID of the agent that should run the thread.",
-          "x-ms-client-name": "assistantId"
+          "x-ms-client-name": "agentId"
         },
         "model": {
           "type": "string",
@@ -5212,19 +5218,54 @@
         }
       }
     },
+    "Agents.MessageDeltaTextUrlCitationAnnotation": {
+      "type": "object",
+      "description": "A citation within the message that points to a specific URL associated with the message. Generated when the agent uses tools such as 'bing_grounding' to search the Internet.",
+      "properties": {
+        "url_citation": {
+          "$ref": "#/definitions/Agents.MessageDeltaTextUrlCitationDetails",
+          "description": "The details of the URL citation.",
+          "x-ms-client-name": "urlCitation"
+        },
+        "start_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The first text index associated with this text annotation.",
+          "x-ms-client-name": "startIndex"
+        },
+        "end_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The last text index associated with this text annotation.",
+          "x-ms-client-name": "endIndex"
+        }
+      },
+      "required": [
+        "url_citation"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageDeltaTextAnnotation"
+        }
+      ],
+      "x-ms-discriminator-value": "url_citation"
+    },
     "Agents.MessageDeltaTextUrlCitationDetails": {
       "type": "object",
-      "description": "A representation of the URL used for the text citation.",
+      "description": "A representation of a URL citation, as used in text thread message content.",
       "properties": {
         "url": {
           "type": "string",
-          "description": "The URL where the citation is from."
+          "description": "The URL associated with this citation."
         },
         "title": {
           "type": "string",
           "description": "The title of the URL."
         }
-      }
+      },
+      "required": [
+        "url"
+      ]
     },
     "Agents.MessageImageFileContent": {
       "type": "object",
@@ -5566,6 +5607,55 @@
       },
       "required": [
         "file_id"
+      ]
+    },
+    "Agents.MessageTextUrlCitationAnnotation": {
+      "type": "object",
+      "description": "A citation within the message that points to a specific URL associated with the message. Generated when the agent uses tools such as 'bing_grounding' to search the Internet.",
+      "properties": {
+        "url_citation": {
+          "$ref": "#/definitions/Agents.MessageTextUrlCitationDetails",
+          "description": "The details of the URL citation.",
+          "x-ms-client-name": "urlCitation"
+        },
+        "start_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The first text index associated with this text annotation.",
+          "x-ms-client-name": "startIndex"
+        },
+        "end_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The last text index associated with this text annotation.",
+          "x-ms-client-name": "endIndex"
+        }
+      },
+      "required": [
+        "url_citation"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageTextAnnotation"
+        }
+      ],
+      "x-ms-discriminator-value": "url_citation"
+    },
+    "Agents.MessageTextUrlCitationDetails": {
+      "type": "object",
+      "description": "A representation of a URL citation, as used in text thread message content.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The URL associated with this citation."
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of the URL."
+        }
+      },
+      "required": [
+        "url"
       ]
     },
     "Agents.MicrosoftFabricToolDefinition": {
@@ -6093,7 +6183,7 @@
         "assistant_id": {
           "type": "string",
           "description": "The ID of the agent associated with the run step.",
-          "x-ms-client-name": "assistantId"
+          "x-ms-client-name": "agentId"
         },
         "thread_id": {
           "type": "string",
@@ -7311,7 +7401,7 @@
           "type": "string",
           "description": "If applicable, the ID of the agent that authored this message.",
           "x-nullable": true,
-          "x-ms-client-name": "assistantId"
+          "x-ms-client-name": "agentId"
         },
         "run_id": {
           "type": "string",
@@ -7415,7 +7505,7 @@
         "assistant_id": {
           "type": "string",
           "description": "The ID of the agent associated with the thread this run was performed against.",
-          "x-ms-client-name": "assistantId"
+          "x-ms-client-name": "agentId"
         },
         "status": {
           "$ref": "#/definitions/Agents.RunStatus",
@@ -8909,7 +8999,8 @@
         "Serverless",
         "AzureBlob",
         "AIServices",
-        "CognitiveSearch"
+        "CognitiveSearch",
+        "API Key"
       ],
       "x-ms-enum": {
         "name": "ConnectionType",
@@ -8939,6 +9030,11 @@
             "name": "AzureAISearch",
             "value": "CognitiveSearch",
             "description": "Azure AI Search"
+          },
+          {
+            "name": "APIKey",
+            "value": "API Key",
+            "description": "Generic connection that uses API Key authentication"
           }
         ]
       }
@@ -9653,8 +9749,8 @@
     }
   },
   "parameters": {
-    "Agents.UpdateAgentOptions.assistantId": {
-      "name": "assistantId",
+    "Agents.UpdateAgentOptions.agentId": {
+      "name": "agentId",
       "in": "path",
       "description": "The ID of the agent to modify.",
       "required": true,

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2024-07-01-preview/azure-ai-projects.json
@@ -435,7 +435,7 @@
               "AzureBlob",
               "AIServices",
               "CognitiveSearch",
-              "API Key"
+              "ApiKey"
             ],
             "x-ms-enum": {
               "name": "ConnectionType",
@@ -468,7 +468,7 @@
                 },
                 {
                   "name": "APIKey",
-                  "value": "API Key",
+                  "value": "ApiKey",
                   "description": "Generic connection that uses API Key authentication"
                 }
               ]
@@ -9000,7 +9000,7 @@
         "AzureBlob",
         "AIServices",
         "CognitiveSearch",
-        "API Key"
+        "ApiKey"
       ],
       "x-ms-enum": {
         "name": "ConnectionType",
@@ -9033,7 +9033,7 @@
           },
           {
             "name": "APIKey",
-            "value": "API Key",
+            "value": "ApiKey",
             "description": "Generic connection that uses API Key authentication"
           }
         ]


### PR DESCRIPTION
Add support for URL citation.

Add ConnectionType.APIKey

Also replace `assistantId` with `agentId` in model properties and input arguments of operation methods. Wire format does not change -- it stays `assistant_id` there.