### PR TITLE
[ARM Incremental TypeSpec] Return false if swagger cannot be parsed as JSON

### DIFF
--- a/.github/workflows/src/arm-incremental-typespec-preview.js
+++ b/.github/workflows/src/arm-incremental-typespec-preview.js
@@ -39,7 +39,14 @@ export default async function incrementalTypeSpec({ github, context, core }) {
       }
     }
 
-    const swaggerObj = JSON.parse(swagger);
+    let swaggerObj;
+    try {
+      swaggerObj = JSON.parse(swagger);
+    } catch {
+      // If swagger cannot be parsed as JSON, it's not "incremental typespec"
+      core.info(`File "${file}" cannot be parsed as JSON`);
+      return false;
+    }
 
     if (!swaggerObj["info"]?.["x-typespec-generated"]) {
       core.info(`File "${file}" does not contain "info.x-typespec-generated"`);

--- a/.github/workflows/test/arm-incremental-typespec-preview.test.js
+++ b/.github/workflows/test/arm-incremental-typespec-preview.test.js
@@ -75,6 +75,20 @@ describe("incrementalTypeSpec", () => {
     await expect(incrementalTypeSpec({ core })).resolves.toBe(false);
   });
 
+  it("returns false if swagger cannot be parsed as JSON", async () => {
+    const swaggerPath =
+      "/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json";
+
+    vi.spyOn(
+      changedFiles,
+      "getChangedResourceManagerSwaggerFiles",
+    ).mockResolvedValue([swaggerPath]);
+
+    vi.spyOn(git, "show").mockResolvedValue("not } valid { json");
+
+    await expect(incrementalTypeSpec({ core })).resolves.toBe(false);
+  });
+
   it("returns false if tsp conversion", async () => {
     const swaggerPath =
       "/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json";


### PR DESCRIPTION
Fixes this error, or any error parsing swagger that's not valid JSON:

```
execRoot("git show  HEAD:specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2024-06-01/appconfiguration.json")
SyntaxError: Expected ',' or '}' after property value in JSON at position 56912
    at JSON.parse (<anonymous>)
    at incrementalTypeSpec (file:///home/runner/work/azure-rest-api-specs/azure-rest-api-specs/.github/workflows/src/arm-incremental-typespec-preview.js:30:29)
```

https://github.com/Azure/azure-rest-api-specs/actions/runs/13528838065/job/37805953795#step:3:58