### PR TITLE
[chore] Add Container Service Fleet label to PRs touching fleet files

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -2777,6 +2777,16 @@ configuration:
       - if:
         - includesModifiedFiles:
             files:
+            - specification/containerservice/Fleet.Management
+            - specification/containerservice/fleet
+            excludedFiles:
+            - ''
+        then:
+        - addLabel:
+            label: Container Service Fleet
+      - if:
+        - includesModifiedFiles:
+            files:
             - specification/cosmos-db/
             excludedFiles:
             - ''


### PR DESCRIPTION
Change label configuration to add a "Container Service Fleet" label when the PR is touching the Fleet Manager service files. 

![image](https://github.com/user-attachments/assets/3b8f70d0-0b5e-4347-8205-4a93946c20a7)

