### PR TITLE
add openapi-subtype: rpaas

### DIFF
--- a/specification/storage/resource-manager/readme.md
+++ b/specification/storage/resource-manager/readme.md
@@ -26,6 +26,7 @@ These are the global settings for the Storage API.
 
 ``` yaml
 openapi-type: arm
+openapi-subtype: rpaas
 tag: package-2024-01
 ```
 


### PR DESCRIPTION
add openapi-subtype: rpaas in order for the API Validation Service to pick up your specs 