### PR TITLE
Fix VMSS property type in API response

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-09-01/virtualMachineScaleSet.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-09-01/virtualMachineScaleSet.json
@@ -4993,7 +4993,6 @@
           "description": "Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
         },
         "settings": {
-          "type": "object",
           "description": "Json formatted public settings for the extension."
         },
         "protectedSettings": {

--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/virtualMachineScaleSet.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/virtualMachineScaleSet.json
@@ -5000,7 +5000,6 @@
           "description": "Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
         },
         "settings": {
-          "type": "object",
           "description": "Json formatted public settings for the extension."
         },
         "protectedSettings": {

--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-07-01/virtualMachineScaleSet.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-07-01/virtualMachineScaleSet.json
@@ -5044,7 +5044,6 @@
           "description": "Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
         },
         "settings": {
-          "type": "object",
           "description": "Json formatted public settings for the extension."
         },
         "protectedSettings": {


### PR DESCRIPTION
There's an Azure CLI issue caused by the inconsistence between the Swagger definition and API response.
The actual response could be object type or string, so the definition should be "any" type instead of "object".