### PR TITLE
Add Go Data Plane Rules of tspconfig.yaml for TSV

### DIFF
--- a/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
+++ b/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
@@ -249,7 +249,7 @@ export class TspConfigGoDpServiceDirMatchPatternSubRule extends TspconfigEmitter
 
 export class TspConfigGoDpPackageDirectoryMatchPatternSubRule extends TspconfigEmitterOptionsSubRuleBase {
   constructor() {
-    super("@azure-tools/typespec-go", "package-dir", new RegExp(/^az[^\/]*\/.*$/));
+    super("@azure-tools/typespec-go", "package-dir", new RegExp(/^az.*$/));
   }
   protected skip(_: any, folder: string) {
     return skipForManagementPlane(folder);

--- a/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
+++ b/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
@@ -141,7 +141,15 @@ function isManagementSdk(folder: string): boolean {
 function skipForDataPlane(folder: string): SkipResult {
   return {
     shouldSkip: !isManagementSdk(folder),
-    reason: "This rule is only applicable for management SDKs.",
+    reason: "This rule is only applicable for management plane SDKs.",
+  };
+}
+
+
+function skipForManagementPlane(folder: string): SkipResult {
+  return {
+    shouldSkip: isManagementSdk(folder),
+    reason: "This rule is only applicable for data plane SDKs.",
   };
 }
 
@@ -230,7 +238,17 @@ export class TspConfigTsMgmtModularPackageNameMatchPatternSubRule extends Tspcon
   }
 }
 
-// ----- Go management sub rules -----
+// ----- Go data plane sub rules -----
+export class TspConfigGoDpServiceDirMatchPatternSubRule extends TspconfigEmitterOptionsSubRuleBase {
+  constructor() {
+    super("@azure-tools/typespec-go", "service-dir", new RegExp(/^sdk\/.*$/));
+  }
+  protected skip(_: any, folder: string) {
+    return skipForDataPlane(folder);
+  }
+}
+
+// ----- Go management plane sub rules -----
 export class TspConfigGoMgmtServiceDirMatchPatternSubRule extends TspconfigEmitterOptionsSubRuleBase {
   constructor() {
     super("@azure-tools/typespec-go", "service-dir", new RegExp(/^sdk\/resourcemanager\/[^\/]*$/));

--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -14,9 +14,12 @@ import {
   TspConfigGoMgmtModuleEqualStringSubRule,
   TspConfigGoMgmtFixConstStutteringTrueSubRule,
   TspConfigGoMgmtGenerateExamplesTrueSubRule,
-  TspConfigGoMgmtGenerateFakesTrueSubRule,
   TspConfigGoMgmtHeadAsBooleanTrueSubRule,
-  TspConfigGoMgmtInjectSpansTrueSubRule,
+  TspConfigGoAzGenerateFakesTrueSubRule,
+  TspConfigGoAzInjectSpansTrueSubRule,
+  TspConfigGoDpModuleMatchPatternSubRule,
+  TspConfigGoDpPackageDirectoryMatchPatternSubRule,
+  TspConfigGoDpServiceDirMatchPatternSubRule,
   TspConfigJavaAzPackageDirectorySubRule,
   TspConfigPythonMgmtPackageDirectorySubRule,
   TspConfigPythonMgmtPackageNameEqualStringSubRule,
@@ -105,31 +108,38 @@ function createEmitterOptionTestCases(
   validValue: boolean | string,
   invalidValue: boolean | string,
   subRules: TspconfigSubRuleBase[],
+  allowUndefined: boolean = false,
 ): Case[] {
-  const cases: Case[] = [
-    {
-      description: `Validate ${emitterName}'s option:${key} with valid value ${validValue}`,
-      folder,
-      tspconfigContent: createEmitterOptionExample(emitterName, { key: key, value: validValue }),
-      success: true,
-      subRules,
-    },
-    {
-      description: `Validate ${emitterName}'s option:${key} with invalid value ${invalidValue}`,
-      folder,
-      tspconfigContent: createEmitterOptionExample(emitterName, { key: key, value: invalidValue }),
-      success: false,
-      subRules,
-    },
-    {
-      description: `Validate ${emitterName}'s option:${key} with undefined value`,
-      folder,
-      tspconfigContent: createEmitterOptionExample(emitterName),
-      success: false,
-      subRules,
-    },
-  ];
-  if (key.includes(".")) {
+  const cases: Case[] = [];
+
+  cases.push({
+    description: `Validate ${emitterName}'s option:${key} with valid value ${validValue}`,
+    folder,
+    tspconfigContent: createEmitterOptionExample(emitterName, { key: key, value: validValue }),
+    success: true,
+    subRules,
+  });
+
+  cases.push({
+    description: `Validate ${emitterName}'s option:${key} with invalid value ${invalidValue}`,
+    folder,
+    tspconfigContent: createEmitterOptionExample(emitterName, {
+      key: key,
+      value: invalidValue,
+    }),
+    success: false,
+    subRules,
+  });
+
+  cases.push({
+    description: `Validate ${emitterName}'s option:${key} with undefined value`,
+    folder,
+    tspconfigContent: createEmitterOptionExample(emitterName),
+    success: allowUndefined ? true : false,
+    subRules,
+  });
+
+  if (!allowUndefined && key.includes(".")) {
     cases.push({
       description: `Validate ${emitterName}'s option:${key} with incomplete key`,
       folder,
@@ -267,7 +277,16 @@ const goManagementGenerateFakesTestCases = createEmitterOptionTestCases(
   "generate-fakes",
   true,
   false,
-  [new TspConfigGoMgmtGenerateFakesTrueSubRule()],
+  [new TspConfigGoAzGenerateFakesTrueSubRule()],
+);
+
+const goDpGenerateFakesTestCases = createEmitterOptionTestCases(
+  "@azure-tools/typespec-go",
+  "",
+  "generate-fakes",
+  true,
+  false,
+  [new TspConfigGoAzGenerateFakesTrueSubRule()],
 );
 
 const goManagementHeadAsBooleanTestCases = createEmitterOptionTestCases(
@@ -285,7 +304,44 @@ const goManagementInjectSpansTestCases = createEmitterOptionTestCases(
   "inject-spans",
   true,
   false,
-  [new TspConfigGoMgmtInjectSpansTrueSubRule()],
+  [new TspConfigGoAzInjectSpansTrueSubRule()],
+);
+
+const goDpInjectSpansTestCases = createEmitterOptionTestCases(
+  "@azure-tools/typespec-go",
+  "",
+  "inject-spans",
+  true,
+  false,
+  [new TspConfigGoAzInjectSpansTrueSubRule()],
+);
+
+const goDpModuleTestCases = createEmitterOptionTestCases(
+  "@azure-tools/typespec-go",
+  "",
+  "module",
+  "github.com/Azure/azure-sdk-for-go/aaa",
+  "github.com/Azure/azure-sdk-for-cpp/bbb",
+  [new TspConfigGoDpModuleMatchPatternSubRule()],
+  true,
+);
+
+const goDpPackageDirTestCases = createEmitterOptionTestCases(
+  "@azure-tools/typespec-go",
+  "",
+  "package-dir",
+  "az1/2/3",
+  "bzasd",
+  [new TspConfigGoDpPackageDirectoryMatchPatternSubRule()],
+);
+
+const goDpServiceDirTestCases = createEmitterOptionTestCases(
+  "@azure-tools/typespec-go",
+  "",
+  "service-dir",
+  "sdk/2/3",
+  "sd/k",
+  [new TspConfigGoDpServiceDirMatchPatternSubRule()],
 );
 
 const javaManagementPackageDirTestCases = createEmitterOptionTestCases(
@@ -389,6 +445,11 @@ describe("tspconfig", function () {
     ...goManagementGenerateFakesTestCases,
     ...goManagementHeadAsBooleanTestCases,
     ...goManagementInjectSpansTestCases,
+    ...goDpGenerateFakesTestCases,
+    ...goDpInjectSpansTestCases,
+    ...goDpModuleTestCases,
+    ...goDpPackageDirTestCases,
+    ...goDpServiceDirTestCases,
     // java
     ...javaManagementPackageDirTestCases,
     // python


### PR DESCRIPTION
To improve help warn and provide guides for spec PR author to update and correct their tspconfig rules for go emitter in dataplane, this PR add GO rules based on: [loop](https://microsoft.sharepoint.com/:fl:/s/f34fd372-ad0b-47ae-9b72-0ee767dfa44e/EVqFBHDGEV1KpRB_SRujBWQBPV0wdukJjcX_K41E9wLSTA?e=jhjdZD&nav=cz0lMkZzaXRlcyUyRmYzNGZkMzcyLWFkMGItNDdhZS05YjcyLTBlZTc2N2RmYTQ0ZSZkPWIlMjFUZWt1bHNPU1BFYVB5NkJaWUYyOXg1QlEyQWxkcndoSG1zWmRDREt4WDlvTHE2S1F4aHR5VDRLekRJODdOWWRJJmY9MDFKWDJJQlBTMlFVQ0hCUlFSTFZGS0tFRDdKRU4yR0JMRSZjPSUyRiZhPUxvb3BBcHAmeD0lN0IlMjJ3JTIyJTNBJTIyVDBSVFVIeHRhV055YjNOdlpuUXVjMmhoY21Wd2IybHVkQzVqYjIxOFlpRlVaV3QxYkhOUFUxQkZZVkI1TmtKYVdVWXlPWGcxUWxFeVFXeGtjbmRvU0cxeldtUkRSRXQ0V0RsdlRIRTJTMUY0YUhSNVZEUkxla1JKT0RkT1dXUkpmREF4U2xneVNVSlFVbEZEVWpkTlRrY3lXVTFLUmxsRk0wNHpVbFpJU1U5Qk4xayUzRCUyMiUyQyUyMmklMjIlM0ElMjIzMDQwMjYwOS04N2VjLTQ0N2EtYWI4ZC00NTM0NGQ4M2NkNjYlMjIlN0Q%3D)
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
