### PR TITLE
[typespec-apiview] Upgrade to Node 22

### DIFF
--- a/eng/pipelines/typespec-apiview.yml
+++ b/eng/pipelines/typespec-apiview.yml
@@ -20,6 +20,11 @@ jobs:
   - checkout: self
     fetchDepth: 0
 
+  - task: NodeTool@0
+    inputs:
+      versionSpec: 22.x
+    displayName: "Use Node 22.x"
+
   - pwsh: |
       . $(Build.SourcesDirectory)/eng/scripts/Create-APIView.ps1
       New-TypeSpecAPIViewTokens `

--- a/eng/pipelines/typespec-apiview.yml
+++ b/eng/pipelines/typespec-apiview.yml
@@ -20,6 +20,7 @@ jobs:
   - checkout: self
     fetchDepth: 0
 
+  # TODO: Refactor into shared template used by all pipelines
   - task: NodeTool@0
     inputs:
       versionSpec: 22.x


### PR DESCRIPTION
- Required since specs repo dropped support for Node 18