### PR TITLE
enable C# samples for iotoperations

### DIFF
--- a/specification/iotoperations/IoTOperations.Management/tspconfig.yaml
+++ b/specification/iotoperations/IoTOperations.Management/tspconfig.yaml
@@ -15,8 +15,6 @@ options:
     clear-output-folder: true
     use-write-core: true
     namespace: "{package-dir}"
-    # Disable generate samples until CodGen fix collection initialization issue https://github.com/Azure/azure-sdk-for-net/issues/47929
-    generate-sample-project: false
   "@azure-tools/typespec-python":
     package-dir: "azure-mgmt-iotoperations"
     package-name: "{package-dir}"


### PR DESCRIPTION
Only enables the sample generator for C# for iotoperations. No ARM review needed at all
